### PR TITLE
Improve analysis table appearance

### DIFF
--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -31,6 +31,76 @@ from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.constants import CHECK_MARK, CROSS_MARK
 
 
+def configure_table_style(style_name: str, rowheight: int = 60) -> None:
+    """Apply a consistent look to ttk.Treeview widgets used in analysis tables."""
+    style = ttk.Style()
+    try:
+        style.theme_use("clam")
+    except tk.TclError:
+        pass
+    style.configure(
+        style_name,
+        font=("Segoe UI", 10),
+        rowheight=rowheight,
+        borderwidth=1,
+        relief="solid",
+    )
+    style.configure(
+        f"{style_name}.Heading",
+        font=("Segoe UI", 10, "bold"),
+        background="#d0d0d0",
+        borderwidth=1,
+        relief="raised",
+    )
+
+
+class EditableTreeview(ttk.Treeview):
+    """Treeview with in-place cell editing support."""
+
+    def __init__(self, master=None, *, column_options=None, edit_callback=None, **kwargs):
+        super().__init__(master, **kwargs)
+        self._col_options = column_options or {}
+        self._edit_cb = edit_callback
+        self._edit_widget = None
+        self.bind("<Double-1>", self._begin_edit, add="+")
+
+    def _begin_edit(self, event):
+        if self._edit_widget:
+            return
+        region = self.identify("region", event.x, event.y)
+        if region != "cell":
+            return
+        rowid = self.identify_row(event.y)
+        col = self.identify_column(event.x)
+        if not rowid or not col:
+            return
+        col_index = int(col.replace("#", "")) - 1
+        col_name = self.cget("columns")[col_index]
+        x, y, w, h = self.bbox(rowid, col)
+        value = self.set(rowid, col_name)
+        opts = self._col_options.get(col_name)
+        var = tk.StringVar(value=value)
+        if opts:
+            widget = ttk.Combobox(self, textvariable=var, values=opts, state="readonly")
+        else:
+            widget = tk.Entry(self, textvariable=var)
+        widget.place(x=x, y=y, width=w, height=h)
+        widget.focus_set()
+
+        def save(event=None):
+            self.set(rowid, col_name, var.get())
+            widget.destroy()
+            self._edit_widget = None
+            if self._edit_cb:
+                row_index = self.index(rowid)
+                self._edit_cb(row_index, col_name, var.get())
+
+        widget.bind("<Return>", save)
+        widget.bind("<FocusOut>", save)
+        self._edit_widget = widget
+
+
+
 def _total_fit_from_boms(boms):
     """Return the aggregated FIT of all components in ``boms``.
 
@@ -231,10 +301,18 @@ class ReliabilityWindow(tk.Frame):
         self.analysis_combo.bind("<<ComboboxSelected>>", self.load_selected_analysis)
         self.refresh_analysis_list()
 
-        self.tree = ttk.Treeview(
+        configure_table_style("Reliability.Treeview")
+        column_opts = {
+            "type": list(COMPONENT_ATTR_TEMPLATES.keys()),
+            "qualification": QUALIFICATIONS,
+        }
+        self.tree = EditableTreeview(
             self,
             columns=("name", "type", "qty", "fit", "qualification"),
             show="headings",
+            style="Reliability.Treeview",
+            column_options=column_opts,
+            edit_callback=self.on_cell_edit,
         )
         for col in ("name", "type", "qty", "fit", "qualification"):
             heading = "Qualification" if col == "qualification" else col.capitalize()
@@ -398,6 +476,23 @@ class ReliabilityWindow(tk.Frame):
         self.profile_combo.config(values=[mp.name for mp in self.app.mission_profiles])
         # keep application level components updated so property dialogs see them
         self.app.reliability_components = list(self.components)
+
+    def on_cell_edit(self, row: int, column: str, value: str) -> None:
+        if row >= len(self.components):
+            return
+        comp = self.components[row]
+        if column == "name":
+            comp.name = value
+        elif column == "type":
+            comp.comp_type = value
+        elif column == "qty":
+            try:
+                comp.quantity = int(value)
+            except ValueError:
+                pass
+        elif column == "qualification":
+            comp.qualification = value
+        self.refresh_tree()
 
     def load_csv(self):
         path = filedialog.askopenfilename(filetypes=[("CSV", "*.csv")])
@@ -764,14 +859,14 @@ class FI2TCWindow(tk.Frame):
 
         tree_frame = ttk.Frame(self)
         tree_frame.pack(fill=tk.BOTH, expand=True)
-        style = ttk.Style(self)
-        style.configure("FI2TC.Treeview", rowheight=80)
-        self.tree = ttk.Treeview(
+        configure_table_style("FI2TC.Treeview", rowheight=80)
+        self.tree = EditableTreeview(
             tree_frame,
             columns=self.COLS,
             show="headings",
             style="FI2TC.Treeview",
             height=4,
+            edit_callback=self.on_cell_edit,
         )
         vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
         hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
@@ -1228,6 +1323,11 @@ class FI2TCWindow(tk.Frame):
                 del self.app.fi2tc_entries[idx]
         self.refresh()
 
+    def on_cell_edit(self, row: int, column: str, value: str) -> None:
+        if row >= len(self.app.fi2tc_entries):
+            return
+        self.app.fi2tc_entries[row][column] = value
+
     def export_csv(self):
         path = filedialog.asksaveasfilename(
             defaultextension=".csv", filetypes=[("CSV", "*.csv")]
@@ -1327,7 +1427,14 @@ class HazopWindow(tk.Frame):
         columns = ("function", "malfunction", "type", "safety", "rationale")
         content = ttk.Frame(self)
         content.pack(fill=tk.BOTH, expand=True)
-        self.tree = ttk.Treeview(content, columns=columns, show="headings")
+        configure_table_style("Hazop.Treeview")
+        self.tree = EditableTreeview(
+            content,
+            columns=columns,
+            show="headings",
+            style="Hazop.Treeview",
+            edit_callback=self.on_cell_edit,
+        )
         for col in columns:
             self.tree.heading(col, text=col.capitalize())
             if col in ("rationale", "hazard"):
@@ -1616,6 +1723,26 @@ class HazopWindow(tk.Frame):
                 del self.app.hazop_entries[idx]
         self.refresh()
 
+    def on_cell_edit(self, row: int, column: str, value: str) -> None:
+        if row >= len(self.app.hazop_entries):
+            return
+        entry = self.app.hazop_entries[row]
+        mapping = {
+            "function": "function",
+            "malfunction": "malfunction",
+            "type": "mtype",
+            "safety": "safety",
+            "rationale": "rationale",
+        }
+        attr = mapping.get(column)
+        if not attr:
+            return
+        if attr == "safety":
+            setattr(entry, attr, value.lower() in ("yes", "true", "1"))
+        else:
+            setattr(entry, attr, value)
+        self.refresh()
+
     def load_analysis(self):
         if not self.app.reliability_analyses:
             messagebox.showwarning("Load", "No saved analyses")
@@ -1707,7 +1834,14 @@ class HaraWindow(tk.Frame):
         self.status_lbl = ttk.Label(top, text="")
         self.status_lbl.pack(side=tk.LEFT, padx=10)
 
-        self.tree = ttk.Treeview(self, columns=self.COLS, show="headings")
+        configure_table_style("Hara.Treeview")
+        self.tree = EditableTreeview(
+            self,
+            columns=self.COLS,
+            show="headings",
+            style="Hara.Treeview",
+            edit_callback=self.on_cell_edit,
+        )
         for c in self.COLS:
             self.tree.heading(c, text=c.replace("_", " ").title())
             width = 200 if c == "hazard" else 120
@@ -1998,6 +2132,20 @@ class HaraWindow(tk.Frame):
             self.status_lbl.config(text=f"Status: {self.app.active_hara.status}")
         self.refresh()
 
+    def on_cell_edit(self, row: int, column: str, value: str) -> None:
+        if row >= len(self.app.hara_entries):
+            return
+        entry = self.app.hara_entries[row]
+        if column in self.COLS:
+            if column in {"severity", "controllability", "exposure"}:
+                try:
+                    setattr(entry, column, int(value))
+                except ValueError:
+                    return
+            else:
+                setattr(entry, column, value)
+        self.refresh()
+
     def approve_doc(self):
         if not self.app.active_hara:
             return
@@ -2051,14 +2199,14 @@ class TC2FIWindow(tk.Frame):
             master.geometry("800x400")
         tree_frame = ttk.Frame(self)
         tree_frame.pack(fill=tk.BOTH, expand=True)
-        style = ttk.Style(self)
-        style.configure("TC2FI.Treeview", rowheight=80)
-        self.tree = ttk.Treeview(
+        configure_table_style("TC2FI.Treeview", rowheight=80)
+        self.tree = EditableTreeview(
             tree_frame,
             columns=self.COLS,
             show="headings",
             style="TC2FI.Treeview",
             height=4,
+            edit_callback=self.on_cell_edit,
         )
         vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
         hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
@@ -2553,6 +2701,12 @@ class TC2FIWindow(tk.Frame):
                 del self.app.tc2fi_entries[idx]
         self.refresh()
 
+    def on_cell_edit(self, row: int, column: str, value: str) -> None:
+        if row >= len(self.app.tc2fi_entries):
+            return
+        self.app.tc2fi_entries[row][column] = value
+        self.refresh()
+
     def export_csv(self):
         path = filedialog.asksaveasfilename(
             defaultextension=".csv", filetypes=[("CSV", "*.csv")]
@@ -2635,7 +2789,14 @@ class HazardExplorerWindow(tk.Toplevel):
         self.title("Hazard Explorer")
 
         columns = ("HARA", "Malfunction", "Hazard", "Severity")
-        self.tree = ttk.Treeview(self, columns=columns, show="headings")
+        configure_table_style("HazExp.Treeview")
+        self.tree = EditableTreeview(
+            self,
+            columns=columns,
+            show="headings",
+            style="HazExp.Treeview",
+            edit_callback=self.on_cell_edit,
+        )
         for c in columns:
             self.tree.heading(c, text=c)
             width = 200 if c == "Hazard" else 120
@@ -2668,6 +2829,12 @@ class HazardExplorerWindow(tk.Toplevel):
             for iid in self.tree.get_children():
                 w.writerow(self.tree.item(iid, "values"))
         messagebox.showinfo("Export", "Hazards exported")
+
+    def on_cell_edit(self, row: int, column: str, value: str) -> None:
+        values = list(self.tree.item(self.tree.get_children()[row], "values"))
+        idx = ("HARA", "Malfunction", "Hazard", "Severity").index(column)
+        values[idx] = value
+        self.tree.item(self.tree.get_children()[row], values=values)
 
 
 class RequirementsExplorerWindow(tk.Toplevel):
@@ -2720,7 +2887,14 @@ class RequirementsExplorerWindow(tk.Toplevel):
         tk.Button(filter_frame, text="Apply", command=self.refresh).grid(row=0, column=8, padx=5)
 
         columns = ("ID", "ASIL", "Type", "Status", "Parent", "Text")
-        self.tree = ttk.Treeview(self, columns=columns, show="headings")
+        configure_table_style("ReqExp.Treeview")
+        self.tree = EditableTreeview(
+            self,
+            columns=columns,
+            show="headings",
+            style="ReqExp.Treeview",
+            edit_callback=self.on_cell_edit,
+        )
         for c in columns:
             self.tree.heading(c, text=c)
             width = 100 if c != "Text" else 300
@@ -2767,3 +2941,10 @@ class RequirementsExplorerWindow(tk.Toplevel):
             for iid in self.tree.get_children():
                 w.writerow(self.tree.item(iid, "values"))
         messagebox.showinfo("Export", "Requirements exported")
+
+    def on_cell_edit(self, row: int, column: str, value: str) -> None:
+        values = list(self.tree.item(self.tree.get_children()[row], "values"))
+        idx_map = {"ID":0, "ASIL":1, "Type":2, "Status":3, "Parent":4, "Text":5}
+        if column in idx_map:
+            values[idx_map[column]] = value
+            self.tree.item(self.tree.get_children()[row], values=values)


### PR DESCRIPTION
## Summary
- add helper to configure consistent Treeview styles
- add EditableTreeview class for in-place cell edits
- apply styled, editable tables across analysis windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68879821dde083259aa897e952293fac