### PR TITLE
Propagate part deletions from configuration

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1068,6 +1068,52 @@ def remove_aggregation_part(
                 repo.delete_element(pid)
 
 
+def remove_partproperty_entry(
+    repo: SysMLRepository, block_id: str, entry: str, app=None
+) -> None:
+    """Remove a part property entry and update descendant diagrams."""
+
+    block = repo.elements.get(block_id)
+    if not block:
+        return
+    prop_name, blk_name = parse_part_property(entry)
+    target_id = next(
+        (
+            eid
+            for eid, elem in repo.elements.items()
+            if elem.elem_type == "Block" and elem.name == blk_name
+        ),
+        None,
+    )
+    if not target_id:
+        return
+
+    parts = [p.strip() for p in block.properties.get("partProperties", "").split(",") if p.strip()]
+    parts = [p for p in parts if _part_prop_key(p) != _part_prop_key(entry)]
+    if parts:
+        block.properties["partProperties"] = ", ".join(parts)
+    else:
+        block.properties.pop("partProperties", None)
+    for d in repo.diagrams.values():
+        for o in getattr(d, "objects", []):
+            if o.get("element_id") == block_id:
+                if parts:
+                    o.setdefault("properties", {})["partProperties"] = ", ".join(parts)
+                else:
+                    o.setdefault("properties", {}).pop("partProperties", None)
+
+    _propagate_part_removal(
+        repo,
+        block_id,
+        prop_name,
+        target_id,
+        remove_object=True,
+        app=app,
+    )
+    _remove_parts_from_ibd(repo, block_id, target_id, app=app)
+    _propagate_ibd_part_removal(repo, block_id, target_id, app=app)
+
+
 def inherit_block_properties(repo: SysMLRepository, block_id: str) -> None:
     """Merge parent block properties into the given block."""
     extend_block_parts_with_parents(repo, block_id)
@@ -5723,6 +5769,21 @@ class SysMLObjectDialog(simpledialog.Dialog):
             self.obj.properties[prop] = var.get()
             if self.obj.element_id and self.obj.element_id in repo.elements:
                 repo.elements[self.obj.element_id].properties[prop] = var.get()
+        removed_parts = []
+        prev_parts = []
+        if (
+            self.obj.element_id
+            and self.obj.element_id in repo.elements
+            and "partProperties" in repo.elements[self.obj.element_id].properties
+        ):
+            prev_parts = [
+                p.strip()
+                for p in repo.elements[self.obj.element_id]
+                .properties.get("partProperties", "")
+                .split(",")
+                if p.strip()
+            ]
+
         for prop, lb in self.listboxes.items():
             if prop == "operations":
                 self.obj.properties[prop] = operations_to_json(self._operations)
@@ -5738,6 +5799,10 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 self.obj.properties[prop] = joined
                 if self.obj.element_id and self.obj.element_id in repo.elements:
                     repo.elements[self.obj.element_id].properties[prop] = joined
+                if prop == "partProperties" and prev_parts:
+                    prev_keys = {_part_prop_key(p) for p in prev_parts}
+                    new_keys = {_part_prop_key(i) for i in items}
+                    removed_parts = [p for p in prev_parts if _part_prop_key(p) not in new_keys]
 
         if self.obj.element_id and self.obj.element_id in repo.elements:
             elem_type = repo.elements[self.obj.element_id].elem_type
@@ -5751,6 +5816,12 @@ class SysMLObjectDialog(simpledialog.Dialog):
                     app=getattr(self.master, "app", None),
                     hidden=False,
                 )
+                if removed_parts:
+                    app = getattr(self.master, "app", None)
+                    for val in removed_parts:
+                        remove_partproperty_entry(
+                            repo, self.obj.element_id, val, app=app
+                        )
         try:
             if self.obj.obj_type not in (
                 "Initial",

--- a/tests/test_remove_partproperty.py
+++ b/tests/test_remove_partproperty.py
@@ -1,0 +1,45 @@
+import unittest
+from gui.architecture import (
+    _sync_ibd_partproperty_parts,
+    propagate_block_changes,
+    remove_partproperty_entry,
+)
+from sysml.sysml_repository import SysMLRepository
+
+class RemovePartPropertyTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_remove_partproperty_updates_child_ibds(self):
+        repo = self.repo
+        parent = repo.create_element("Block", name="Parent", properties={"partProperties": "B"})
+        part_blk = repo.create_element("Block", name="B")
+        child = repo.create_element("Block", name="Child")
+        repo.create_relationship("Generalization", child.elem_id, parent.elem_id)
+        ibd_p = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(parent.elem_id, ibd_p.diag_id)
+        ibd_c = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(child.elem_id, ibd_c.diag_id)
+
+        _sync_ibd_partproperty_parts(repo, parent.elem_id)
+        propagate_block_changes(repo, parent.elem_id)
+
+        self.assertTrue(
+            any(
+                o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part_blk.elem_id
+                for o in ibd_c.objects
+            )
+        )
+
+        remove_partproperty_entry(repo, parent.elem_id, "B")
+
+        self.assertFalse(
+            any(
+                o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part_blk.elem_id
+                for o in ibd_c.objects
+            )
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add helper `remove_partproperty_entry` to purge removed partProperties
- invoke helper from the SysML object dialog when partProperties change
- test removing partProperties removes descendant IBD parts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688af395cf8883258fbca5457ea206cd