### PR TITLE
Fix Add Contained Parts for inherited multiplicities

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -702,6 +702,8 @@ def _sync_ibd_partproperty_parts(
             for p in block.properties.get("partProperties", "").split(",")
             if p.strip()
         ]
+    else:
+        names = [n.split("[")[0].strip() for n in names]
     added: list[dict] = []
     base_x = 50.0
     base_y = 50.0 + 60.0 * len(existing_defs)

--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -213,6 +213,23 @@ class InheritPartsTests(unittest.TestCase):
             any(d.get("properties", {}).get("definition") == part_blk.elem_id for d in added)
         )
 
+    def test_sync_partproperty_parts_with_multiplicity(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "B[1..2]"})
+        part_blk = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+        added = _sync_ibd_partproperty_parts(repo, blk.elem_id, names=["B[1..2]"])
+        self.assertTrue(
+            any(
+                o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part_blk.elem_id
+                for o in ibd.objects
+            )
+        )
+        self.assertTrue(
+            any(d.get("properties", {}).get("definition") == part_blk.elem_id for d in added)
+        )
+
 
     def test_sync_aggregation_parts_with_parent(self):
         repo = self.repo


### PR DESCRIPTION
## Summary
- ensure `_sync_ibd_partproperty_parts` handles names with multiplicities
- test adding partproperty parts when multiplicities are present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a71e5af7c8325bf41497963082fba