### PR TITLE
Add list management tools

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -321,6 +321,7 @@ styles.add(preformatted_style)
 
 # Characters used to display pass/fail status in metrics labels.
 from analysis.constants import CHECK_MARK, CROSS_MARK
+from analysis.utils import append_unique_insensitive
 
 from gui.toolboxes import (
     ReliabilityWindow,
@@ -1727,8 +1728,8 @@ class EditNodeDialog(simpledialog.Dialog):
                             self.mal_var.set(new_mal)
                             break
                 target_node.malfunction = new_mal
-                if target_node.malfunction and target_node.malfunction not in self.app.malfunctions:
-                    self.app.malfunctions.append(target_node.malfunction)
+                if target_node.malfunction:
+                    self.app.add_malfunction(target_node.malfunction)
                 target_node.ftti = self.ftti_entry.get().strip()
                 try:
                     target_node.sg_dc_target = float(self.dc_target_var.get())
@@ -1826,6 +1827,8 @@ class FaultTreeApp:
         # Lists of user-defined faults and malfunctions
         self.faults: list[str] = []
         self.malfunctions: list[str] = []
+        self.hazards: list[str] = []
+        self.failures: list[str] = []
         self.hazop_docs = []  # list of HazopDoc
         self.hara_docs = []   # list of HaraDoc
         self.active_hazop = None
@@ -1947,6 +1950,10 @@ class FaultTreeApp:
         qualitative_menu.add_command(label="HAZOP Analysis", command=self.open_hazop_window)
         qualitative_menu.add_command(label="HARA Analysis", command=self.open_hara_window)
         qualitative_menu.add_command(label="Hazard Explorer", command=self.show_hazard_explorer)
+        qualitative_menu.add_command(label="Hazards", command=self.show_hazard_list)
+        qualitative_menu.add_command(label="Malfunctions", command=self.show_malfunction_list)
+        qualitative_menu.add_command(label="Faults", command=self.show_fault_list)
+        qualitative_menu.add_command(label="Failures", command=self.show_failure_list)
         qualitative_menu.add_separator()
         qualitative_menu.add_command(label="Triggering Conditions", command=self.show_triggering_condition_list)
         qualitative_menu.add_command(label="Functional Insufficiencies", command=self.show_functional_insufficiency_list)
@@ -2060,6 +2067,10 @@ class FaultTreeApp:
             "FMEA Manager": self.show_fmea_list,
             "HAZOP Analysis": self.open_hazop_window,
             "HARA Analysis": self.open_hara_window,
+            "Hazards": self.show_hazard_list,
+            "Malfunctions": self.show_malfunction_list,
+            "Faults": self.show_fault_list,
+            "Failures": self.show_failure_list,
             "FI2TC Analysis": self.open_fi2tc_window,
             "TC2FI Analysis": self.open_tc2fi_window,
             "AutoML Explorer": self.manage_architecture,
@@ -3033,6 +3044,22 @@ class FaultTreeApp:
             if name in mals:
                 return True
         return False
+
+    def add_malfunction(self, name: str) -> None:
+        """Add a malfunction to the list if it does not already exist."""
+        append_unique_insensitive(self.malfunctions, name)
+
+    def add_fault(self, name: str) -> None:
+        """Add a fault to the list if not already present."""
+        append_unique_insensitive(self.faults, name)
+
+    def add_failure(self, name: str) -> None:
+        """Add a failure to the list if not already present."""
+        append_unique_insensitive(self.failures, name)
+
+    def add_hazard(self, name: str) -> None:
+        """Add a hazard to the list if not already present."""
+        append_unique_insensitive(self.hazards, name)
 
     def calculate_fmeda_metrics(self, events):
         """Return ASIL and FMEDA metrics for the given events."""
@@ -7737,6 +7764,25 @@ class FaultTreeApp:
         for lib in self.odd_libraries:
             self.odd_elements.extend(lib.get("elements", []))
 
+    def update_hazard_list(self):
+        """Aggregate hazards from all HARA documents into ``hazards`` list."""
+        hazards: list[str] = []
+        for doc in self.hara_docs:
+            for e in doc.entries:
+                h = getattr(e, "hazard", "").strip()
+                if h and h not in hazards:
+                    hazards.append(h)
+        self.hazards = hazards
+
+    def update_failure_list(self):
+        """Aggregate failure effects from FMEA and FMEDA entries."""
+        failures: list[str] = []
+        for entry in self.get_all_fmea_entries():
+            eff = getattr(entry, "fmea_effect", "").strip()
+            if eff and eff not in failures:
+                failures.append(eff)
+        self.failures = failures
+
     def get_entry_field(self, entry, field, default=""):
         """Retrieve attribute or dict value from an entry."""
         if isinstance(entry, dict):
@@ -9031,6 +9077,176 @@ class FaultTreeApp:
             messagebox.showinfo("Export","Triggering conditions exported.")
         ttk.Button(win, text="Export CSV", command=export_csv).pack(side=tk.RIGHT, padx=5, pady=5)
 
+    def show_hazard_list(self):
+        win = tk.Toplevel(self.root)
+        win.title("Hazards")
+        lb = tk.Listbox(win, height=10, width=40)
+        lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.update_hazard_list()
+        for h in self.hazards:
+            lb.insert(tk.END, h)
+
+        def add():
+            name = simpledialog.askstring("Add Hazard", "Name:")
+            if name:
+                self.add_hazard(name)
+                lb.insert(tk.END, name)
+
+        def rename():
+            sel = lb.curselection()
+            if not sel:
+                return
+            current = lb.get(sel[0])
+            name = simpledialog.askstring("Rename Hazard", "Name:", initialvalue=current)
+            if not name:
+                return
+            self.hazards.remove(current)
+            self.add_hazard(name)
+            lb.delete(sel[0])
+            lb.insert(sel[0], name)
+
+        def delete():
+            sel = lb.curselection()
+            if not sel:
+                return
+            current = lb.get(sel[0])
+            if messagebox.askyesno("Delete", f"Delete '{current}'?"):
+                self.hazards.remove(current)
+                lb.delete(sel[0])
+
+        btn = ttk.Frame(win)
+        btn.pack(side=tk.RIGHT, fill=tk.Y)
+        ttk.Button(btn, text="Add", command=add).pack(fill=tk.X)
+        ttk.Button(btn, text="Rename", command=rename).pack(fill=tk.X)
+        ttk.Button(btn, text="Delete", command=delete).pack(fill=tk.X)
+
+    def show_malfunction_list(self):
+        win = tk.Toplevel(self.root)
+        win.title("Malfunctions")
+        lb = tk.Listbox(win, height=10, width=40)
+        lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        for m in self.malfunctions:
+            lb.insert(tk.END, m)
+
+        def add():
+            name = simpledialog.askstring("Add Malfunction", "Name:")
+            if name:
+                self.add_malfunction(name)
+                lb.insert(tk.END, name)
+
+        def rename():
+            sel = lb.curselection()
+            if not sel:
+                return
+            current = lb.get(sel[0])
+            name = simpledialog.askstring("Rename Malfunction", "Name:", initialvalue=current)
+            if not name:
+                return
+            self.malfunctions.remove(current)
+            self.add_malfunction(name)
+            lb.delete(sel[0])
+            lb.insert(sel[0], name)
+
+        def delete():
+            sel = lb.curselection()
+            if not sel:
+                return
+            current = lb.get(sel[0])
+            if messagebox.askyesno("Delete", f"Delete '{current}'?"):
+                self.malfunctions.remove(current)
+                lb.delete(sel[0])
+
+        btn = ttk.Frame(win)
+        btn.pack(side=tk.RIGHT, fill=tk.Y)
+        ttk.Button(btn, text="Add", command=add).pack(fill=tk.X)
+        ttk.Button(btn, text="Rename", command=rename).pack(fill=tk.X)
+        ttk.Button(btn, text="Delete", command=delete).pack(fill=tk.X)
+
+    def show_fault_list(self):
+        win = tk.Toplevel(self.root)
+        win.title("Faults")
+        lb = tk.Listbox(win, height=10, width=40)
+        lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        for f in self.faults:
+            lb.insert(tk.END, f)
+
+        def add():
+            name = simpledialog.askstring("Add Fault", "Name:")
+            if name:
+                self.add_fault(name)
+                lb.insert(tk.END, name)
+
+        def rename():
+            sel = lb.curselection()
+            if not sel:
+                return
+            current = lb.get(sel[0])
+            name = simpledialog.askstring("Rename Fault", "Name:", initialvalue=current)
+            if not name:
+                return
+            self.faults.remove(current)
+            self.add_fault(name)
+            lb.delete(sel[0])
+            lb.insert(sel[0], name)
+
+        def delete():
+            sel = lb.curselection()
+            if not sel:
+                return
+            current = lb.get(sel[0])
+            if messagebox.askyesno("Delete", f"Delete '{current}'?"):
+                self.faults.remove(current)
+                lb.delete(sel[0])
+
+        btn = ttk.Frame(win)
+        btn.pack(side=tk.RIGHT, fill=tk.Y)
+        ttk.Button(btn, text="Add", command=add).pack(fill=tk.X)
+        ttk.Button(btn, text="Rename", command=rename).pack(fill=tk.X)
+        ttk.Button(btn, text="Delete", command=delete).pack(fill=tk.X)
+
+    def show_failure_list(self):
+        win = tk.Toplevel(self.root)
+        win.title("Failures")
+        lb = tk.Listbox(win, height=10, width=40)
+        lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.update_failure_list()
+        for fl in self.failures:
+            lb.insert(tk.END, fl)
+
+        def add():
+            name = simpledialog.askstring("Add Failure", "Name:")
+            if name:
+                self.add_failure(name)
+                lb.insert(tk.END, name)
+
+        def rename():
+            sel = lb.curselection()
+            if not sel:
+                return
+            current = lb.get(sel[0])
+            name = simpledialog.askstring("Rename Failure", "Name:", initialvalue=current)
+            if not name:
+                return
+            self.failures.remove(current)
+            self.add_failure(name)
+            lb.delete(sel[0])
+            lb.insert(sel[0], name)
+
+        def delete():
+            sel = lb.curselection()
+            if not sel:
+                return
+            current = lb.get(sel[0])
+            if messagebox.askyesno("Delete", f"Delete '{current}'?"):
+                self.failures.remove(current)
+                lb.delete(sel[0])
+
+        btn = ttk.Frame(win)
+        btn.pack(side=tk.RIGHT, fill=tk.Y)
+        ttk.Button(btn, text="Add", command=add).pack(fill=tk.X)
+        ttk.Button(btn, text="Rename", command=rename).pack(fill=tk.X)
+        ttk.Button(btn, text="Delete", command=delete).pack(fill=tk.X)
+
     def show_functional_insufficiency_list(self):
         win = tk.Toplevel(self.root)
         win.title("Functional Insufficiencies")
@@ -9183,10 +9399,10 @@ class FaultTreeApp:
                     name = name.strip()
                 if not name:
                     return
-                if name in self.app.malfunctions:
+                if any(m.lower() == name.lower() for m in self.app.malfunctions):
                     messagebox.showinfo("Malfunction", "Already exists")
                     return
-                self.app.malfunctions.append(name)
+                self.app.add_malfunction(name)
                 var = tk.BooleanVar(value=True)
                 ttk.Checkbutton(self.mal_frame, text=name, variable=var, command=update_sg).pack(anchor="w")
                 self.mal_vars[name] = var
@@ -9393,8 +9609,8 @@ class FaultTreeApp:
             selected_mals = [m for m, v in self.mal_vars.items() if v.get()]
             self.node.fmeda_malfunction = ";".join(selected_mals)
             for m in selected_mals:
-                if m and m not in self.app.malfunctions:
-                    self.app.malfunctions.append(m)
+                if m:
+                    self.app.add_malfunction(m)
             self.node.fmeda_safety_goal = self.sg_var.get()
             try:
                 self.node.fmeda_diag_cov = float(self.dc_var.get())
@@ -12239,6 +12455,8 @@ class FaultTreeApp:
             "odd_libraries": self.odd_libraries,
             "faults": self.faults,
             "malfunctions": self.malfunctions,
+            "hazards": self.hazards,
+            "failures": self.failures,
             "project_properties": self.project_properties,
             "global_requirements": global_requirements,
             "reviews": reviews,
@@ -12324,6 +12542,8 @@ class FaultTreeApp:
                 "entries": entries,
                 "bom": doc.get("bom", ""),
             })
