### PR TITLE
Ensure parts stay synced on rename and confirm deletions

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -142,6 +142,9 @@ def _find_blocks_with_part(repo: SysMLRepository, part_id: str) -> set[str]:
             if obj.get("properties", {}).get("definition") == part_id:
                 blocks.add(blk_id)
                 break
+    for rel in repo.relationships:
+        if rel.rel_type in ("Aggregation", "Composite Aggregation") and rel.target == part_id:
+            blocks.add(rel.source)
     return blocks
 
 
@@ -2113,14 +2116,16 @@ class SysMLDiagramWindow(tk.Frame):
                                     "Aggregation",
                                     "Composite Aggregation",
                                 ):
-                                    remove_aggregation_part(
-                                        self.repo,
-                                        src_obj.element_id,
-                                        dst_obj.element_id,
-                                        remove_object=self.selected_conn.conn_type
-                                        == "Composite Aggregation",
-                                        app=getattr(self, "app", None),
-                                    )
+                                    msg = "Remove selected part?"
+                                    if messagebox.askyesno("Remove Part", msg):
+                                        remove_aggregation_part(
+                                            self.repo,
+                                            src_obj.element_id,
+                                            dst_obj.element_id,
+                                            remove_object=self.selected_conn.conn_type
+                                            == "Composite Aggregation",
+                                            app=getattr(self, "app", None),
+                                        )
                                 if self.dragging_endpoint == "dst":
                                     rel.target = obj.element_id
                                     self.selected_conn.dst = obj.obj_id
@@ -2637,7 +2642,7 @@ class SysMLDiagramWindow(tk.Frame):
             def_id = obj.properties.get("definition")
             if def_id and def_id in self.repo.elements:
                 def_name = self.repo.elements[def_id].name or def_id
-                name = f"{name} : {def_name}" if name else def_name
+                name = f"{def_name} : {name}" if name else def_name
 
         lines: list[str] = []
         diag_id = self.repo.get_linked_diagram(obj.element_id)
@@ -3221,7 +3226,7 @@ class SysMLDiagramWindow(tk.Frame):
                 def_id = obj.properties.get("definition")
                 if def_id and def_id in self.repo.elements:
                     def_name = self.repo.elements[def_id].name or def_id
-                    label = f"{name} : {def_name}" if name else def_name
+                    label = f"{def_name} : {name}" if name else def_name
             diag_id = self.repo.get_linked_diagram(obj.element_id)
             label_lines = []
             if diag_id and diag_id in self.repo.diagrams:
@@ -3573,6 +3578,9 @@ class SysMLDiagramWindow(tk.Frame):
                         "properties and attributes. Continue?"
                     )
                     if not messagebox.askyesno("Remove Inheritance", msg):
+                        return
+                if self.selected_conn.conn_type in ("Aggregation", "Composite Aggregation") and src_elem and dst_elem:
+                    if not messagebox.askyesno("Remove Part", "Remove selected part?"):
                         return
                 self.connections.remove(self.selected_conn)
                 # remove matching repository relationship

--- a/tests/test_rename_block.py
+++ b/tests/test_rename_block.py
@@ -1,6 +1,7 @@
 import unittest
 from gui.architecture import (
     add_composite_aggregation_part,
+    remove_aggregation_part,
     rename_block,
     inherit_block_properties,
 )
@@ -48,6 +49,26 @@ class RenameBlockTests(unittest.TestCase):
         self.assertIn(
             "b",
             repo.elements[child.elem_id].properties.get("partProperties", ""),
+        )
+
+    def test_rename_then_remove_without_ibd(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        # establish composite aggregation without IBD
+        repo.create_relationship("Composite Aggregation", whole.elem_id, part.elem_id)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id)
+        # rename part block
+        rename_block(repo, part.elem_id, "NewPart")
+        self.assertIn(
+            "NewPart",
+            repo.elements[whole.elem_id].properties.get("partProperties", ""),
+        )
+        # remove aggregation
+        remove_aggregation_part(repo, whole.elem_id, part.elem_id)
+        self.assertEqual(
+            "",
+            repo.elements[whole.elem_id].properties.get("partProperties", ""),
         )
 
 


### PR DESCRIPTION
## Summary
- keep blocks using a part in sync when the part's block is renamed
- reverse part labels to `BlockName : PartName`
- ask for confirmation when removing aggregation connections
- test renaming and removing a part without an IBD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888e75c8d4083258c64197ac7a1c5cf