### PR TITLE
Add aggregation existence check

### DIFF
--- a/tests/test_aggregation_validation.py
+++ b/tests/test_aggregation_validation.py
@@ -1,0 +1,54 @@
+import unittest
+from gui.architecture import _aggregation_exists
+from sysml.sysml_repository import SysMLRepository
+
+class AggregationExistsTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_direct_relationship(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Aggregation", whole.elem_id, part.elem_id)
+        self.assertTrue(_aggregation_exists(repo, whole.elem_id, part.elem_id))
+
+    def test_inherited_relationship(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        repo.create_relationship("Composite Aggregation", parent.elem_id, part.elem_id)
+        self.assertTrue(_aggregation_exists(repo, child.elem_id, part.elem_id))
+
+    def test_father_part_definition(self):
+        repo = self.repo
+        father = repo.create_element("Block", name="Father")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        diag_f = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(father.elem_id, diag_f.diag_id)
+        part_elem = repo.create_element("Part", name="P", properties={"definition": part.elem_id})
+        diag_f.objects.append({
+            "obj_id": 1,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": part_elem.elem_id,
+            "properties": {"definition": part.elem_id},
+        })
+        diag_c = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(child.elem_id, diag_c.diag_id)
+        diag_c.father = father.elem_id
+        self.assertTrue(_aggregation_exists(repo, child.elem_id, part.elem_id))
+
+    def test_negative_case(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        self.assertFalse(_aggregation_exists(repo, a.elem_id, b.elem_id))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `_aggregation_exists` utility to detect inherited aggregations
- prevent duplicate aggregation connections in `validate_connection`
- add tests for the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889093af64c8325ae03a3f1f69fb36e