### PR TITLE
Render direction triangles for flow connectors

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -682,7 +682,10 @@ class SysMLDiagramWindow(tk.Frame):
                         return None
                     new_dir_a = "out" if dir_a == "out" else "in"
                     new_dir_b = "out" if dir_b == "out" else "in"
-                    for c in self.connections:
+                    connections = getattr(self, "connections", None)
+                    if connections is None:
+                        return False, "Inconsistent data flow on port"
+                    for c in connections:
                         if c.conn_type != "Connector":
                             continue
                         if src.obj_id in (c.src, c.dst):
@@ -2375,23 +2378,17 @@ class SysMLDiagramWindow(tk.Frame):
                         self._draw_open_arrow(mend, mstart, color=color, width=width)
                 else:
                     if mid_forward or not mid_backward:
-                        self.canvas.create_line(
-                            mstart[0],
-                            mstart[1],
-                            mend[0],
-                            mend[1],
-                            arrow=tk.LAST,
-                            fill=color,
+                        self._draw_filled_arrow(
+                            mstart,
+                            mend,
+                            color=color,
                             width=width,
                         )
                     if mid_backward:
-                        self.canvas.create_line(
-                            mend[0],
-                            mend[1],
-                            mstart[0],
-                            mstart[1],
-                            arrow=tk.LAST,
-                            fill=color,
+                        self._draw_filled_arrow(
+                            mend,
+                            mstart,
+                            color=color,
                             width=width,
                         )
                 if flow_port:
@@ -2399,33 +2396,30 @@ class SysMLDiagramWindow(tk.Frame):
                     if flow_port is b:
                         direction = "in" if direction == "out" else "out" if direction == "in" else direction
                     if direction == "inout":
-                        self.canvas.create_line(
-                            mstart[0],
-                            mstart[1],
-                            mend[0],
-                            mend[1],
-                            arrow=tk.BOTH,
-                            fill=color,
+                        self._draw_filled_arrow(
+                            mstart,
+                            mend,
+                            color=color,
+                            width=width,
+                        )
+                        self._draw_filled_arrow(
+                            mend,
+                            mstart,
+                            color=color,
                             width=width,
                         )
                     elif direction == "in":
-                        self.canvas.create_line(
-                            mend[0],
-                            mend[1],
-                            mstart[0],
-                            mstart[1],
-                            arrow=tk.LAST,
-                            fill=color,
+                        self._draw_filled_arrow(
+                            mend,
+                            mstart,
+                            color=color,
                             width=width,
                         )
                     else:
-                        self.canvas.create_line(
-                            mstart[0],
-                            mstart[1],
-                            mend[0],
-                            mend[1],
-                            arrow=tk.LAST,
-                            fill=color,
+                        self._draw_filled_arrow(
+                            mstart,
+                            mend,
+                            color=color,
                             width=width,
                         )
                     mx = (mstart[0] + mend[0]) / 2


### PR DESCRIPTION
## Summary
- show filled triangular flow direction indicators on connector midpoints
- handle cases where connections list isn't provided during validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888b4d011f48325a4ee1f641d980a5f