### PR TITLE
Improve build instructions for PyInstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ options are always applied.
 The scripts exclude the `scipy` package, which is not required by AutoML but
 can cause PyInstaller to fail on some Python installations. If you encounter
 errors about ``IndexError`` while building, try upgrading your Python runtime
-or reinstalling SciPy.
+or reinstalling SciPy. This is most common when using a pre-release Python
+interpreter (e.g. ``3.10.0rc2``). Install the latest stable release of Python
+and run the build again if you hit this issue.
 
 
 ## Version History

--- a/bin/build_exe.bat
+++ b/bin/build_exe.bat
@@ -7,6 +7,13 @@ REM Determine important paths
 set "BIN_DIR=%~dp0"
 set "REPO_ROOT=%~dp0.."
 
+REM Warn if running a pre-release Python build which may cause PyInstaller errors
+for /f "delims=" %%V in ('python -c "import sys;print(sys.version)"') do set "PYVER=%%V"
+echo %PYVER% | findstr /I "alpha beta candidate rc" >nul
+if not errorlevel 1 (
+    echo Warning: pre-release Python builds can fail with PyInstaller. Use a stable release.
+)
+
 REM Run PyInstaller from the repository root so it can locate AutoML.py
 cd /d "%REPO_ROOT%"
 if exist AutoML.spec del AutoML.spec

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -6,6 +6,11 @@ if ! command -v pyinstaller >/dev/null 2>&1; then
     exit 1
 fi
 
+# Warn if running a pre-release Python build which may cause PyInstaller errors
+if python -c "import sys, re; v=sys.version; print('pre' if re.search('(alpha|beta|candidate|rc)', v) else '')" | grep -q pre; then
+    echo "Warning: pre-release Python builds can fail with PyInstaller. Use a stable release." >&2
+fi
+
 # Ensure commands run from repository root (parent directory of this script)
 SCRIPT_DIR="$(dirname "$0")"
 cd "$SCRIPT_DIR/.."


### PR DESCRIPTION
## Summary
- mention using a stable Python release when building
- warn about pre-release Python in build scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688638526d98832587fb61aa2d1bb501