### PR TITLE
Ensure added parts show in child IBDs

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -722,7 +722,11 @@ def _sync_ibd_aggregation_parts(
 
 
 def _sync_ibd_partproperty_parts(
-    repo: SysMLRepository, block_id: str, names: list[str] | None = None, app=None
+    repo: SysMLRepository,
+    block_id: str,
+    names: list[str] | None = None,
+    app=None,
+    visible: bool = False,
 ) -> list[dict]:
     """Ensure ``block_id``'s IBD includes parts for given ``names``.
 
@@ -754,8 +758,15 @@ def _sync_ibd_partproperty_parts(
         entries = [n for n in names if n.strip()]
     parsed = [parse_part_property(e) for e in entries]
     added: list[dict] = []
-    base_x = 50.0
-    base_y = 50.0 + 60.0 * len(existing_props)
+    boundary = next((o for o in diag.objects if o.get("obj_type") == "Block Boundary"), None)
+    if boundary:
+        base_x = boundary["x"] - boundary["width"] / 2 + 30.0
+        base_y = (
+            boundary["y"] - boundary["height"] / 2 + 30.0 + 60.0 * len(existing_props)
+        )
+    else:
+        base_x = 50.0
+        base_y = 50.0 + 60.0 * len(existing_props)
     for prop_name, block_name in parsed:
         if prop_name in existing_props:
             continue
@@ -785,7 +796,7 @@ def _sync_ibd_partproperty_parts(
             "height": 40.0,
             "element_id": part_elem.elem_id,
             "properties": {"definition": target_id},
-            "hidden": True,
+            "hidden": not visible,
         }
         base_y += 60.0
         diag.objects.append(obj_dict)
@@ -799,6 +810,48 @@ def _sync_ibd_partproperty_parts(
                     win.redraw()
                     win._sync_to_repository()
     return added
+
+
+def _propagate_boundary_parts(
+    repo: SysMLRepository, block_id: str, parts: list[dict], app=None
+) -> None:
+    """Insert *parts* into diagrams containing boundaries for ``block_id``."""
+
+    for diag in repo.diagrams.values():
+        if diag.diag_type != "Internal Block Diagram":
+            continue
+        boundary = next(
+            (
+                o
+                for o in getattr(diag, "objects", [])
+                if o.get("obj_type") == "Block Boundary" and o.get("element_id") == block_id
+            ),
+            None,
+        )
+        if not boundary:
+            continue
+        diag.objects = getattr(diag, "objects", [])
+        existing = {o.get("element_id") for o in diag.objects if o.get("obj_type") == "Part"}
+        base_x = boundary["x"] - boundary["width"] / 2 + 30.0
+        base_y = boundary["y"] - boundary["height"] / 2 + 30.0
+        for obj in parts:
+            if obj.get("element_id") in existing:
+                continue
+            new_obj = obj.copy()
+            new_obj["obj_id"] = _get_next_id()
+            new_obj["x"] = base_x
+            new_obj["y"] = base_y
+            new_obj["hidden"] = False
+            diag.objects.append(new_obj)
+            repo.add_element_to_diagram(diag.diag_id, new_obj["element_id"])
+            base_y += 60.0
+            if app:
+                for win in getattr(app, "ibd_windows", []):
+                    if getattr(win, "diagram_id", None) == diag.diag_id:
+                        win.objects.append(SysMLObject(**new_obj))
+                        win.redraw()
+                        win._sync_to_repository()
+
 
 
 def _sync_block_parts_from_ibd(repo: SysMLRepository, diag_id: str) -> None:
@@ -5618,11 +5671,34 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 propagate_block_port_changes(repo, self.obj.element_id)
                 propagate_block_part_changes(repo, self.obj.element_id)
                 propagate_block_changes(repo, self.obj.element_id)
-                _sync_ibd_partproperty_parts(
+                app_ref = getattr(self.master, "app", None)
+                added = _sync_ibd_partproperty_parts(
                     repo,
                     self.obj.element_id,
-                    app=getattr(self.master, "app", None),
+                    app=app_ref,
+                    visible=True,
                 )
+                for data in added:
+                    data["hidden"] = False
+                _propagate_boundary_parts(repo, self.obj.element_id, added, app=app_ref)
+                father_diag_id = repo.get_linked_diagram(self.obj.element_id)
+                for diag in repo.diagrams.values():
+                    if (
+                        diag.diag_type == "Internal Block Diagram"
+                        and getattr(diag, "father", None) == self.obj.element_id
+                        and diag.diag_id != father_diag_id
+                    ):
+                        added_child = inherit_father_parts(repo, diag)
+                        for obj in added_child:
+                            if obj.get("obj_type") == "Part":
+                                obj["hidden"] = False
+                        if app_ref:
+                            for win in getattr(app_ref, "ibd_windows", []):
+                                if getattr(win, "diagram_id", None) == diag.diag_id:
+                                    for obj in added_child:
+                                        win.objects.append(SysMLObject(**obj))
+                                    win.redraw()
+                                    win._sync_to_repository()
         try:
             if self.obj.obj_type not in (
                 "Initial",

--- a/tests/test_boundary_partprop_propagation.py
+++ b/tests/test_boundary_partprop_propagation.py
@@ -1,0 +1,40 @@
+import unittest
+from gui.architecture import _sync_ibd_partproperty_parts, _propagate_boundary_parts
+from sysml.sysml_repository import SysMLRepository
+
+class BoundaryPartPropagationTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_new_parts_show_in_boundary_diagrams(self):
+        repo = self.repo
+        block_a = repo.create_element("Block", name="A")
+        block_b = repo.create_element("Block", name="B")
+        block_c = repo.create_element("Block", name="C")
+        ibd_b = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(block_b.elem_id, ibd_b.diag_id)
+        ibd_a = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(block_a.elem_id, ibd_a.diag_id)
+        ibd_a.objects.append({
+            "obj_id": 1,
+            "obj_type": "Block Boundary",
+            "x": 100.0,
+            "y": 80.0,
+            "width": 200.0,
+            "height": 120.0,
+            "element_id": block_b.elem_id,
+            "properties": {"name": "B"},
+        })
+        block_b.properties["partProperties"] = "C"
+        added = _sync_ibd_partproperty_parts(repo, block_b.elem_id, visible=True)
+        _propagate_boundary_parts(repo, block_b.elem_id, added)
+        self.assertTrue(any(
+            o.get("obj_type") == "Part" and o.get("element_id") == added[0]["element_id"]
+            for o in ibd_a.objects
+        ))
+        part = next(o for o in ibd_a.objects if o.get("element_id") == added[0]["element_id"])
+        self.assertFalse(part.get("hidden", False))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `_sync_ibd_partproperty_parts` to place new parts inside block boundaries and optionally make them visible
- when saving block configuration, display new parts in the block's diagram and in any child IBDs
- propagate added parts to diagrams containing block boundaries for that block
- test boundary part propagation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688aec89068c832593a2b815d1773bab