### PR TITLE
Fix block rename synchronization

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4434,7 +4434,10 @@ class SysMLObjectDialog(simpledialog.Dialog):
         self.obj.properties["name"] = self.name_var.get()
         repo = SysMLRepository.get_instance()
         if self.obj.element_id and self.obj.element_id in repo.elements:
-            repo.elements[self.obj.element_id].name = self.name_var.get()
+            if self.obj.obj_type == "Block":
+                rename_block(repo, self.obj.element_id, self.name_var.get())
+            else:
+                repo.elements[self.obj.element_id].name = self.name_var.get()
         for prop, var in self.entries.items():
             self.obj.properties[prop] = var.get()
             if self.obj.element_id and self.obj.element_id in repo.elements:


### PR DESCRIPTION
## Summary
- ensure renaming a block through the object dialog keeps aggregation links

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888ea6620ec832588086c5a1b8f3044