### PR TITLE
Implement CallBehaviorAction support

### DIFF
--- a/sysml_repository.py
+++ b/sysml_repository.py
@@ -232,7 +232,7 @@ class SysMLRepository:
                 names.append(diag.name)
             for obj in diag.objects:
                 typ = obj.get("obj_type") or obj.get("type")
-                if typ in ("Action Usage", "Action"):
+                if typ in ("Action Usage", "Action", "CallBehaviorAction"):
                     name = obj.get("properties", {}).get("name", "")
                     elem_id = obj.get("element_id")
                     if not name and elem_id in self.elements:
@@ -241,7 +241,7 @@ class SysMLRepository:
                         names.append(name)
             for elem_id in getattr(diag, "elements", []):
                 elem = self.elements.get(elem_id)
-                if elem and elem.elem_type in ("Action Usage", "Action"):
+                if elem and elem.elem_type in ("Action Usage", "Action", "CallBehaviorAction"):
                     if elem.name:
                         names.append(elem.name)
         return sorted(set(n for n in names if n))

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -11,10 +11,10 @@ class ActionNameTests(unittest.TestCase):
 
     def test_activity_actions(self):
         diag = self.repo.create_diagram("Activity Diagram", name="MainFlow")
-        act = self.repo.create_element("Action Usage", name="DoThing")
+        act = self.repo.create_element("Action", name="DoThing")
         obj = {
             "obj_id": 1,
-            "obj_type": "Action Usage",
+            "obj_type": "Action",
             "x": 10,
             "y": 10,
             "element_id": act.elem_id,
@@ -29,11 +29,26 @@ class ActionNameTests(unittest.TestCase):
 
     def test_activity_actions_from_elements(self):
         diag = self.repo.create_diagram("Activity Diagram", name="Flow")
-        act = self.repo.create_element("Action Usage", name="Act")
+        act = self.repo.create_element("Action", name="Act")
         self.repo.add_element_to_diagram(diag.diag_id, act.elem_id)
         names = self.repo.get_activity_actions()
         self.assertIn("Flow", names)
         self.assertIn("Act", names)
+
+    def test_call_behavior_action_names(self):
+        diag = self.repo.create_diagram("Activity Diagram", name="Top")
+        cba = self.repo.create_element("CallBehaviorAction", name="Invoke")
+        diag.objects.append({
+            "obj_id": 2,
+            "obj_type": "CallBehaviorAction",
+            "x": 0,
+            "y": 0,
+            "element_id": cba.elem_id,
+            "properties": {"name": "Invoke"},
+        })
+        names = self.repo.get_activity_actions()
+        self.assertIn("Invoke", names)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,0 +1,26 @@
+import unittest
+from architecture import parse_operations, operations_to_json, OperationDefinition, OperationParameter, format_operation
+
+class OperationParseTests(unittest.TestCase):
+    def test_parse_json(self):
+        raw = '[{"name": "op", "parameters": [{"name": "a", "type": "int"}], "return_type": "bool"}]'
+        ops = parse_operations(raw)
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0].name, "op")
+        self.assertEqual(ops[0].parameters[0].name, "a")
+        self.assertEqual(ops[0].parameters[0].type, "int")
+        self.assertEqual(ops[0].return_type, "bool")
+
+    def test_parse_comma(self):
+        ops = parse_operations('foo, bar')
+        self.assertEqual(len(ops), 2)
+        self.assertEqual(ops[0].name, 'foo')
+
+    def test_json_round_trip(self):
+        op = OperationDefinition('f', [OperationParameter('x', 'int')], 'int')
+        js = operations_to_json([op])
+        parsed = parse_operations(js)
+        self.assertEqual(format_operation(parsed[0]), 'f(x: int) : int')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `CallBehaviorAction` type and update drawing logic
- rename activity diagram object from action usage to action
- allow call behavior actions to reference both behavior diagrams and internal block diagram views
- restrict standard actions to reference only behavior diagrams
- update repository action name queries and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6884d542ff048325a186cbc4ea1b41c5