### PR TITLE
Allow selecting multiple design measures

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,8 +682,9 @@ Two additional tables support tracing between these elements:
   table includes dedicated **triggering_conditions** and
   **functional_insufficiencies** columns populated via comboboxes so new items
   can be added on the fly.
-  The **design_measures** column now offers a drop-down listing all existing
+  The **design_measures** column now offers a multi-select list of all existing
   requirements labelled as *functional modification* for quick selection.
+  Hold **Ctrl** while clicking to choose multiple items.
 * **TC2FI Analysis** – starts from the triggering condition and lists the
   impacted functions, architecture elements and related insufficiencies. The
   **triggering_conditions** and **functional_insufficiencies** fields mirror

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -745,10 +745,15 @@ class FI2TCWindow(tk.Frame):
                     cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "design_measures":
-                    var = tk.StringVar(value=self.data.get(col, ""))
-                    cb = ttk.Combobox(master, textvariable=var, values=req_opts)
-                    cb.grid(row=r, column=1, padx=5, pady=2)
-                    self.widgets[col] = var
+                    lb = tk.Listbox(master, selectmode="extended", height=5)
+                    for opt in req_opts:
+                        lb.insert(tk.END, opt)
+                    existing = [e.strip() for e in self.data.get(col, "").split(",") if e.strip()]
+                    for i, opt in enumerate(req_opts):
+                        if opt in existing:
+                            lb.selection_set(i)
+                    lb.grid(row=r, column=1, padx=5, pady=2)
+                    self.widgets[col] = lb
                 elif col == "system_function":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(
@@ -803,6 +808,9 @@ class FI2TCWindow(tk.Frame):
                     self.data[col] = widget.get()
                 elif isinstance(widget, tk.Text):
                     self.data[col] = widget.get("1.0", "end-1c")
+                elif isinstance(widget, tk.Listbox):
+                    sel = [widget.get(i) for i in widget.curselection()]
+                    self.data[col] = ",".join(sel)
                 else:
                     self.data[col] = widget.get()
             self.result = True
@@ -1754,10 +1762,15 @@ class TC2FIWindow(tk.Frame):
                     cb.grid(row=r, column=1, padx=5, pady=2)
                     self.widgets[col] = var
                 elif col == "design_measures":
-                    var = tk.StringVar(value=self.data.get(col, ""))
-                    cb = ttk.Combobox(master, textvariable=var, values=req_opts)
-                    cb.grid(row=r, column=1, padx=5, pady=2)
-                    self.widgets[col] = var
+                    lb = tk.Listbox(master, selectmode="extended", height=5)
+                    for opt in req_opts:
+                        lb.insert(tk.END, opt)
+                    existing = [e.strip() for e in self.data.get(col, "").split(",") if e.strip()]
+                    for i, opt in enumerate(req_opts):
+                        if opt in existing:
+                            lb.selection_set(i)
+                    lb.grid(row=r, column=1, padx=5, pady=2)
+                    self.widgets[col] = lb
                 elif col == "triggering_conditions":
                     var = tk.StringVar(value=self.data.get(col, ""))
                     cb = ttk.Combobox(master, textvariable=var, values=tc_names)
@@ -1817,6 +1830,9 @@ class TC2FIWindow(tk.Frame):
                     self.data[col] = widget.get()
                 elif isinstance(widget, tk.Text):
                     self.data[col] = widget.get("1.0", "end-1c")
+                elif isinstance(widget, tk.Listbox):
+                    sel = [widget.get(i) for i in widget.curselection()]
+                    self.data[col] = ",".join(sel)
                 else:
                     self.data[col] = widget.get()
 


### PR DESCRIPTION
## Summary
- make FI2TC and TC2FI row dialogs show design measures in a multi-select list
- save selected requirements as a comma separated string
- update README to mention multi-select design measures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68870440a3888325886df7041eff7540