### PR TITLE
Remove block value/reference/constraint props, allow editing lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,9 @@ classDiagram
 The repository tracks each element by its specific type rather than using the
 generic `SysMLElement` placeholder. Key classes include:
 
-- **BlockUsage** – structural block definition. Properties: `valueProperties`,
-  `partProperties`, `referenceProperties`, `ports`, `constraintProperties`,
-  `operations`, plus reliability attributes `analysis`, `fit`, `qualification`
-  and `failureModes`.
+- **BlockUsage** – structural block definition. Properties: `partProperties`,
+  `ports`, `operations`, plus reliability attributes `analysis`, `fit`,
+  `qualification` and `failureModes`.
 - **PartUsage** – internal part with `component`, `failureModes` and `asil`
   fields for BOM links and safety ratings.
 - **PortUsage** – port on a block or part. Provides `direction`, `flow`,

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2167,9 +2167,7 @@ class SysMLDiagramWindow(tk.Frame):
     def _block_compartments(self, obj: SysMLObject) -> list[tuple[str, str]]:
         """Return the list of compartments displayed for a Block."""
         return [
-            ("Attributes", obj.properties.get("valueProperties", "")),
             ("Parts", obj.properties.get("partProperties", "")),
-            ("References", obj.properties.get("referenceProperties", "")),
             (
                 "Operations",
                 "; ".join(
@@ -2177,7 +2175,6 @@ class SysMLDiagramWindow(tk.Frame):
                     for op in parse_operations(obj.properties.get("operations", ""))
                 ),
             ),
-            ("Constraints", obj.properties.get("constraintProperties", "")),
             ("Ports", obj.properties.get("ports", "")),
             (
                 "Reliability",
@@ -2671,9 +2668,7 @@ class SysMLDiagramWindow(tk.Frame):
                 font=self.font,
             )
             compartments = [
-                ("Attributes", obj.properties.get("valueProperties", "")),
                 ("Parts", obj.properties.get("partProperties", "")),
-                ("References", obj.properties.get("referenceProperties", "")),
                 (
                     "Operations",
                     "; ".join(
@@ -2681,7 +2676,6 @@ class SysMLDiagramWindow(tk.Frame):
                         for op in parse_operations(obj.properties.get("operations", ""))
                     ),
                 ),
-                ("Constraints", obj.properties.get("constraintProperties", "")),
                 ("Ports", obj.properties.get("ports", "")),
                 (
                     "Reliability",
@@ -3301,12 +3295,10 @@ class SysMLObjectDialog(simpledialog.Dialog):
         list_props = {
             "ports",
             "partProperties",
-            "referenceProperties",
-            "valueProperties",
-            "constraintProperties",
             "operations",
             "failureModes",
         }
+        editable_list_props = {"ports", "partProperties"}
         reliability_props = {
             "analysis",
             "component",
@@ -3345,6 +3337,13 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 ttk.Button(btnf, text="Add", command=lambda p=prop: self.add_list_item(p)).pack(
                     side=tk.TOP
                 )
+                if prop in editable_list_props:
+                    if prop == "ports":
+                        ttk.Button(btnf, text="Edit", command=self.edit_port).pack(side=tk.TOP)
+                    else:
+                        ttk.Button(
+                            btnf, text="Edit", command=lambda p=prop: self.edit_list_item(p)
+                        ).pack(side=tk.TOP)
                 ttk.Button(
                     btnf, text="Remove", command=lambda p=prop: self.remove_list_item(p)
                 ).pack(side=tk.TOP)
@@ -3598,6 +3597,18 @@ class SysMLObjectDialog(simpledialog.Dialog):
         for idx in reversed(sel):
             self.listboxes["ports"].delete(idx)
 
+    def edit_port(self):
+        lb = self.listboxes["ports"]
+        sel = lb.curselection()
+        if not sel:
+            return
+        idx = sel[0]
+        cur = lb.get(idx)
+        name = simpledialog.askstring("Port", "Name:", initialvalue=cur, parent=self)
+        if name:
+            lb.delete(idx)
+            lb.insert(idx, name)
+
     def add_list_item(self, prop: str):
         val = simpledialog.askstring(prop, "Value:", parent=self)
         if val:
@@ -3608,6 +3619,18 @@ class SysMLObjectDialog(simpledialog.Dialog):
         sel = list(lb.curselection())
         for idx in reversed(sel):
             lb.delete(idx)
+
+    def edit_list_item(self, prop: str):
+        lb = self.listboxes[prop]
+        sel = lb.curselection()
+        if not sel:
+            return
+        idx = sel[0]
+        cur = lb.get(idx)
+        val = simpledialog.askstring(prop, "Value:", initialvalue=cur, parent=self)
+        if val:
+            lb.delete(idx)
+            lb.insert(idx, val)
 
     class OperationDialog(simpledialog.Dialog):
         def __init__(self, parent, operation=None):

--- a/sysml/sysml_spec.py
+++ b/sysml/sysml_spec.py
@@ -29,11 +29,8 @@ def load_sysml_properties():
 SYSML_PROPERTIES = load_sysml_properties()
 if 'BlockUsage' not in SYSML_PROPERTIES:
     SYSML_PROPERTIES['BlockUsage'] = [
-        'valueProperties',
         'partProperties',
-        'referenceProperties',
         'ports',
-        'constraintProperties',
         'operations',
     ]
 if 'PortUsage' not in SYSML_PROPERTIES:

--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -147,21 +147,20 @@ class InheritPartsTests(unittest.TestCase):
         parent = repo.create_element(
             "Block",
             name="Parent",
-            properties={"partProperties": "p1", "valueProperties": "a1"},
+            properties={"partProperties": "p1"},
         )
         child = repo.create_element("Block", name="Child")
         repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
         inherit_block_properties(repo, child.elem_id)
         props = repo.elements[child.elem_id].properties
         self.assertIn("p1", props.get("partProperties", ""))
-        self.assertIn("a1", props.get("valueProperties", ""))
 
     def test_remove_generalization_clears_properties(self):
         repo = self.repo
         parent = repo.create_element(
             "Block",
             name="Parent",
-            properties={"partProperties": "p1", "valueProperties": "a1"},
+            properties={"partProperties": "p1"},
         )
         child = repo.create_element("Block", name="Child")
         rel = repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
@@ -171,19 +170,18 @@ class InheritPartsTests(unittest.TestCase):
         inherit_block_properties(repo, child.elem_id)
         props = repo.elements[child.elem_id].properties
         self.assertNotIn("p1", props.get("partProperties", ""))
-        self.assertNotIn("a1", props.get("valueProperties", ""))
 
     def test_reroute_generalization_updates_properties(self):
         repo = self.repo
         parent1 = repo.create_element(
             "Block",
             name="Parent1",
-            properties={"valueProperties": "a1"},
+            properties={"partProperties": "p1"},
         )
         parent2 = repo.create_element(
             "Block",
             name="Parent2",
-            properties={"valueProperties": "a2"},
+            properties={"partProperties": "p2"},
         )
         child = repo.create_element("Block", name="Child")
         rel = repo.create_relationship("Generalization", child.elem_id, parent1.elem_id)
@@ -192,8 +190,8 @@ class InheritPartsTests(unittest.TestCase):
         rel.target = parent2.elem_id
         inherit_block_properties(repo, child.elem_id)
         props = repo.elements[child.elem_id].properties
-        self.assertIn("a2", props.get("valueProperties", ""))
-        self.assertNotIn("a1", props.get("valueProperties", ""))
+        self.assertIn("p2", props.get("partProperties", ""))
+        self.assertNotIn("p1", props.get("partProperties", ""))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rename_block.py
+++ b/tests/test_rename_block.py
@@ -38,16 +38,16 @@ class RenameBlockTests(unittest.TestCase):
         parent = repo.create_element(
             "Block",
             name="Parent",
-            properties={"valueProperties": "a"},
+            properties={"partProperties": "a"},
         )
         child = repo.create_element("Block", name="Child")
         repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
         inherit_block_properties(repo, child.elem_id)
-        parent.properties["valueProperties"] = "b"
+        parent.properties["partProperties"] = "b"
         rename_block(repo, parent.elem_id, "ParentNew")
         self.assertIn(
             "b",
-            repo.elements[child.elem_id].properties.get("valueProperties", ""),
+            repo.elements[child.elem_id].properties.get("partProperties", ""),
         )
 
 


### PR DESCRIPTION
## Summary
- simplify SysML spec for `BlockUsage` by removing `valueProperties`, `referenceProperties` and `constraintProperties`
- update block drawing and property dialogs accordingly
- enable editing of `partProperties` and `ports` lists
- refresh docs about block properties
- adjust tests for the new property set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888c654d15483258737d58a2f1c4da3