### PR TITLE
Add property viewer and fix metadata author defaults

### DIFF
--- a/analysis/models.py
+++ b/analysis/models.py
@@ -1,6 +1,7 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 from dataclasses import dataclass, field
 import datetime
+from analysis.user_config import CURRENT_USER_NAME
 
 
 @dataclass
@@ -8,9 +9,9 @@ class Metadata:
     """Track creation and modification info."""
 
     created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    author: str = ""
+    author: str = field(default_factory=lambda: CURRENT_USER_NAME)
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    modified_by: str = ""
+    modified_by: str = field(default_factory=lambda: CURRENT_USER_NAME)
 
 @dataclass
 class MissionProfile:

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -17,9 +17,9 @@ class SysMLElement:
     stereotypes: Dict[str, str] = field(default_factory=dict)
     owner: Optional[str] = None
     created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    author: str = CURRENT_USER_NAME
+    author: str = field(default_factory=lambda: CURRENT_USER_NAME)
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    modified_by: str = CURRENT_USER_NAME
+    modified_by: str = field(default_factory=lambda: CURRENT_USER_NAME)
 
 @dataclass
 class SysMLRelationship:
@@ -30,9 +30,9 @@ class SysMLRelationship:
     stereotype: Optional[str] = None
     properties: Dict[str, str] = field(default_factory=dict)
     created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    author: str = CURRENT_USER_NAME
+    author: str = field(default_factory=lambda: CURRENT_USER_NAME)
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    modified_by: str = CURRENT_USER_NAME
+    modified_by: str = field(default_factory=lambda: CURRENT_USER_NAME)
 
 @dataclass
 class SysMLDiagram:
@@ -48,9 +48,9 @@ class SysMLDiagram:
     objects: List[dict] = field(default_factory=list)
     connections: List[dict] = field(default_factory=list)
     created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    author: str = CURRENT_USER_NAME
+    author: str = field(default_factory=lambda: CURRENT_USER_NAME)
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    modified_by: str = CURRENT_USER_NAME
+    modified_by: str = field(default_factory=lambda: CURRENT_USER_NAME)
 
 class SysMLRepository:
     """Singleton repository for all AutoML elements and relationships."""


### PR DESCRIPTION
## Summary
- show selected object properties and metadata in diagrams
- ensure author metadata uses current user at creation time
- sync changes across cut, paste, delete, etc.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888a5bc61408325b862d6d77661c1f1