### PR TITLE
Ensure composite parts persist in diagrams

### DIFF
--- a/tests/test_composite_aggregation.py
+++ b/tests/test_composite_aggregation.py
@@ -3,6 +3,7 @@ from gui.architecture import (
     add_composite_aggregation_part,
     remove_aggregation_part,
     set_ibd_father,
+    _sync_ibd_composite_parts,
 )
 from sysml.sysml_repository import SysMLRepository
 
@@ -83,6 +84,32 @@ class CompositeAggregationTests(unittest.TestCase):
             o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
         )
         self.assertTrue(obj.get("locked"))
+
+    def test_sync_composite_parts_relocks_and_restores(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Composite Aggregation", whole.elem_id, part.elem_id)
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        # manually add part object without lock
+        pe = repo.create_element("Part", properties={"definition": part.elem_id})
+        repo.add_element_to_diagram(ibd.diag_id, pe.elem_id)
+        ibd.objects.append({
+            "obj_id": 1,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": pe.elem_id,
+            "properties": {"definition": part.elem_id},
+        })
+        _sync_ibd_composite_parts(repo, whole.elem_id)
+        obj = ibd.objects[0]
+        self.assertTrue(obj.get("locked"))
+        ibd.objects.clear()
+        added = _sync_ibd_composite_parts(repo, whole.elem_id)
+        self.assertTrue(any(o.get("properties", {}).get("definition") == part.elem_id for o in ibd.objects))
+        self.assertTrue(all(d.get("locked") for d in added))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- lock existing composite parts on sync
- auto sync composite and inherited parts when opening an IBD
- test that sync relocks existing parts and recreates deleted ones

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888d2a47f188325b34d22ab2fb788e6