### PR TITLE
Implement Add Contained Parts

### DIFF
--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -6,6 +6,7 @@ from gui.architecture import (
     inherit_father_parts,
     inherit_block_properties,
     remove_inherited_block_properties,
+    _sync_ibd_partproperty_parts,
 )
 
 class InheritPartsTests(unittest.TestCase):
@@ -194,6 +195,23 @@ class InheritPartsTests(unittest.TestCase):
         props = repo.elements[child.elem_id].properties
         self.assertIn("a2", props.get("valueProperties", ""))
         self.assertNotIn("a1", props.get("valueProperties", ""))
+
+    def test_sync_partproperty_parts(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "B"})
+        part_blk = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+        added = _sync_ibd_partproperty_parts(repo, blk.elem_id)
+        self.assertTrue(
+            any(
+                o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part_blk.elem_id
+                for o in ibd.objects
+            )
+        )
+        self.assertTrue(
+            any(d.get("properties", {}).get("definition") == part_blk.elem_id for d in added)
+        )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- rename *Add Inherited Parts* button and feature to **Add Contained Parts**
- support adding parts from `partProperties` through new helper
- update GUI logic and messages
- test syncing parts from block properties

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888c45ec33883258cb2fdb5b27a4bbc