### PR TITLE
Dynamic component parameters

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9231,12 +9231,13 @@ class FaultTreeApp:
                 ttk.Entry(dlg, textvariable=name_var).grid(row=0, column=1, padx=5, pady=5)
                 ttk.Label(dlg, text="Type").grid(row=1, column=0, padx=5, pady=5, sticky="e")
                 type_var = tk.StringVar(value="capacitor")
-                ttk.Combobox(
+                type_cb = ttk.Combobox(
                     dlg,
                     textvariable=type_var,
                     values=list(COMPONENT_ATTR_TEMPLATES.keys()),
                     state="readonly",
-                ).grid(row=1, column=1, padx=5, pady=5)
+                )
+                type_cb.grid(row=1, column=1, padx=5, pady=5)
                 ttk.Label(dlg, text="Quantity").grid(row=2, column=0, padx=5, pady=5, sticky="e")
                 qty_var = tk.IntVar(value=1)
                 ttk.Entry(dlg, textvariable=qty_var).grid(row=2, column=1, padx=5, pady=5)
@@ -9245,6 +9246,28 @@ class FaultTreeApp:
                 ttk.Combobox(dlg, textvariable=qual_var, values=QUALIFICATIONS, state="readonly").grid(row=3, column=1, padx=5, pady=5)
                 passive_var = tk.BooleanVar(value=False)
                 ttk.Checkbutton(dlg, text="Passive", variable=passive_var).grid(row=4, column=0, columnspan=2, pady=5)
+
+                attr_frame = ttk.Frame(dlg)
+                attr_frame.grid(row=5, column=0, columnspan=2)
+                attr_vars = {}
+
+                def refresh_attr_fields(*_):
+                    for child in attr_frame.winfo_children():
+                        child.destroy()
+                    attr_vars.clear()
+                    template = COMPONENT_ATTR_TEMPLATES.get(type_var.get(), {})
+                    for i, (k, v) in enumerate(template.items()):
+                        ttk.Label(attr_frame, text=k).grid(row=i, column=0, padx=5, pady=5, sticky="e")
+                        if isinstance(v, list):
+                            var = tk.StringVar(value=v[0])
+                            ttk.Combobox(attr_frame, textvariable=var, values=v, state="readonly").grid(row=i, column=1, padx=5, pady=5)
+                        else:
+                            var = tk.StringVar(value=str(v))
+                            ttk.Entry(attr_frame, textvariable=var).grid(row=i, column=1, padx=5, pady=5)
+                        attr_vars[k] = var
+
+                type_cb.bind("<<ComboboxSelected>>", refresh_attr_fields)
+                refresh_attr_fields()
 
                 def ok():
                     comp = ReliabilityComponent(
@@ -9255,14 +9278,13 @@ class FaultTreeApp:
                         qual_var.get(),
                         is_passive=passive_var.get(),
                     )
-                    template = COMPONENT_ATTR_TEMPLATES.get(comp.comp_type, {})
-                    for k, v in template.items():
-                        comp.attributes[k] = v[0] if isinstance(v, list) else v
+                    for k, var in attr_vars.items():
+                        comp.attributes[k] = var.get()
                     self.reliability_components.append(comp)
                     dlg.destroy()
                     refresh_tree()
 
-                ttk.Button(dlg, text="Add", command=ok).grid(row=5, column=0, columnspan=2, pady=5)
+                ttk.Button(dlg, text="Add", command=ok).grid(row=6, column=0, columnspan=2, pady=5)
                 dlg.grab_set()
                 dlg.wait_window()
 

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -116,7 +116,13 @@ class ReliabilityWindow(tk.Toplevel):
         ttk.Entry(dialog, textvariable=name_var).grid(row=0, column=1, padx=5, pady=5)
         ttk.Label(dialog, text="Type").grid(row=1, column=0, padx=5, pady=5, sticky="e")
         type_var = tk.StringVar(value="capacitor")
-        ttk.Combobox(dialog, textvariable=type_var, values=list(COMPONENT_ATTR_TEMPLATES.keys()), state="readonly").grid(row=1, column=1, padx=5, pady=5)
+        type_cb = ttk.Combobox(
+            dialog,
+            textvariable=type_var,
+            values=list(COMPONENT_ATTR_TEMPLATES.keys()),
+            state="readonly",
+        )
+        type_cb.grid(row=1, column=1, padx=5, pady=5)
         ttk.Label(dialog, text="Quantity").grid(row=2, column=0, padx=5, pady=5, sticky="e")
         qty_var = tk.IntVar(value=1)
         ttk.Entry(dialog, textvariable=qty_var).grid(row=2, column=1, padx=5, pady=5)
@@ -125,6 +131,28 @@ class ReliabilityWindow(tk.Toplevel):
         ttk.Combobox(dialog, textvariable=qual_var, values=QUALIFICATIONS, state="readonly").grid(row=3, column=1, padx=5, pady=5)
         passive_var = tk.BooleanVar(value=False)
         ttk.Checkbutton(dialog, text="Passive", variable=passive_var).grid(row=4, column=0, columnspan=2, pady=5)
+
+        attr_frame = ttk.Frame(dialog)
+        attr_frame.grid(row=5, column=0, columnspan=2)
+        attr_vars = {}
+
+        def refresh_attr_fields(*_):
+            for child in attr_frame.winfo_children():
+                child.destroy()
+            attr_vars.clear()
+            template = COMPONENT_ATTR_TEMPLATES.get(type_var.get(), {})
+            for i, (k, v) in enumerate(template.items()):
+                ttk.Label(attr_frame, text=k).grid(row=i, column=0, padx=5, pady=5, sticky="e")
+                if isinstance(v, list):
+                    var = tk.StringVar(value=v[0])
+                    ttk.Combobox(attr_frame, textvariable=var, values=v, state="readonly").grid(row=i, column=1, padx=5, pady=5)
+                else:
+                    var = tk.StringVar(value=str(v))
+                    ttk.Entry(attr_frame, textvariable=var).grid(row=i, column=1, padx=5, pady=5)
+                attr_vars[k] = var
+
+        type_cb.bind("<<ComboboxSelected>>", refresh_attr_fields)
+        refresh_attr_fields()
 
         def ok():
             comp = ReliabilityComponent(
@@ -135,14 +163,13 @@ class ReliabilityWindow(tk.Toplevel):
                 qual_var.get(),
                 is_passive=passive_var.get(),
             )
-            template = COMPONENT_ATTR_TEMPLATES.get(comp.comp_type, {})
-            for k, v in template.items():
-                comp.attributes[k] = v[0] if isinstance(v, list) else v
+            for k, var in attr_vars.items():
+                comp.attributes[k] = var.get()
             self.components.append(comp)
             self.refresh_tree()
             dialog.destroy()
 
-        ttk.Button(dialog, text="Add", command=ok).grid(row=5, column=0, columnspan=2, pady=5)
+        ttk.Button(dialog, text="Add", command=ok).grid(row=6, column=0, columnspan=2, pady=5)
         dialog.grab_set()
         dialog.wait_window()
 


### PR DESCRIPTION
## Summary
- update Add Component dialog to show parameters for the selected type
- mirror same changes in embedded reliability window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68864c337388832581a423ad9c870cce