### PR TITLE
Fix block name synchronization

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5092,7 +5092,12 @@ class ElementPropertiesDialog(simpledialog.Dialog):
             row += 1
 
     def apply(self):
-        self.element.name = self.name_var.get()
+        repo = SysMLRepository.get_instance()
+        new_name = self.name_var.get()
+        if self.element.elem_type == "Block":
+            rename_block(repo, self.element.elem_id, new_name)
+        else:
+            self.element.name = new_name
         for prop, var in self.entries.items():
             self.element.properties[prop] = var.get()
 


### PR DESCRIPTION
## Summary
- ensure renaming a Block via ElementPropertiesDialog propagates to parts by invoking `rename_block`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688902ce55188325a18c6b7910fa22b1