### PR TITLE
Fix FMEDA metrics display

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2758,6 +2758,130 @@ class FaultTreeApp:
                     best = te.safety_goal_asil or "QM"
         return best
 
+    def get_top_event_safety_goals(self, node):
+        """Return names of safety goals for top events containing ``node``."""
+        result = []
+        target = self.get_failure_mode_node(node)
+        for te in self.top_events:
+            if any(n.unique_id == target.unique_id for n in self.get_all_nodes(te)):
+                sg = te.safety_goal_description or te.user_name or ""
+                if sg:
+                    result.append(sg)
+        return result
+
+    def calculate_fmeda_metrics(self, events):
+        """Return ASIL and FMEDA metrics for the given events."""
+        total = 0.0
+        unc_spf = 0.0
+        unc_lpf = 0.0
+        asil = "QM"
+        for be in events:
+            src = self.get_failure_mode_node(be)
+            fit_mode = getattr(be, "fmeda_fit", 0.0)
+            total += fit_mode
+            if src.fmeda_fault_type == "permanent":
+                unc_spf += fit_mode * (1 - src.fmeda_diag_cov)
+            else:
+                unc_lpf += fit_mode * (1 - src.fmeda_diag_cov)
+            sg = getattr(src, "fmeda_safety_goal", "")
+            sgs = self.get_top_event_safety_goals(src)
+            if sgs:
+                sg = ", ".join(sgs)
+            a = self.get_safety_goal_asil(sg)
+            if ASIL_ORDER.get(a, 0) > ASIL_ORDER.get(asil, 0):
+                asil = a
+        dc = (total - (unc_spf + unc_lpf)) / total if total else 0.0
+        self.reliability_total_fit = total
+        self.reliability_dc = dc
+        self.spfm = unc_spf
+        self.lpfm = unc_lpf
+        spfm_metric = 1 - unc_spf / total if total else 0.0
+        lpfm_metric = 1 - unc_lpf / total if total else 0.0
+        return asil, dc, spfm_metric, lpfm_metric
+
+    def compute_fmeda_metrics(self, events):
+        """Return aggregate and per-goal FMEDA metrics."""
+        comp_fit = component_fit_map(self.reliability_components)
+        goal_metrics = {}
+        total = 0.0
+        spf_total = 0.0
+        lpf_total = 0.0
+        asil = "QM"
+        for be in events:
+            src = self.get_failure_mode_node(be)
+            goals = self.get_top_event_safety_goals(src) or [getattr(src, "fmeda_safety_goal", "")]
+            comp_name = src.parents[0].user_name if src.parents else getattr(src, "fmea_component", "")
+            fit = comp_fit.get(comp_name)
+            frac = getattr(src, "fmeda_fault_fraction", 0.0)
+            if frac > 1.0:
+                frac /= 100.0
+            value = fit * frac if fit is not None else getattr(src, "fmeda_fit", 0.0)
+            fault_spf = value * (1 - src.fmeda_diag_cov) if src.fmeda_fault_type == "permanent" else 0.0
+            fault_lpf = value * (1 - src.fmeda_diag_cov) if src.fmeda_fault_type != "permanent" else 0.0
+            for sg in goals:
+                gm = goal_metrics.setdefault(
+                    sg,
+                    {
+                        "total": 0.0,
+                        "spfm_raw": 0.0,
+                        "lpfm_raw": 0.0,
+                        "asil": self.get_safety_goal_asil(sg),
+                    },
+                )
+                gm["total"] += value
+                gm["spfm_raw"] += fault_spf
+                gm["lpfm_raw"] += fault_lpf
+            total += value
+            spf_total += fault_spf
+            lpf_total += fault_lpf
+            for sg in goals:
+                a = self.get_safety_goal_asil(sg)
+                if ASIL_ORDER.get(a, 0) > ASIL_ORDER.get(asil, 0):
+                    asil = a
+
+        for sg, vals in goal_metrics.items():
+            t = vals["total"]
+            spf = vals["spfm_raw"]
+            lpf = vals["lpfm_raw"]
+            dc = (t - (spf + lpf)) / t if t else 0.0
+            spfm_metric = 1 - spf / t if t else 0.0
+            lpfm_metric = 1 - lpf / t if t else 0.0
+            thresh = ASIL_TARGETS.get(vals["asil"], ASIL_TARGETS["QM"])
+            vals.update(
+                {
+                    "dc": dc,
+                    "spfm_metric": spfm_metric,
+                    "lpfm_metric": lpfm_metric,
+                    "ok_dc": dc >= thresh["dc"],
+                    "ok_spfm": spfm_metric >= thresh["spfm"],
+                    "ok_lpfm": lpfm_metric >= thresh["lpfm"],
+                }
+            )
+
+        dc_total = (total - (spf_total + lpf_total)) / total if total else 0.0
+        spfm_metric_total = 1 - spf_total / total if total else 0.0
+        lpfm_metric_total = 1 - lpf_total / total if total else 0.0
+        thresh_total = ASIL_TARGETS.get(asil, ASIL_TARGETS["QM"])
+
+        self.reliability_total_fit = total
+        self.reliability_dc = dc_total
+        self.spfm = spf_total
+        self.lpfm = lpf_total
+
+        return {
+            "total": total,
+            "spfm_raw": spf_total,
+            "lpfm_raw": lpf_total,
+            "dc": dc_total,
+            "spfm_metric": spfm_metric_total,
+            "lpfm_metric": lpfm_metric_total,
+            "asil": asil,
+            "ok_dc": dc_total >= thresh_total["dc"],
+            "ok_spfm": spfm_metric_total >= thresh_total["spfm"],
+            "ok_lpfm": lpfm_metric_total >= thresh_total["lpfm"],
+            "goal_metrics": goal_metrics,
+        }
+
     def sync_hara_to_safety_goals(self):
         """Propagate HARA values to safety goals when the HARA is approved."""
         sg_data = {}