+
+        self.update_failure_list()
 
         # Link FMEA entries to the fault tree nodes so edits propagate
         node_map = {}
@@ -12436,6 +12656,7 @@ class FaultTreeApp:
             )
         self.active_hara = self.hara_docs[0] if self.hara_docs else None
         self.hara_entries = self.active_hara.entries if self.active_hara else []
+        self.update_hazard_list()
 
         self.fi2tc_docs = []
         for d in data.get("fi2tc_docs", []):
@@ -12463,7 +12684,12 @@ class FaultTreeApp:
             desc = be.description.strip()
             if desc and desc not in self.faults:
                 self.faults.append(desc)
-        self.malfunctions = data.get("malfunctions", [])
+        mals = []
+        for m in data.get("malfunctions", []):
+            append_unique_insensitive(mals, m)
+        self.malfunctions = mals
+        self.hazards = data.get("hazards", [])
+        self.failures = data.get("failures", [])
         if not self.odd_libraries and "odd_elements" in data:
             self.odd_libraries = [{"name": "Default", "elements": data.get("odd_elements", [])}]
         self.update_odd_elements()

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -1,0 +1,18 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+"""Utility helpers for analysis package."""
+
+from typing import List
+
+
+def append_unique_insensitive(items: List[str], name: str) -> None:
+    """Append ``name`` to ``items`` if not already present (case-insensitive)."""
+    if not name:
+        return
+    name = name.strip()
+    if not name:
+        return
+    lower = name.lower()
+    for existing in items:
+        if existing.lower() == lower:
+            return
+    items.append(name)

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -881,7 +881,11 @@ class HazopWindow(tk.Frame):
 
             ttk.Label(master, text="Malfunction").grid(row=1, column=0, sticky="e", padx=5, pady=5)
             self.mal = tk.StringVar(value=self.row.malfunction)
