### PR TITLE
Improve handling of pre‑release Python in build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,11 @@ options are always applied.
 The scripts exclude the `scipy` package, which is not required by AutoML but
 can cause PyInstaller to fail on some Python installations. If you encounter
 errors about ``IndexError`` while building, try upgrading your Python runtime
-or reinstalling SciPy.
+or reinstalling SciPy. This is most common when using a pre-release Python
+interpreter (e.g. ``3.10.0rc2``). Install the latest stable release of Python
+and run the build again if you hit this issue. The build scripts now abort
+with an informative message if they detect a pre-release interpreter so the
+problem is obvious.
 
 
 ## Version History

--- a/bin/build_exe.bat
+++ b/bin/build_exe.bat
@@ -7,6 +7,14 @@ REM Determine important paths
 set "BIN_DIR=%~dp0"
 set "REPO_ROOT=%~dp0.."
 
+REM Abort if running a pre-release Python build which is known to break PyInstaller
+for /f "delims=" %%V in ('python -c "import sys;print(sys.version)"') do set "PYVER=%%V"
+echo %PYVER% | findstr /I "alpha beta candidate rc" >nul
+if not errorlevel 1 (
+    echo Error: pre-release Python builds can fail with PyInstaller. Use a stable release.
+    exit /b 1
+)
+
 REM Run PyInstaller from the repository root so it can locate AutoML.py
 cd /d "%REPO_ROOT%"
 if exist AutoML.spec del AutoML.spec

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -6,6 +6,12 @@ if ! command -v pyinstaller >/dev/null 2>&1; then
     exit 1
 fi
 
+# Abort if running a pre-release Python build which is known to break PyInstaller
+if python -c "import sys, re; v=sys.version; print('pre' if re.search('(alpha|beta|candidate|rc)', v) else '')" | grep -q pre; then
+    echo "Error: pre-release Python builds can fail with PyInstaller. Use a stable release." >&2
+    exit 1
+fi
+
 # Ensure commands run from repository root (parent directory of this script)
 SCRIPT_DIR="$(dirname "$0")"
 cd "$SCRIPT_DIR/.."


### PR DESCRIPTION
## Summary
- exit early in build scripts if Python is a pre-release build
- mention this behaviour in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688638526d98832587fb61aa2d1bb501