### PR TITLE
Fix module check for Pillow

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ Each summary email embeds PNG images showing the differences between the current
 
 If sending fails with a connection error, the dialog will prompt again so you can correct the server address or port.
 
+## Dependencies
+
+AutoML relies on a few third‑party Python packages which must be installed
+before running the tool or creating the executable. Install them with pip:
+
+```
+pip install pillow openpyxl networkx matplotlib reportlab adjustText
+```
+
+PyInstaller requires these packages to be present so they are bundled into
+`AutoML.exe`. Missing dependencies, such as Pillow, will otherwise lead to
+`ModuleNotFoundError` when launching the built executable.
+
+Note that Pillow provides the `PIL` module, so the import check in the build
+scripts uses `PIL` rather than `pillow`.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.

--- a/bin/build_exe.bat
+++ b/bin/build_exe.bat
@@ -14,6 +14,18 @@ if not errorlevel 1 (
     echo Warning: pre-release Python builds can fail with PyInstaller. Use a stable release.
 )
 
+REM Verify required Python packages are installed using their module names
+python -c "import PIL" 2>NUL || (
+    echo Missing required package 'pillow'. Install with: pip install pillow
+    exit /b 1
+)
+for %%P in (openpyxl networkx matplotlib reportlab adjustText) do (
+    python -c "import %%P" 2>NUL || (
+        echo Missing required package '%%P'. Install with: pip install %%P
+        exit /b 1
+    )
+)
+
 REM Run PyInstaller from the repository root so it can locate AutoML.py
 cd /d "%REPO_ROOT%"
 if exist AutoML.spec del AutoML.spec

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -6,6 +6,18 @@ if ! command -v pyinstaller >/dev/null 2>&1; then
     exit 1
 fi
 
+# Ensure Pillow and other dependencies are installed so PyInstaller bundles them
+python -c "import PIL" 2>/dev/null || {
+    echo "Missing required package 'pillow'. Install with: pip install pillow" >&2
+    exit 1
+}
+for pkg in openpyxl networkx matplotlib reportlab adjustText; do
+    python -c "import $pkg" 2>/dev/null || {
+        echo "Missing required package '$pkg'. Install with: pip install $pkg" >&2
+        exit 1
+    }
+done
+
 # Warn if running a pre-release Python build which may cause PyInstaller errors
 if python -c "import sys, re; v=sys.version; print('pre' if re.search('(alpha|beta|candidate|rc)', v) else '')" | grep -q pre; then
     echo "Warning: pre-release Python builds can fail with PyInstaller. Use a stable release." >&2


### PR DESCRIPTION
## Summary
- correct the dependency checks in the build scripts to import `PIL`
- note the `PIL` module in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68863cc48c088325a2910dc6b28a35ad