### PR TITLE
Add options to remove parts from diagrams or model

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,6 +939,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.1.3 - Added context menu actions to remove parts from a diagram or from the model.
 - 0.1.2 - Clarified systems safety focus in description and About dialog.
 - 0.1.1 - Updated description and About dialog.
 - 0.1.0 - Added Help menu and version tracking.


### PR DESCRIPTION
## Summary
- add new context menu entries in Internal Block Diagrams for removing part objects
- implement `remove_part_diagram` and `remove_part_model` helpers
- document new feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688942226b64832589612f968ada73e2