### PR TITLE
Fix parent part inheritance

### DIFF
--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -72,8 +72,9 @@ class InheritPartsTests(unittest.TestCase):
         dc = repo.create_diagram("Internal Block Diagram", name="Child")
         repo.link_diagram(child.elem_id, dc.diag_id)
         dc.father = father.elem_id
-        inherit_father_parts(repo, dc)
+        added = inherit_father_parts(repo, dc)
         self.assertTrue(any(o.get("element_id") == pf.elem_id for o in dc.objects))
+        self.assertTrue(any(o["element_id"] == pf.elem_id for o in added))
         self.assertIn("p1", repo.elements[child.elem_id].properties.get("partProperties", ""))
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- return inherited parts from `inherit_father_parts`
- use returned parts when adding block/parent parts
- show inherited parts after changing a diagram's parent
- test that returned parts list is correct

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887de72b1148325a339d3c40d61bd88