### PR TITLE
Fix invisible partproperty objects by setting default size

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -761,6 +761,8 @@ def _sync_ibd_partproperty_parts(
             "obj_type": "Part",
             "x": base_x,
             "y": base_y,
+            "width": 80.0,
+            "height": 40.0,
             "element_id": part_elem.elem_id,
             "properties": {"definition": target_id},
             "hidden": True,

--- a/tests/test_partproperty_visibility.py
+++ b/tests/test_partproperty_visibility.py
@@ -18,5 +18,18 @@ class PartPropertyVisibilityTests(unittest.TestCase):
         self.assertTrue(part.get("hidden", False))
         self.assertTrue(any(d.get("hidden", False) for d in added))
 
+    def test_partproperty_default_size(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "B"})
+        repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+        added = _sync_ibd_partproperty_parts(repo, blk.elem_id)
+        part = added[0]
+        self.assertIn("width", part)
+        self.assertIn("height", part)
+        self.assertGreater(part["width"], 0)
+        self.assertGreater(part["height"], 0)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- default newly added part property objects to standard size
- verify part property parts include size in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688ae93ed0648325953337bc034f5755