### PR TITLE
Add father option in IBD context menu

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -73,6 +73,11 @@ def _find_parent_blocks(repo: SysMLRepository, block_id: str) -> set[str]:
             parents.add(rel.target)
         elif rel.target == block_id and rel.source in repo.elements:
             parents.add(rel.source)
+    # include father block from internal block diagram linkage
+    diag_id = repo.get_linked_diagram(block_id)
+    diag = repo.diagrams.get(diag_id)
+    if diag and getattr(diag, "father", None) in repo.elements:
+        parents.add(diag.father)
     return parents
 
 
@@ -113,6 +118,52 @@ def extend_block_parts_with_parents(repo: SysMLRepository, block_id: str) -> Non
         for o in getattr(d, "objects", []):
             if o.get("element_id") == block_id:
                 o.setdefault("properties", {})["partProperties"] = joined
+
+
+def inherit_father_parts(repo: SysMLRepository, diagram: SysMLDiagram) -> None:
+    """Copy parts from the diagram's father block into the diagram."""
+    father = getattr(diagram, "father", None)
+    if not father:
+        return
+    father_diag_id = repo.get_linked_diagram(father)
+    father_diag = repo.diagrams.get(father_diag_id)
+    if not father_diag:
+        return
+    diagram.objects = getattr(diagram, "objects", [])
+    existing = {
+        o.get("element_id")
+        for o in diagram.objects
+        if o.get("obj_type") == "Part"
+    }
+    for obj in getattr(father_diag, "objects", []):
+        if obj.get("obj_type") != "Part":
+            continue
+        if obj.get("element_id") in existing:
+            continue
+        new_obj = obj.copy()
+        new_obj["obj_id"] = _get_next_id()
+        diagram.objects.append(new_obj)
+        repo.add_element_to_diagram(diagram.diag_id, obj.get("element_id"))
+    # update child block partProperties with inherited names
+    child_id = next(
+        (eid for eid, did in repo.element_diagrams.items() if did == diagram.diag_id),
+        None,
+    )
+    if child_id and father in repo.elements:
+        child = repo.elements[child_id]
+        father_elem = repo.elements[father]
+        names = [p.strip() for p in child.properties.get("partProperties", "").split(",") if p.strip()]
+        father_names = [p.strip() for p in father_elem.properties.get("partProperties", "").split(",") if p.strip()]
+        for n in father_names:
+            if n not in names:
+                names.append(n)
+        joined = ", ".join(names)
+        child.properties["partProperties"] = joined
+        for d in repo.diagrams.values():
+            for o in getattr(d, "objects", []):
+                if o.get("element_id") == child_id:
+                    o.setdefault("properties", {})["partProperties"] = joined
+        extend_block_parts_with_parents(repo, child_id)
 
 
 @dataclass
@@ -880,6 +931,11 @@ class SysMLDiagramWindow(tk.Frame):
         if not obj:
             conn = self.find_connection(x, y)
             if not conn:
+                diag = self.repo.diagrams.get(self.diagram_id)
+                if diag and diag.diag_type == "Internal Block Diagram":
+                    menu = tk.Menu(self, tearoff=0)
+                    menu.add_command(label="Set Father", command=self._set_diagram_father)
+                    menu.tk_popup(event.x_root, event.y_root)
                 return
         self.selected_obj = obj
         self.selected_conn = conn
@@ -932,6 +988,14 @@ class SysMLDiagramWindow(tk.Frame):
         self._sync_to_repository()
         self.destroy()
         return True
+
+    def _set_diagram_father(self) -> None:
+        diag = self.repo.diagrams.get(self.diagram_id)
+        if not diag or diag.diag_type != "Internal Block Diagram":
+            return
+        DiagramPropertiesDialog(self, diag)
+        self._sync_to_repository()
+        self.redraw()
 
     def go_back(self):
         if not self.diagram_history:
@@ -2588,22 +2652,24 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
             messagebox.showinfo("Add Parts", "No block is linked to this diagram")
             return
         block = repo.elements[block_id]
+        diag = repo.diagrams.get(self.diagram_id)
+        if diag:
+            inherit_father_parts(repo, diag)
         ra_name = block.properties.get("analysis", "")
-        if not ra_name:
-            messagebox.showinfo("Add Parts", "Block has no reliability analysis assigned")
-            return
         analyses = getattr(self.app, "reliability_analyses", [])
         ra_map = {ra.name: ra for ra in analyses}
         ra = ra_map.get(ra_name)
-        if not ra or not ra.components:
+        if ra_name and (not ra or not ra.components):
             messagebox.showinfo("Add Parts", "Analysis has no components")
             return
