### PR TITLE
Add author email to metadata

### DIFF
--- a/analysis/models.py
+++ b/analysis/models.py
@@ -1,7 +1,7 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 from dataclasses import dataclass, field
 import datetime
-from analysis.user_config import CURRENT_USER_NAME
+from analysis.user_config import CURRENT_USER_NAME, CURRENT_USER_EMAIL
 
 
 @dataclass
@@ -10,8 +10,10 @@ class Metadata:
 
     created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
     author: str = field(default_factory=lambda: CURRENT_USER_NAME)
+    author_email: str = field(default_factory=lambda: CURRENT_USER_EMAIL)
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
     modified_by: str = field(default_factory=lambda: CURRENT_USER_NAME)
+    modified_by_email: str = field(default_factory=lambda: CURRENT_USER_EMAIL)
 
 @dataclass
 class MissionProfile:

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field, asdict
 from typing import Dict, List, Optional
 import os
 import datetime
-from analysis.user_config import CURRENT_USER_NAME
+import analysis.user_config as user_config
 
 @dataclass
 class SysMLElement:
@@ -17,9 +17,11 @@ class SysMLElement:
     stereotypes: Dict[str, str] = field(default_factory=dict)
     owner: Optional[str] = None
     created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    author: str = field(default_factory=lambda: CURRENT_USER_NAME)
+    author: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
+    author_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    modified_by: str = field(default_factory=lambda: CURRENT_USER_NAME)
+    modified_by: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
+    modified_by_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
 
 @dataclass
 class SysMLRelationship:
@@ -30,9 +32,11 @@ class SysMLRelationship:
     stereotype: Optional[str] = None
     properties: Dict[str, str] = field(default_factory=dict)
     created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    author: str = field(default_factory=lambda: CURRENT_USER_NAME)
+    author: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
+    author_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    modified_by: str = field(default_factory=lambda: CURRENT_USER_NAME)
+    modified_by: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
+    modified_by_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
 
 @dataclass
 class SysMLDiagram:
@@ -48,9 +52,11 @@ class SysMLDiagram:
     objects: List[dict] = field(default_factory=list)
     connections: List[dict] = field(default_factory=list)
     created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    author: str = field(default_factory=lambda: CURRENT_USER_NAME)
+    author: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
+    author_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
-    modified_by: str = field(default_factory=lambda: CURRENT_USER_NAME)
+    modified_by: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
+    modified_by_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
 
 class SysMLRepository:
     """Singleton repository for all AutoML elements and relationships."""
@@ -68,19 +74,22 @@ class SysMLRepository:
         elem = self.elements.get(elem_id)
         if elem:
             elem.modified = datetime.datetime.now().isoformat()
-            elem.modified_by = CURRENT_USER_NAME
+            elem.modified_by = user_config.CURRENT_USER_NAME
+            elem.modified_by_email = user_config.CURRENT_USER_EMAIL
 
     def touch_diagram(self, diag_id: str) -> None:
         diag = self.diagrams.get(diag_id)
         if diag:
             diag.modified = datetime.datetime.now().isoformat()
-            diag.modified_by = CURRENT_USER_NAME
+            diag.modified_by = user_config.CURRENT_USER_NAME
+            diag.modified_by_email = user_config.CURRENT_USER_EMAIL
 
     def touch_relationship(self, rel_id: str) -> None:
         rel = next((r for r in self.relationships if r.rel_id == rel_id), None)
         if rel:
             rel.modified = datetime.datetime.now().isoformat()
-            rel.modified_by = CURRENT_USER_NAME
+            rel.modified_by = user_config.CURRENT_USER_NAME
+            rel.modified_by_email = user_config.CURRENT_USER_EMAIL
 
     @classmethod
     def get_instance(cls) -> "SysMLRepository":
@@ -96,8 +105,10 @@ class SysMLRepository:
             name,
             properties or {},
             owner=owner,
-            author=CURRENT_USER_NAME,
-            modified_by=CURRENT_USER_NAME,
+            author=user_config.CURRENT_USER_NAME,
+            author_email=user_config.CURRENT_USER_EMAIL,
+            modified_by=user_config.CURRENT_USER_NAME,
+            modified_by_email=user_config.CURRENT_USER_EMAIL,
         )
         self.elements[elem_id] = elem
         return elem
@@ -144,8 +155,10 @@ class SysMLRepository:
             description,
             color,
             father,
-            author=CURRENT_USER_NAME,
-            modified_by=CURRENT_USER_NAME,
+            author=user_config.CURRENT_USER_NAME,
+            author_email=user_config.CURRENT_USER_EMAIL,
+            modified_by=user_config.CURRENT_USER_NAME,
+            modified_by_email=user_config.CURRENT_USER_EMAIL,
         )
         self.diagrams[diag_id] = diagram
         return diagram
@@ -240,8 +253,10 @@ class SysMLRepository:
             target,
             stereotype,
             properties or {},
-            author=CURRENT_USER_NAME,
-            modified_by=CURRENT_USER_NAME,
+            author=user_config.CURRENT_USER_NAME,
+            author_email=user_config.CURRENT_USER_EMAIL,
+            modified_by=user_config.CURRENT_USER_NAME,
+            modified_by_email=user_config.CURRENT_USER_EMAIL,
         )
         self.relationships.append(rel)
         return rel

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -4,10 +4,12 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from sysml.sysml_repository import SysMLRepository
+from analysis.user_config import set_current_user
 
 class RepositoryTests(unittest.TestCase):
     def setUp(self):
         SysMLRepository._instance = None
+        set_current_user("Test User", "test@example.com")
         self.repo = SysMLRepository.get_instance()
 
     def test_create_elements(self):
@@ -23,6 +25,17 @@ class RepositoryTests(unittest.TestCase):
         rel = self.repo.create_relationship("Association", a.elem_id, b.elem_id)
         self.assertEqual(rel.source, a.elem_id)
         self.assertEqual(rel.target, b.elem_id)
+
+    def test_author_metadata(self):
+        elem = self.repo.create_element("Block", name="Engine")
+        diag = self.repo.create_diagram("Block Diagram", name="BD")
+        rel = self.repo.create_relationship("Association", elem.elem_id, diag.diag_id)
+        self.assertEqual(elem.author, "Test User")
+        self.assertEqual(elem.author_email, "test@example.com")
+        self.assertEqual(elem.modified_by, "Test User")
+        self.assertEqual(elem.modified_by_email, "test@example.com")
+        self.assertEqual(diag.author_email, "test@example.com")
+        self.assertEqual(rel.author_email, "test@example.com")
 
     def test_serialize(self):
         blk = self.repo.create_element("Block", name="Car")


### PR DESCRIPTION
## Summary
- track the current user's email alongside their name when elements, diagrams, and relationships are created or modified
- include email fields in analysis metadata
- update unit tests for repository to confirm author metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888b1a9cbd48325ba8b1ca02c24f984