### PR TITLE
Remove duplicate functions

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8065,18 +8065,6 @@ class FaultTreeApp:
                     names.append(name)
         return names
 
-    def get_all_scenery_names(self):
-        """Return the list of scenery/ODD element names."""
-        names = []
-        for lib in self.odd_libraries:
-            for el in lib.get("elements", []):
-                if isinstance(el, dict):
-                    name = el.get("name") or el.get("element") or el.get("id")
-                else:
-                    name = str(el)
-                if name:
-                    names.append(name)
-        return names
 
     def get_all_function_names(self):
         """Return unique function names from HAZOP entries."""

--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -213,22 +213,6 @@ class InheritPartsTests(unittest.TestCase):
             any(d.get("properties", {}).get("definition") == part_blk.elem_id for d in added)
         )
 
-    def test_sync_partproperty_parts(self):
-        repo = self.repo
-        blk = repo.create_element("Block", name="A", properties={"partProperties": "B"})
-        part_blk = repo.create_element("Block", name="B")
-        ibd = repo.create_diagram("Internal Block Diagram")
-        repo.link_diagram(blk.elem_id, ibd.diag_id)
-        added = _sync_ibd_partproperty_parts(repo, blk.elem_id)
-        self.assertTrue(
-            any(
-                o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part_blk.elem_id
-                for o in ibd.objects
-            )
-        )
-        self.assertTrue(
-            any(d.get("properties", {}).get("definition") == part_blk.elem_id for d in added)
-        )
 
     def test_sync_aggregation_parts_with_parent(self):
         repo = self.repo


### PR DESCRIPTION
## Summary
- remove duplicate `get_all_scenery_names` in `AutoML.py`
- remove duplicate `test_sync_partproperty_parts` in `tests/test_inherit_parts.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888ff07b0b88325a7ad8fdc406e457a