@@ -8487,8 +8611,26 @@ class FaultTreeApp:
             ttk.Entry(master, textvariable=self.mal_var, width=30).grid(row=4, column=1, padx=5, pady=5)
 
             ttk.Label(master, text="Violates Safety Goal:").grid(row=5, column=0, sticky="e", padx=5, pady=5)
-            self.sg_var = tk.StringVar(value=getattr(self.node, 'fmeda_safety_goal', ''))
-            ttk.Entry(master, textvariable=self.sg_var, width=30).grid(row=5, column=1, padx=5, pady=5)
+            preset_goals = self.app.get_top_event_safety_goals(self.node)
+            sg_value = ", ".join(preset_goals) if preset_goals else getattr(self.node, 'fmeda_safety_goal', '')
+            self.sg_var = tk.StringVar(value=sg_value)
+            self.sg_entry = ttk.Entry(master, textvariable=self.sg_var, width=30)
+            if preset_goals:
+                self.sg_entry.config(state='readonly')
+            self.sg_entry.grid(row=5, column=1, padx=5, pady=5)
+            if not preset_goals:
+                def choose_goals():
+                    names = [g.strip() for g in self.sg_var.get().split(',') if g.strip()]
+                    dlg = self.app.SelectSafetyGoalsDialog(self, self.app.top_events, names)
+                    if dlg.result:
+                        self.sg_var.set(
+                            ", ".join(
+                                sg.user_name or sg.safety_goal_description or f"SG {sg.unique_id}"
+                                for sg in dlg.result
+                            )
+                        )
+
+                ttk.Button(master, text="Select", command=choose_goals).grid(row=5, column=2, padx=5, pady=5)
 
             ttk.Label(master, text="Severity (1-10):").grid(row=6, column=0, sticky="e", padx=5, pady=5)
             self.sev_spin = tk.Spinbox(master, from_=1, to=10, width=5)
@@ -8597,7 +8739,11 @@ class FaultTreeApp:
             except ValueError:
                 self.node.fmea_detection = 1
             self.node.fmeda_malfunction = self.mal_var.get()
-            self.node.fmeda_safety_goal = self.sg_var.get()
+            preset_goals = self.app.get_top_event_safety_goals(self.node)
+            if preset_goals:
+                self.node.fmeda_safety_goal = ", ".join(preset_goals)
+            else:
+                self.node.fmeda_safety_goal = self.sg_var.get()
             try:
                 self.node.fmeda_diag_cov = float(self.dc_var.get())
             except ValueError:
@@ -8739,6 +8885,26 @@ class FaultTreeApp:
                 else:
                     self.selected = self.events[idx]
 
+    class SelectSafetyGoalsDialog(simpledialog.Dialog):
+        def __init__(self, parent, goals, initial=None):
+            self.goals = goals
+            self.initial = initial or []
+            self.result = []
+            super().__init__(parent, title="Select Safety Goals")
+
+        def body(self, master):
+            ttk.Label(master, text="Select violated safety goals:").pack(padx=5, pady=5)
+            self.vars = {}
+            for sg in self.goals:
+                name = sg.user_name or sg.safety_goal_description or f"SG {sg.unique_id}"
+                var = tk.BooleanVar(value=name in self.initial)
+                self.vars[sg] = var
+                ttk.Checkbutton(master, text=name, variable=var).pack(anchor="w", padx=5, pady=2)
+            return master
+
+        def apply(self):
+            self.result = [sg for sg, var in self.vars.items() if var.get()]
+
     def show_fmea_table(self, fmea=None, fmeda=False):
         """Display an editable AIAG-compliant FMEA or FMEDA table."""
         basic_events = self.get_all_basic_events()
