### PR TITLE
Fix parent port direction inheritance

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -120,21 +120,32 @@ def extend_block_parts_with_parents(repo: SysMLRepository, block_id: str) -> Non
                 o.setdefault("properties", {})["partProperties"] = joined
 
 
-def inherit_father_parts(repo: SysMLRepository, diagram: SysMLDiagram) -> None:
-    """Copy parts from the diagram's father block into the diagram."""
+def inherit_father_parts(repo: SysMLRepository, diagram: SysMLDiagram) -> list[dict]:
+    """Copy parts from the diagram's father block into the diagram.
+
+    Returns a list with the inherited object dictionaries (parts and ports)."""
     father = getattr(diagram, "father", None)
     if not father:
-        return
+        return []
     father_diag_id = repo.get_linked_diagram(father)
     father_diag = repo.diagrams.get(father_diag_id)
     if not father_diag:
-        return
+        return []
     diagram.objects = getattr(diagram, "objects", [])
+    added: list[dict] = []
+    # Track existing parts by element id to avoid duplicates
     existing = {
         o.get("element_id")
         for o in diagram.objects
         if o.get("obj_type") == "Part"
     }
+
+    # Map of source part obj_id -> new obj_id so ports can be updated
+    part_map: dict[int, int] = {}
+
+    # ------------------------------------------------------------------
+    # Copy parts from the father diagram
+    # ------------------------------------------------------------------
     for obj in getattr(father_diag, "objects", []):
         if obj.get("obj_type") != "Part":
             continue
@@ -144,6 +155,32 @@ def inherit_father_parts(repo: SysMLRepository, diagram: SysMLDiagram) -> None:
         new_obj["obj_id"] = _get_next_id()
         diagram.objects.append(new_obj)
         repo.add_element_to_diagram(diagram.diag_id, obj.get("element_id"))
