### PR TITLE
Add LinkedIn link to README author info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Author: Miguel Marina <karel.capek.robotics@gmail.com>
+Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
 This repository contains a graphical fault tree analysis tool. The latest update adds a **Review Toolbox** supporting peer and joint review workflows. The explorer pane now includes an **Analyses** tab listing all FMEAs, FMEDAs, HAZOPs, HARAs and AutoML diagrams so they can be opened directly. Architecture objects can now be resized either by editing width and height values or by dragging the red handles that appear when an item is selected. Fork and join bars keep a constant thickness so only their length changes.


### PR DESCRIPTION
## Summary
- update README author header with a LinkedIn link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688594b855d083259c13ca68003223dc