### PR TITLE
Remove FM and fault mapping from FTA dialogs

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -916,12 +916,6 @@ class EditNodeDialog(simpledialog.Dialog):
             self.prob_entry.grid(row=row_next, column=1, padx=5, pady=5)
             row_next += 1
 
-            ttk.Label(safety_frame, text="Represents Fault:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
-            self.fm_map = {name: name for name in self.app.faults}
-            self.fm_var = tk.StringVar(value=getattr(self.node, 'fault_ref', ''))
-            self.fm_combo = ttk.Combobox(safety_frame, textvariable=self.fm_var, values=list(self.fm_map.keys()), width=40)
-            self.fm_combo.grid(row=row_next, column=1, padx=5, pady=5, sticky='w')
-            row_next += 1
 
 
             ttk.Label(safety_frame, text="Probability Formula:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
@@ -967,22 +961,7 @@ class EditNodeDialog(simpledialog.Dialog):
             self.gate_combo.grid(row=row_next, column=1, padx=5, pady=5)
             row_next += 1
 
-            ttk.Label(safety_frame, text="Represents FM:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
-            modes = self.app.get_available_failure_modes_for_gates(self.node)
-            self.fm_map = {self.app.format_failure_mode_label(m): m.unique_id for m in modes}
-            self.fm_var = tk.StringVar()
-            current = ''
-            if getattr(self.node, 'failure_mode_ref', None):
-                n = self.app.find_node_by_id_all(self.node.failure_mode_ref)
-                if n:
-                    current = self.app.format_failure_mode_label(n)
-                    # Ensure the current selection is in the map even if it would normally be filtered out
-                    if current not in self.fm_map:
-                        self.fm_map[current] = n.unique_id
-            self.fm_var.set(current)
-            self.fm_combo = ttk.Combobox(safety_frame, textvariable=self.fm_var, values=list(self.fm_map.keys()), width=40)
-            self.fm_combo.grid(row=row_next, column=1, padx=5, pady=5, sticky='w')
-            row_next += 1
+
             if self.node.node_type.upper() == "TOP EVENT":
                 ttk.Label(safety_frame, text="Severity (1-3):").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
                 self.sev_combo = ttk.Combobox(safety_frame, values=["1", "2", "3"],
@@ -1653,7 +1632,7 @@ class EditNodeDialog(simpledialog.Dialog):
         return "break"
 
     def update_probability(self, *_):
-        if hasattr(self, "prob_entry") and hasattr(self, "fm_var"):
+        if hasattr(self, "prob_entry"):
             formula = self.formula_var.get() if hasattr(self, "formula_var") else None
             if str(formula).strip().lower() == "constant":
                 if not self.prob_entry.get().strip():
@@ -1663,26 +1642,11 @@ class EditNodeDialog(simpledialog.Dialog):
                         val = 0.0
                     self.prob_entry.insert(0, str(val))
                 return
-            label = self.fm_var.get().strip()
-            ref = self.fm_map.get(label)
-            prob = self.app.compute_failure_prob(self.node, failure_mode_ref=ref, formula=formula)
+            prob = self.app.compute_failure_prob(self.node, formula=formula)
             self.prob_entry.delete(0, tk.END)
             self.prob_entry.insert(0, f"{prob:.10g}")
 
     def validate(self):
-        if hasattr(self, 'fm_var'):
-            label = self.fm_var.get().strip()
-            if self.node.node_type.upper() != 'BASIC EVENT':
-                ref = self.fm_map.get(label)
-                if ref:
-                    for n in self.app.get_all_gates():
-                        if n is self.node:
-                            continue
-                        if not n.is_primary_instance:
-                            continue
-                        if getattr(n, 'failure_mode_ref', None) == ref:
-                            messagebox.showerror('Failure Mode', 'Selected failure mode already assigned to another gate')
-                            return False
         return True
 
     def apply(self):
@@ -1701,10 +1665,7 @@ class EditNodeDialog(simpledialog.Dialog):
             except ValueError:
                 messagebox.showerror("Invalid Input", "Select a value between 1 and 5.")
         elif self.node.node_type.upper() == "BASIC EVENT":
-            label = self.fm_var.get().strip()
-            target_node.fault_ref = label
-            if label and label not in self.app.faults:
-                self.app.faults.append(label)
+            target_node.fault_ref = target_node.description
             target_node.prob_formula = self.formula_var.get()
             if target_node.prob_formula == "constant":
                 try:
@@ -1716,9 +1677,7 @@ class EditNodeDialog(simpledialog.Dialog):
                     target_node, failure_mode_ref=getattr(target_node, 'failure_mode_ref', None), formula=target_node.prob_formula)
         elif self.node.node_type.upper() in GATE_NODE_TYPES:
             target_node.gate_type = self.gate_var.get().strip().upper()
-            label = self.fm_var.get().strip()
-            ref = self.fm_map.get(label)
-            target_node.failure_mode_ref = ref
+            target_node.failure_mode_ref = None
             if self.node.node_type.upper() == "TOP EVENT":
                 try:
                     sev = float(self.sev_combo.get().strip())


### PR DESCRIPTION
## Summary
- simplify FTA event editing
- descriptions now define faults/failure modes
- drop probability dialog fields for selecting faults and FMs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886a3772ab88325b5b5a159cdfbe5d5