### PR TITLE
Enhance table styling

### DIFF
--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -38,19 +38,39 @@ def configure_table_style(style_name: str, rowheight: int = 60) -> None:
         style.theme_use("clam")
     except tk.TclError:
         pass
+    border_opts = {"bordercolor": "black", "borderwidth": 1, "relief": "solid"}
     style.configure(
         style_name,
         font=("Segoe UI", 10),
         rowheight=rowheight,
-        borderwidth=1,
-        relief="solid",
+        **border_opts,
     )
     style.configure(
         f"{style_name}.Heading",
         font=("Segoe UI", 10, "bold"),
         background="#d0d0d0",
-        borderwidth=1,
-        relief="raised",
+        **border_opts,
+    )
+    style.layout(
+        style_name,
+        [
+            (
+                "Treeview.field",
+                {
+                    "sticky": "nswe",
+                    **border_opts,
+                    "children": [
+                        (
+                            "Treeview.padding",
+                            {
+                                "sticky": "nswe",
+                                "children": [("Treeview.treearea", {"sticky": "nswe"})],
+                            },
+                        )
+                    ],
+                },
+            )
+        ],
     )
 
 
@@ -98,6 +118,14 @@ class EditableTreeview(ttk.Treeview):
         widget.bind("<Return>", save)
         widget.bind("<FocusOut>", save)
         self._edit_widget = widget
+
+
+def stripe_rows(tree: ttk.Treeview) -> None:
+    """Apply alternating background colors to rows for visual separation."""
+    tree.tag_configure("even", background="#f0f0f0")
+    tree.tag_configure("odd", background="#ffffff")
+    for i, item in enumerate(tree.get_children("")):
+        tree.item(item, tags=("even" if i % 2 else "odd",))
 
 
 def _total_fit_from_boms(boms):
@@ -904,6 +932,7 @@ class FI2TCWindow(tk.Frame):
         for row in self.app.fi2tc_entries:
             vals = [_wrap_val(row.get(k, "")) for k in self.COLS]
             self.tree.insert("", "end", values=vals)
+        stripe_rows(self.tree)
 
     class RowDialog(simpledialog.Dialog):
         def __init__(self, parent, app, data=None):
@@ -1505,6 +1534,7 @@ class HazopWindow(tk.Frame):
                 row.covered_by,
             ]
             self.tree.insert("", "end", values=vals)
+        stripe_rows(self.tree)
 
     class RowDialog(simpledialog.Dialog):
         def __init__(self, parent, row=None):
@@ -1946,6 +1976,7 @@ class HaraWindow(tk.Frame):
                 row.safety_goal,
             ]
             self.tree.insert("", "end", values=vals)
+        stripe_rows(self.tree)
         self.app.sync_hara_to_safety_goals()
 
     class RowDialog(simpledialog.Dialog):
@@ -2243,6 +2274,7 @@ class TC2FIWindow(tk.Frame):
         for row in self.app.tc2fi_entries:
             vals = [_wrap_val(row.get(k, "")) for k in self.COLS]
             self.tree.insert("", "end", values=vals)
+        stripe_rows(self.tree)
 
     class RowDialog(simpledialog.Dialog):
         def __init__(self, parent, app, data=None):


### PR DESCRIPTION
## Summary
- tweak treeview styles to set a black border
- add helper to stripe rows for readability
- apply striping in FI2TC, HAZOP, HARA and TC2FI refresh functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887a1cff3a08325a234de85f21dbc10