### PR TITLE
Handle missing pillow gracefully

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -289,7 +289,11 @@ from sysml.sysml_repository import SysMLRepository
 from analysis.fmeda_utils import compute_fmeda_metrics
 import copy
 import tkinter.font as tkFont
-from PIL import Image, ImageDraw, ImageFont, ImageTk
+try:
+    from PIL import Image, ImageDraw, ImageFont, ImageTk
+except ModuleNotFoundError:
+    print("Error: Pillow package is required for image support. Please install pillow.")
+    sys.exit(1)
 import os
 import types
 os.environ["GS_EXECUTABLE"] = r"C:\Program Files\gs\gs10.04.0\bin\gswin64c.exe"

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -24,7 +24,11 @@ import difflib
 import sys
 import json
 import re
-from PIL import Image, ImageTk
+try:
+    from PIL import Image, ImageTk
+except ModuleNotFoundError:
+    print("Error: Pillow package is required for image support. Please install pillow.")
+    sys.exit(1)
 
 # Node types treated as gates when deriving component names
 GATE_NODE_TYPES = {"GATE", "RIGOR LEVEL", "TOP EVENT", "FUNCTIONAL INSUFFICIENCY"}


### PR DESCRIPTION
## Summary
- add a try/except around Pillow imports in `AutoML.py` and `review_toolbox.py`
- exit with a helpful message if Pillow isn't installed

## Testing
- `pytest -q`
- `python AutoML.py` (fails gracefully without Pillow)

------
https://chatgpt.com/codex/tasks/task_b_6886e2c6f6948325ba2fa23482ea1747