### PR TITLE
Replace malfunction list with editor

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -1950,10 +1950,10 @@ class FaultTreeApp:
         qualitative_menu.add_command(label="HAZOP Analysis", command=self.open_hazop_window)
         qualitative_menu.add_command(label="HARA Analysis", command=self.open_hara_window)
         qualitative_menu.add_command(label="Hazard Explorer", command=self.show_hazard_explorer)
-        qualitative_menu.add_command(label="Hazards", command=self.show_hazard_list)
-        qualitative_menu.add_command(label="Malfunctions", command=self.show_malfunction_list)
-        qualitative_menu.add_command(label="Faults", command=self.show_fault_list)
-        qualitative_menu.add_command(label="Failures", command=self.show_failure_list)
+        qualitative_menu.add_command(label="Hazards Editor", command=self.show_hazard_editor)
+        qualitative_menu.add_command(label="Malfunctions Editor", command=self.show_malfunction_editor)
+        qualitative_menu.add_command(label="Faults Editor", command=self.show_fault_editor)
+        qualitative_menu.add_command(label="Failures Editor", command=self.show_failure_editor)
         qualitative_menu.add_separator()
         qualitative_menu.add_command(label="Triggering Conditions", command=self.show_triggering_condition_list)
         qualitative_menu.add_command(label="Functional Insufficiencies", command=self.show_functional_insufficiency_list)
@@ -2067,10 +2067,10 @@ class FaultTreeApp:
             "FMEA Manager": self.show_fmea_list,
             "HAZOP Analysis": self.open_hazop_window,
             "HARA Analysis": self.open_hara_window,
-            "Hazards": self.show_hazard_list,
-            "Malfunctions": self.show_malfunction_list,
-            "Faults": self.show_fault_list,
-            "Failures": self.show_failure_list,
+            "Hazards Editor": self.show_hazard_editor,
+            "Malfunctions Editor": self.show_malfunction_editor,
+            "Faults Editor": self.show_fault_editor,
+            "Failures Editor": self.show_failure_editor,
             "FI2TC Analysis": self.open_fi2tc_window,
             "TC2FI Analysis": self.open_tc2fi_window,
             "AutoML Explorer": self.manage_architecture,
@@ -9077,20 +9077,28 @@ class FaultTreeApp:
             messagebox.showinfo("Export","Triggering conditions exported.")
         ttk.Button(win, text="Export CSV", command=export_csv).pack(side=tk.RIGHT, padx=5, pady=5)
 
-    def show_hazard_list(self):
-        win = tk.Toplevel(self.root)
-        win.title("Hazards")
+    def show_hazard_editor(self):
+        """Open a tab to manage global hazards."""
+        if hasattr(self, "_haz_tab") and self._haz_tab.winfo_exists():
+            self.doc_nb.select(self._haz_tab)
+            return
+        self._haz_tab = self._new_tab("Hazards")
+        win = self._haz_tab
+
         lb = tk.Listbox(win, height=10, width=40)
         lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        self.update_hazard_list()
-        for h in self.hazards:
-            lb.insert(tk.END, h)
+
+        def refresh():
+            lb.delete(0, tk.END)
+            self.update_hazard_list()
+            for h in self.hazards:
+                lb.insert(tk.END, h)
 
         def add():
             name = simpledialog.askstring("Add Hazard", "Name:")
             if name:
                 self.add_hazard(name)
-                lb.insert(tk.END, name)
+                refresh()
 
         def rename():
             sel = lb.curselection()
@@ -9102,8 +9110,7 @@ class FaultTreeApp:
                 return
             self.hazards.remove(current)
             self.add_hazard(name)
-            lb.delete(sel[0])
-            lb.insert(sel[0], name)
+            refresh()
 
         def delete():
             sel = lb.curselection()
@@ -9112,7 +9119,7 @@ class FaultTreeApp:
             current = lb.get(sel[0])
             if messagebox.askyesno("Delete", f"Delete '{current}'?"):
                 self.hazards.remove(current)
-                lb.delete(sel[0])
+                refresh()
 
         btn = ttk.Frame(win)
         btn.pack(side=tk.RIGHT, fill=tk.Y)
@@ -9120,19 +9127,29 @@ class FaultTreeApp:
         ttk.Button(btn, text="Rename", command=rename).pack(fill=tk.X)
         ttk.Button(btn, text="Delete", command=delete).pack(fill=tk.X)
 
-    def show_malfunction_list(self):
-        win = tk.Toplevel(self.root)
-        win.title("Malfunctions")
+        refresh()
+
+    def show_malfunction_editor(self):
+        """Open a tab to manage global malfunctions."""
+        if hasattr(self, "_mal_tab") and self._mal_tab.winfo_exists():
+            self.doc_nb.select(self._mal_tab)
+            return
+        self._mal_tab = self._new_tab("Malfunctions")
+        win = self._mal_tab
+
         lb = tk.Listbox(win, height=10, width=40)
         lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        for m in self.malfunctions:
-            lb.insert(tk.END, m)
+
+        def refresh():
+            lb.delete(0, tk.END)
+            for m in self.malfunctions:
+                lb.insert(tk.END, m)
 
         def add():
             name = simpledialog.askstring("Add Malfunction", "Name:")
             if name:
                 self.add_malfunction(name)
-                lb.insert(tk.END, name)
+                refresh()
 
         def rename():
             sel = lb.curselection()
