### PR TITLE
Fix FMEDA FIT rate calculation with BOM components

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -261,6 +261,7 @@ from models import (
     QUALIFICATIONS,
     COMPONENT_ATTR_TEMPLATES,
     RELIABILITY_MODELS,
+    component_fit_map,
     ASIL_LEVEL_OPTIONS,
     ASIL_ORDER,
     ASIL_TARGETS,
@@ -8948,7 +8949,7 @@ class FaultTreeApp:
             entries[:] = list(unique.values())
             events = entries
 
-            comp_fit = {c.name: c.fit * c.quantity for c in self.reliability_components}
+            comp_fit = component_fit_map(self.reliability_components)
             frac_totals = {}
             for be in events:
                 src = self.get_failure_mode_node(be)

--- a/models.py
+++ b/models.py
@@ -406,3 +406,26 @@ ASIL_TABLE = {
 def calc_asil(sev: int, cont: int, expo: int) -> str:
     """Return ASIL based on severity, controllability and exposure."""
     return ASIL_TABLE.get((sev, cont, expo), "QM")
+
+
+def component_fit_map(components: list) -> dict:
+    """Return a mapping of component names to aggregated FIT values.
+
+    The returned FIT values include quantity and recursively handle any
+    ``sub_boms`` so nested BOM structures are flattened. Quantities of parent
+    components multiply the FIT contribution of their children.
+    """
+
+    mapping = {}
+
+    def add(comp, mult=1.0):
+        mapping[comp.name] = mapping.get(comp.name, 0.0) + comp.fit * comp.quantity * mult
+        for bom in getattr(comp, "sub_boms", []):
+            for sub in bom:
+                add(sub, mult * comp.quantity)
+
+    for c in components:
+        add(c)
+
+    return mapping
+

--- a/toolboxes.py
+++ b/toolboxes.py
@@ -16,6 +16,7 @@ from models import (
     COMPONENT_ATTR_TEMPLATES,
     RELIABILITY_MODELS,
     PASSIVE_QUAL_FACTORS,
+    component_fit_map,
     calc_asil,
 )
 
@@ -346,7 +347,7 @@ class ReliabilityWindow(tk.Toplevel):
                     comp.fit = 0.0
             total += comp.fit * comp.quantity
 
-        comp_fit = {c.name: c.fit * c.quantity for c in self.components}
+        comp_fit = component_fit_map(self.components)
         spf = 0.0
         lpf = 0.0
         total_modes = 0.0


### PR DESCRIPTION
## Summary
- support nested BOMs when computing component FIT totals
- use new `component_fit_map` helper inside FMEDA calculation and reliability toolbox

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68835bf95ec48325a47ea8d50ac10d14