### PR TITLE
Populate partDefinition for aggregated parts

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -273,7 +273,11 @@ def add_composite_aggregation_part(
             part_elem = repo.create_element(
                 "Part",
                 name=repo.elements.get(part_id).name or part_id,
-                properties={"definition": part_id, "force_ibd": "true"},
+                properties={
+                    "definition": part_id,
+                    "force_ibd": "true",
+                    "partDefinition": repo.elements.get(part_id).name or part_id,
+                },
                 owner=repo.root_package.elem_id,
             )
             rel.properties["part_elem"] = part_elem.elem_id
@@ -294,11 +298,18 @@ def add_composite_aggregation_part(
     if rel and rel.properties.get("part_elem") and rel.properties["part_elem"] in repo.elements:
         part_elem = repo.elements[rel.properties["part_elem"]]
         part_elem.properties["force_ibd"] = "true"
+        part_elem.properties.setdefault(
+            "partDefinition", repo.elements.get(part_id).name or part_id
+        )
     else:
         part_elem = repo.create_element(
             "Part",
             name=repo.elements.get(part_id).name or part_id,
-            properties={"definition": part_id, "force_ibd": "true"},
+            properties={
+                "definition": part_id,
+                "force_ibd": "true",
+                "partDefinition": repo.elements.get(part_id).name or part_id,
+            },
             owner=repo.root_package.elem_id,
         )
         if rel:
@@ -368,11 +379,18 @@ def _sync_ibd_composite_parts(
         if rel.properties.get("part_elem") and rel.properties["part_elem"] in repo.elements:
             part_elem = repo.elements[rel.properties["part_elem"]]
             part_elem.properties["force_ibd"] = "true"
+            part_elem.properties.setdefault(
+                "partDefinition", repo.elements.get(pid).name or pid
+            )
         else:
             part_elem = repo.create_element(
                 "Part",
                 name=repo.elements.get(pid).name or pid,
-                properties={"definition": pid, "force_ibd": "true"},
+                properties={
+                    "definition": pid,
+                    "force_ibd": "true",
+                    "partDefinition": repo.elements.get(pid).name or pid,
+                },
                 owner=repo.root_package.elem_id,
             )
             rel.properties["part_elem"] = part_elem.elem_id
@@ -431,7 +449,10 @@ def _sync_ibd_aggregation_parts(
         part_elem = repo.create_element(
             "Part",
             name=repo.elements.get(pid).name or pid,
-            properties={"definition": pid},
+            properties={
+                "definition": pid,
+                "partDefinition": repo.elements.get(pid).name or pid,
+            },
             owner=repo.root_package.elem_id,
         )
         repo.add_element_to_diagram(diag.diag_id, part_elem.elem_id)
@@ -3861,7 +3882,7 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 state = "normal"
                 if self.obj.obj_type == "Block" and prop in ("fit", "qualification"):
                     state = "readonly"
-                if self.obj.obj_type == "Part" and prop == "asil":
+                if self.obj.obj_type == "Part" and prop in ("asil", "partDefinition"):
                     state = "readonly"
                 ttk.Entry(frame, textvariable=var, state=state).grid(
                     row=row, column=1, padx=4, pady=2

--- a/tests/test_aggregation_ports.py
+++ b/tests/test_aggregation_ports.py
@@ -20,6 +20,10 @@ class AggregationPortTests(unittest.TestCase):
         repo.link_diagram(whole.elem_id, ibd.diag_id)
         added = _sync_ibd_aggregation_parts(repo, whole.elem_id)
         part_obj = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+        self.assertEqual(
+            repo.elements[part_obj["element_id"]].properties.get("partDefinition"),
+            "Part",
+        )
         ports = [
             o for o in ibd.objects
             if o.get("obj_type") == "Port" and o.get("properties", {}).get("parent") == str(part_obj["obj_id"])
@@ -36,6 +40,10 @@ class AggregationPortTests(unittest.TestCase):
         repo.link_diagram(whole.elem_id, ibd.diag_id)
         add_composite_aggregation_part(repo, whole.elem_id, part.elem_id)
         part_obj = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+        self.assertEqual(
+            repo.elements[part_obj["element_id"]].properties.get("partDefinition"),
+            "Part",
+        )
         ports = [
             o for o in ibd.objects
             if o.get("obj_type") == "Port" and o.get("properties", {}).get("parent") == str(part_obj["obj_id"])

--- a/tests/test_composite_aggregation.py
+++ b/tests/test_composite_aggregation.py
@@ -27,6 +27,13 @@ class CompositeAggregationTests(unittest.TestCase):
                 for o in ibd.objects
             )
         )
+        obj = next(
+            o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        )
+        self.assertEqual(
+            repo.elements[obj["element_id"]].properties.get("partDefinition"),
+            "Part",
+        )
 
     def test_remove_composite_part_from_ibd(self):
         repo = self.repo
@@ -58,6 +65,13 @@ class CompositeAggregationTests(unittest.TestCase):
                 for o in ibd.objects
             )
         )
+        obj = next(
+            o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        )
+        self.assertEqual(
+            repo.elements[obj["element_id"]].properties.get("partDefinition"),
+            "Part",
+        )
         # ensure added list includes the new part
         self.assertTrue(any(d.get("properties", {}).get("definition") == part.elem_id for d in added))
 
@@ -71,6 +85,10 @@ class CompositeAggregationTests(unittest.TestCase):
         pid = rel.properties.get("part_elem")
         self.assertIsNotNone(pid)
         self.assertEqual(repo.elements[pid].properties.get("force_ibd"), "true")
+        self.assertEqual(
+            repo.elements[pid].properties.get("partDefinition"),
+            "Part",
+        )
         ibd = repo.create_diagram("Internal Block Diagram")
         repo.link_diagram(whole.elem_id, ibd.diag_id)
         set_ibd_father(repo, ibd, whole.elem_id)


### PR DESCRIPTION
## Summary
- set `partDefinition` when parts are created from aggregation relationships
- lock `partDefinition` field in part property dialogs
- validate `partDefinition` in aggregation unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888d72fbf808325b336ad25ba12ad81