### PR TITLE
Add metadata display for FMEA explorers

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -248,6 +248,13 @@ try:
 except Exception:  # openpyxl may not be installed
     load_workbook = None
 from gui.drawing_helper import FTADrawingHelper, fta_drawing_helper
+from analysis.user_config import (
+    load_user_config,
+    save_user_config,
+    set_current_user,
+    CURRENT_USER_NAME,
+    CURRENT_USER_EMAIL,
+)
 from analysis.risk_assessment import (
     DERIVED_MATURITY_TABLE,
     ASSURANCE_AGGREGATION_AND,
@@ -350,6 +357,28 @@ def get_version() -> str:
 
 
 VERSION = get_version()
+
+
+class UserInfoDialog(simpledialog.Dialog):
+    """Prompt for the user's name and email."""
+
+    def __init__(self, parent, name: str = "", email: str = ""):
+        self._name = name
+        self._email = email
+        super().__init__(parent, title="User Information")
+
+    def body(self, master):
+        ttk.Label(master, text="Name:").grid(row=0, column=0, sticky="e")
+        self.name_var = tk.StringVar(value=self._name)
+        name_entry = ttk.Entry(master, textvariable=self.name_var)
+        name_entry.grid(row=0, column=1, padx=5, pady=5)
+        ttk.Label(master, text="Email:").grid(row=1, column=0, sticky="e")
+        self.email_var = tk.StringVar(value=self._email)
+        ttk.Entry(master, textvariable=self.email_var).grid(row=1, column=1, padx=5, pady=5)
+        return name_entry
+
+    def apply(self):
+        self.result = (self.name_var.get().strip(), self.email_var.get().strip())
 
 
 class ClosableNotebook(ttk.Notebook):
@@ -8178,6 +8207,11 @@ class FaultTreeApp:
                 be.prob_formula = fm_node.prob_formula
                 be.failure_prob = self.compute_failure_prob(be)
 
+    def touch_doc(self, doc):
+        """Update modification metadata for the given document."""
+        doc["modified"] = datetime.datetime.now().isoformat()
+        doc["modified_by"] = CURRENT_USER_NAME
+
     def refresh_model(self):
         """Propagate changes across analyses when the model updates."""
         self.ensure_asil_consistency()
@@ -9200,54 +9234,86 @@ class FaultTreeApp:
             return
         self._fmea_tab = self._new_tab("FMEA List")
         win = self._fmea_tab
-        listbox = tk.Listbox(win, height=10, width=40)
-        listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        columns = ("Name", "Created", "Author", "Modified", "ModifiedBy")
+        tree = ttk.Treeview(win, columns=columns, show="headings")
+        for c in columns:
+            tree.heading(c, text=c)
+            width = 150 if c == "Name" else 120
+            tree.column(c, width=width)
+        tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
+        item_map = {}
         for fmea in self.fmeas:
-            listbox.insert(tk.END, fmea['name'])
+            iid = tree.insert(
+                "",
+                "end",
+                values=(
+                    fmea.get("name", ""),
+                    fmea.get("created", ""),
+                    fmea.get("author", ""),
+                    fmea.get("modified", ""),
+                    fmea.get("modified_by", ""),
+                ),
+            )
+            item_map[iid] = fmea
 
         def open_selected(event=None):
-            sel = listbox.curselection()
-            if not sel:
+            iid = tree.focus()
+            doc = item_map.get(iid)
+            if not doc:
                 return
-            idx = sel[0]
             win.destroy()
             self._fmea_tab = None
-            self.show_fmea_table(self.fmeas[idx])
+            self.show_fmea_table(doc)
 
         def add_fmea():
             name = simpledialog.askstring("New FMEA", "Enter FMEA name:")
             if name:
                 file_name = f"fmea_{name}.csv"
-                self.fmeas.append({'name': name, 'entries': [], 'file': file_name})
-                listbox.insert(tk.END, name)
+                now = datetime.datetime.now().isoformat()
+                doc = {
+                    "name": name,
+                    "entries": [],
+                    "file": file_name,
+                    "created": now,
+                    "author": CURRENT_USER_NAME,
+                    "modified": now,
+                    "modified_by": CURRENT_USER_NAME,
+                }
+                self.fmeas.append(doc)
+                iid = tree.insert(
+                    "",
+                    "end",
+                    values=(name, now, CURRENT_USER_NAME, now, CURRENT_USER_NAME),
+                )
+                item_map[iid] = doc
                 self.update_views()
 
         def delete_fmea():
-            sel = listbox.curselection()
-            if not sel:
+            iid = tree.focus()
+            doc = item_map.get(iid)
+            if not doc:
                 return
-            idx = sel[0]
-            del self.fmeas[idx]
-            listbox.delete(idx)
+            self.fmeas.remove(doc)
+            tree.delete(iid)
+            item_map.pop(iid, None)
             self.update_views()
 
         def rename_fmea():
-            sel = listbox.curselection()
-            if not sel:
+            iid = tree.focus()
+            doc = item_map.get(iid)
+            if not doc:
                 return
-            idx = sel[0]
-            current = self.fmeas[idx]['name']
+            current = doc.get("name", "")
             name = simpledialog.askstring("Rename FMEA", "Enter new name:", initialvalue=current)
             if not name:
                 return
-            self.fmeas[idx]['name'] = name
-            listbox.delete(idx)
-            listbox.insert(idx, name)
-            listbox.select_set(idx)
+            doc["name"] = name
+            self.touch_doc(doc)
+            tree.item(iid, values=(name, doc["created"], doc["author"], doc["modified"], doc["modified_by"]))
             self.update_views()
 
-        listbox.bind("<Double-1>", open_selected)
+        tree.bind("<Double-1>", open_selected)
         btn_frame = ttk.Frame(win)
         btn_frame.pack(side=tk.RIGHT, fill=tk.Y)
         ttk.Button(btn_frame, text="Open", command=open_selected).pack(fill=tk.X)
@@ -9261,54 +9327,87 @@ class FaultTreeApp:
             return
         self._fmeda_tab = self._new_tab("FMEDA List")
         win = self._fmeda_tab
-        listbox = tk.Listbox(win, height=10, width=40)
-        listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        columns = ("Name", "Created", "Author", "Modified", "ModifiedBy")
+        tree = ttk.Treeview(win, columns=columns, show="headings")
+        for c in columns:
+            tree.heading(c, text=c)
+            width = 150 if c == "Name" else 120
+            tree.column(c, width=width)
+        tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
+        item_map = {}
         for doc in self.fmedas:
-            listbox.insert(tk.END, doc['name'])
+            iid = tree.insert(
+                "",
+                "end",
+                values=(
+                    doc.get("name", ""),
+                    doc.get("created", ""),
+                    doc.get("author", ""),
+                    doc.get("modified", ""),
+                    doc.get("modified_by", ""),
+                ),
+            )
+            item_map[iid] = doc
 
         def open_selected(event=None):
-            sel = listbox.curselection()
-            if not sel:
+            iid = tree.focus()
+            d = item_map.get(iid)
+            if not d:
                 return
-            idx = sel[0]
             win.destroy()
             self._fmeda_tab = None
-            self.show_fmea_table(self.fmedas[idx], fmeda=True)
+            self.show_fmea_table(d, fmeda=True)
 
         def add_fmeda():
             name = simpledialog.askstring("New FMEDA", "Enter FMEDA name:")
             if name:
                 file_name = f"fmeda_{name}.csv"
-                self.fmedas.append({'name': name, 'entries': [], 'file': file_name, 'bom': ''})
-                listbox.insert(tk.END, name)
+                now = datetime.datetime.now().isoformat()
+                doc = {
+                    "name": name,
+                    "entries": [],
+                    "file": file_name,
+                    "bom": "",
+                    "created": now,
+                    "author": CURRENT_USER_NAME,
+                    "modified": now,
+                    "modified_by": CURRENT_USER_NAME,
+                }
+                self.fmedas.append(doc)
+                iid = tree.insert(
+                    "",
+                    "end",
+                    values=(name, now, CURRENT_USER_NAME, now, CURRENT_USER_NAME),
+                )
+                item_map[iid] = doc
                 self.update_views()
 
         def delete_fmeda():
-            sel = listbox.curselection()
-            if not sel:
+            iid = tree.focus()
+            d = item_map.get(iid)
+            if not d:
                 return
-            idx = sel[0]
-            del self.fmedas[idx]
-            listbox.delete(idx)
+            self.fmedas.remove(d)
+            tree.delete(iid)
+            item_map.pop(iid, None)
             self.update_views()
 
         def rename_fmeda():
-            sel = listbox.curselection()
-            if not sel:
+            iid = tree.focus()
+            d = item_map.get(iid)
+            if not d:
                 return
-            idx = sel[0]
-            current = self.fmedas[idx]['name']
+            current = d.get("name", "")
             name = simpledialog.askstring("Rename FMEDA", "Enter new name:", initialvalue=current)
             if not name:
                 return
-            self.fmedas[idx]['name'] = name
-            listbox.delete(idx)
-            listbox.insert(idx, name)
-            listbox.select_set(idx)
+            d["name"] = name
+            self.touch_doc(d)
+            tree.item(iid, values=(name, d["created"], d["author"], d["modified"], d["modified_by"]))
             self.update_views()
 
-        listbox.bind("<Double-1>", open_selected)
+        tree.bind("<Double-1>", open_selected)
         btn_frame = ttk.Frame(win)
         btn_frame.pack(side=tk.RIGHT, fill=tk.Y)
         ttk.Button(btn_frame, text="Open", command=open_selected).pack(fill=tk.X)
@@ -10018,6 +10117,8 @@ class FaultTreeApp:
                 self.node.fmeda_spfm_target = getattr(fta_goal, "sg_spfm_target", 0.0)
                 self.node.fmeda_lpfm_target = getattr(fta_goal, "sg_lpfm_target", 0.0)
             self.app.propagate_failure_mode_attributes(self.node)
+            self.node.modified = datetime.datetime.now().isoformat()
+            self.node.modified_by = CURRENT_USER_NAME
 
         def add_existing_requirement(self):
             global global_requirements
@@ -10251,6 +10352,7 @@ class FaultTreeApp:
                 "DiagCov",
                 "Mechanism",
             ])
