### PR TITLE
Fix duplicate diagram elements

### DIFF
--- a/architecture.py
+++ b/architecture.py
@@ -1957,6 +1957,14 @@ class ArchitectureManagerDialog(tk.Toplevel):
 
         visited: set[str] = set()
 
+        # collect all elements that already appear on a diagram so they don't
+        # show up twice in the hierarchy
+        diagram_elems = {
+            elem_id
+            for diag in self.repo.diagrams.values()
+            for elem_id in getattr(diag, "elements", [])
+        }
+
         def add_elem(elem_id: str, parent: str):
             if elem_id in visited:
                 return
@@ -1995,8 +2003,9 @@ class ArchitectureManagerDialog(tk.Toplevel):
             for e in self.repo.elements.values():
                 if (
                     e.owner == pkg_id
-                    and e.elem_type != "Package"
+                    and e.elem_type not in ("Package", "Part")
                     and e.name
+                    and e.elem_id not in diagram_elems
                 ):
                     add_elem(e.elem_id, node)
             for d in self.repo.diagrams.values():


### PR DESCRIPTION
## Summary
- skip elements already placed on a diagram when populating the architecture explorer

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688330bc34288325907cd9e8afb97cfb