### PR TITLE
Fix sg_var initialization order

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9637,8 +9637,6 @@ class FaultTreeApp:
                 self.mal_combo.grid(row=row_next, column=1, padx=5, pady=5, sticky="w")
                 self.mal_combo.bind("<<ComboboxSelected>>", update_sg)
 
-            update_sg()
-
             row_next += 1
 
             ttk.Label(gen_frame, text="Violates Safety Goal:").grid(row=row_next, column=0, sticky="e", padx=5, pady=5)


### PR DESCRIPTION
## Summary
- fix AttributeError in FMEARowDialog by removing premature `update_sg` call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886d8ea872483258dcd1b967d5db44b