### PR TITLE
Add block boundary shape for internal block diagrams

### DIFF
--- a/tests/test_block_boundary.py
+++ b/tests/test_block_boundary.py
@@ -1,0 +1,26 @@
+import unittest
+from gui.architecture import set_ibd_father
+from sysml.sysml_repository import SysMLRepository
+
+class BlockBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_boundary_created_with_ports(self):
+        repo = self.repo
+        block = repo.create_element("Block", name="B", properties={"ports": "a, b"})
+        ibd = repo.create_diagram("Internal Block Diagram")
+        added = set_ibd_father(repo, ibd, block.elem_id)
+        boundary = next(o for o in ibd.objects if o.get("obj_type") == "Block Boundary")
+        self.assertEqual(boundary.get("element_id"), block.elem_id)
+        port_names = {
+            o["properties"]["name"]
+            for o in ibd.objects
+            if o.get("obj_type") == "Port" and o.get("properties", {}).get("parent") == str(boundary["obj_id"])
+        }
+        self.assertEqual(port_names, {"a", "b"})
+        self.assertTrue(any(d.get("obj_type") == "Block Boundary" for d in added))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- draw new `Block Boundary` objects as dashed boxes
- sync and update ports for block boundary
- place boundary automatically when setting IBD father
- include regression test for boundary creation and port visibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68897c5d9d788325bc16c1064cb8782d