### PR TITLE
Ensure newly configured parts appear in nested IBDs

### DIFF
--- a/tests/test_partproperty_visibility.py
+++ b/tests/test_partproperty_visibility.py
@@ -31,5 +31,16 @@ class PartPropertyVisibilityTests(unittest.TestCase):
         self.assertGreater(part["width"], 0)
         self.assertGreater(part["height"], 0)
 
+    def test_partproperty_visible_flag(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "B"})
+        part_blk = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+        added = _sync_ibd_partproperty_parts(repo, blk.elem_id, hidden=False)
+        part = next(o for o in ibd.objects if o.get("properties", {}).get("definition") == part_blk.elem_id)
+        self.assertFalse(part.get("hidden", True))
+        self.assertTrue(any(not d.get("hidden", True) for d in added))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_propagate_block_changes.py
+++ b/tests/test_propagate_block_changes.py
@@ -77,6 +77,23 @@ class PropagateBlockChangesTests(unittest.TestCase):
         req_ids = [r["id"] for r in d_child.objects[0].get("requirements", [])]
         self.assertIn("R2", req_ids)
 
+    def test_part_changes_propagate_to_child_ibd(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent", properties={"partProperties": "P"})
+        child = repo.create_element("Block", name="Child")
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        part_blk = repo.create_element("Block", name="P")
+        ibd_child = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(child.elem_id, ibd_child.diag_id)
+
+        inherit_block_properties(repo, child.elem_id)
+        propagate_block_changes(repo, parent.elem_id)
+
+        obj = next(
+            o for o in ibd_child.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part_blk.elem_id
+        )
+        self.assertFalse(obj.get("hidden", True))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow controlling visibility when syncing part property parts
- grow IBD boundaries when visible parts are added
- show new parts when editing block properties
- propagate new parts to child blocks' internal diagrams
- test visible flag and propagation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688aec89068c832593a2b815d1773bab