### PR TITLE
Implement aggregation part sync features

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -238,6 +238,26 @@ def add_aggregation_part(
             if o.get("element_id") == whole_id:
                 o.setdefault("properties", {})["partProperties"] = ", ".join(parts)
 
+    # ensure a Part element exists representing the aggregation
+    rel = next(
+        (
+            r
+            for r in repo.relationships
+            if r.rel_type == "Aggregation"
+            and r.source == whole_id
+            and r.target == part_id
+        ),
+        None,
+    )
+    if rel and not rel.properties.get("part_elem"):
+        part_elem = repo.create_element(
+            "Part",
+            name=repo.elements.get(part_id).name or part_id,
+            properties={"definition": part_id},
+            owner=repo.root_package.elem_id,
+        )
+        rel.properties["part_elem"] = part_elem.elem_id
+
     # propagate changes to any generalization children
     for child_id in _find_generalization_children(repo, whole_id):
         remove_inherited_block_properties(repo, child_id, whole_id)
@@ -409,23 +429,28 @@ def _sync_ibd_aggregation_parts(
         if o.get("obj_type") == "Part"
     }
     src_ids = [block_id] + _collect_generalization_parents(repo, block_id)
-    part_ids = [
-        rel.target
+    rels = [
+        rel
         for rel in repo.relationships
         if rel.rel_type == "Aggregation" and rel.source in src_ids
     ]
     added: list[dict] = []
     base_x = 50.0
     base_y = 50.0 + 60.0 * len(existing_defs)
-    for pid in part_ids:
+    for rel in rels:
+        pid = rel.target
         if pid in existing_defs:
             continue
-        part_elem = repo.create_element(
-            "Part",
-            name=repo.elements.get(pid).name or pid,
-            properties={"definition": pid},
-            owner=repo.root_package.elem_id,
-        )
+        if rel.properties.get("part_elem") and rel.properties["part_elem"] in repo.elements:
+            part_elem = repo.elements[rel.properties["part_elem"]]
+        else:
+            part_elem = repo.create_element(
+                "Part",
+                name=repo.elements.get(pid).name or pid,
+                properties={"definition": pid},
+                owner=repo.root_package.elem_id,
+            )
+            rel.properties["part_elem"] = part_elem.elem_id
         repo.add_element_to_diagram(diag.diag_id, part_elem.elem_id)
         obj_dict = {
             "obj_id": _get_next_id(),
@@ -700,7 +725,7 @@ def remove_aggregation_part(
             (
                 r
                 for r in repo.relationships
-                if r.rel_type == "Composite Aggregation"
+                if r.rel_type in ("Composite Aggregation", "Aggregation")
                 and r.source == whole_id
                 and r.target == part_id
             ),
@@ -1129,6 +1154,24 @@ def propagate_block_port_changes(repo: SysMLRepository, block_id: str) -> None:
                     updated = True
             if updated:
                 repo.touch_diagram(diag.diag_id)
+
+
+def propagate_block_part_changes(repo: SysMLRepository, block_id: str) -> None:
+    """Propagate attribute updates on ``block_id`` to all parts referencing it."""
+
+    block = repo.elements.get(block_id)
+    if not block or block.elem_type != "Block":
+        return
+    props = ["operations", "partProperties", "behaviors"]
+    for elem in repo.elements.values():
+        if elem.elem_type != "Part" or elem.properties.get("definition") != block_id:
+            continue
+        elem.name = block.name
+        for prop in props:
+            if prop in block.properties:
+                elem.properties[prop] = block.properties[prop]
+            else:
+                elem.properties.pop(prop, None)
 
 
 def _propagate_block_requirement_changes(
@@ -2127,14 +2170,18 @@ class SysMLDiagramWindow(tk.Frame):
                                     "Aggregation",
                                     "Composite Aggregation",
                                 ):
-                                    remove_aggregation_part(
-                                        self.repo,
-                                        src_obj.element_id,
-                                        dst_obj.element_id,
-                                        remove_object=self.selected_conn.conn_type
-                                        == "Composite Aggregation",
-                                        app=getattr(self, "app", None),
-                                    )
+                                    msg = "Delete aggregation and its part?"
+                                    if messagebox.askyesno(
+                                        "Remove Aggregation", msg
+                                    ):
+                                        remove_aggregation_part(
+                                            self.repo,
+                                            src_obj.element_id,
+                                            dst_obj.element_id,
+                                            remove_object=self.selected_conn.conn_type
+                                            == "Composite Aggregation",
+                                            app=getattr(self, "app", None),
+                                        )
                                 if self.dragging_endpoint == "dst":
                                     rel.target = obj.element_id
                                     self.selected_conn.dst = obj.obj_id
@@ -2290,6 +2337,10 @@ class SysMLDiagramWindow(tk.Frame):
 
     def _open_linked_diagram(self, obj) -> bool:
         diag_id = self.repo.get_linked_diagram(obj.element_id)
+        if not diag_id and obj.obj_type == "Part":
+            def_id = obj.properties.get("definition")
+            if def_id:
+                diag_id = self.repo.get_linked_diagram(def_id)
         view_id = obj.properties.get("view")
         if (
             obj.obj_type == "CallBehaviorAction"
@@ -3576,12 +3627,23 @@ class SysMLDiagramWindow(tk.Frame):
             if self.selected_conn in self.connections:
                 src_elem = self.get_object(self.selected_conn.src)
                 dst_elem = self.get_object(self.selected_conn.dst)
-                if self.selected_conn.conn_type == "Generalization" and src_elem and dst_elem:
+                if (
+                    self.selected_conn.conn_type == "Generalization"
+                    and src_elem
+                    and dst_elem
+                ):
                     msg = (
                         "Removing this inheritance will delete all inherited parts, "
                         "properties and attributes. Continue?"
                     )
                     if not messagebox.askyesno("Remove Inheritance", msg):
+                        return
+                elif self.selected_conn.conn_type in (
+                    "Aggregation",
+                    "Composite Aggregation",
+                ):
+                    msg = "Delete aggregation and its part?"
+                    if not messagebox.askyesno("Remove Aggregation", msg):
                         return
                 self.connections.remove(self.selected_conn)
                 # remove matching repository relationship
@@ -4337,10 +4399,15 @@ class SysMLObjectDialog(simpledialog.Dialog):
         return ", ".join(sorted(modes))
 
     def apply(self):
-        self.obj.properties["name"] = self.name_var.get()
+        new_name = self.name_var.get()
+        self.obj.properties["name"] = new_name
         repo = SysMLRepository.get_instance()
         if self.obj.element_id and self.obj.element_id in repo.elements:
-            repo.elements[self.obj.element_id].name = self.name_var.get()
+            elem = repo.elements[self.obj.element_id]
+            if self.obj.obj_type == "Block" and elem.name != new_name:
+                rename_block(repo, elem.elem_id, new_name)
+            else:
+                elem.name = new_name
         for prop, var in self.entries.items():
             self.obj.properties[prop] = var.get()
             if self.obj.element_id and self.obj.element_id in repo.elements:
@@ -4363,6 +4430,7 @@ class SysMLObjectDialog(simpledialog.Dialog):
 
         if self.obj.obj_type == "Block" and self.obj.element_id:
             propagate_block_port_changes(repo, self.obj.element_id)
+            propagate_block_part_changes(repo, self.obj.element_id)
             propagate_block_changes(repo, self.obj.element_id)
         try:
             if self.obj.obj_type not in ("Initial", "Final"):

--- a/tests/test_aggregation_part_creation.py
+++ b/tests/test_aggregation_part_creation.py
@@ -1,0 +1,103 @@
+import unittest
+from gui.architecture import (
+    add_aggregation_part,
+    _sync_ibd_aggregation_parts,
+    propagate_block_part_changes,
+    remove_aggregation_part,
+)
+from sysml.sysml_repository import SysMLRepository
+
+
+class AggregationPartCreationTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_add_aggregation_creates_part(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Aggregation", whole.elem_id, part.elem_id)
+        add_aggregation_part(repo, whole.elem_id, part.elem_id)
+        rel = next(
+            r
+            for r in repo.relationships
+            if r.rel_type == "Aggregation"
+            and r.source == whole.elem_id
+            and r.target == part.elem_id
+        )
+        pid = rel.properties.get("part_elem")
+        self.assertIsNotNone(pid)
+        self.assertIn(pid, repo.elements)
+        self.assertEqual(repo.elements[pid].properties.get("definition"), part.elem_id)
+
+    def test_part_updates_with_block(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Aggregation", whole.elem_id, part.elem_id)
+        add_aggregation_part(repo, whole.elem_id, part.elem_id)
+        rel = next(
+            r
+            for r in repo.relationships
+            if r.rel_type == "Aggregation"
+            and r.source == whole.elem_id
+            and r.target == part.elem_id
+        )
+        pid = rel.properties.get("part_elem")
+        part.properties["operations"] = '[{"name":"op"}]'
+        propagate_block_part_changes(repo, part.elem_id)
+        self.assertEqual(repo.elements[pid].properties.get("operations"), part.properties["operations"])
+
+    def test_part_name_sync_on_block_rename(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Aggregation", whole.elem_id, part.elem_id)
+        add_aggregation_part(repo, whole.elem_id, part.elem_id)
+        rel = next(
+            r
+            for r in repo.relationships
+            if r.rel_type == "Aggregation"
+            and r.source == whole.elem_id
+            and r.target == part.elem_id
+        )
+        pid = rel.properties.get("part_elem")
+        part.name = "Renamed"
+        propagate_block_part_changes(repo, part.elem_id)
+        self.assertEqual(repo.elements[pid].name, "Renamed")
+
+    def test_remove_aggregation_part_object(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Aggregation", whole.elem_id, part.elem_id)
+        add_aggregation_part(repo, whole.elem_id, part.elem_id)
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        _sync_ibd_aggregation_parts(repo, whole.elem_id)
+        self.assertTrue(
+            any(
+                o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+                for o in ibd.objects
+            )
+        )
+        remove_aggregation_part(repo, whole.elem_id, part.elem_id, remove_object=True)
+        self.assertFalse(
+            any(
+                o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+                for o in ibd.objects
+            )
+        )
+        rel = next(
+            r
+            for r in repo.relationships
+            if r.rel_type == "Aggregation"
+            and r.source == whole.elem_id
+            and r.target == part.elem_id
+        )
+        self.assertNotIn(rel.properties.get("part_elem"), repo.elements)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure part elements stay in sync with block names when block properties change
- call `rename_block` when editing block names via the object dialog
- open internal block diagrams from part objects when their definition has one
- test name propagation for aggregation parts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888f430e0888325aafa52f2304ec06b