### PR TITLE
Fix new part visibility in IBD

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6086,6 +6086,7 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
                 repo, block_id, names=to_add_names, app=getattr(self, "app", None)
             )
             for data in added_props:
+                data["hidden"] = False
                 self.objects.append(SysMLObject(**data))
 
         if added:

--- a/tests/test_add_contained_parts.py
+++ b/tests/test_add_contained_parts.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import patch
+
+from gui import architecture
+from gui.architecture import SysMLObject, InternalBlockDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+class DummyWindow:
+    _get_part_name = InternalBlockDiagramWindow._get_part_name
+
+    def __init__(self, diagram):
+        self.repo = SysMLRepository.get_instance()
+        self.diagram_id = diagram.diag_id
+        self.objects = []
+        self.connections = []
+        self.app = None
+
+    def _sync_to_repository(self):
+        diag = self.repo.diagrams.get(self.diagram_id)
+        if diag:
+            diag.objects = [obj.__dict__ for obj in self.objects]
+            diag.connections = [conn.__dict__ for conn in self.connections]
+
+    def redraw(self):
+        pass
+
+class AddContainedPartsRenderTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_new_parts_become_visible(self):
+        repo = self.repo
+        block = repo.create_element("Block", name="A", properties={"partProperties": "B"})
+        part_blk = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(block.elem_id, ibd.diag_id)
+        win = DummyWindow(ibd)
+
+        class DummyDialog:
+            def __init__(self, parent, names, visible, hidden):
+                self.result = names
+
+        with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
+            InternalBlockDiagramWindow.add_contained_parts(win)
+
+        diag = repo.diagrams[ibd.diag_id]
+        self.assertEqual(len(diag.objects), 1)
+        self.assertFalse(diag.objects[0].get('hidden', False))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure new parts added through the Add Contained Parts dialog are visible
- test rendering of new parts when added from block properties

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a819198a483259c079eb8ba37bc1d