### PR TITLE
Refactor fault & failure mode handling

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -913,19 +913,11 @@ class EditNodeDialog(simpledialog.Dialog):
             self.prob_entry.grid(row=row_next, column=1, padx=5, pady=5)
             row_next += 1
 
-            ttk.Label(safety_frame, text="Represents FM:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
-            modes = self.app.get_all_failure_modes()
-            self.fm_map = {self.app.format_failure_mode_label(m): m.unique_id for m in modes}
-            self.fm_var = tk.StringVar()
-            current = ''
-            if getattr(self.node, 'failure_mode_ref', None):
-                n = self.app.find_node_by_id_all(self.node.failure_mode_ref)
-                if n:
-                    current = self.app.format_failure_mode_label(n)
-            self.fm_var.set(current)
-            self.fm_combo = ttk.Combobox(safety_frame, textvariable=self.fm_var, values=list(self.fm_map.keys()), state='readonly', width=40)
+            ttk.Label(safety_frame, text="Represents Fault:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
+            self.fm_map = {name: name for name in self.app.faults}
+            self.fm_var = tk.StringVar(value=getattr(self.node, 'fault_ref', ''))
+            self.fm_combo = ttk.Combobox(safety_frame, textvariable=self.fm_var, values=list(self.fm_map.keys()), width=40)
             self.fm_combo.grid(row=row_next, column=1, padx=5, pady=5, sticky='w')
-            self.fm_combo.bind("<<ComboboxSelected>>", self.update_probability)
             row_next += 1
 
 
@@ -971,6 +963,20 @@ class EditNodeDialog(simpledialog.Dialog):
                                            state="readonly", width=10)
             self.gate_combo.grid(row=row_next, column=1, padx=5, pady=5)
             row_next += 1
+
+            ttk.Label(safety_frame, text="Represents FM:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
+            modes = self.app.get_all_failure_modes()
+            self.fm_map = {self.app.format_failure_mode_label(m): m.unique_id for m in modes}
+            self.fm_var = tk.StringVar()
+            current = ''
+            if getattr(self.node, 'failure_mode_ref', None):
+                n = self.app.find_node_by_id_all(self.node.failure_mode_ref)
+                if n:
+                    current = self.app.format_failure_mode_label(n)
+            self.fm_var.set(current)
+            self.fm_combo = ttk.Combobox(safety_frame, textvariable=self.fm_var, values=list(self.fm_map.keys()), width=40)
+            self.fm_combo.grid(row=row_next, column=1, padx=5, pady=5, sticky='w')
+            row_next += 1
             if self.node.node_type.upper() == "TOP EVENT":
                 ttk.Label(safety_frame, text="Severity (1-3):").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
                 self.sev_combo = ttk.Combobox(safety_frame, values=["1", "2", "3"],
@@ -1011,6 +1017,12 @@ class EditNodeDialog(simpledialog.Dialog):
                 self.safe_state_entry = tk.Entry(safety_frame, width=40, font=dialog_font)
                 self.safe_state_entry.insert(0, self.node.safe_state)
                 self.safe_state_entry.grid(row=row_next, column=1, padx=5, pady=5, sticky="w")
+                row_next += 1
+
+                ttk.Label(safety_frame, text="Malfunction:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
+                self.mal_var = tk.StringVar(value=getattr(self.node, 'malfunction', ''))
+                self.mal_combo = ttk.Combobox(safety_frame, textvariable=self.mal_var, values=sorted(self.app.malfunctions), width=30)
+                self.mal_combo.grid(row=row_next, column=1, padx=5, pady=5, sticky="w")
                 row_next += 1
 
                 ttk.Label(safety_frame, text="FTTI:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
@@ -1647,16 +1659,19 @@ class EditNodeDialog(simpledialog.Dialog):
     def validate(self):
         if hasattr(self, 'fm_var'):
             label = self.fm_var.get().strip()
-            ref = self.fm_map.get(label)
-            if ref:
-                for n in self.app.get_all_nodes_in_model():
-                    if n is self.node:
-                        continue
-                    if not n.is_primary_instance:
-                        continue
-                    if getattr(n, 'failure_mode_ref', None) == ref:
-                        messagebox.showerror('Failure Mode', 'Selected failure mode already assigned to another node')
-                        return False
+            if self.node.node_type.upper() == 'BASIC EVENT':
+                pass
+            else:
+                ref = self.fm_map.get(label)
+                if ref:
+                    for n in self.app.get_all_nodes_in_model():
+                        if n is self.node:
+                            continue
+                        if not n.is_primary_instance:
+                            continue
+                        if getattr(n, 'failure_mode_ref', None) == ref:
+                            messagebox.showerror('Failure Mode', 'Selected failure mode already assigned to another node')
+                            return False
         return True
 
     def apply(self):
@@ -1676,8 +1691,9 @@ class EditNodeDialog(simpledialog.Dialog):
                 messagebox.showerror("Invalid Input", "Select a value between 1 and 5.")
         elif self.node.node_type.upper() == "BASIC EVENT":
             label = self.fm_var.get().strip()
-            ref = self.fm_map.get(label)
-            target_node.failure_mode_ref = ref
+            target_node.fault_ref = label
+            if label and label not in self.app.faults:
+                self.app.faults.append(label)
             target_node.prob_formula = self.formula_var.get()
             if target_node.prob_formula == "constant":
                 try:
@@ -1686,9 +1702,12 @@ class EditNodeDialog(simpledialog.Dialog):
                     target_node.failure_prob = 0.0
             else:
                 target_node.failure_prob = self.app.compute_failure_prob(
-                    target_node, failure_mode_ref=ref, formula=target_node.prob_formula)
+                    target_node, failure_mode_ref=getattr(target_node, 'failure_mode_ref', None), formula=target_node.prob_formula)
         elif self.node.node_type.upper() in ["GATE", "RIGOR LEVEL", "TOP EVENT"]:
             target_node.gate_type = self.gate_var.get().strip().upper()
+            label = self.fm_var.get().strip()
+            ref = self.fm_map.get(label)
+            target_node.failure_mode_ref = ref
             if self.node.node_type.upper() == "TOP EVENT":
                 try:
                     sev = float(self.sev_combo.get().strip())
@@ -1708,6 +1727,9 @@ class EditNodeDialog(simpledialog.Dialog):
                 target_node.safety_goal_description = self.safety_goal_text.get("1.0", "end-1c")
                 target_node.safety_goal_asil = self.sg_asil_var.get().strip()
                 target_node.safe_state = self.safe_state_entry.get().strip()
+                target_node.malfunction = self.mal_var.get().strip()
+                if target_node.malfunction and target_node.malfunction not in self.app.malfunctions:
+                    self.app.malfunctions.append(target_node.malfunction)
                 target_node.ftti = self.ftti_entry.get().strip()
                 try:
                     target_node.sg_dc_target = float(self.dc_target_var.get())
@@ -1802,6 +1824,9 @@ class FaultTreeApp:
         self.spfm = 0.0
         self.lpfm = 0.0
         self.reliability_dc = 0.0
+        # Lists of user-defined faults and malfunctions
+        self.faults: list[str] = []
+        self.malfunctions: list[str] = []
         self.hazop_docs = []  # list of HazopDoc
         self.hara_docs = []   # list of HaraDoc
         self.active_hazop = None
@@ -7487,6 +7512,14 @@ class FaultTreeApp:
         """Return a list of all basic events across all top-level trees."""
         return [n for n in self.get_all_nodes_in_model() if n.node_type.upper() == "BASIC EVENT"]
 
+    def get_all_gates(self):
+        """Return a list of all gate nodes (including top events)."""
+        return [
+            n
+            for n in self.get_all_nodes_in_model()
+            if n.node_type.upper() in ["GATE", "RIGOR LEVEL", "TOP EVENT"]
+        ]
+
     def get_all_triggering_conditions(self):
         """Return all triggering condition nodes."""
         return [n for n in self.get_all_nodes_in_model() if n.node_type.upper() == "TRIGGERING CONDITION"]
@@ -7593,7 +7626,7 @@ class FaultTreeApp:
 
     def get_all_failure_modes(self):
         """Return list of all failure mode nodes from FTA, FMEAs and FMEDAs."""
-        modes = list(self.get_all_basic_events())
+        modes = list(self.get_all_gates())
         for doc in self.fmea_entries:
             modes.append(doc)
         for f in self.fmeas:
@@ -8850,13 +8883,18 @@ class FaultTreeApp:
             self.effect_text.grid(row=2, column=1, padx=5, pady=5)
 
             ttk.Label(gen_frame, text="Potential Cause:").grid(row=3, column=0, sticky="e", padx=5, pady=5)
-            self.cause_text = tk.Text(gen_frame, width=30, height=3)
-            self.cause_text.insert("1.0", getattr(self.node, 'fmea_cause', ''))
-            self.cause_text.grid(row=3, column=1, padx=5, pady=5)
+            fault_names = set(self.app.faults)
+            for be in self.app.get_all_basic_events():
+                label = be.description or (be.user_name or f"BE {be.unique_id}")
+                fault_names.add(label)
+            self.cause_var = tk.StringVar(value=getattr(self.node, 'fmea_cause', ''))
+            self.cause_combo = ttk.Combobox(gen_frame, textvariable=self.cause_var, values=sorted(fault_names), width=30)
+            self.cause_combo.grid(row=3, column=1, padx=5, pady=5)
 
             ttk.Label(gen_frame, text="Related Malfunction:").grid(row=4, column=0, sticky="e", padx=5, pady=5)
             self.mal_var = tk.StringVar(value=getattr(self.node, 'fmeda_malfunction', ''))
-            ttk.Entry(gen_frame, textvariable=self.mal_var, width=30).grid(row=4, column=1, padx=5, pady=5)
+            self.mal_combo = ttk.Combobox(gen_frame, textvariable=self.mal_var, values=sorted(self.app.malfunctions), width=30)
+            self.mal_combo.grid(row=4, column=1, padx=5, pady=5)
 
             ttk.Label(gen_frame, text="Violates Safety Goal:").grid(row=5, column=0, sticky="e", padx=5, pady=5)
             preset_goals = self.app.get_top_event_safety_goals(self.node)
@@ -8995,7 +9033,9 @@ class FaultTreeApp:
             self.node.fmea_component = comp
             self.node.description = self.mode_var.get()
             self.node.fmea_effect = self.effect_text.get("1.0", "end-1c")
-            self.node.fmea_cause = self.cause_text.get("1.0", "end-1c")
+            self.node.fmea_cause = self.cause_var.get()
+            if self.node.fmea_cause and self.node.fmea_cause not in self.app.faults:
+                self.app.faults.append(self.node.fmea_cause)
             try:
                 self.node.fmea_severity = int(self.sev_spin.get())
             except ValueError:
@@ -9009,6 +9049,8 @@ class FaultTreeApp:
             except ValueError:
                 self.node.fmea_detection = 1
             self.node.fmeda_malfunction = self.mal_var.get()
+            if self.node.fmeda_malfunction and self.node.fmeda_malfunction not in self.app.malfunctions:
+                self.app.malfunctions.append(self.node.fmeda_malfunction)
             preset_goals = self.app.get_top_event_safety_goals(self.node)
             if preset_goals:
                 self.node.fmeda_safety_goal = ", ".join(preset_goals)
@@ -11779,6 +11821,8 @@ class FaultTreeApp:
             "tc2fi_entries": self.tc2fi_entries,
             "scenario_libraries": self.scenario_libraries,
             "odd_libraries": self.odd_libraries,
+            "faults": self.faults,
+            "malfunctions": self.malfunctions,
             "project_properties": self.project_properties,
             "global_requirements": global_requirements,
             "reviews": reviews,
@@ -11987,6 +12031,8 @@ class FaultTreeApp:
         self.tc2fi_entries = self.active_tc2fi.entries if self.active_tc2fi else []
         self.scenario_libraries = data.get("scenario_libraries", [])
         self.odd_libraries = data.get("odd_libraries", [])
+        self.faults = data.get("faults", [])
+        self.malfunctions = data.get("malfunctions", [])
         if not self.odd_libraries and "odd_elements" in data:
             self.odd_libraries = [{"name": "Default", "elements": data.get("odd_elements", [])}]
         self.update_odd_elements()
@@ -13208,6 +13254,10 @@ class FaultTreeNode:
         self.fmeda_lpfm_target = 0.0
         # Reference to a unique failure mode this node represents
         self.failure_mode_ref = None
+        # Reference to a fault represented by a basic event
+        self.fault_ref = ""
+        # Malfunction name for top level events
+        self.malfunction = ""
         # Probability values for classical FTA calculations
         self.failure_prob = 0.0
         self.probability = 0.0
@@ -13266,6 +13316,8 @@ class FaultTreeNode:
             "fmeda_spfm_target": self.fmeda_spfm_target,
             "fmeda_lpfm_target": self.fmeda_lpfm_target,
             "failure_mode_ref": self.failure_mode_ref,
+            "fault_ref": self.fault_ref,
+            "malfunction": self.malfunction,
             # Save the safety requirements list (which now includes custom_id)
             "safety_requirements": self.safety_requirements,
             "failure_prob": self.failure_prob,
@@ -13323,6 +13375,8 @@ class FaultTreeNode:
         node.fmeda_spfm_target = data.get("fmeda_spfm_target", 0.0)
         node.fmeda_lpfm_target = data.get("fmeda_lpfm_target", 0.0)
         node.failure_mode_ref = data.get("failure_mode_ref")
+        node.fault_ref = data.get("fault_ref", "")
+        node.malfunction = data.get("malfunction", "")
         # NEW: Load safety_requirements (or default to empty list)
         node.safety_requirements = data.get("safety_requirements", [])
         node.failure_prob = data.get("failure_prob", 0.0)


### PR DESCRIPTION
## Summary
- support dedicated `fault_ref` and `malfunction` attributes on fault tree nodes
- manage lists of user-defined faults and malfunctions in the main app
- persist these new fields when saving and loading models
- allow editing faults and malfunctions via combo boxes in FMEA/FMEDA dialogs and node editors
- map gate nodes to failure modes and basic events to faults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688681a5ef488325b2b6b6f7cd589e57