### PR TITLE
Prevent duplicate aggregations via inheritance

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -173,6 +173,20 @@ def _collect_generalization_parents(
     return parents
 
 
+def _parent_has_aggregation(repo: SysMLRepository, child_id: str, part_id: str) -> bool:
+    """Return ``True`` if any ancestor of ``child_id`` aggregates ``part_id``."""
+
+    parents = _collect_generalization_parents(repo, child_id)
+    for rel in repo.relationships:
+        if (
+            rel.rel_type in ("Aggregation", "Composite Aggregation")
+            and rel.source in parents
+            and rel.target == part_id
+        ):
+            return True
+    return False
+
+
 def rename_block(repo: SysMLRepository, block_id: str, new_name: str) -> None:
     """Rename ``block_id`` and propagate changes to related blocks."""
     block = repo.elements.get(block_id)
@@ -220,6 +234,8 @@ def add_aggregation_part(
     whole = repo.elements.get(whole_id)
     part = repo.elements.get(part_id)
     if not whole or not part:
+        return
+    if _parent_has_aggregation(repo, whole_id, part_id):
         return
     name = part.name or part_id
     entry = f"{name}[{multiplicity}]" if multiplicity else name
@@ -1279,6 +1295,12 @@ class SysMLDiagramWindow(tk.Frame):
             elif conn_type in ("Aggregation", "Composite Aggregation"):
                 if src.obj_type != "Block" or dst.obj_type != "Block":
                     return False, "Aggregations must connect Blocks"
+                if (
+                    src.element_id
+                    and dst.element_id
+                    and _parent_has_aggregation(self.repo, src.element_id, dst.element_id)
+                ):
+                    return False, "Block already inherits this part via generalization"
 
         elif diag_type == "Internal Block Diagram":
             if conn_type == "Connector":

--- a/tests/test_generalization_part_updates.py
+++ b/tests/test_generalization_part_updates.py
@@ -3,14 +3,23 @@ from gui.architecture import (
     add_aggregation_part,
     add_composite_aggregation_part,
     remove_aggregation_part,
+    SysMLDiagramWindow,
+    SysMLObject,
 )
-from sysml.sysml_repository import SysMLRepository
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
 
 
 class GeneralizationPartUpdateTests(unittest.TestCase):
     def setUp(self):
         SysMLRepository._instance = None
         self.repo = SysMLRepository.get_instance()
+
+    class DummyBlockWindow:
+        def __init__(self):
+            self.repo = SysMLRepository.get_instance()
+            diag = SysMLDiagram(diag_id="d", diag_type="Block Diagram")
+            self.repo.diagrams[diag.diag_id] = diag
+            self.diagram_id = diag.diag_id
 
     def test_add_aggregation_updates_child(self):
         repo = self.repo
@@ -52,6 +61,44 @@ class GeneralizationPartUpdateTests(unittest.TestCase):
             "PartC",
             repo.elements[child.elem_id].properties.get("partProperties", ""),
         )
+
+    def test_child_cannot_duplicate_aggregation(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="PartD")
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        repo.create_relationship("Aggregation", parent.elem_id, part.elem_id)
+        add_aggregation_part(repo, parent.elem_id, part.elem_id)
+
+        win = self.DummyBlockWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=child.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=part.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Aggregation")
+        self.assertFalse(valid)
+        before = repo.elements[child.elem_id].properties.get("partProperties", "")
+        add_aggregation_part(repo, child.elem_id, part.elem_id)
+        after = repo.elements[child.elem_id].properties.get("partProperties", "")
+        self.assertEqual(before, after)
+
+    def test_child_cannot_duplicate_composite(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="PartE")
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        repo.create_relationship("Composite Aggregation", parent.elem_id, part.elem_id)
+        add_composite_aggregation_part(repo, parent.elem_id, part.elem_id)
+
+        win = self.DummyBlockWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=child.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=part.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Composite Aggregation")
+        self.assertFalse(valid)
+        before = repo.elements[child.elem_id].properties.get("partProperties", "")
+        add_composite_aggregation_part(repo, child.elem_id, part.elem_id)
+        after = repo.elements[child.elem_id].properties.get("partProperties", "")
+        self.assertEqual(before, after)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid adding repeated aggregations already inherited through a parent block
- disallow connections that duplicate inherited parts
- test that duplicate aggregations are ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888d8d45e708325be502a227248236f