### PR TITLE
Add multiplicity part support

### DIFF
--- a/tests/test_aggregation_validation.py
+++ b/tests/test_aggregation_validation.py
@@ -1,0 +1,54 @@
+import unittest
+from gui.architecture import _aggregation_exists
+from sysml.sysml_repository import SysMLRepository
+
+class AggregationExistsTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_direct_relationship(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Aggregation", whole.elem_id, part.elem_id)
+        self.assertTrue(_aggregation_exists(repo, whole.elem_id, part.elem_id))
+
+    def test_inherited_relationship(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        repo.create_relationship("Composite Aggregation", parent.elem_id, part.elem_id)
+        self.assertTrue(_aggregation_exists(repo, child.elem_id, part.elem_id))
+
+    def test_father_part_definition(self):
+        repo = self.repo
+        father = repo.create_element("Block", name="Father")
+        child = repo.create_element("Block", name="Child")
+        part = repo.create_element("Block", name="Part")
+        diag_f = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(father.elem_id, diag_f.diag_id)
+        part_elem = repo.create_element("Part", name="P", properties={"definition": part.elem_id})
+        diag_f.objects.append({
+            "obj_id": 1,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": part_elem.elem_id,
+            "properties": {"definition": part.elem_id},
+        })
+        diag_c = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(child.elem_id, diag_c.diag_id)
+        diag_c.father = father.elem_id
+        self.assertTrue(_aggregation_exists(repo, child.elem_id, part.elem_id))
+
+    def test_negative_case(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        self.assertFalse(_aggregation_exists(repo, a.elem_id, b.elem_id))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multiplicity_parts.py
+++ b/tests/test_multiplicity_parts.py
@@ -1,0 +1,41 @@
+import unittest
+from gui.architecture import add_composite_aggregation_part, add_multiplicity_parts
+from sysml.sysml_repository import SysMLRepository
+
+class MultiplicityPartTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_exact_multiplicity(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "3")
+        objs = [
+            o for o in ibd.objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(objs), 3)
+        names = {repo.elements[o["element_id"]].name for o in objs}
+        self.assertIn("Part[1]", names)
+        self.assertIn("Part[3]", names)
+
+    def test_unbounded_multiplicity(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="W")
+        part = repo.create_element("Block", name="P")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "1..*")
+        add_multiplicity_parts(repo, whole.elem_id, part.elem_id, "1..*", count=3)
+        objs = [
+            o for o in ibd.objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(objs), 4)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prevent duplicate aggregations by checking ancestors
- parse multiplicity ranges and allow instantiating multiple part objects
- show multiplicity chooser when editing relationships
- create part instances according to multiplicity
- add tests for multiplicity handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889093af64c8325ae03a3f1f69fb36e