### PR TITLE
Fix FTA tab opening from explorer

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -7180,9 +7180,10 @@ class FaultTreeApp:
             self.show_requirements_editor()
         elif kind == "sg":
             self.show_safety_goals_editor()
-        elif kind == "fta":
-            te = next((t for t in self.top_events if t.unique_id == idx), None)
-            if te:
+       elif kind == "fta":
+           te = next((t for t in self.top_events if t.unique_id == idx), None)
+           if te:
+                self.doc_nb.select(self.canvas_tab)
                 self.open_page_diagram(te)
         elif kind == "arch":
             self.open_arch_window(idx)


### PR DESCRIPTION
## Summary
- select the FTA tab when an FTA is double-clicked in the Analyses & Architecture explorer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688656d3d57083258e62bd62d17c8bcb