### PR TITLE
Fix IBD part sync with block compartments

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -733,6 +733,42 @@ def set_ibd_father(
     return added
 
 
+def update_block_parts_from_ibd(repo: SysMLRepository, diagram: SysMLDiagram) -> None:
+    """Sync the father block's ``partProperties`` from diagram part objects."""
+
+    if diagram.diag_type != "Internal Block Diagram":
+        return
+    block_id = getattr(diagram, "father", None)
+    if not block_id:
+        block_id = next((eid for eid, did in repo.element_diagrams.items() if did == diagram.diag_id), None)
+    if not block_id or block_id not in repo.elements:
+        return
+    block = repo.elements[block_id]
+    names = [p.strip() for p in block.properties.get("partProperties", "").split(",") if p.strip()]
+    bases = [n.split("[")[0].strip() for n in names]
+    changed = False
+    for obj in getattr(diagram, "objects", []):
+        if obj.get("obj_type") != "Part":
+            continue
+        def_id = obj.get("properties", {}).get("definition")
+        if def_id and def_id in repo.elements:
+            name = repo.elements[def_id].name or def_id
+            if name not in bases:
+                names.append(name)
+                bases.append(name)
+                changed = True
+    if changed:
+        joined = ", ".join(names)
+        block.properties["partProperties"] = joined
+        for d in repo.diagrams.values():
+            for o in getattr(d, "objects", []):
+                if o.get("element_id") == block_id:
+                    o.setdefault("properties", {})["partProperties"] = joined
+        for child_id in _find_generalization_children(repo, block_id):
+            inherit_block_properties(repo, child_id)
+        repo.touch_element(block_id)
+
+
 def remove_aggregation_part(
     repo: SysMLRepository,
     whole_id: str,
@@ -3829,6 +3865,7 @@ class SysMLDiagramWindow(tk.Frame):
         if diag:
             diag.objects = [obj.__dict__ for obj in self.objects]
             diag.connections = [conn.__dict__ for conn in self.connections]
+            update_block_parts_from_ibd(self.repo, diag)
             self.repo.touch_diagram(self.diagram_id)
 
     def on_close(self):

--- a/tests/test_ibd_part_sync.py
+++ b/tests/test_ibd_part_sync.py
@@ -1,0 +1,31 @@
+import unittest
+from gui.architecture import set_ibd_father, update_block_parts_from_ibd
+from sysml.sysml_repository import SysMLRepository
+
+class IBDPartSyncTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_ibd_part_addition_updates_block_parts(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        set_ibd_father(repo, ibd, whole.elem_id)
+        elem = repo.create_element("Part", name="Part", properties={"definition": part.elem_id})
+        repo.add_element_to_diagram(ibd.diag_id, elem.elem_id)
+        ibd.objects.append({
+            "obj_id": 1,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": elem.elem_id,
+            "properties": {"definition": part.elem_id},
+        })
+        update_block_parts_from_ibd(repo, ibd)
+        props = repo.elements[whole.elem_id].properties.get("partProperties", "")
+        self.assertIn("Part", props)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure block `partProperties` reflect parts added to its IBD
- update `_sync_to_repository` to call new sync helper
- test that adding a part object updates the block parts list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688933df522083258efcec4c3aaecaf2