### PR TITLE
Fix minimum window sizes

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -15614,6 +15614,8 @@ def main():
 
     # Show and maximize the main window after login
     root.deiconify()
+    # Prevent resizing below a usable size so all tools remain accessible
+    root.minsize(1200, 800)
     try:
         root.state("zoomed")
     except tk.TclError:

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1232,6 +1232,7 @@ class SysMLDiagramWindow(tk.Frame):
         self.master.title(title) if isinstance(self.master, tk.Toplevel) else None
         if isinstance(self.master, tk.Toplevel):
             self.master.geometry("800x600")
+            self.master.minsize(800, 600)
 
         self.repo = SysMLRepository.get_instance()
         if diagram_id and diagram_id in self.repo.diagrams:
@@ -5189,6 +5190,7 @@ class ArchitectureManagerDialog(tk.Frame):
         if isinstance(master, tk.Toplevel):
             master.title("AutoML Explorer")
             master.geometry("350x400")
+            master.minsize(350, 400)
             self.pack(fill=tk.BOTH, expand=True)
         self.repo = SysMLRepository.get_instance()
 

--- a/gui/fault_prioritization.py
+++ b/gui/fault_prioritization.py
@@ -196,6 +196,7 @@ class FaultPrioritizationWindow(tk.Frame):
         if isinstance(master, tk.Toplevel):
             master.title("Fault Prioritization")
             master.geometry("1000x600")
+            master.minsize(1000, 600)
             self.pack(fill=tk.BOTH, expand=True)
 
         self.rows: List[Dict[str, Any]] = default_rows()

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -291,6 +291,7 @@ class ReliabilityWindow(tk.Frame):
         if isinstance(master, tk.Toplevel):
             master.title("Reliability Analysis")
             master.geometry("600x400")
+            master.minsize(600, 400)
             self.pack(fill=tk.BOTH, expand=True)
         self.components = []
 
@@ -1441,6 +1442,7 @@ class HazopWindow(tk.Frame):
         if isinstance(master, tk.Toplevel):
             master.title("HAZOP Analysis")
             master.geometry("600x400")
+            master.minsize(600, 400)
         top = ttk.Frame(self)
         top.pack(fill=tk.X)
         doc_lbl = ttk.Label(top, text="HAZOP:")
@@ -2319,6 +2321,7 @@ class TC2FIWindow(tk.Frame):
 
         if isinstance(master, tk.Toplevel):
             master.geometry("800x400")
+            master.minsize(800, 400)
         tree_frame = ttk.Frame(self)
         tree_frame.pack(fill=tk.BOTH, expand=True)
         configure_table_style("TC2FI.Treeview", rowheight=80)


### PR DESCRIPTION
## Summary
- prevent shrinking the main window below a usable size
- set minimum sizes for auxiliary Toplevel windows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888eb7cb9648325a77eaad5a06e09b9