### PR TITLE
Add basic metadata tracking

### DIFF
--- a/analysis/models.py
+++ b/analysis/models.py
@@ -1,5 +1,16 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 from dataclasses import dataclass, field
+import datetime
+
+
+@dataclass
+class Metadata:
+    """Track creation and modification info."""
+
+    created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
+    author: str = ""
+    modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
+    modified_by: str = ""
 
 @dataclass
 class MissionProfile:
@@ -131,6 +142,7 @@ class HazopDoc:
     """Container for a HAZOP with a name and list of entries."""
     name: str
     entries: list
+    meta: Metadata = field(default_factory=Metadata)
 
 @dataclass
 class HaraDoc:
@@ -140,18 +152,21 @@ class HaraDoc:
     entries: list
     approved: bool = False
     status: str = "draft"
+    meta: Metadata = field(default_factory=Metadata)
 
 @dataclass
 class FI2TCDoc:
     """Container for an FI2TC analysis."""
     name: str
     entries: list
+    meta: Metadata = field(default_factory=Metadata)
 
 @dataclass
 class TC2FIDoc:
     """Container for a TC2FI analysis."""
     name: str
     entries: list
+    meta: Metadata = field(default_factory=Metadata)
 
 COMPONENT_ATTR_TEMPLATES = {
     "capacitor": {

--- a/analysis/user_config.py
+++ b/analysis/user_config.py
@@ -1,0 +1,26 @@
+import configparser
+from pathlib import Path
+
+CONFIG_PATH = Path.home() / ".automl.ini"
+
+CURRENT_USER_NAME = ""
+CURRENT_USER_EMAIL = ""
+
+def load_user_config():
+    parser = configparser.ConfigParser()
+    if CONFIG_PATH.exists():
+        parser.read(CONFIG_PATH)
+    name = parser.get('user', 'name', fallback='')
+    email = parser.get('user', 'email', fallback='')
+    return name, email
+
+def save_user_config(name: str, email: str) -> None:
+    parser = configparser.ConfigParser()
+    parser['user'] = {'name': name, 'email': email}
+    with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
+        parser.write(f)
+
+def set_current_user(name: str, email: str) -> None:
+    global CURRENT_USER_NAME, CURRENT_USER_EMAIL
+    CURRENT_USER_NAME = name
+    CURRENT_USER_EMAIL = email

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1812,6 +1812,7 @@ class SysMLDiagramWindow(tk.Frame):
         if diag:
             diag.objects = [obj.__dict__ for obj in self.objects]
             diag.connections = [conn.__dict__ for conn in self.connections]
+            self.repo.touch_diagram(self.diagram_id)
 
     def on_close(self):
         self._sync_to_repository()
@@ -2451,6 +2452,9 @@ class SysMLObjectDialog(simpledialog.Dialog):
                                     joined = repo.elements[self.obj.element_id].properties["partProperties"]
                                     self.obj.properties["partProperties"] = joined
                             repo.diagrams[diag_id] = diag
+                            repo.touch_diagram(diag_id)
+                            if self.obj.element_id:
+                                repo.touch_element(self.obj.element_id)
                             if hasattr(self.master, "_sync_to_repository"):
                                 self.master._sync_to_repository()
 


### PR DESCRIPTION
## Summary
- store user metadata (author, creation/modification dates)
- prompt for user info on startup and keep it in `~/.automl.ini`
- display metadata columns in the FMEA table
- update repository and dialogs to touch objects/diagrams on change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886e55795d48325ab236f47c1b12bf2