+        added.append(new_obj)
+        part_map[obj.get("obj_id")] = new_obj["obj_id"]
+
+    # ------------------------------------------------------------------
+    # Copy ports belonging to the inherited parts so orientation and other
+    # attributes are preserved. Only ports referencing a copied part are
+    # considered.
+    # ------------------------------------------------------------------
+    for obj in getattr(father_diag, "objects", []):
+        if obj.get("obj_type") != "Port":
+            continue
+        parent_id = obj.get("properties", {}).get("parent")
+        if not parent_id:
+            continue
+        try:
+            parent_id_int = int(parent_id)
+        except Exception:
+            continue
+        new_parent = part_map.get(parent_id_int)
+        if not new_parent:
+            continue
+        new_obj = obj.copy()
+        new_obj["obj_id"] = _get_next_id()
+        new_obj.setdefault("properties", {})["parent"] = str(new_parent)
+        diagram.objects.append(new_obj)
+        added.append(new_obj)
     # update child block partProperties with inherited names
     child_id = next(
         (eid for eid, did in repo.element_diagrams.items() if did == diagram.diag_id),
@@ -164,6 +201,7 @@ def inherit_father_parts(repo: SysMLRepository, diagram: SysMLDiagram) -> None:
                 if o.get("element_id") == child_id:
                     o.setdefault("properties", {})["partProperties"] = joined
         extend_block_parts_with_parents(repo, child_id)
+    return added
 
 
 @dataclass
@@ -993,7 +1031,9 @@ class SysMLDiagramWindow(tk.Frame):
         diag = self.repo.diagrams.get(self.diagram_id)
         if not diag or diag.diag_type != "Internal Block Diagram":
             return
-        DiagramPropertiesDialog(self, diag)
+        dlg = DiagramPropertiesDialog(self, diag)
+        for data in getattr(dlg, "added_parts", []):
+            self.objects.append(SysMLObject(**data))
         self._sync_to_repository()
         self.redraw()
 
@@ -2657,7 +2697,9 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
         block = repo.elements[block_id]
         diag = repo.diagrams.get(self.diagram_id)
         if diag:
-            inherit_father_parts(repo, diag)
+            added_parent = inherit_father_parts(repo, diag)
+            for data in added_parent:
+                self.objects.append(SysMLObject(**data))
         ra_name = block.properties.get("analysis", "")
         analyses = getattr(self.app, "reliability_analyses", [])
         ra_map = {ra.name: ra for ra in analyses}
@@ -2734,7 +2776,9 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
         if not diag or not getattr(diag, "father", None):
             messagebox.showinfo("Add Parent Parts", "No father block assigned")
             return
-        inherit_father_parts(repo, diag)
+        added = inherit_father_parts(repo, diag)
+        for data in added:
+            self.objects.append(SysMLObject(**data))
         self.redraw()
         self._sync_to_repository()
 
@@ -2764,6 +2808,7 @@ class DiagramPropertiesDialog(simpledialog.Dialog):
 
     def __init__(self, master, diagram: SysMLDiagram):
         self.diagram = diagram
+        self.added_parts: list[dict] = []
         super().__init__(master, title="Diagram Properties")
 
     def body(self, master):
@@ -2797,7 +2842,9 @@ class DiagramPropertiesDialog(simpledialog.Dialog):
         if self.diagram.diag_type == "Internal Block Diagram":
             father_id = self.father_map.get(self.father_var.get())
             self.diagram.father = father_id
-            inherit_father_parts(SysMLRepository.get_instance(), self.diagram)
+            self.added_parts = inherit_father_parts(
+                SysMLRepository.get_instance(), self.diagram
+            )
 
 class PackagePropertiesDialog(simpledialog.Dialog):
     """Dialog to edit a package's name."""

--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -72,9 +72,64 @@ class InheritPartsTests(unittest.TestCase):
         dc = repo.create_diagram("Internal Block Diagram", name="Child")
         repo.link_diagram(child.elem_id, dc.diag_id)
         dc.father = father.elem_id
-        inherit_father_parts(repo, dc)
+        added = inherit_father_parts(repo, dc)
         self.assertTrue(any(o.get("element_id") == pf.elem_id for o in dc.objects))
+        self.assertTrue(any(o["element_id"] == pf.elem_id for o in added))
         self.assertIn("p1", repo.elements[child.elem_id].properties.get("partProperties", ""))
+
+    def test_inherit_father_parts_copies_ports(self):
+        repo = self.repo
+        father = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        p1 = repo.create_element("Part", name="P1")
+        p2 = repo.create_element("Part", name="P2")
+        df = repo.create_diagram("Internal Block Diagram", name="Father")
+        repo.link_diagram(father.elem_id, df.diag_id)
+        df.objects.extend(
+            [
+                {
+                    "obj_id": 1,
+                    "obj_type": "Part",
+                    "x": 0,
+                    "y": 0,
+                    "element_id": p1.elem_id,
+                    "properties": {"definition": father.elem_id, "ports": "a"},
+                },
+                {
+                    "obj_id": 2,
+                    "obj_type": "Port",
+                    "x": 10,
+                    "y": 0,
+                    "properties": {"parent": "1", "name": "a", "direction": "in"},
+                },
+                {
+                    "obj_id": 3,
+                    "obj_type": "Part",
+                    "x": 40,
+                    "y": 0,
+                    "element_id": p2.elem_id,
+                    "properties": {"definition": father.elem_id, "ports": "b"},
+                },
+                {
+                    "obj_id": 4,
+                    "obj_type": "Port",
+                    "x": 50,
+                    "y": 0,
+                    "properties": {"parent": "3", "name": "b", "direction": "out"},
+                },
+            ]
+        )
+        dc = repo.create_diagram("Internal Block Diagram", name="Child")
+        repo.link_diagram(child.elem_id, dc.diag_id)
+        dc.father = father.elem_id
+        added = inherit_father_parts(repo, dc)
+        ports = [o for o in dc.objects if o.get("obj_type") == "Port"]
+        self.assertEqual(len(ports), 2)
+        dir_map = {p["properties"]["name"]: p["properties"].get("direction") for p in ports}
+        self.assertEqual(dir_map["a"], "in")
+        self.assertEqual(dir_map["b"], "out")
+        port_added = [o for o in added if o.get("obj_type") == "Port"]
+        self.assertEqual(len(port_added), 2)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- copy port objects when inheriting father parts so port attributes persist
- test that inherited ports keep their direction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887de72b1148325a339d3c40d61bd88