-            ttk.Entry(master, textvariable=self.mal).grid(row=1, column=1, padx=5, pady=5)
+            ttk.Combobox(
+                master,
+                textvariable=self.mal,
+                values=sorted(self.app.malfunctions),
+            ).grid(row=1, column=1, padx=5, pady=5)
 
             ttk.Label(master, text="Type").grid(row=2, column=0, sticky="e", padx=5, pady=5)
             self.typ = tk.StringVar(value=self.row.mtype)
@@ -929,6 +933,7 @@ class HazopWindow(tk.Frame):
         def apply(self):
             self.row.function = self.func.get()
             self.row.malfunction = self.mal.get()
+            self.app.add_malfunction(self.row.malfunction)
             self.row.mtype = self.typ.get()
             self.row.scenario = self.scen.get()
             self.row.conditions = self.cond.get()

--- a/tests/test_malfunctions.py
+++ b/tests/test_malfunctions.py
@@ -1,0 +1,16 @@
+import unittest
+from analysis.utils import append_unique_insensitive
+
+class MalfunctionUtilsTests(unittest.TestCase):
+    def test_append_unique_insensitive(self):
+        items = ['Brake Failure', 'Sensor Fault']
+        append_unique_insensitive(items, 'brake failure')
+        self.assertEqual(len(items), 2)
+        append_unique_insensitive(items, '  SENSOR FAULT  ')
+        self.assertEqual(len(items), 2)
+        append_unique_insensitive(items, 'Power Loss')
+        self.assertEqual(items[-1], 'Power Loss')
+        self.assertEqual(len(items), 3)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- manage hazard, failure, fault and malfunction lists in the app
- include new list dialogs in the menu
- export/import hazards and failures with the model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6886c9008dfc832596043eaff082601b