### PR TITLE
Add scenario exposure field with HARA sync

### DIFF
--- a/analysis/models.py
+++ b/analysis/models.py
@@ -131,6 +131,7 @@ class HazopEntry:
 class HaraEntry:
     malfunction: str
     hazard: str
+    scenario: str
     severity: int
     sev_rationale: str
     controllability: int


### PR DESCRIPTION
## Summary
- extend scenario library dialog with an exposure value
- display scenario exposure in Scenario Libraries explorer
- add `get_scenario_exposure` helper in `AutoML`
- store scenario name in HARA entries and auto-fill exposure from scenario
- make HARA exposure read-only and populated when selecting a scenario

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a2ed7a6748325a2677db8f9652977