+        columns.extend(["Created", "Author", "Modified", "ModifiedBy"])
         btn_frame = ttk.Frame(win)
         btn_frame.pack(side=tk.TOP, pady=2)
         add_btn = ttk.Button(btn_frame, text="Add Failure Mode")
@@ -10423,6 +10525,10 @@ class FaultTreeApp:
                 width = 150
             elif col in ["FaultType", "Fraction", "FIT", "DiagCov", "Mechanism"]:
                 width = 80
+            elif col in ["Created", "Modified"]:
+                width = 130
+            elif col in ["Author", "ModifiedBy"]:
+                width = 100
             tree.column(col, width=width, anchor="center")
         tree.grid(row=0, column=0, sticky="nsew")
         vsb.grid(row=0, column=1, sticky="ns")
@@ -10532,6 +10638,12 @@ class FaultTreeApp:
                         f"{src.fmeda_diag_cov:.2f}",
                         getattr(src, "fmeda_mechanism", ""),
                     ])
+                vals.extend([
+                    getattr(src, "created", ""),
+                    getattr(src, "author", ""),
+                    getattr(src, "modified", ""),
+                    getattr(src, "modified_by", ""),
+                ])
                 tags = ["evenrow" if idx % 2 == 0 else "oddrow"]
                 if rpn >= 100:
                     tags.append("highrpn")
