### PR TITLE
Remove partDefinition property from PartUsage

### DIFF
--- a/sysml/sysml_spec.py
+++ b/sysml/sysml_spec.py
@@ -53,6 +53,10 @@ for p in ('labelX', 'labelY'):
 SYSML_PROPERTIES.setdefault('BlockUsage', [])
 SYSML_PROPERTIES.setdefault('PartUsage', [])
 
+# Remove the derived SysML property 'partDefinition' from PartUsage entries.
+if 'partDefinition' in SYSML_PROPERTIES['PartUsage']:
+    SYSML_PROPERTIES['PartUsage'].remove('partDefinition')
+
 for prop in ('analysis', 'fit', 'qualification', 'failureModes'):
     if prop not in SYSML_PROPERTIES['BlockUsage']:
         SYSML_PROPERTIES['BlockUsage'].append(prop)


### PR DESCRIPTION
## Summary
- ensure partDefinition is no longer listed for `PartUsage` elements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688908c701988325934ec2642974a812