### PR TITLE
Fix indentation error causing crash

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8929,7 +8929,7 @@ class FaultTreeApp:
             del self.node.safety_requirements[index]
             self.req_listbox.delete(index)
 
-class SelectBaseEventDialog(simpledialog.Dialog):
+    class SelectBaseEventDialog(simpledialog.Dialog):
         def __init__(self, parent, events, allow_new=False):
             self.events = events
             self.allow_new = allow_new


### PR DESCRIPTION
## Summary
- adjust indentation for `SelectBaseEventDialog` so that nested dialogs are defined within the `FaultTreeApp` class

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6883a0320db883259d828633826f152b