@@ -8802,6 +8968,23 @@ class FaultTreeApp:
                     load_bom()
                 else:
                     refresh_tree()
+                metrics = self.compute_fmeda_metrics(entries)
+                asil = metrics["asil"]
+                dc = metrics["dc"]
+                spfm_m = metrics["spfm_metric"]
+                lpfm_m = metrics["lpfm_metric"]
+                thresh = ASIL_TARGETS.get(asil, ASIL_TARGETS["QM"])
+                ok_dc = dc >= thresh["dc"]
+                ok_spf = spfm_m >= thresh["spfm"]
+                ok_lpf = lpfm_m >= thresh["lpfm"]
+                msg = (
+                    f"Total FIT: {self.reliability_total_fit:.2f}\n"
+                    f"DC: {dc:.2f} {'PASS' if ok_dc else 'FAIL'}\n"
+                    f"SPFM: {spfm_m:.2f} {'PASS' if ok_spf else 'FAIL'}\n"
+                    f"LPFM: {lpfm_m:.2f} {'PASS' if ok_lpf else 'FAIL'}\n"
+                    f"ASIL {asil}"
+                )
+                messagebox.showinfo("FMEDA", msg)
 
             calc_btn = ttk.Button(btn_frame, text="Calculate FMEDA", command=calculate_fmeda)
             calc_btn.pack(side=tk.LEFT, padx=2)
@@ -8926,7 +9109,7 @@ class FaultTreeApp:
         tree_frame.grid_columnconfigure(0, weight=1)
         tree_frame.grid_rowconfigure(0, weight=1)
 
-        metrics_lbl = ttk.Label(win, text="")
+        metrics_lbl = tk.Label(win, text="", anchor="w")
         metrics_lbl.pack(anchor="w", padx=5, pady=2)
 
         # alternating row colours and high RPN highlight
@@ -9021,9 +9204,13 @@ class FaultTreeApp:
                     req_ids,
                 ]
                 if fmeda:
