### PR TITLE
Prevent reciprocal aggregation connections

### DIFF
--- a/tests/test_aggregation_validation.py
+++ b/tests/test_aggregation_validation.py
@@ -1,6 +1,10 @@
 import unittest
-from gui.architecture import _aggregation_exists
-from sysml.sysml_repository import SysMLRepository
+from gui.architecture import (
+    _aggregation_exists,
+    SysMLDiagramWindow,
+    SysMLObject,
+)
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
 
 class AggregationExistsTests(unittest.TestCase):
     def setUp(self):
@@ -49,6 +53,41 @@ class AggregationExistsTests(unittest.TestCase):
         a = repo.create_element("Block", name="A")
         b = repo.create_element("Block", name="B")
         self.assertFalse(_aggregation_exists(repo, a.elem_id, b.elem_id))
+
+
+class ReciprocalAggregationTests(unittest.TestCase):
+    class DummyWindow:
+        def __init__(self):
+            self.repo = SysMLRepository.get_instance()
+            diag = SysMLDiagram(diag_id="d", diag_type="Block Diagram")
+            self.repo.diagrams[diag.diag_id] = diag
+            self.diagram_id = diag.diag_id
+
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_reciprocal_aggregation_invalid(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Aggregation", a.elem_id, b.elem_id)
+        win = self.DummyWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=b.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=a.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Aggregation")
+        self.assertFalse(valid)
+
+    def test_reciprocal_composite_aggregation_invalid(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Composite Aggregation", a.elem_id, b.elem_id)
+        win = self.DummyWindow()
+        src = SysMLObject(1, "Block", 0, 0, element_id=b.elem_id)
+        dst = SysMLObject(2, "Block", 0, 0, element_id=a.elem_id)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Composite Aggregation")
+        self.assertFalse(valid)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `_reverse_aggregation_exists` helper
- validate that blocks do not aggregate each other in `validate_connection`
- test reciprocal aggregation rejection for both aggregation types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a6a1577d083259b820143d5a126d4