### PR TITLE
Ensure IBD parts update block list

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -715,6 +715,45 @@ def _sync_ibd_partproperty_parts(
     return added
 
 
+def _sync_block_parts_from_ibd(repo: SysMLRepository, diag_id: str) -> None:
+    """Ensure the block linked to ``diag_id`` lists all part definitions."""
+
+    diag = repo.diagrams.get(diag_id)
+    if not diag or diag.diag_type != "Internal Block Diagram":
+        return
+    block_id = (
+        getattr(diag, "father", None)
+        or next((eid for eid, did in repo.element_diagrams.items() if did == diag_id), None)
+    )
+    if not block_id or block_id not in repo.elements:
+        return
+    block = repo.elements[block_id]
+    names = [
+        p.strip()
+        for p in block.properties.get("partProperties", "").split(",")
+        if p.strip()
+    ]
+    bases = {n.split("[")[0].strip() for n in names}
+    for obj in getattr(diag, "objects", []):
+        if obj.get("obj_type") != "Part":
+            continue
+        def_id = obj.get("properties", {}).get("definition")
+        if def_id and def_id in repo.elements:
+            pname = repo.elements[def_id].name or def_id
+            if pname not in bases:
+                names.append(pname)
+                bases.add(pname)
+    if names:
+        joined = ", ".join(names)
+        block.properties["partProperties"] = joined
+        for d in repo.diagrams.values():
+            for o in getattr(d, "objects", []):
+                if o.get("element_id") == block_id:
+                    o.setdefault("properties", {})["partProperties"] = joined
+        for child_id in _find_generalization_children(repo, block_id):
+            inherit_block_properties(repo, child_id)
+
+
 def set_ibd_father(
     repo: SysMLRepository, diagram: SysMLDiagram, father_id: str | None, app=None
 ) -> list[dict]:
@@ -3830,6 +3869,7 @@ class SysMLDiagramWindow(tk.Frame):
             diag.objects = [obj.__dict__ for obj in self.objects]
             diag.connections = [conn.__dict__ for conn in self.connections]
             self.repo.touch_diagram(self.diagram_id)
+            _sync_block_parts_from_ibd(self.repo, self.diagram_id)
 
     def on_close(self):
         self._sync_to_repository()

--- a/tests/test_ibd_part_block_update.py
+++ b/tests/test_ibd_part_block_update.py
@@ -1,0 +1,36 @@
+import unittest
+from gui.architecture import _sync_block_parts_from_ibd
+from sysml.sysml_repository import SysMLRepository
+
+class IBDPartBlockUpdateTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_part_definition_adds_block_part(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part_blk = repo.create_element("Block", name="Inner")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        part_elem = repo.create_element(
+            "Part", name="Inner", properties={"definition": part_blk.elem_id}
+        )
+        ibd.objects.append(
+            {
+                "obj_id": 1,
+                "obj_type": "Part",
+                "x": 0,
+                "y": 0,
+                "element_id": part_elem.elem_id,
+                "properties": {"definition": part_blk.elem_id},
+            }
+        )
+        _sync_block_parts_from_ibd(repo, ibd.diag_id)
+        self.assertIn(
+            "Inner",
+            repo.elements[whole.elem_id].properties.get("partProperties", ""),
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- sync Internal Block Diagram parts back to the owning block
- update repository on save
- add regression test for block part synchronization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688933df522083258efcec4c3aaecaf2