### PR TITLE
Fix IBD parts sync

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -296,6 +296,8 @@ from gui.architecture import (
     BlockDiagramWindow,
     InternalBlockDiagramWindow,
     ArchitectureManagerDialog,
+    update_block_parts_from_ibd,
+    _sync_block_parts_from_ibd,
 )
 from sysml.sysml_repository import SysMLRepository
 from analysis.fmeda_utils import compute_fmeda_metrics
@@ -1448,6 +1450,9 @@ class EditNodeDialog(simpledialog.Dialog):
         for fm in self.get_all_failure_modes():
             self.propagate_failure_mode_attributes(fm)
         self.update_basic_event_probabilities()
+        for diag in self.repo.diagrams.values():
+            update_block_parts_from_ibd(self.repo, diag)
+            _sync_block_parts_from_ibd(self.repo, diag.diag_id)
 
     def invalidate_reviews_for_hara(self, name):
         """Reopen reviews associated with the given HARA."""
@@ -8493,6 +8498,9 @@ class FaultTreeApp:
                     entry.fmeda_lpfm_target = getattr(te, "sg_lpfm_target", 0.0)
 
         self.update_basic_event_probabilities()
+        for diag in self.repo.diagrams.values():
+            update_block_parts_from_ibd(self.repo, diag)
+            _sync_block_parts_from_ibd(self.repo, diag.diag_id)
 
     def insert_node_in_tree(self, parent_item, node):
         # If the node has no parent (i.e. it's a top-level event), display it.

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5272,6 +5272,9 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
             self.objects.append(SysMLObject(**data))
         self.redraw()
         self._sync_to_repository()
+        if diag is not None:
+            update_block_parts_from_ibd(repo, diag)
+            _sync_block_parts_from_ibd(repo, diag.diag_id)
         if added:
             names = [
                 n.strip()
@@ -5365,6 +5368,8 @@ class DiagramPropertiesDialog(simpledialog.Dialog):
                 repo, self.diagram, father_id, app=getattr(self.master, "app", None)
             )
             self.added_parts.extend(inherit_father_parts(repo, self.diagram))
+            update_block_parts_from_ibd(repo, self.diagram)
+            _sync_block_parts_from_ibd(repo, self.diagram.diag_id)
 
 
 class PackagePropertiesDialog(simpledialog.Dialog):


### PR DESCRIPTION
## Summary
- sync block parts when adding contained parts
- keep father block updated when assigning in Diagram Properties
- update refresh_model to sync IBD parts across diagrams

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688944a50c7c832587847875571dced3