### PR TITLE
Fix block name synchronization

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -220,7 +220,7 @@ def rename_block(repo: SysMLRepository, block_id: str, new_name: str) -> None:
         for idx, val in enumerate(parts):
             base = val.split("[")[0].strip()
             suffix = val[len(base):]
-            if base == old_name:
+            if base == old_name or base == block_id:
                 parts[idx] = new_name + suffix
                 changed = True
         if changed:
@@ -5092,7 +5092,12 @@ class ElementPropertiesDialog(simpledialog.Dialog):
             row += 1
 
     def apply(self):
-        self.element.name = self.name_var.get()
+        repo = SysMLRepository.get_instance()
+        new_name = self.name_var.get()
+        if self.element.elem_type == "Block":
+            rename_block(repo, self.element.elem_id, new_name)
+        else:
+            self.element.name = new_name
         for prop, var in self.entries.items():
             self.element.properties[prop] = var.get()
 

--- a/tests/test_rename_block.py
+++ b/tests/test_rename_block.py
@@ -2,6 +2,7 @@ import unittest
 from gui.architecture import (
     add_composite_aggregation_part,
     add_aggregation_part,
+    remove_aggregation_part,
     rename_block,
     inherit_block_properties,
 )
@@ -72,6 +73,23 @@ class RenameBlockTests(unittest.TestCase):
         pid = rel.properties.get("part_elem")
         self.assertIsNotNone(pid)
         self.assertEqual(repo.elements[pid].name, "NewPart")
+
+    def test_rename_empty_block_syncs_and_removes(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="")
+        repo.create_relationship("Aggregation", whole.elem_id, part.elem_id)
+        add_aggregation_part(repo, whole.elem_id, part.elem_id)
+        rename_block(repo, part.elem_id, "Renamed")
+        self.assertIn(
+            "Renamed",
+            repo.elements[whole.elem_id].properties.get("partProperties", ""),
+        )
+        remove_aggregation_part(repo, whole.elem_id, part.elem_id)
+        self.assertNotIn(
+            "Renamed",
+            repo.elements[whole.elem_id].properties.get("partProperties", ""),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow rename_block to update parent part lists that still reference the block by id
- cover renaming an unnamed block in test suite

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688902ce55188325a18c6b7910fa22b1