### PR TITLE
Improve multiplicity handling

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -527,8 +527,7 @@ def add_multiplicity_parts(
     """Ensure ``count`` part instances exist according to ``multiplicity``."""
 
     low, high = _parse_multiplicity_range(multiplicity)
-    if low <= 1 and high == 1:
-        return []
+
     desired = count if count is not None else low
     if high is not None:
         desired = min(desired, high)
@@ -547,15 +546,37 @@ def add_multiplicity_parts(
     total = len(existing)
     if count is not None:
         target_total = total + desired
+        if high is not None:
+            target_total = min(target_total, high)
     else:
-        target_total = max(total, desired)
-    if high is not None:
-        target_total = min(target_total, high)
+        target_total = total
+        if total < low:
+            target_total = low
+        if high is not None and target_total > high:
+            target_total = high
 
     added: list[dict] = []
     base_name = repo.elements.get(part_id).name or part_id
 
-    # rename existing part elements so their names follow the indexing scheme
+    # remove extra part objects if multiplicity decreased
+    if total > target_total:
+        to_remove = existing[target_total:]
+        remove_ids = {o["obj_id"] for o in to_remove}
+        for obj in to_remove:
+            diag.objects.remove(obj)
+            repo.delete_element(obj.get("element_id"))
+        diag.objects = [
+            o
+            for o in diag.objects
+            if not (
+                o.get("obj_type") == "Port"
+                and o.get("properties", {}).get("parent") in {str(rid) for rid in remove_ids}
+            )
+        ]
+        existing = existing[:target_total]
+        total = target_total
+
+    # rename remaining part elements so their names follow the indexing scheme
     for idx, obj in enumerate(existing):
         elem = repo.elements.get(obj.get("element_id"))
         if elem:

--- a/tests/test_multiplicity_parts.py
+++ b/tests/test_multiplicity_parts.py
@@ -52,5 +52,34 @@ class MultiplicityPartTests(unittest.TestCase):
         ]
         self.assertEqual(names, ["P[1]", "P[2]", "P[3]"])
 
+    def test_multiplicity_reduction_and_increase(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="W")
+        part = repo.create_element("Block", name="P")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "1..3")
+        add_multiplicity_parts(repo, whole.elem_id, part.elem_id, "1..3", count=2)
+        objs = [
+            o
+            for o in ibd.objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(objs), 3)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "1")
+        objs = [
+            o
+            for o in ibd.objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(objs), 1)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "4")
+        objs = [
+            o
+            for o in ibd.objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(objs), 4)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support reducing and increasing multiplicity for part instances
- test multiplicity reduction/removal and increase

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b06a3c57c8325a1405b6033cf741b