### PR TITLE
Implement port flow arrows and direction checks

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -661,6 +661,15 @@ class SysMLDiagramWindow(tk.Frame):
                     "Part",
                 ):
                     return False, "Connectors must link Parts or Ports"
+                if src.obj_type == "Port" and dst.obj_type == "Port":
+                    src_dir = src.properties.get("direction")
+                    dst_dir = dst.properties.get("direction")
+                    if {src_dir, dst_dir} == {"in", "out"}:
+                        return False, "Ports must have compatible directions"
+                    s_flow = src.properties.get("flow")
+                    d_flow = dst.properties.get("flow")
+                    if s_flow and d_flow and s_flow != d_flow:
+                        return False, "Connected ports must use the same flow"
 
         elif diag_type == "Activity Diagram":
             # Basic control flow rules
@@ -2247,7 +2256,16 @@ class SysMLDiagramWindow(tk.Frame):
                 self._draw_filled_arrow(points[-2], points[-1], color=color, width=width)
             if backward:
                 self._draw_filled_arrow(points[1], points[0], color=color, width=width)
-        if conn.mid_arrow:
+        flow_port = None
+        flow_name = ""
+        if a.obj_type == "Port" and a.properties.get("flow"):
+            flow_port = a
+            flow_name = a.properties.get("flow", "")
+        elif b.obj_type == "Port" and b.properties.get("flow"):
+            flow_port = b
+            flow_name = b.properties.get("flow", "")
+
+        if conn.mid_arrow or flow_port:
             mid_idx = len(points) // 2
             if mid_idx > 0:
                 mstart = points[mid_idx - 1]
@@ -2278,6 +2296,48 @@ class SysMLDiagramWindow(tk.Frame):
                             fill=color,
                             width=width,
                         )
+                if flow_port:
+                    direction = flow_port.properties.get("direction", "")
+                    if flow_port is b:
+                        direction = "in" if direction == "out" else "out" if direction == "in" else direction
+                    if direction == "inout":
+                        self.canvas.create_line(
+                            mstart[0],
+                            mstart[1],
+                            mend[0],
+                            mend[1],
+                            arrow=tk.BOTH,
+                            fill=color,
+                            width=width,
+                        )
+                    elif direction == "in":
+                        self.canvas.create_line(
+                            mend[0],
+                            mend[1],
+                            mstart[0],
+                            mstart[1],
+                            arrow=tk.LAST,
+                            fill=color,
+                            width=width,
+                        )
+                    else:
+                        self.canvas.create_line(
+                            mstart[0],
+                            mstart[1],
+                            mend[0],
+                            mend[1],
+                            arrow=tk.LAST,
+                            fill=color,
+                            width=width,
+                        )
+                    mx = (mstart[0] + mend[0]) / 2
+                    my = (mstart[1] + mend[1]) / 2
+                    self.canvas.create_text(
+                        mx,
+                        my - 10 * self.zoom,
+                        text=flow_name,
+                        font=self.font,
+                    )
         if selected:
             if conn.style == "Custom":
                 for px, py in conn.points:

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -4,7 +4,9 @@ from gui.architecture import (
     SysMLObject,
     remove_orphan_ports,
     update_ports_for_part,
+    SysMLDiagramWindow,
 )
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
 
 class PortParentTests(unittest.TestCase):
     def test_remove_orphan_ports(self):
@@ -34,6 +36,26 @@ class PortParentTests(unittest.TestCase):
         part.width = 100
         update_ports_for_part(part, objs)
         self.assertEqual(port.x, part.x + part.width / 2)
+
+
+class DirectionValidationTests(unittest.TestCase):
+    class DummyWindow:
+        def __init__(self):
+            self.repo = SysMLRepository.get_instance()
+            diag = SysMLDiagram(diag_id="d", diag_type="Internal Block Diagram")
+            self.repo.diagrams[diag.diag_id] = diag
+            self.diagram_id = diag.diag_id
+
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_incompatible_directions(self):
+        win = self.DummyWindow()
+        src = SysMLObject(1, "Port", 0, 0, properties={"direction": "out"})
+        dst = SysMLObject(2, "Port", 0, 0, properties={"direction": "in"})
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Connector")
+        self.assertFalse(valid)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- render flow arrows with label on connectors when connecting ports
- disallow connectors between ports with opposite directions or mismatched flow names
- validate incompatible directions in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888ade5e1248325a5ac1fa1b62d0e64