### PR TITLE
Implement minimal SysML repository

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -3,6 +3,8 @@ from tkinter import ttk, simpledialog
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
+from sysml_repository import SysMLRepository
+
 from sysml_spec import SYSML_PROPERTIES
 
 
@@ -22,6 +24,7 @@ class SysMLObject:
     obj_type: str
     x: float
     y: float
+    element_id: str | None = None
     width: float = 80.0
     height: float = 40.0
     properties: Dict[str, str] = field(default_factory=dict)
@@ -34,6 +37,8 @@ class SysMLDiagramWindow(tk.Toplevel):
         super().__init__(master)
         self.title(title)
         self.geometry("800x600")
+
+        self.repo = SysMLRepository.get_instance()
 
         self.zoom = 1.0
         self.current_tool = None
@@ -86,13 +91,19 @@ class SysMLDiagramWindow(tk.Toplevel):
             else:
                 if obj and obj != self.start:
                     self.connections.append((self.start.obj_id, obj.obj_id, t))
+                    src_id = self.start.element_id
+                    dst_id = obj.element_id
+                    if src_id and dst_id:
+                        self.repo.create_relationship(t, src_id, dst_id)
                 self.start = None
                 self.redraw()
         elif t and t != "Select":
-            new_obj = SysMLObject(_get_next_id(), t, x / self.zoom, y / self.zoom)
+            element = self.repo.create_element(t)
+            new_obj = SysMLObject(_get_next_id(), t, x / self.zoom, y / self.zoom, element_id=element.elem_id)
             key = f"{t.replace(' ', '')}Usage"
             for prop in SYSML_PROPERTIES.get(key, []):
                 new_obj.properties.setdefault(prop, "")
+            element.properties.update(new_obj.properties)
             self.objects.append(new_obj)
             self.redraw()
         else:
@@ -269,8 +280,13 @@ class SysMLObjectDialog(simpledialog.Dialog):
 
     def apply(self):
         self.obj.properties["name"] = self.name_var.get()
+        repo = SysMLRepository.get_instance()
+        if self.obj.element_id and self.obj.element_id in repo.elements:
+            repo.elements[self.obj.element_id].name = self.name_var.get()
         for prop, var in self.entries.items():
             self.obj.properties[prop] = var.get()
+            if self.obj.element_id and self.obj.element_id in repo.elements:
+                repo.elements[self.obj.element_id].properties[prop] = var.get()
         try:
             self.obj.width = float(self.width_var.get())
             self.obj.height = float(self.height_var.get())

--- a/sysml_repository.py
+++ b/sysml_repository.py
@@ -1,0 +1,57 @@
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+@dataclass
+class SysMLElement:
+    """Basic SysML element stored in the repository."""
+    elem_id: str
+    elem_type: str
+    name: str = ""
+    properties: Dict[str, str] = field(default_factory=dict)
+    stereotypes: Dict[str, str] = field(default_factory=dict)
+    owner: Optional[str] = None
+
+@dataclass
+class SysMLRelationship:
+    rel_id: str
+    rel_type: str
+    source: str
+    target: str
+    stereotype: Optional[str] = None
+    properties: Dict[str, str] = field(default_factory=dict)
+
+class SysMLRepository:
+    """Singleton repository for all SysML elements and relationships."""
+    _instance = None
+
+    def __init__(self):
+        self.elements: Dict[str, SysMLElement] = {}
+        self.relationships: List[SysMLRelationship] = []
+
+    @classmethod
+    def get_instance(cls) -> "SysMLRepository":
+        if cls._instance is None:
+            cls._instance = SysMLRepository()
+        return cls._instance
+
+    def create_element(self, elem_type: str, name: str = "", properties: Optional[Dict[str, str]] = None) -> SysMLElement:
+        elem_id = str(uuid.uuid4())
+        elem = SysMLElement(elem_id, elem_type, name, properties or {})
+        self.elements[elem_id] = elem
+        return elem
+
+    def create_relationship(self, rel_type: str, source: str, target: str, stereotype: Optional[str] = None, properties: Optional[Dict[str, str]] = None) -> SysMLRelationship:
+        rel_id = str(uuid.uuid4())
+        rel = SysMLRelationship(rel_id, rel_type, source, target, stereotype, properties or {})
+        self.relationships.append(rel)
+        return rel
+
+    def serialize(self) -> str:
+        data = {
+            "elements": [elem.__dict__ for elem in self.elements.values()],
+            "relationships": [rel.__dict__ for rel in self.relationships],
+        }
+        return json.dumps(data, indent=2)
+

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,31 @@
+import unittest
+from sysml_repository import SysMLRepository
+
+class RepositoryTests(unittest.TestCase):
+    def setUp(self):
+        self.repo = SysMLRepository.get_instance()
+        self.repo.elements.clear()
+        self.repo.relationships.clear()
+
+    def test_create_elements(self):
+        actor = self.repo.create_element("Actor", name="User")
+        use_case = self.repo.create_element("Use Case", name="Login")
+        self.assertNotEqual(actor.elem_id, use_case.elem_id)
+        self.assertEqual(actor.name, "User")
+        self.assertEqual(use_case.name, "Login")
+
+    def test_create_relationship(self):
+        a = self.repo.create_element("Actor")
+        b = self.repo.create_element("Use Case")
+        rel = self.repo.create_relationship("Association", a.elem_id, b.elem_id)
+        self.assertEqual(rel.source, a.elem_id)
+        self.assertEqual(rel.target, b.elem_id)
+
+    def test_serialize(self):
+        blk = self.repo.create_element("Block", name="Car")
+        js = self.repo.serialize()
+        self.assertIn("Car", js)
+        self.assertIn(blk.elem_id, js)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a basic repository for SysML elements and relationships
- track created diagram objects in the repository
- update property dialog to sync with repository
- add unit tests for repository functionality

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6882414e2d088325bc401c562b3cf160