### PR TITLE
Display implementing block for HAZOP functions

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8080,6 +8080,14 @@ class FaultTreeApp:
         repo = SysMLRepository.get_instance()
         return repo.get_activity_actions()
 
+    def get_all_action_labels(self) -> list[str]:
+        """Return action/activity names with implementing block labels."""
+        repo = SysMLRepository.get_instance()
+        labels = []
+        for name, block in repo.get_activity_action_pairs():
+            labels.append(f"{name} : {block}" if block else name)
+        return sorted(set(labels))
+
     def get_use_case_for_function(self, func: str) -> str:
         """Return the use case (activity diagram name) implementing a function."""
         repo = SysMLRepository.get_instance()

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -1603,7 +1603,7 @@ class HazopWindow(tk.Frame):
             func_lbl = ttk.Label(master, text="Function")
             func_lbl.grid(row=0, column=0, sticky="e", padx=5, pady=5)
             ToolTip(func_lbl, "Select the vehicle function under analysis.")
-            funcs = self.app.get_all_action_names()
+            funcs = self.app.get_all_action_labels()
             self.func = tk.StringVar(value=self.row.function)
             func_cb = ttk.Combobox(
                 master, textvariable=self.func, values=funcs, state="readonly"
@@ -1747,7 +1747,10 @@ class HazopWindow(tk.Frame):
             self.haz_cb.configure(values=sorted(self.app.hazards))
 
         def apply(self):
-            self.row.function = self.func.get()
+            func_val = self.func.get()
+            if " : " in func_val:
+                func_val = func_val.split(" : ", 1)[0]
+            self.row.function = func_val
             old_mal = self.row.malfunction
             self.row.malfunction = self.mal.get()
             if old_mal and old_mal != self.row.malfunction:


### PR DESCRIPTION
## Summary
- show block name next to each function when editing HAZOP entries
- preserve action name when saving rows
- provide helpers in `SysMLRepository` and `AutoML` to label functions with blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68895ad0a3708325b32a82f0ae254e1a