### PR TITLE
Fix location for new part properties

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -761,6 +761,8 @@ def _sync_ibd_partproperty_parts(
             "obj_type": "Part",
             "x": base_x,
             "y": base_y,
+            "width": 80.0,
+            "height": 40.0,
             "element_id": part_elem.elem_id,
             "properties": {"definition": target_id},
             "hidden": True,


### PR DESCRIPTION
## Summary
- ensure parts added via part property sync have default dimensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688ae93ed0648325953337bc034f5755