### PR TITLE
Add Windows build & run scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ If sending fails with a connection error, the dialog will prompt again so you ca
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.
 
+## Building the Executable
+To create a standalone Windows executable with PyInstaller:
+
+- **Linux/macOS:** run `bin/build_exe.sh`
+- **Windows:** run `bin\build_exe.bat`
+
+You can invoke these scripts from any directory; they locate the repository
+root automatically. Both generate `AutoML.exe` inside the `bin` directory.
+After building you can launch the application directly or use
+`bin/run_automl.sh` on Unix-like systems or `bin\run_automl.bat` on
+Windows.
+
+
 ## Version History
 - 0.1.2 - Clarified systems safety focus in description and About dialog.
 - 0.1.1 - Updated description and About dialog.

--- a/bin/build_exe.bat
+++ b/bin/build_exe.bat
@@ -1,0 +1,22 @@
+@echo off
+REM Build AutoML executable using PyInstaller
+
+REM Determine the repository root (parent of this script)
+set SCRIPT_DIR=%~dp0
+pushd "%SCRIPT_DIR%.." >nul
+
+pyinstaller --noconfirm --onefile --windowed --name AutoML AutoML.py
+if errorlevel 1 (
+    echo Failed to build executable.
+    popd
+    exit /b %errorlevel%
+)
+
+if not exist bin mkdir bin
+move /Y dist\AutoML.exe bin\AutoML.exe >nul
+rmdir /S /Q build 2>nul
+rmdir /S /Q dist 2>nul
+if exist AutoML.spec del AutoML.spec
+
+popd >nul
+echo Executable created at bin\AutoML.exe

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Script to build AutoML executable using PyInstaller
+set -e
+if ! command -v pyinstaller >/dev/null 2>&1; then
+    echo "PyInstaller is required. Install with: pip install pyinstaller" >&2
+    exit 1
+fi
+
+# Ensure commands run from repository root (parent directory of this script)
+SCRIPT_DIR="$(dirname "$0")"
+cd "$SCRIPT_DIR/.."
+
+# Use PyInstaller to create a single-file executable
+pyinstaller --noconfirm --onefile --windowed \
+    --name AutoML AutoML.py
+
+# Move the resulting executable to the bin directory
+mkdir -p bin
+mv -f dist/AutoML.exe bin/
+# Clean up build artifacts
+rm -rf build dist __pycache__ AutoML.spec
+
+echo "Executable created at bin/AutoML.exe"

--- a/bin/run_automl.bat
+++ b/bin/run_automl.bat
@@ -1,0 +1,15 @@
+@echo off
+REM Helper to run the AutoML executable
+
+REM Locate repository root (parent of this script)
+set SCRIPT_DIR=%~dp0
+pushd "%SCRIPT_DIR%.." >nul
+
+if not exist bin\AutoML.exe (
+    echo Executable not found. Run bin\build_exe.bat first.
+    popd
+    exit /b 1
+)
+
+bin\AutoML.exe %*
+popd >nul

--- a/bin/run_automl.sh
+++ b/bin/run_automl.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run the AutoML executable. Build it first if not present.
+
+# Determine repository root (parent directory of this script)
+SCRIPT_DIR="$(dirname "$0")"
+cd "$SCRIPT_DIR/.."
+
+if [ ! -f "bin/AutoML.exe" ]; then
+    echo "Executable not found. Run bin/build_exe.sh first." >&2
+    exit 1
+fi
+
+./bin/AutoML.exe "$@"


### PR DESCRIPTION
## Summary
- add `build_exe.bat` and `run_automl.bat` for Windows
- document Windows build instructions in README
- ensure build and run scripts work from any directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688628779e5c8325baca7ec7eecc89aa