### PR TITLE
Fix generalization connection tool

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -558,6 +558,7 @@ class SysMLDiagramWindow(tk.Frame):
                     "Flow",
                     "Connector",
                     "Generalize",
+                    "Generalization",
                     "Communication Path",
                 )
                 else "tcross"
@@ -581,6 +582,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Flow",
             "Connector",
             "Generalize",
+            "Generalization",
             "Communication Path",
         ):
             if src == dst:
@@ -707,6 +709,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Flow",
             "Connector",
             "Generalize",
+            "Generalization",
             "Communication Path",
         ):
             if self.start is None:
@@ -720,7 +723,9 @@ class SysMLDiagramWindow(tk.Frame):
                 if obj and obj != self.start:
                     valid, msg = self.validate_connection(self.start, obj, t)
                     if valid:
-                        arrow_default = "forward" if t in ("Flow", "Generalize") else "none"
+                        arrow_default = (
+                            "forward" if t in ("Flow", "Generalize", "Generalization") else "none"
+                        )
                         conn = DiagramConnection(
                             self.start.obj_id,
                             obj.obj_id,


### PR DESCRIPTION
## Summary
- recognize the **Generalization** tool as a connector instead of an element
- include the connector in cursor/validation logic
- ensure newly drawn Generalizations get a default forward arrow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888a71af858832595a95a081a93c295