### PR TITLE
Fix FTA root handling when loading empty projects

### DIFF
--- a/analysis/risk_assessment.py
+++ b/analysis/risk_assessment.py
@@ -164,7 +164,11 @@ class AutoMLHelper:
         all_ids = []
         for event in top_events:
             all_ids.extend(traverse(event))
-        self.unique_node_id_counter = max(all_ids) + 1
+        if all_ids:
+            self.unique_node_id_counter = max(all_ids) + 1
+        else:
+            # No nodes yet. Start numbering from 1.
+            self.unique_node_id_counter = 1
 
     def round_to_half(self, val):
         try:


### PR DESCRIPTION
## Summary
- avoid crash when computing unique node IDs if no top events exist
- allocate the first malfunction to existing root node instead of creating another
- ensure default FTA root when loading a model without any `top_events`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a777d367c83259dedd7f7df043159