### PR TITLE
Fix port cleanup on part deletion

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1869,9 +1869,17 @@ class SysMLDiagramWindow(tk.Frame):
                 self.redraw()
 
     def remove_object(self, obj: SysMLObject) -> None:
+        removed_ids = {obj.obj_id}
         if obj in self.objects:
             self.objects.remove(obj)
-        self.connections = [c for c in self.connections if c.src != obj.obj_id and c.dst != obj.obj_id]
+        if obj.obj_type == "Part":
+            before = {o.obj_id for o in self.objects}
+            remove_orphan_ports(self.objects)
+            removed_ids.update(before - {o.obj_id for o in self.objects})
+        self.connections = [
+            c for c in self.connections
+            if c.src not in removed_ids and c.dst not in removed_ids
+        ]
         diag = self.repo.diagrams.get(self.diagram_id)
         if diag and obj.element_id in diag.elements:
             diag.elements.remove(obj.element_id)

--- a/tests/test_delete_ports_on_part_removal.py
+++ b/tests/test_delete_ports_on_part_removal.py
@@ -1,0 +1,34 @@
+import unittest
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+class DummyWindow:
+    def __init__(self):
+        self.repo = SysMLRepository.get_instance()
+        diag = SysMLDiagram(diag_id="d", diag_type="Internal Block Diagram")
+        self.repo.diagrams[diag.diag_id] = diag
+        self.diagram_id = diag.diag_id
+        self.objects = []
+        self.connections = []
+
+    def _sync_to_repository(self):
+        diag = self.repo.diagrams.get(self.diagram_id)
+        if diag:
+            diag.objects = [obj.__dict__ for obj in self.objects]
+            diag.connections = [conn.__dict__ for conn in self.connections]
+
+class RemovePartPortsTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_ports_removed_with_part(self):
+        win = DummyWindow()
+        part = SysMLObject(1, "Part", 0, 0)
+        port = SysMLObject(2, "Port", 0, 0, properties={"parent": "1"})
+        win.objects = [part, port]
+        SysMLDiagramWindow.remove_object(win, part)
+        self.assertNotIn(port, win.objects)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove orphaned ports when a `Part` object is deleted
- test that ports are removed along with their parent part

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6887e116c2fc8325a655772baba7730e