### PR TITLE
Propagate block rename and restrict inherited aggregation

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1385,6 +1385,16 @@ class SysMLDiagramWindow(tk.Frame):
             elif conn_type in ("Aggregation", "Composite Aggregation"):
                 if src.obj_type != "Block" or dst.obj_type != "Block":
                     return False, "Aggregations must connect Blocks"
+                # Prevent duplicate aggregations when inherited via generalization
+                parents = _collect_generalization_parents(self.repo, src.element_id)
+                for p in parents:
+                    if any(
+                        r.rel_type in ("Aggregation", "Composite Aggregation")
+                        and r.source == p
+                        and r.target == dst.element_id
+                        for r in self.repo.relationships
+                    ):
+                        return False, "Target already aggregated through generalization"
 
         elif diag_type == "Internal Block Diagram":
             if conn_type == "Connector":
@@ -4319,7 +4329,10 @@ class SysMLObjectDialog(simpledialog.Dialog):
         self.obj.properties["name"] = self.name_var.get()
         repo = SysMLRepository.get_instance()
         if self.obj.element_id and self.obj.element_id in repo.elements:
-            repo.elements[self.obj.element_id].name = self.name_var.get()
+            if self.obj.obj_type == "Block":
+                rename_block(repo, self.obj.element_id, self.name_var.get())
+            else:
+                repo.elements[self.obj.element_id].name = self.name_var.get()
         for prop, var in self.entries.items():
             self.obj.properties[prop] = var.get()
             if self.obj.element_id and self.obj.element_id in repo.elements:

--- a/tests/test_aggregation_generalization_rule.py
+++ b/tests/test_aggregation_generalization_rule.py
@@ -1,0 +1,44 @@
+import unittest
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+class DummyWindow:
+    def __init__(self):
+        self.repo = SysMLRepository.get_instance()
+        diag = SysMLDiagram(diag_id="d", diag_type="Block Diagram")
+        self.repo.diagrams[diag.diag_id] = diag
+        self.diagram_id = diag.diag_id
+
+class AggregationGeneralizationRuleTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_duplicate_aggregation_prevented(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Aggregation", parent.elem_id, part.elem_id)
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        win = DummyWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=child.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=part.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Aggregation")
+        self.assertFalse(valid)
+
+    def test_duplicate_composite_prevented(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Composite Aggregation", parent.elem_id, part.elem_id)
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        win = DummyWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=child.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=part.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Composite Aggregation")
+        self.assertFalse(valid)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- propagate block renames to all aggregated parts when editing block properties
- prevent adding an aggregation or composite aggregation if an ancestor already aggregates the target block
- test new aggregation restriction rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888dca5e88c832599ae3f67b7983923