### PR TITLE
Ensure new malfunctions create top events

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -3051,7 +3051,17 @@ class FaultTreeApp:
 
     def add_malfunction(self, name: str) -> None:
         """Add a malfunction to the list if it does not already exist."""
+        if not name:
+            return
+        name = name.strip()
+        if not name:
+            return
+        exists = any(m.lower() == name.lower() for m in self.malfunctions)
         append_unique_insensitive(self.malfunctions, name)
+        if not exists and not any(
+            getattr(te, "malfunction", "") == name for te in self.top_events
+        ):
+            self.create_top_event_for_malfunction(name)
 
     def add_fault(self, name: str) -> None:
         """Add a fault to the list if not already present."""
@@ -9257,7 +9267,6 @@ class FaultTreeApp:
             name = simpledialog.askstring("Add Malfunction", "Name:")
             if name:
                 self.add_malfunction(name)
-                self.create_top_event_for_malfunction(name)
                 refresh()
 
         def rename():
@@ -9454,8 +9463,7 @@ class FaultTreeApp:
                 return
             self.malfunctions.append(name)
             lb.insert(tk.END, name)
-            self.create_top_event_for_malfunction(name)
-
+            
         def edit_mal():
             sel = lb.curselection()
             if not sel:

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -913,6 +913,10 @@ class HazopWindow(tk.Frame):
         def apply(self):
             self.row.function = self.func.get()
             self.row.malfunction = self.mal.get()
+            # When a new malfunction is introduced from a HAZOP entry,
+            # automatically create a corresponding top level event.
+            # Register the malfunction globally; AutoML will create a
+            # corresponding top level event if it's new.
             self.app.add_malfunction(self.row.malfunction)
             self.row.mtype = self.typ.get()
             self.row.scenario = self.scen.get()


### PR DESCRIPTION
## Summary
- create FTA top events automatically when new malfunctions are added
- rely on `add_malfunction` to handle top event creation from HAZOP dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886d85e5b2083259e28dd20a5790f9b