+                    sg_value = src.fmeda_safety_goal
+                    goals = self.get_top_event_safety_goals(src)
+                    if goals:
+                        sg_value = ", ".join(goals)
                     vals.extend([
                         src.fmeda_malfunction,
-                        src.fmeda_safety_goal,
+                        sg_value,
                         src.fmeda_fault_type,
                         f"{src.fmeda_fault_fraction:.2f}",
                         f"{src.fmeda_fit:.2f}",
@@ -9039,39 +9226,36 @@ class FaultTreeApp:
                 tree.item(iid, open=True)
 
             if fmeda:
-                total = 0.0
-                spf = 0.0
-                lpf = 0.0
-                asil = "QM"
-                for be in events:
-                    src = self.get_failure_mode_node(be)
-                    fit_mode = be.fmeda_fit
-                    total += fit_mode
-                    if src.fmeda_fault_type == "permanent":
-                        spf += fit_mode * (1 - src.fmeda_diag_cov)
-                    else:
-                        lpf += fit_mode * (1 - src.fmeda_diag_cov)
-                    sg = getattr(src, "fmeda_safety_goal", "")
-                    a = self.get_safety_goal_asil(sg)
-                    if ASIL_ORDER.get(a,0) > ASIL_ORDER.get(asil,0):
-                        asil = a
-                dc = (total - (spf + lpf)) / total if total else 0.0
-                self.reliability_total_fit = total
-                self.spfm = spf
-                self.lpfm = lpf
-                spfm_metric = 1 - spf / total if total else 0.0
-                lpfm_metric = 1 - lpf / (total - spf) if total > spf else 0.0
+                metrics = self.compute_fmeda_metrics(events)
+                asil = metrics["asil"]
+                dc = metrics["dc"]
+                spfm_metric = metrics["spfm_metric"]
+                lpfm_metric = metrics["lpfm_metric"]
                 thresh = ASIL_TARGETS.get(asil, ASIL_TARGETS["QM"])
                 ok_dc = dc >= thresh["dc"]
                 ok_spf = spfm_metric >= thresh["spfm"]
                 ok_lpf = lpfm_metric >= thresh["lpfm"]
                 text = (
-                    f"Total FIT: {total:.2f}  DC: {dc:.2f}{CHECK_MARK if ok_dc else CROSS_MARK}"
+                    f"Total FIT: {self.reliability_total_fit:.2f}  DC: {dc:.2f}{CHECK_MARK if ok_dc else CROSS_MARK}"
                     f"  SPFM: {spfm_metric:.2f}{CHECK_MARK if ok_spf else CROSS_MARK}"
                     f"  LPFM: {lpfm_metric:.2f}{CHECK_MARK if ok_lpf else CROSS_MARK}"
                     f"  (ASIL {asil})"
                 )
-                metrics_lbl.config(text=text)
+                if metrics.get("goal_metrics"):
+                    parts = []
+                    for sg, gm in metrics["goal_metrics"].items():
+                        ok = gm["ok_dc"] and gm["ok_spfm"] and gm["ok_lpfm"]
+                        symbol = CHECK_MARK if ok else CROSS_MARK
+                        parts.append(f"{sg}:{symbol}")
+                    text += " [" + "; ".join(parts) + "]"
+                overall_ok = ok_dc and ok_spf and ok_lpf
+                if metrics.get("goal_metrics"):
+                    overall_ok = overall_ok and all(
+                        gm["ok_dc"] and gm["ok_spfm"] and gm["ok_lpfm"]
+                        for gm in metrics["goal_metrics"].values()
+                    )
+                color = "#c8ffc8" if overall_ok else "#ffc8c8"
+                metrics_lbl.config(text=text, bg=color)
 
         if fmeda and bom_var.get():
             load_bom()
@@ -9212,62 +9396,6 @@ class FaultTreeApp:
                 row = [comp, parent_name, failure_mode, be.fmea_effect, be.fmea_cause, be.fmea_severity, be.fmea_occurrence, be.fmea_detection, rpn, req_ids]
                 writer.writerow(row)
 
-    def export_fmeda_to_csv(self, fmeda, path):
-        columns = [
-            "Component",
-            "Parent",
-            "Failure Mode",
-            "Failure Effect",
-            "Cause",
-            "S",
-            "O",
-            "D",
-            "RPN",
-            "Requirements",
-            "Malfunction",
-            "Safety Goal",
-            "FaultType",
-            "Fraction",
-            "FIT",
-            "DiagCov",
-            "Mechanism",
-        ]
-        with open(path, "w", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerow(columns)
-            for be in fmeda['entries']:
-                parent = be.parents[0] if be.parents else None
-                if parent:
-                    comp = parent.user_name if parent.user_name else f"Node {parent.unique_id}"
-                    if parent.description:
-                        comp = f"{comp} - {parent.description}"
-                    parent_name = parent.user_name if parent.user_name else f"Node {parent.unique_id}"
-                else:
-                    comp = getattr(be, "fmea_component", "") or "N/A"
-                    parent_name = ""
-                req_ids = "; ".join([f"{req['req_type']}:{req['text']}" for req in getattr(be, 'safety_requirements', [])])
-                rpn = be.fmea_severity * be.fmea_occurrence * be.fmea_detection
-                failure_mode = be.description or (be.user_name or f"BE {be.unique_id}")
-                row = [
-                    comp,
-                    parent_name,
-                    failure_mode,
-                    be.fmea_effect,
-                    be.fmea_cause,
-                    be.fmea_severity,
-                    be.fmea_occurrence,
-                    be.fmea_detection,
-                    rpn,
-                    req_ids,
-                    getattr(be, "fmeda_malfunction", ""),
-                    getattr(be, "fmeda_safety_goal", ""),
-                    getattr(be, "fmeda_fault_type", ""),
-                    be.fmeda_fault_fraction,
-                    be.fmeda_fit,
-                    be.fmeda_diag_cov,
-                    getattr(be, "fmeda_mechanism", ""),
-                ]
-                writer.writerow(row)
 
     def export_fmeda_to_csv(self, fmeda, path):
         columns = [
@@ -9317,7 +9445,7 @@ class FaultTreeApp:
                     rpn,
                     req_ids,
                     getattr(be, "fmeda_malfunction", ""),
-                    getattr(be, "fmeda_safety_goal", ""),
+                    ", ".join(self.get_top_event_safety_goals(be)) or getattr(be, "fmeda_safety_goal", ""),
                     getattr(be, "fmeda_fault_type", ""),
                     be.fmeda_fault_fraction,
                     be.fmeda_fit,


### PR DESCRIPTION
## Summary
- compute FMEDA metrics with per-goal values
- show pass/fail for each safety goal in FMEDA table
- color FMEDA summary green/red based on metrics
- allow selecting violated safety goals from a dialog
- fix indentation for dialog classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68838893ccdc8325868aec1d8b9c4eb7