### PR TITLE
Fix duplicate diagram openings in explorer

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2974,16 +2974,34 @@ class ArchitectureManagerDialog(tk.Frame):
         diag = self.repo.diagrams.get(diag_id)
         if not diag:
             return None
+
+        # If an application instance is available, open the diagram using
+        # the main document notebook so duplicate tabs are avoided.
+        if self.app and hasattr(self.app, "diagram_tabs"):
+            idx = next(
+                (i for i, d in enumerate(self.app.arch_diagrams) if d.diag_id == diag_id),
+                -1,
+            )
+            if idx != -1:
+                self.app.open_arch_window(idx)
+                tab = self.app.diagram_tabs.get(diag_id)
+                if tab and tab.winfo_exists():
+                    for child in tab.winfo_children():
+                        if isinstance(child, SysMLDiagramWindow):
+                            return child
+                return None
+
         master = self.master if self.master else self
         win = None
         if diag.diag_type == "Use Case Diagram":
-            UseCaseDiagramWindow(master, self.app, diagram_id=diag_id)
+            win = UseCaseDiagramWindow(master, self.app, diagram_id=diag_id)
         elif diag.diag_type == "Activity Diagram":
-            ActivityDiagramWindow(master, self.app, diagram_id=diag_id)
+            win = ActivityDiagramWindow(master, self.app, diagram_id=diag_id)
         elif diag.diag_type == "Block Diagram":
-            BlockDiagramWindow(master, self.app, diagram_id=diag_id)
+            win = BlockDiagramWindow(master, self.app, diagram_id=diag_id)
         elif diag.diag_type == "Internal Block Diagram":
-            InternalBlockDiagramWindow(master, self.app, diagram_id=diag_id)
+            win = InternalBlockDiagramWindow(master, self.app, diagram_id=diag_id)
+        return win
 
     def new_package(self):
         item = self.selected() or self.repo.root_package.elem_id


### PR DESCRIPTION
## Summary
- ensure AutoML Explorer reuses existing tabs
- return opened diagram window so objects can be selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886ef7323748325934f3d0650b655fd