### PR TITLE
Add build script for Windows executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ If sending fails with a connection error, the dialog will prompt again so you ca
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.
 
+## Building the Executable
+To create a standalone Windows executable, run `bin/build_exe.sh`. This script uses
+PyInstaller to generate `AutoML.exe` in the `bin` directory. After building you
+can launch the application using `bin/AutoML.exe` or with `bin/run_automl.sh`.
+
+
 ## Version History
 - 0.1.2 - Clarified systems safety focus in description and About dialog.
 - 0.1.1 - Updated description and About dialog.

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Script to build AutoML executable using PyInstaller
+set -e
+if ! command -v pyinstaller >/dev/null 2>&1; then
+    echo "PyInstaller is required. Install with: pip install pyinstaller" >&2
+    exit 1
+fi
+
+# Use PyInstaller to create a single-file executable
+pyinstaller --noconfirm --onefile --windowed \
+    --name AutoML AutoML.py
+
+# Move the resulting executable to the bin directory
+mkdir -p bin
+mv -f dist/AutoML.exe bin/
+# Clean up build artifacts
+rm -rf build dist __pycache__ AutoML.spec
+
+echo "Executable created at bin/AutoML.exe"

--- a/bin/run_automl.sh
+++ b/bin/run_automl.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Run the AutoML executable. Build it first if not present.
+if [ ! -f "bin/AutoML.exe" ]; then
+    echo "Executable not found. Run bin/build_exe.sh first." >&2
+    exit 1
+fi
+./bin/AutoML.exe "$@"


### PR DESCRIPTION
## Summary
- add `bin/build_exe.sh` to produce `AutoML.exe`
- add `bin/run_automl.sh` helper to launch the executable
- document build procedure in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688628779e5c8325baca7ec7eecc89aa