@@ -10630,9 +10742,11 @@ class FaultTreeApp:
                     for lib in selected_libs:
                         mechs.extend(lib.mechanisms)
                     comp_name = self.get_component_name_for_node(be)
-                    is_passive = any(c.name == comp_name and c.is_passive for c in self.reliability_components)
-                    self.FMEARowDialog(win, be, self, entries, mechanisms=mechs, hide_diagnostics=is_passive, is_fmeda=fmeda)
+                is_passive = any(c.name == comp_name and c.is_passive for c in self.reliability_components)
+                self.FMEARowDialog(win, be, self, entries, mechanisms=mechs, hide_diagnostics=is_passive, is_fmeda=fmeda)
             refresh_tree()
+            if fmea is not None:
+                self.touch_doc(fmea)
 
         add_btn.config(command=add_failure_mode)
 
@@ -10646,6 +10760,8 @@ class FaultTreeApp:
                 if node in entries:
                     entries.remove(node)
             refresh_tree()
+            if fmea is not None:
+                self.touch_doc(fmea)
 
         remove_btn.config(command=remove_from_fmea)
 
@@ -10661,6 +10777,8 @@ class FaultTreeApp:
                 if node in entries:
                     entries.remove(node)
             refresh_tree()
+            if fmea is not None:
+                self.touch_doc(fmea)
 
         del_btn.config(command=delete_failure_mode)
 
