### PR TITLE
Fix IBD partproperty parsing with ':' syntax

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -691,28 +691,38 @@ def _sync_ibd_partproperty_parts(
         for o in diag.objects
         if o.get("obj_type") == "Part"
     }
-    existing_names = {
-        repo.elements[did].name
-        for did in existing_defs
-        if did in repo.elements and repo.elements[did].elem_type == "Block"
+    existing_props = {
+        repo.elements[o.get("element_id")].name
+        for o in diag.objects
+        if o.get("obj_type") == "Part" and o.get("element_id") in repo.elements
     }
+    def _parse_entry(raw: str) -> tuple[str, str]:
+        """Return (property name, block name) for a raw part property entry."""
+        raw = raw.strip()
+        prop = raw
+        block = raw
+        if ":" in raw:
+            prop, block = raw.split(":", 1)
+        prop = prop.split("[")[0].strip()
+        block = block.split("[")[0].strip()
+        return prop or block, block
+
     if names is None:
-        names = [
-            p.split("[")[0].strip()
-            for p in block.properties.get("partProperties", "").split(",")
-            if p.strip()
-        ]
+        entries = [p for p in block.properties.get("partProperties", "").split(",") if p.strip()]
+    else:
+        entries = [n for n in names if n.strip()]
+    parsed = [_parse_entry(e) for e in entries]
     added: list[dict] = []
     base_x = 50.0
-    base_y = 50.0 + 60.0 * len(existing_defs)
-    for name in names:
-        if name in existing_names:
+    base_y = 50.0 + 60.0 * len(existing_props)
+    for prop_name, block_name in parsed:
+        if prop_name in existing_props:
             continue
         target_id = next(
             (
                 eid
                 for eid, elem in repo.elements.items()
-                if elem.elem_type == "Block" and elem.name == name
+                if elem.elem_type == "Block" and elem.name == block_name
             ),
             None,
         )
@@ -720,7 +730,7 @@ def _sync_ibd_partproperty_parts(
             continue
         part_elem = repo.create_element(
             "Part",
-            name=name,
+            name=prop_name,
             properties={"definition": target_id},
             owner=repo.root_package.elem_id,
         )
@@ -736,6 +746,8 @@ def _sync_ibd_partproperty_parts(
         base_y += 60.0
         diag.objects.append(obj_dict)
         added.append(obj_dict)
+        existing_props.add(prop_name)
+        existing_defs.add(target_id)
         if app:
             for win in getattr(app, "ibd_windows", []):
                 if getattr(win, "diagram_id", None) == diag.diag_id:

--- a/tests/test_inherit_parts.py
+++ b/tests/test_inherit_parts.py
@@ -244,5 +244,37 @@ class InheritPartsTests(unittest.TestCase):
         )
         self.assertTrue(any(d.get("properties", {}).get("definition") == part.elem_id for d in added))
 
+    def test_partproperty_names_with_brackets(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "B[2]"})
+        part_blk = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+        added = _sync_ibd_partproperty_parts(repo, blk.elem_id, names=["B[2]"])
+        self.assertTrue(
+            any(
+                o.get("obj_type") == "Part"
+                and repo.elements[o.get("element_id")].name == "B"
+                and o.get("properties", {}).get("definition") == part_blk.elem_id
+                for o in ibd.objects
+            )
+        )
+
+    def test_partproperty_name_with_colon(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "p:B"})
+        part_blk = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+        added = _sync_ibd_partproperty_parts(repo, blk.elem_id)
+        self.assertTrue(
+            any(
+                o.get("obj_type") == "Part"
+                and repo.elements[o.get("element_id")].name == "p"
+                and o.get("properties", {}).get("definition") == part_blk.elem_id
+                for o in ibd.objects
+            )
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle `name:type` syntax when adding partproperties to IBDs
- store property names on Part elements so labels match
- unit tests for bracket and colon notation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688a71e5af7c8325bf41497963082fba