@@ -9142,19 +9159,24 @@ class FaultTreeApp:
             name = simpledialog.askstring("Rename Malfunction", "Name:", initialvalue=current)
             if not name:
                 return
+            if any(m.lower() == name.lower() for m in self.malfunctions if m != current):
+                messagebox.showinfo("Malfunction", "Already exists")
+                return
             self.malfunctions.remove(current)
             self.add_malfunction(name)
-            lb.delete(sel[0])
-            lb.insert(sel[0], name)
+            refresh()
 
         def delete():
             sel = lb.curselection()
             if not sel:
                 return
             current = lb.get(sel[0])
+            if self.is_malfunction_used(current):
+                messagebox.showinfo("Delete", "Malfunction is in use")
+                return
             if messagebox.askyesno("Delete", f"Delete '{current}'?"):
                 self.malfunctions.remove(current)
-                lb.delete(sel[0])
+                refresh()
 
         btn = ttk.Frame(win)
         btn.pack(side=tk.RIGHT, fill=tk.Y)
@@ -9162,19 +9184,29 @@ class FaultTreeApp:
         ttk.Button(btn, text="Rename", command=rename).pack(fill=tk.X)
         ttk.Button(btn, text="Delete", command=delete).pack(fill=tk.X)
 
-    def show_fault_list(self):
-        win = tk.Toplevel(self.root)
-        win.title("Faults")
+        refresh()
+
+    def show_fault_editor(self):
+        """Open a tab to manage global faults."""
+        if hasattr(self, "_fault_tab") and self._fault_tab.winfo_exists():
+            self.doc_nb.select(self._fault_tab)
+            return
+        self._fault_tab = self._new_tab("Faults")
+        win = self._fault_tab
+
         lb = tk.Listbox(win, height=10, width=40)
         lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        for f in self.faults:
-            lb.insert(tk.END, f)
+
+        def refresh():
+            lb.delete(0, tk.END)
+            for f in self.faults:
+                lb.insert(tk.END, f)
 
         def add():
             name = simpledialog.askstring("Add Fault", "Name:")
             if name:
                 self.add_fault(name)
-                lb.insert(tk.END, name)
+                refresh()
 
         def rename():
             sel = lb.curselection()
@@ -9186,8 +9218,7 @@ class FaultTreeApp:
                 return
             self.faults.remove(current)
             self.add_fault(name)
-            lb.delete(sel[0])
-            lb.insert(sel[0], name)
+            refresh()
 
         def delete():
             sel = lb.curselection()
@@ -9196,7 +9227,7 @@ class FaultTreeApp:
             current = lb.get(sel[0])
             if messagebox.askyesno("Delete", f"Delete '{current}'?"):
                 self.faults.remove(current)
-                lb.delete(sel[0])
+                refresh()
 
         btn = ttk.Frame(win)
         btn.pack(side=tk.RIGHT, fill=tk.Y)
@@ -9204,20 +9235,30 @@ class FaultTreeApp:
         ttk.Button(btn, text="Rename", command=rename).pack(fill=tk.X)
         ttk.Button(btn, text="Delete", command=delete).pack(fill=tk.X)
 
-    def show_failure_list(self):
-        win = tk.Toplevel(self.root)
-        win.title("Failures")
+        refresh()
+
+    def show_failure_editor(self):
+        """Open a tab to manage global failures."""
+        if hasattr(self, "_failure_tab") and self._failure_tab.winfo_exists():
+            self.doc_nb.select(self._failure_tab)
+            return
+        self._failure_tab = self._new_tab("Failures")
+        win = self._failure_tab
+
         lb = tk.Listbox(win, height=10, width=40)
         lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        self.update_failure_list()
-        for fl in self.failures:
-            lb.insert(tk.END, fl)
+
+        def refresh():
+            lb.delete(0, tk.END)
+            self.update_failure_list()
+            for fl in self.failures:
+                lb.insert(tk.END, fl)
 
         def add():
             name = simpledialog.askstring("Add Failure", "Name:")
             if name:
                 self.add_failure(name)
-                lb.insert(tk.END, name)
+                refresh()
 
         def rename():
             sel = lb.curselection()
@@ -9229,8 +9270,7 @@ class FaultTreeApp:
                 return
             self.failures.remove(current)
             self.add_failure(name)
-            lb.delete(sel[0])
-            lb.insert(sel[0], name)
+            refresh()
 
         def delete():
             sel = lb.curselection()
@@ -9239,13 +9279,15 @@ class FaultTreeApp:
             current = lb.get(sel[0])
             if messagebox.askyesno("Delete", f"Delete '{current}'?"):
                 self.failures.remove(current)
-                lb.delete(sel[0])
+                refresh()
 
         btn = ttk.Frame(win)
         btn.pack(side=tk.RIGHT, fill=tk.Y)
         ttk.Button(btn, text="Add", command=add).pack(fill=tk.X)
         ttk.Button(btn, text="Rename", command=rename).pack(fill=tk.X)
         ttk.Button(btn, text="Delete", command=delete).pack(fill=tk.X)
+
+        refresh()
 
     def show_functional_insufficiency_list(self):
         win = tk.Toplevel(self.root)


### PR DESCRIPTION
## Summary
- remove the simple malfunction list window
- provide a Malfunction Editor tab like the Requirements Editor
- register Malfunction Editor in menus and tool list
- show Faults, Failures and Hazards in similar tabbed editors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6886cdc9e2388325bd6b49f6271629df