### PR TITLE
Connect diamond elements at nearest corner

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2984,6 +2984,20 @@ class SysMLDiagramWindow(tk.Frame):
             return ix, iy, t
         return None
 
+    def _nearest_diamond_corner(self, obj: SysMLObject, tx: float, ty: float) -> Tuple[float, float]:
+        """Return the diamond corner of *obj* closest to the target (*tx*, *ty*)."""
+        x = obj.x * self.zoom
+        y = obj.y * self.zoom
+        w = obj.width * self.zoom / 2
+        h = obj.height * self.zoom / 2
+        corners = [
+            (x, y - h),
+            (x + w, y),
+            (x, y + h),
+            (x - w, y),
+        ]
+        return min(corners, key=lambda p: (p[0] - tx) ** 2 + (p[1] - ty) ** 2)
+
     def find_connection(self, x: float, y: float) -> DiagramConnection | None:
         for conn in self.connections:
             src = self.get_object(conn.src)
@@ -3075,23 +3089,7 @@ class SysMLDiagramWindow(tk.Frame):
             dist = (dx**2 + dy**2) ** 0.5 or 1
             return x + dx / dist * r, y + dy / dist * r
         if obj.obj_type in ("Decision", "Merge"):
-            points = [
-                (x, y - h),
-                (x + w, y),
-                (x, y + h),
-                (x - w, y),
-            ]
-            best = None
-            for i in range(len(points)):
-                p3 = points[i]
-                p4 = points[(i + 1) % len(points)]
-                inter = self._segment_intersection((x, y), (tx, ty), p3, p4)
-                if inter:
-                    ix, iy, t = inter
-                    if best is None or t < best[2]:
-                        best = (ix, iy, t)
-            if best:
-                return best[0], best[1]
+            return self._nearest_diamond_corner(obj, tx, ty)
         if abs(dx) > abs(dy):
             if dx > 0:
                 x += w

--- a/tests/test_diamond_corners.py
+++ b/tests/test_diamond_corners.py
@@ -1,0 +1,21 @@
+import unittest
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+
+class DummyWindow:
+    def __init__(self):
+        self.zoom = 1.0
+
+    _nearest_diamond_corner = SysMLDiagramWindow._nearest_diamond_corner
+    edge_point = SysMLDiagramWindow.edge_point
+
+class DiamondCornerTests(unittest.TestCase):
+    def test_edge_point_nearest_corner(self):
+        win = DummyWindow()
+        obj = SysMLObject(1, "Decision", 0, 0, width=40.0, height=40.0)
+        self.assertEqual(win.edge_point(obj, 100.0, 0.0), (20.0, 0.0))
+        self.assertEqual(win.edge_point(obj, -100.0, 0.0), (-20.0, 0.0))
+        self.assertEqual(win.edge_point(obj, 0.0, -100.0), (0.0, -20.0))
+        self.assertEqual(win.edge_point(obj, 0.0, 100.0), (0.0, 20.0))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure relationship lines connecting to diamond-style elements use the nearest corner only
- add tests for diamond corner routing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a4c405fbc8325a724eaf889a17ac8