### PR TITLE
Fix PMHF bottom-up calculation

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -8290,9 +8290,13 @@ class FaultTreeApp:
                 lpf += fit * (1 - dc)
         self.spfm = spf
         self.lpfm = lpf
-        pmhf = (spf + lpf) * 1e-9
+
+        pmhf = 0.0
         for te in self.top_events:
-            te.probability = pmhf
+            prob = self.calculate_probability_recursive(te)
+            te.probability = prob
+            pmhf += prob
+
         self.update_views()
         msg = f"PMHF = {pmhf:.2e}\nSPFM = {spf:.2f}\nLPFM = {lpf:.2f}"
         messagebox.showinfo("PMHF Calculation", msg)


### PR DESCRIPTION
## Summary
- update PMHF computation to propagate failure probabilities from basic events
- keep SPFM/LPFM summation but derive PMHF from tree structure

## Testing
- `python -m py_compile FreeCTA.py review_toolbox.py mechanisms.py`

------
https://chatgpt.com/codex/tasks/task_b_68802d1a23948325bb7934bd5172f6dd