### PR TITLE
Add tooltips for notebook tabs

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -227,7 +227,7 @@ import math
 import sys
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox, simpledialog
-from gui.tooltip import ToolTip
+from gui.tooltip import add_tab_tooltips
 from gui.review_toolbox import (
     ReviewToolbox,
     ReviewData,
@@ -918,6 +918,7 @@ class EditNodeDialog(simpledialog.Dialog):
         dialog_font = tkFont.Font(family="Arial", size=10)
 
         nb = ttk.Notebook(master)
+        add_tab_tooltips(nb)
         nb.pack(fill=tk.BOTH, expand=True)
         general_frame = ttk.Frame(nb)
         safety_frame = ttk.Frame(nb)
@@ -2131,6 +2132,7 @@ class FaultTreeApp:
         self.main_pane.pack(fill=tk.BOTH, expand=True)
 
         self.explorer_nb = ttk.Notebook(self.main_pane)
+        add_tab_tooltips(self.explorer_nb)
         self.main_pane.add(self.explorer_nb, width=300)
 
         self.analysis_tab = ttk.Frame(self.explorer_nb)
@@ -2158,11 +2160,8 @@ class FaultTreeApp:
         self.tools_group = ttk.LabelFrame(self.analysis_tab, text="Tools")
         self.tools_group.pack(fill=tk.BOTH, expand=False, pady=5)
         self.tools_nb = ttk.Notebook(self.tools_group)
+        add_tab_tooltips(self.tools_nb)
         self.tools_nb.pack(fill=tk.BOTH, expand=True)
-        # Tooltip helper for tabs (text may be clipped)
-        self._tools_tip = ToolTip(self.tools_nb, "", automatic=False)
-        self.tools_nb.bind("<Motion>", self._on_tool_tab_motion)
-        self.tools_nb.bind("<Leave>", lambda _e: self._tools_tip.hide())
 
         self.tool_actions = {
             "Mission Profiles": self.manage_mission_profiles,
@@ -2270,6 +2269,7 @@ class FaultTreeApp:
 
         # Notebook for diagrams and analyses
         self.doc_nb = ClosableNotebook(self.main_pane)
+        add_tab_tooltips(self.doc_nb)
         self.doc_nb.bind("<<NotebookTabClosed>>", self._on_tab_close)
         self.main_pane.add(self.doc_nb, stretch="always")
 
@@ -7706,23 +7706,6 @@ class FaultTreeApp:
         if action:
             action()
 
-    def _on_tool_tab_motion(self, event):
-        """Show tooltip for notebook tabs when hovering over them."""
-        try:
-            idx = self.tools_nb.index(f"@{event.x},{event.y}")
-        except tk.TclError:
-            self._tools_tip.hide()
-            return
-        text = self.tools_nb.tab(idx, "text")
-        bbox = self.tools_nb.bbox(idx)
-        if not bbox:
-            self._tools_tip.hide()
-            return
-        x = self.tools_nb.winfo_rootx() + bbox[0] + bbox[2] // 2
-        y = self.tools_nb.winfo_rooty() + bbox[1] + bbox[3]
-        if self._tools_tip.text != text:
-            self._tools_tip.text = text
-        self._tools_tip.show(x, y)
 
     def on_ctrl_mousewheel(self, event):
         if event.delta > 0:
@@ -10058,6 +10041,7 @@ class FaultTreeApp:
         def body(self, master):
             self.resizable(False, False)
             nb = ttk.Notebook(master)
+            add_tab_tooltips(nb)
             nb.pack(fill=tk.BOTH, expand=True)
             gen_frame = ttk.Frame(nb)
             metric_frame = ttk.Frame(nb)

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2,6 +2,7 @@
 import tkinter as tk
 import tkinter.font as tkFont
 from tkinter import ttk, simpledialog, messagebox
+from gui.tooltip import add_tab_tooltips
 import json
 import math
 from dataclasses import dataclass, field, asdict
@@ -4151,6 +4152,7 @@ class SysMLObjectDialog(simpledialog.Dialog):
 
         # Use a notebook to keep the dialog compact by grouping fields
         self.nb = ttk.Notebook(master)
+        add_tab_tooltips(self.nb)
         self.nb.grid(row=0, column=0, columnspan=3, sticky="nsew")
 
         gen_frame = ttk.Frame(self.nb)

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -18,6 +18,7 @@
 
 import tkinter as tk
 from tkinter import simpledialog, messagebox, ttk
+from gui.tooltip import add_tab_tooltips
 from dataclasses import dataclass, field
 from typing import List
 import difflib
@@ -89,6 +90,7 @@ class ParticipantDialog(simpledialog.Dialog):
     def body(self, master):
         self.resizable(False, False)
         nb = ttk.Notebook(master)
+        add_tab_tooltips(nb)
         nb.pack(fill=tk.BOTH, expand=True)
 
         mod_tab = ttk.Frame(nb)
@@ -202,6 +204,7 @@ class EmailConfigDialog(simpledialog.Dialog):
     def body(self, master):
         self.resizable(False, False)
         nb = ttk.Notebook(master)
+        add_tab_tooltips(nb)
         nb.pack(fill=tk.BOTH, expand=True)
 
         server_tab = ttk.Frame(nb)

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -6,7 +6,7 @@ import copy
 import textwrap
 import uuid
 
-from gui.tooltip import ToolTip
+from gui.tooltip import ToolTip, add_tab_tooltips
 from analysis.models import (
     ReliabilityComponent,
     ReliabilityAnalysis,
@@ -616,6 +616,7 @@ class ReliabilityWindow(tk.Frame):
                 self.resizable(False, False)
                 self.vars = {}
                 nb = ttk.Notebook(master)
+                add_tab_tooltips(nb)
                 nb.pack(fill=tk.BOTH, expand=True)
                 gen_tab = ttk.Frame(nb)
                 attr_tab = ttk.Frame(nb)
@@ -973,6 +974,7 @@ class FI2TCWindow(tk.Frame):
             )
             self.widgets = {}
             nb = ttk.Notebook(master)
+            add_tab_tooltips(nb)
             nb.pack(fill=tk.BOTH, expand=True)
             categories = {
                 "Known Functional Weakness": [
@@ -2401,6 +2403,7 @@ class TC2FIWindow(tk.Frame):
             )
             self.widgets = {}
             nb = ttk.Notebook(master)
+            add_tab_tooltips(nb)
             nb.pack(fill=tk.BOTH, expand=True)
             categories = {
                 "Known Env/Operational Condition": [

--- a/gui/tooltip.py
+++ b/gui/tooltip.py
@@ -66,3 +66,30 @@ class ToolTip:
         if self.id:
             self.widget.after_cancel(self.id)
             self.id = None
+
+
+def add_tab_tooltips(nb: tk.Widget) -> ToolTip:
+    """Display the tab text in a tooltip when hovering over a notebook tab."""
+
+    tip = ToolTip(nb, "", automatic=False)
+
+    def _on_motion(event: tk.Event) -> None:
+        try:
+            idx = nb.index(f"@{event.x},{event.y}")
+        except tk.TclError:
+            tip.hide()
+            return
+        text = nb.tab(idx, "text")
+        bbox = nb.bbox(idx)
+        if not bbox:
+            tip.hide()
+            return
+        x = nb.winfo_rootx() + bbox[0] + bbox[2] // 2
+        y = nb.winfo_rooty() + bbox[1] + bbox[3]
+        if tip.text != text:
+            tip.text = text
+        tip.show(x, y)
+
+    nb.bind("<Motion>", _on_motion)
+    nb.bind("<Leave>", lambda _e: tip.hide())
+    return tip


### PR DESCRIPTION
## Summary
- provide helper function `add_tab_tooltips` to display a notebook tab's text on hover
- use the helper across the GUI so all notebook tabs show their names as tooltips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68895b6d28c48325b7bf020265a18b5d