### PR TITLE
Fix generalization arrow style

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2243,10 +2243,13 @@ class SysMLDiagramWindow(tk.Frame):
             if backward:
                 self._draw_open_arrow(points[1], points[0], color=color, width=width)
         elif conn.conn_type in ("Generalize", "Generalization"):
+            # SysML uses an open triangular arrow head for generalization
+            # relationships. Use the open arrow drawing helper so the arrow
+            # interior matches the canvas background (typically white).
             if forward:
-                self._draw_filled_arrow(points[-2], points[-1], color=color, width=width)
+                self._draw_open_arrow(points[-2], points[-1], color=color, width=width)
             if backward:
-                self._draw_filled_arrow(points[1], points[0], color=color, width=width)
+                self._draw_open_arrow(points[1], points[0], color=color, width=width)
         if conn.mid_arrow:
             mid_idx = len(points) // 2
             if mid_idx > 0:


### PR DESCRIPTION
## Summary
- follow SysML standard for Generalization arrows by using an open triangular head

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888ad38c0e88325b07f83e6bd36a66f