### PR TITLE
Fix mission profile persistence and document probability formula

### DIFF
--- a/FreeCTA.py
+++ b/FreeCTA.py
@@ -7755,7 +7755,9 @@ class FaultTreeApp:
         if formula == "exponential":
             return 1 - math.exp(-lam * t)
         elif formula == "constant":
-            return lam
+            # Treat the FIT value as a probability independent of mission time
+            # so no conversion to a failure rate is applied.
+            return fit
         else:
             return lam * t
 
@@ -10837,6 +10839,7 @@ class FaultTreeApp:
                 for lib in self.mechanism_libraries
             ],
             "selected_mechanism_libraries": [lib.name for lib in self.selected_mechanism_libraries],
+            "mission_profiles": [asdict(mp) for mp in self.mission_profiles],
             "reliability_analyses": [
                 {
                     "name": ra.name,
@@ -10937,6 +10940,14 @@ class FaultTreeApp:
                 self.selected_mechanism_libraries.append(found)
         if not self.mechanism_libraries:
             self.load_default_mechanisms()
+
+        # Mission profiles
+        self.mission_profiles = []
+        for mp_data in data.get("mission_profiles", []):
+            try:
+                self.mission_profiles.append(MissionProfile(**mp_data))
+            except TypeError:
+                pass
 
         # Reliability analyses
         self.reliability_analyses = []

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ attached so they can be opened in Excel or another spreadsheet application. Requ
 If sending fails with a connection error, the dialog will prompt again so you
 can correct the server address or port.
 
+## Mission Profiles and Probability Formulas
+
+The **Reliability** menu lets you define mission profiles describing the on/off
+time, temperatures and other conditions for your system.  When a profile is
+present its total `TAU` value is used to convert FIT rates into failure
+probabilities for each basic event.
+
+In the *Edit Node* dialog for a basic event you can choose how the FIT rate is
+interpreted:
+
+* **linear** – probability is calculated as `λ × τ` where `λ` is the FIT value
+  expressed as failures per hour and `τ` comes from the selected mission profile.
+* **exponential** – uses the exponential model `1 − exp(−λ × τ)`.
+* **constant** – the numeric FIT value is used directly as the
+  probability, ignoring mission time. Use this when the value already
+  represents a probability rather than a failure rate.
+
+Mission profiles and the selected formula for each basic event are stored in the
+JSON model so results remain consistent when reloading the file.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- persist mission profiles when saving models
- reload mission profiles from JSON files
- document mission profiles and probability formulas in README
- ensure constant formula uses FIT value directly

## Testing
- `python -m py_compile FreeCTA.py`


------
https://chatgpt.com/codex/tasks/task_b_6880332b56148325b24a5b5052cb8f71