### PR TITLE
Fix circular import causing crash in AutoML

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -312,8 +312,7 @@ preformatted_style = ParagraphStyle(name="Preformatted", fontName="Courier", fon
 styles.add(preformatted_style)
 
 # Characters used to display pass/fail status in metrics labels.
-CHECK_MARK = "\u2713"
-CROSS_MARK = "\u2717"
+from constants import CHECK_MARK, CROSS_MARK
 
 from toolboxes import (
     ReliabilityWindow,

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,2 @@
+CHECK_MARK = "\u2713"
+CROSS_MARK = "\u2717"

--- a/toolboxes.py
+++ b/toolboxes.py
@@ -20,7 +20,7 @@ from models import (
     calc_asil,
 )
 from fmeda_utils import compute_fmeda_metrics
-from AutoML import CHECK_MARK, CROSS_MARK
+from constants import CHECK_MARK, CROSS_MARK
 
 
 def _total_fit_from_boms(boms):


### PR DESCRIPTION
## Summary
- break the circular dependency between `AutoML.py` and `toolboxes.py`
- introduce new `constants.py` module for shared icons
- update imports to use the new constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688391e8c3f48325a7d80c99b58cf5ea