### PR TITLE
Restrict duplicate aggregation via generalization

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -173,6 +173,35 @@ def _collect_generalization_parents(
     return parents
 
 
+def _parent_has_aggregation(repo: SysMLRepository, block_id: str, part_id: str) -> bool:
+    """Return True if any generalization parent of ``block_id`` aggregates ``part_id``."""
+
+    part_elem = repo.elements.get(part_id)
+    if not part_elem:
+        return False
+    part_name = part_elem.name or part_id
+    parents = _collect_generalization_parents(repo, block_id)
+    for parent in parents:
+        parent_elem = repo.elements.get(parent)
+        if not parent_elem:
+            continue
+        names = [
+            p.split("[")[0].strip()
+            for p in parent_elem.properties.get("partProperties", "").split(",")
+            if p.strip()
+        ]
+        if part_name in names:
+            return True
+        for rel in repo.relationships:
+            if (
+                rel.source == parent
+                and rel.target == part_id
+                and rel.rel_type in ("Aggregation", "Composite Aggregation")
+            ):
+                return True
+    return False
+
+
 def rename_block(repo: SysMLRepository, block_id: str, new_name: str) -> None:
     """Rename ``block_id`` and propagate changes to related blocks."""
     block = repo.elements.get(block_id)
@@ -220,6 +249,8 @@ def add_aggregation_part(
     whole = repo.elements.get(whole_id)
     part = repo.elements.get(part_id)
     if not whole or not part:
+        return
+    if _parent_has_aggregation(repo, whole_id, part_id):
         return
     name = part.name or part_id
     entry = f"{name}[{multiplicity}]" if multiplicity else name
@@ -1279,6 +1310,8 @@ class SysMLDiagramWindow(tk.Frame):
             elif conn_type in ("Aggregation", "Composite Aggregation"):
                 if src.obj_type != "Block" or dst.obj_type != "Block":
                     return False, "Aggregations must connect Blocks"
+                if _parent_has_aggregation(self.repo, src.element_id, dst.element_id):
+                    return False, "Part already aggregated through generalization"
 
         elif diag_type == "Internal Block Diagram":
             if conn_type == "Connector":

--- a/tests/test_aggregation_generalization_restrict.py
+++ b/tests/test_aggregation_generalization_restrict.py
@@ -1,0 +1,44 @@
+import unittest
+from gui.architecture import (
+    add_composite_aggregation_part,
+    add_aggregation_part,
+    inherit_block_properties,
+)
+from sysml.sysml_repository import SysMLRepository
+
+class AggregationGeneralizationRestrictTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_prevent_duplicate_aggregation_via_generalization(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        # parent aggregates part
+        add_composite_aggregation_part(repo, parent.elem_id, part.elem_id)
+        # child generalizes parent
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        inherit_block_properties(repo, child.elem_id)
+        before = repo.elements[child.elem_id].properties.get("partProperties", "")
+        # attempt to aggregate same part in child
+        add_composite_aggregation_part(repo, child.elem_id, part.elem_id)
+        after = repo.elements[child.elem_id].properties.get("partProperties", "")
+        self.assertEqual(before, after)
+
+    def test_prevent_duplicate_regular_aggregation_via_generalization(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        add_aggregation_part(repo, parent.elem_id, part.elem_id)
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        inherit_block_properties(repo, child.elem_id)
+        before = repo.elements[child.elem_id].properties.get("partProperties", "")
+        add_aggregation_part(repo, child.elem_id, part.elem_id)
+        after = repo.elements[child.elem_id].properties.get("partProperties", "")
+        self.assertEqual(before, after)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- block diagrams: disallow aggregating a block already inherited as a part
- check ancestor parts before adding aggregation or composite aggregation
- validate connections for the same rule
- test restriction on regular and composite aggregations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888d8d45e708325be502a227248236f