### PR TITLE
Fix inherited part duplication after renaming block

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -277,13 +277,14 @@ def rename_block(repo: SysMLRepository, block_id: str, new_name: str) -> None:
                 parts[idx] = new_name + suffix
                 changed = True
         if changed:
+            for child_id in _find_generalization_children(repo, parent_id):
+                remove_inherited_block_properties(repo, child_id, parent_id)
             parent.properties["partProperties"] = ", ".join(parts)
             for d in repo.diagrams.values():
                 for o in getattr(d, "objects", []):
                     if o.get("element_id") == parent_id:
                         o.setdefault("properties", {})["partProperties"] = parent.properties["partProperties"]
             for child_id in _find_generalization_children(repo, parent_id):
-                remove_inherited_block_properties(repo, child_id, parent_id)
                 inherit_block_properties(repo, child_id)
     # propagate property inheritance to children blocks
     for child_id in _find_generalization_children(repo, block_id):


### PR DESCRIPTION
## Summary
- ensure inherited parts are removed before reapplying generalization when a part block is renamed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688931de51948325aa42b78d77eef2dc