### PR TITLE
Add tooltips to toolbox tabs

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -227,6 +227,7 @@ import math
 import sys
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox, simpledialog
+from gui.tooltip import ToolTip
 from gui.review_toolbox import (
     ReviewToolbox,
     ReviewData,
@@ -2064,6 +2065,10 @@ class FaultTreeApp:
         self.tools_group.pack(fill=tk.BOTH, expand=False, pady=5)
         self.tools_nb = ttk.Notebook(self.tools_group)
         self.tools_nb.pack(fill=tk.BOTH, expand=True)
+        # Tooltip helper for tabs (text may be clipped)
+        self._tools_tip = ToolTip(self.tools_nb, "", automatic=False)
+        self.tools_nb.bind("<Motion>", self._on_tool_tab_motion)
+        self.tools_nb.bind("<Leave>", lambda _e: self._tools_tip.hide())
 
         self.tool_actions = {
             "Mission Profiles": self.manage_mission_profiles,
@@ -7525,6 +7530,24 @@ class FaultTreeApp:
         action = self.tool_actions.get(name)
         if action:
             action()
+
+    def _on_tool_tab_motion(self, event):
+        """Show tooltip for notebook tabs when hovering over them."""
+        try:
+            idx = self.tools_nb.index(f"@{event.x},{event.y}")
+        except tk.TclError:
+            self._tools_tip.hide()
+            return
+        text = self.tools_nb.tab(idx, "text")
+        bbox = self.tools_nb.bbox(idx)
+        if not bbox:
+            self._tools_tip.hide()
+            return
+        x = self.tools_nb.winfo_rootx() + bbox[0] + bbox[2] // 2
+        y = self.tools_nb.winfo_rooty() + bbox[1] + bbox[3]
+        if self._tools_tip.text != text:
+            self._tools_tip.text = text
+        self._tools_tip.show(x, y)
 
     def on_ctrl_mousewheel(self, event):
         if event.delta > 0:

--- a/gui/tooltip.py
+++ b/gui/tooltip.py
@@ -1,26 +1,33 @@
 import tkinter as tk
 
 class ToolTip:
-    """Simple tooltip for Tkinter widgets."""
+    """Simple tooltip for Tkinter widgets.
 
-    def __init__(self, widget, text: str, delay: int = 500):
+    By default the tooltip is displayed when the mouse hovers over the
+    associated widget.  The ``show`` and ``hide`` methods can also be used to
+    control the tooltip manually (e.g. for notebook tabs).
+    """
+
+    def __init__(self, widget, text: str, delay: int = 500, *, automatic: bool = True):
         self.widget = widget
         self.text = text
         self.delay = delay
         self.tipwindow = None
         self.id = None
-        widget.bind("<Enter>", self._schedule)
-        widget.bind("<Leave>", self._hide)
+        if automatic:
+            widget.bind("<Enter>", self._schedule)
+            widget.bind("<Leave>", self._hide)
 
     def _schedule(self, _event=None):
         self._unschedule()
         self.id = self.widget.after(self.delay, self._show)
 
-    def _show(self):
+    def _show(self, x: int | None = None, y: int | None = None):
         if self.tipwindow or not self.text:
             return
-        x = self.widget.winfo_rootx() + 20
-        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 1
+        if x is None:
+            x = self.widget.winfo_rootx() + 20
+            y = self.widget.winfo_rooty() + self.widget.winfo_height() + 1
         self.tipwindow = tw = tk.Toplevel(self.widget)
         tw.wm_overrideredirect(True)
         # Ensure the tooltip stays above other windows
@@ -39,6 +46,15 @@ class ToolTip:
             wraplength=300,
         )
         label.pack(ipadx=1)
+
+    def show(self, x: int | None = None, y: int | None = None):
+        """Show the tooltip immediately."""
+        self._hide()
+        self._show(x, y)
+
+    def hide(self):
+        """Hide the tooltip immediately."""
+        self._hide()
 
     def _hide(self, _event=None):
         self._unschedule()


### PR DESCRIPTION
## Summary
- support manual tooltip mode for generic widgets
- show tooltips when hovering over toolbox tabs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886ff1d82788325afcf314c218127ce