-        comps = list(ra.components)
+        comps = list(ra.components) if ra_name and ra and ra.components else []
+        if not comps and not getattr(diag, "father", None):
+            messagebox.showinfo("Add Parts", "Block has no reliability analysis assigned")
+            return
         dlg = SysMLObjectDialog.SelectComponentsDialog(self, comps)
         selected = dlg.result or []
         if not selected:
             return
-        diag = repo.diagrams.get(self.diagram_id)
         if diag is None:
             return
         diag.objects = getattr(diag, "objects", [])
@@ -2696,11 +2762,28 @@ class DiagramPropertiesDialog(simpledialog.Dialog):
         ttk.Label(master, text="Color:").grid(row=2, column=0, sticky="e", padx=4, pady=2)
         self.color_var = tk.StringVar(value=getattr(self.diagram, "color", "#FFFFFF"))
         ttk.Entry(master, textvariable=self.color_var).grid(row=2, column=1, padx=4, pady=2)
+        if self.diagram.diag_type == "Internal Block Diagram":
+            repo = SysMLRepository.get_instance()
+            blocks = [e for e in repo.elements.values() if e.elem_type == "Block"]
+            idmap = {b.name or b.elem_id: b.elem_id for b in blocks}
+            ttk.Label(master, text="Father:").grid(row=3, column=0, sticky="e", padx=4, pady=2)
+            self.father_map = idmap
+            cur_id = getattr(self.diagram, "father", "")
+            cur_name = next((n for n, i in idmap.items() if i == cur_id), "")
+            self.father_var = tk.StringVar(value=cur_name)
+            ttk.Combobox(master, textvariable=self.father_var, values=list(idmap.keys())).grid(row=3, column=1, padx=4, pady=2)
+        else:
+            self.father_map = {}
+            self.father_var = tk.StringVar()
 
     def apply(self):
         self.diagram.name = self.name_var.get()
         self.diagram.description = self.desc_var.get()
         self.diagram.color = self.color_var.get()
+        if self.diagram.diag_type == "Internal Block Diagram":
+            father_id = self.father_map.get(self.father_var.get())
+            self.diagram.father = father_id
+            inherit_father_parts(SysMLRepository.get_instance(), self.diagram)
 
 class PackagePropertiesDialog(simpledialog.Dialog):
     """Dialog to edit a package's name."""

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -42,6 +42,7 @@ class SysMLDiagram:
     package: Optional[str] = None
     description: str = ""
     color: str = "#FFFFFF"
+    father: Optional[str] = None
     elements: List[str] = field(default_factory=list)
     relationships: List[str] = field(default_factory=list)
     objects: List[dict] = field(default_factory=list)
@@ -118,6 +119,7 @@ class SysMLRepository:
         package: Optional[str] = None,
         description: str = "",
         color: str = "#FFFFFF",
+        father: Optional[str] = None,
     ) -> SysMLDiagram:
         if diag_id is None:
             diag_id = str(uuid.uuid4())
@@ -141,6 +143,7 @@ class SysMLRepository:
             package,
             description,
             color,
+            father,
             author=CURRENT_USER_NAME,
             modified_by=CURRENT_USER_NAME,
         )

--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -1,7 +1,7 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 import unittest
 from sysml.sysml_repository import SysMLRepository
-from gui.architecture import extend_block_parts_with_parents
+from gui.architecture import extend_block_parts_with_parents, inherit_father_parts
 
 class InheritPartsTests(unittest.TestCase):
     def setUp(self):
@@ -53,6 +53,28 @@ class InheritPartsTests(unittest.TestCase):
         props_b = repo.elements[b.elem_id].properties["partProperties"]
         self.assertIn("b1", props_b)
         self.assertIn("a1", props_b)
+
+    def test_inherit_father_parts(self):
+        repo = self.repo
+        father = repo.create_element("Block", name="Parent", properties={"partProperties": "p1"})
+        child = repo.create_element("Block", name="Child")
+        pf = repo.create_element("Part", name="P1")
+        df = repo.create_diagram("Internal Block Diagram", name="Father")
+        repo.link_diagram(father.elem_id, df.diag_id)
+        df.objects.append({
+            "obj_id": 1,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": pf.elem_id,
+            "properties": {"definition": father.elem_id},
+        })
+        dc = repo.create_diagram("Internal Block Diagram", name="Child")
+        repo.link_diagram(child.elem_id, dc.diag_id)
+        dc.father = father.elem_id
+        inherit_father_parts(repo, dc)
+        self.assertTrue(any(o.get("element_id") == pf.elem_id for o in dc.objects))
+        self.assertIn("p1", repo.elements[child.elem_id].properties.get("partProperties", ""))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expose `Set Father` from the IBD canvas right-click menu
- update internal method to open the properties dialog and apply inheritance
- allow `Add Block Parts` to inherit parts from the father when no analysis exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6887cb803c808325a3d978c8c9583518