### PR TITLE
Refine failure mode component handling

### DIFF
--- a/analysis/fmeda_utils.py
+++ b/analysis/fmeda_utils.py
@@ -1,6 +1,9 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 from analysis.models import ASIL_ORDER, ASIL_TARGETS, component_fit_map
 
+# Node types treated as gates when determining component names
+GATE_NODE_TYPES = {"GATE", "RIGOR LEVEL", "TOP EVENT", "FUNCTIONAL INSUFFICIENCY"}
+
 
 def _aggregate_goal_metrics(entries, components, sg_to_asil, sg_targets=None, get_node=lambda x: x):
     """Return metrics per safety goal."""
@@ -18,7 +21,11 @@ def _aggregate_goal_metrics(entries, components, sg_to_asil, sg_targets=None, ge
                 "asil": sg_to_asil(sg),
             },
         )
-        comp_name = src.parents[0].user_name if src.parents else getattr(src, "fmea_component", "")
+        parent = src.parents[0] if src.parents else None
+        if parent and getattr(parent, "node_type", "").upper() not in GATE_NODE_TYPES:
+            comp_name = getattr(parent, "user_name", "")
+        else:
+            comp_name = getattr(src, "fmea_component", "")
         fit = comp_fit.get(comp_name)
         frac = getattr(src, "fmeda_fault_fraction", 0.0)
         if frac > 1.0:

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -26,6 +26,9 @@ import json
 import re
 from PIL import Image, ImageTk
 
+# Node types treated as gates when deriving component names
+GATE_NODE_TYPES = {"GATE", "RIGOR LEVEL", "TOP EVENT", "FUNCTIONAL INSUFFICIENCY"}
+
 EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")
 
 # Access the drawing helper defined in the main application if available.
@@ -1376,8 +1379,12 @@ class ReviewDocumentDialog(tk.Frame):
 
                 parent = entry.get("parents", [{}])
                 parent = parent[0] if parent else {}
-                comp = parent.get("user_name") or entry.get("fmea_component", "") or "N/A"
-                parent_name = parent.get("user_name", f"Node {parent.get('unique_id')}") if parent else ""
+                if parent and parent.get("node_type", "").upper() not in GATE_NODE_TYPES and parent.get("user_name"):
+                    comp = parent.get("user_name")
+                    parent_name = parent.get("user_name")
+                else:
+                    comp = entry.get("fmea_component", "") or "N/A"
+                    parent_name = ""
                 rpn = int(entry.get("fmea_severity", 1)) * int(entry.get("fmea_occurrence", 1)) * int(entry.get("fmea_detection", 1))
                 req_ids = "; ".join(
                     f"{r.get('req_type', '')}:{r.get('text', '')}"
@@ -2280,10 +2287,11 @@ class VersionCompareDialog(tk.Frame):
                 failure = entry.get("description", entry.get("user_name", f"BE {uid}"))
                 parent = entry.get("parents", [{}])
                 parent = parent[0] if parent else {}
-                comp = parent.get("user_name") or entry.get("fmea_component", "") or "N/A"
-                if parent:
-                    parent_name = parent.get("user_name", f"Node {parent.get('unique_id')}")
+                if parent and parent.get("node_type", "").upper() not in GATE_NODE_TYPES and parent.get("user_name"):
+                    comp = parent.get("user_name")
+                    parent_name = parent.get("user_name")
                 else:
+                    comp = entry.get("fmea_component", "") or "N/A"
                     parent_name = ""
                 rpn = (
                     int(entry.get("fmea_severity", 1))
@@ -2355,8 +2363,12 @@ class VersionCompareDialog(tk.Frame):
                         entry = ent2[uid]
                 parent = entry.get("parents", [{}])
                 parent = parent[0] if parent else {}
-                comp = parent.get("user_name") or entry.get("fmea_component", "") or "N/A"
-                parent_name = parent.get("user_name", f"Node {parent.get('unique_id')}") if parent else ""
+                if parent and parent.get("node_type", "").upper() not in GATE_NODE_TYPES and parent.get("user_name"):
+                    comp = parent.get("user_name")
+                    parent_name = parent.get("user_name")
+                else:
+                    comp = entry.get("fmea_component", "") or "N/A"
+                    parent_name = ""
                 row = [
                     name,
                     comp,


### PR DESCRIPTION
## Summary
- exclude gate nodes when gathering all failure modes
- derive component names ignoring gates
- add failure modes from FTAs to component name lookup
- skip gates when exporting or displaying FMEA/FMEDA data
- adjust review toolbox to ignore gate names
- update FMEDA metrics helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68869792a74483259c65d461ed483881