@@ -10680,6 +10798,7 @@ class FaultTreeApp:
 
         def on_close():
             if fmea is not None:
+                self.touch_doc(fmea)
                 if fmeda:
                     self.export_fmeda_to_csv(fmea, fmea['file'])
                 else:
@@ -12789,6 +12908,10 @@ class FaultTreeApp:
                     "name": f["name"],
                     "file": f["file"],
                     "entries": [e.to_dict() for e in f["entries"]],
+                    "created": f.get("created", ""),
+                    "author": f.get("author", ""),
+                    "modified": f.get("modified", ""),
+                    "modified_by": f.get("modified_by", ""),
                 }
                 for f in self.fmeas
             ],
@@ -12798,6 +12921,10 @@ class FaultTreeApp:
                     "file": d["file"],
                     "entries": [e.to_dict() for e in d["entries"]],
                     "bom": d.get("bom", ""),
+                    "created": d.get("created", ""),
+                    "author": d.get("author", ""),
+                    "modified": d.get("modified", ""),
+                    "modified_by": d.get("modified_by", ""),
                 }
                 for d in self.fmedas
             ],
@@ -12936,7 +13063,15 @@ class FaultTreeApp:
         self.fmeas = []
         for fmea_data in data.get("fmeas", []):
             entries = [FaultTreeNode.from_dict(e) for e in fmea_data.get("entries", [])]
-            self.fmeas.append({"name": fmea_data.get("name", "FMEA"), "file": fmea_data.get("file", f"fmea_{len(self.fmeas)}.csv"), "entries": entries})
+            self.fmeas.append({
+                "name": fmea_data.get("name", "FMEA"),
+                "file": fmea_data.get("file", f"fmea_{len(self.fmeas)}.csv"),
+                "entries": entries,
+                "created": fmea_data.get("created", datetime.datetime.now().isoformat()),
+                "author": fmea_data.get("author", CURRENT_USER_NAME),
+                "modified": fmea_data.get("modified", datetime.datetime.now().isoformat()),
+                "modified_by": fmea_data.get("modified_by", CURRENT_USER_NAME),
+            })
         if not self.fmeas and "fmea_entries" in data:
             entries = [FaultTreeNode.from_dict(e) for e in data.get("fmea_entries", [])]
             self.fmeas.append({"name": "Default FMEA", "file": "fmea_default.csv", "entries": entries})
@@ -12949,6 +13084,10 @@ class FaultTreeApp:
                 "file": doc.get("file", f"fmeda_{len(self.fmedas)}.csv"),
                 "entries": entries,
                 "bom": doc.get("bom", ""),
+                "created": doc.get("created", datetime.datetime.now().isoformat()),
+                "author": doc.get("author", CURRENT_USER_NAME),
+                "modified": doc.get("modified", datetime.datetime.now().isoformat()),
+                "modified_by": doc.get("modified_by", CURRENT_USER_NAME),
             })
 
         self.update_failure_list()
@@ -14277,6 +14416,10 @@ class FaultTreeNode:
         self.is_page = False
         self.is_primary_instance = True
         self.original = self
