### PR TITLE
Add button for inheriting parent parts

### DIFF
--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -42,6 +42,7 @@ class SysMLDiagram:
     package: Optional[str] = None
     description: str = ""
     color: str = "#FFFFFF"
+    father: Optional[str] = None
     elements: List[str] = field(default_factory=list)
     relationships: List[str] = field(default_factory=list)
     objects: List[dict] = field(default_factory=list)
@@ -118,6 +119,7 @@ class SysMLRepository:
         package: Optional[str] = None,
         description: str = "",
         color: str = "#FFFFFF",
+        father: Optional[str] = None,
     ) -> SysMLDiagram:
         if diag_id is None:
             diag_id = str(uuid.uuid4())
@@ -141,6 +143,7 @@ class SysMLRepository:
             package,
             description,
             color,
+            father,
             author=CURRENT_USER_NAME,
             modified_by=CURRENT_USER_NAME,
         )

--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -1,7 +1,7 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 import unittest
 from sysml.sysml_repository import SysMLRepository
-from gui.architecture import extend_block_parts_with_parents
+from gui.architecture import extend_block_parts_with_parents, inherit_father_parts
 
 class InheritPartsTests(unittest.TestCase):
     def setUp(self):
@@ -53,6 +53,28 @@ class InheritPartsTests(unittest.TestCase):
         props_b = repo.elements[b.elem_id].properties["partProperties"]
         self.assertIn("b1", props_b)
         self.assertIn("a1", props_b)
+
+    def test_inherit_father_parts(self):
+        repo = self.repo
+        father = repo.create_element("Block", name="Parent", properties={"partProperties": "p1"})
+        child = repo.create_element("Block", name="Child")
+        pf = repo.create_element("Part", name="P1")
+        df = repo.create_diagram("Internal Block Diagram", name="Father")
+        repo.link_diagram(father.elem_id, df.diag_id)
+        df.objects.append({
+            "obj_id": 1,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": pf.elem_id,
+            "properties": {"definition": father.elem_id},
+        })
+        dc = repo.create_diagram("Internal Block Diagram", name="Child")
+        repo.link_diagram(child.elem_id, dc.diag_id)
+        dc.father = father.elem_id
+        inherit_father_parts(repo, dc)
+        self.assertTrue(any(o.get("element_id") == pf.elem_id for o in dc.objects))
+        self.assertIn("p1", repo.elements[child.elem_id].properties.get("partProperties", ""))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add 'Add Parent Parts' button to internal block diagrams
- implement handler that copies parts from the father block

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6887cb803c808325a3d978c8c9583518