### PR TITLE
Fix visibility default for new part properties

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -742,6 +742,7 @@ def _sync_ibd_partproperty_parts(
             "y": base_y,
             "element_id": part_elem.elem_id,
             "properties": {"definition": target_id},
+            "hidden": True,
         }
         base_y += 60.0
         diag.objects.append(obj_dict)

--- a/tests/test_partproperty_visibility.py
+++ b/tests/test_partproperty_visibility.py
@@ -1,0 +1,22 @@
+import unittest
+from gui.architecture import _sync_ibd_partproperty_parts
+from sysml.sysml_repository import SysMLRepository
+
+class PartPropertyVisibilityTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_partproperty_hidden_by_default(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "B"})
+        part_blk = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+        added = _sync_ibd_partproperty_parts(repo, blk.elem_id)
+        part = next(o for o in ibd.objects if o.get("properties", {}).get("definition") == part_blk.elem_id)
+        self.assertTrue(part.get("hidden", False))
+        self.assertTrue(any(d.get("hidden", False) for d in added))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure parts created from `partProperties` start hidden
- test that part property objects are hidden by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a7b8c0fbc8325980a80b330875de0