### PR TITLE
Add multiple HAZOP/HARA support

### DIFF
--- a/models.py
+++ b/models.py
@@ -92,6 +92,19 @@ class HaraEntry:
     asil: str
     safety_goal: str
 
+@dataclass
+class HazopDoc:
+    """Container for a HAZOP with a name and list of entries."""
+    name: str
+    entries: list
+
+@dataclass
+class HaraDoc:
+    """Container for a HARA linked to a specific HAZOP."""
+    name: str
+    hazop: str
+    entries: list
+
 COMPONENT_ATTR_TEMPLATES = {
     "capacitor": {
         "dielectric": ["ceramic", "electrolytic", "tantalum"],


### PR DESCRIPTION
## Summary
- introduce `HazopDoc` and `HaraDoc` dataclasses
- store lists of HAZOPs/HARAs and choose active documents
- allow selecting/creating HAZOPs and HARAs in their windows
- compute safety goal ASIL across all HARAs
- update combobox lists to use all HAZOP data

## Testing
- `python -m py_compile toolboxes.py AutoSafeguard.py models.py mechanisms.py drawing_helper.py review_toolbox.py risk_assessment.py`

------
https://chatgpt.com/codex/tasks/task_b_6880752d6c0083259f797ac938e97238