### PR TITLE
Enable selecting functional mod requirements in FI2TC/TC2FI

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,8 @@ Two additional tables support tracing between these elements:
   table includes dedicated **triggering_conditions** and
   **functional_insufficiencies** columns populated via comboboxes so new items
   can be added on the fly.
+  The **design_measures** column now offers a drop-down listing all existing
+  requirements labelled as *functional modification* for quick selection.
 * **TC2FI Analysis** – starts from the triggering condition and lists the
   impacted functions, architecture elements and related insufficiencies. The
   **triggering_conditions** and **functional_insufficiencies** fields mirror

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -21,6 +21,7 @@ from analysis.models import (
     PASSIVE_QUAL_FACTORS,
     component_fit_map,
     calc_asil,
+    global_requirements,
 )
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.constants import CHECK_MARK, CROSS_MARK
@@ -703,6 +704,11 @@ class FI2TCWindow(tk.Frame):
             comp_names = self.app.get_all_component_names()
             scen_names = self.app.get_all_scenario_names()
             scene_names = self.app.get_all_scenery_names()
+            req_opts = [
+                f"[{r['id']}] {r['text']}"
+                for r in global_requirements.values()
+                if r.get("req_type") == "functional modification"
+            ]
             self.widgets = {}
             r = 0
 
@@ -734,6 +740,11 @@ class FI2TCWindow(tk.Frame):
                 elif col == "functional_insufficiencies":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=fi_names)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
+                    self.widgets[col] = var
+                elif col == "design_measures":
+                    var = tk.StringVar(value=self.data.get(col, ""))
+                    cb = ttk.Combobox(master, textvariable=var, values=req_opts)
                     cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "system_function":
@@ -1707,6 +1718,11 @@ class TC2FIWindow(tk.Frame):
             comp_names = self.app.get_all_component_names()
             scen_names = self.app.get_all_scenario_names()
             scene_names = self.app.get_all_scenery_names()
+            req_opts = [
+                f"[{r['id']}] {r['text']}"
+                for r in global_requirements.values()
+                if r.get("req_type") == "functional modification"
+            ]
             self.widgets = {}
             r = 0
 
@@ -1733,6 +1749,11 @@ class TC2FIWindow(tk.Frame):
                 if col == "functional_insufficiencies":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=fi_names)
+                    cb.grid(row=r, column=1, padx=5, pady=2)
+                    self.widgets[col] = var
+                elif col == "design_measures":
+                    var = tk.StringVar(value=self.data.get(col, ""))
+                    cb = ttk.Combobox(master, textvariable=var, values=req_opts)
                     cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "triggering_conditions":


### PR DESCRIPTION
## Summary
- import `global_requirements` into the toolboxes
- offer functional modification requirements in the FI2TC and TC2FI `design_measures` fields
- document the new drop-down in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887003a70a883259216027197ffc02e