### PR TITLE
Fix dashed line preview for all connections

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2029,6 +2029,10 @@ class SysMLDiagramWindow(tk.Frame):
                 "Flow",
                 "Connector",
                 "Generalization",
+                "Generalize",
+                "Communication Path",
+                "Aggregation",
+                "Composite Aggregation",
             )
         ):
             sx, sy = self.edge_point(self.start, *self.temp_line_end)


### PR DESCRIPTION
## Summary
- show temporary dashed line while drawing Aggregation, Composite Aggregation, Generalize and Communication Path connections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888bca59fa883259b29c3c77050fef5