### PR TITLE
Add multi-user selection dialog

### DIFF
--- a/analysis/user_config.py
+++ b/analysis/user_config.py
@@ -6,17 +6,57 @@ CONFIG_PATH = Path.home() / ".automl.ini"
 CURRENT_USER_NAME = ""
 CURRENT_USER_EMAIL = ""
 
-def load_user_config():
+def load_all_users() -> dict:
+    """Return a dictionary mapping user names to emails."""
     parser = configparser.ConfigParser()
     if CONFIG_PATH.exists():
         parser.read(CONFIG_PATH)
-    name = parser.get('user', 'name', fallback='')
-    email = parser.get('user', 'email', fallback='')
-    return name, email
+    users = {}
+    if parser.has_section('users'):
+        users = dict(parser.items('users'))
+    elif parser.has_section('user'):  # backward compatibility
+        name = parser.get('user', 'name', fallback='')
+        email = parser.get('user', 'email', fallback='')
+        if name and email:
+            users[name] = email
+    return users
+
+def get_last_user() -> str:
+    parser = configparser.ConfigParser()
+    if CONFIG_PATH.exists():
+        parser.read(CONFIG_PATH)
+    return parser.get('current', 'name', fallback='')
+
+def load_user_config():
+    users = load_all_users()
+    last = get_last_user()
+    if last and last in users:
+        return last, users[last]
+    if users:
+        name = next(iter(users))
+        return name, users[name]
+    return "", ""
 
 def save_user_config(name: str, email: str) -> None:
     parser = configparser.ConfigParser()
-    parser['user'] = {'name': name, 'email': email}
+    if CONFIG_PATH.exists():
+        parser.read(CONFIG_PATH)
+    if 'users' not in parser:
+        parser['users'] = {}
+    parser['users'][name] = email
+    if 'current' not in parser:
+        parser['current'] = {}
+    parser['current']['name'] = name
+    with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
+        parser.write(f)
+
+def set_last_user(name: str) -> None:
+    parser = configparser.ConfigParser()
+    if CONFIG_PATH.exists():
+        parser.read(CONFIG_PATH)
+    if 'current' not in parser:
+        parser['current'] = {}
+    parser['current']['name'] = name
     with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
         parser.write(f)
 


### PR DESCRIPTION
## Summary
- track multiple users in `.automl.ini`
- provide `UserSelectDialog` to pick an existing user
- allow adding new users and store the last used
- use selected user as author metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888ae8db3e48325b0eac7cfeb2bc532