### PR TITLE
Fix SysML diagram font scaling

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3141,7 +3141,9 @@ class SysMLDiagramWindow(tk.Frame):
             for i in range(len(points)):
                 p3 = points[i]
                 p4 = points[(i + 1) % len(points)]
-                inter = self._segment_intersection((cx, cy), (tx, ty), p3, p4)
+                inter = SysMLDiagramWindow._segment_intersection(
+                    self, (cx, cy), (tx, ty), p3, p4
+                )
                 if inter:
                     ix, iy, t = inter
                     if best is None or t < best[2]:
@@ -4040,12 +4042,30 @@ class SysMLDiagramWindow(tk.Frame):
                 sy = obj.height / 40.0 * self.zoom
                 label_x = x
                 label_y = y + 40 * sy + 10 * self.zoom
-                self.canvas.create_text(label_x, label_y, text="\n".join(label_lines), anchor="n")
+                self.canvas.create_text(
+                    label_x,
+                    label_y,
+                    text="\n".join(label_lines),
+                    anchor="n",
+                    font=self.font,
+                )
             elif obj.obj_type in ("Initial", "Final"):
                 label_y = y + obj.height / 2 * self.zoom + 10 * self.zoom
-                self.canvas.create_text(x, label_y, text="\n".join(label_lines), anchor="n")
+                self.canvas.create_text(
+                    x,
+                    label_y,
+                    text="\n".join(label_lines),
+                    anchor="n",
+                    font=self.font,
+                )
             else:
-                self.canvas.create_text(x, y, text="\n".join(label_lines), anchor="center")
+                self.canvas.create_text(
+                    x,
+                    y,
+                    text="\n".join(label_lines),
+                    anchor="center",
+                    font=self.font,
+                )
 
         if obj in self.selected_objs:
             bx = x - w


### PR DESCRIPTION
## Summary
- ensure SysML text uses zoomed font
- use class method for segment intersection to satisfy tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a5e6f947c8325a5b4699d5935988e