+        self.created = datetime.datetime.now().isoformat()
+        self.author = CURRENT_USER_NAME
+        self.modified = self.created
+        self.modified_by = CURRENT_USER_NAME
         self.safety_goal_description = ""
         self.safety_goal_asil = ""
         self.safe_state = ""
@@ -14926,10 +15069,16 @@ class PageDiagram:
 
 def main():
     root = tk.Tk()
+    name, email = load_user_config()
+    dlg = UserInfoDialog(root, name, email)
+    if dlg.result:
+        name, email = dlg.result
+        save_user_config(name, email)
+    set_current_user(name, email)
     # Create a fresh helper each session:
     global AutoML_Helper
     AutoML_Helper = AutoMLHelper()
-    
+
     app = FaultTreeApp(root)
     root.mainloop()
 

--- a/analysis/models.py
+++ b/analysis/models.py
@@ -1,5 +1,16 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 from dataclasses import dataclass, field
+import datetime
+
+
+@dataclass
+class Metadata:
+    """Track creation and modification info."""
+
+    created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
+    author: str = ""
+    modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
+    modified_by: str = ""
 
 @dataclass
 class MissionProfile:
@@ -131,6 +142,7 @@ class HazopDoc:
     """Container for a HAZOP with a name and list of entries."""
     name: str
     entries: list
+    meta: Metadata = field(default_factory=Metadata)
 
 @dataclass
 class HaraDoc:
@@ -140,18 +152,21 @@ class HaraDoc:
     entries: list
     approved: bool = False
     status: str = "draft"
+    meta: Metadata = field(default_factory=Metadata)
 
 @dataclass
 class FI2TCDoc:
     """Container for an FI2TC analysis."""
     name: str
     entries: list
+    meta: Metadata = field(default_factory=Metadata)
 
 @dataclass
 class TC2FIDoc:
     """Container for a TC2FI analysis."""
     name: str
     entries: list
+    meta: Metadata = field(default_factory=Metadata)
 
 COMPONENT_ATTR_TEMPLATES = {
     "capacitor": {

--- a/analysis/user_config.py
+++ b/analysis/user_config.py
@@ -1,0 +1,26 @@
+import configparser
+from pathlib import Path
+
+CONFIG_PATH = Path.home() / ".automl.ini"
+
+CURRENT_USER_NAME = ""
+CURRENT_USER_EMAIL = ""
+
+def load_user_config():
+    parser = configparser.ConfigParser()
+    if CONFIG_PATH.exists():
+        parser.read(CONFIG_PATH)
+    name = parser.get('user', 'name', fallback='')
+    email = parser.get('user', 'email', fallback='')
+    return name, email
+
+def save_user_config(name: str, email: str) -> None:
+    parser = configparser.ConfigParser()
+    parser['user'] = {'name': name, 'email': email}
+    with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
+        parser.write(f)
+
+def set_current_user(name: str, email: str) -> None:
+    global CURRENT_USER_NAME, CURRENT_USER_EMAIL
+    CURRENT_USER_NAME = name
+    CURRENT_USER_EMAIL = email

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1812,6 +1812,7 @@ class SysMLDiagramWindow(tk.Frame):
         if diag:
             diag.objects = [obj.__dict__ for obj in self.objects]
             diag.connections = [conn.__dict__ for conn in self.connections]
+            self.repo.touch_diagram(self.diagram_id)
 
     def on_close(self):
         self._sync_to_repository()
@@ -2451,6 +2452,9 @@ class SysMLObjectDialog(simpledialog.Dialog):
                                     joined = repo.elements[self.obj.element_id].properties["partProperties"]
                                     self.obj.properties["partProperties"] = joined
                             repo.diagrams[diag_id] = diag
+                            repo.touch_diagram(diag_id)
+                            if self.obj.element_id:
+                                repo.touch_element(self.obj.element_id)
                             if hasattr(self.master, "_sync_to_repository"):
                                 self.master._sync_to_repository()
 


### PR DESCRIPTION
## Summary
- show metadata columns in the FMEA and FMEDA list views
- update documents' modification info when edited
- persist metadata for FMEA/FMEDA docs in model files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6886e55795d48325ab236f47c1b12bf2