### PR TITLE
Update multiplicity part logic

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -527,11 +527,6 @@ def add_multiplicity_parts(
     """Ensure ``count`` part instances exist according to ``multiplicity``."""
 
     low, high = _parse_multiplicity_range(multiplicity)
-    if low <= 1 and high == 1:
-        return []
-    desired = count if count is not None else low
-    if high is not None:
-        desired = min(desired, high)
 
     diag_id = repo.get_linked_diagram(whole_id)
     diag = repo.diagrams.get(diag_id)
@@ -545,12 +540,55 @@ def add_multiplicity_parts(
         and o.get("properties", {}).get("definition") == part_id
     ]
     total = len(existing)
+
+    if low <= 1 and high == 1:
+        if total > 1:
+            for obj in existing[1:]:
+                diag.objects.remove(obj)
+                elem_id = obj.get("element_id")
+                if elem_id in repo.elements:
+                    repo.delete_element(elem_id)
+                if app:
+                    for win in getattr(app, "ibd_windows", []):
+                        if getattr(win, "diagram_id", None) == diag.diag_id:
+                            win.objects = [
+                                o
+                                for o in win.objects
+                                if getattr(o, "obj_id", None) != obj.get("obj_id")
+                            ]
+                            win.redraw()
+                            win._sync_to_repository()
+        return []
+
+    desired = count if count is not None else low
+    if high is not None:
+        desired = min(desired, high)
     if count is not None:
         target_total = total + desired
     else:
         target_total = max(total, desired)
     if high is not None:
         target_total = min(target_total, high)
+
+    if total > target_total:
+        # remove excess parts starting from the end of the list
+        for obj in existing[target_total:]:
+            diag.objects.remove(obj)
+            elem_id = obj.get("element_id")
+            if elem_id in repo.elements:
+                repo.delete_element(elem_id)
+            if app:
+                for win in getattr(app, "ibd_windows", []):
+                    if getattr(win, "diagram_id", None) == diag.diag_id:
+                        win.objects = [
+                            o
+                            for o in win.objects
+                            if getattr(o, "obj_id", None) != obj.get("obj_id")
+                        ]
+                        win.redraw()
+                        win._sync_to_repository()
+        existing = existing[:target_total]
+        total = len(existing)
 
     added: list[dict] = []
     base_name = repo.elements.get(part_id).name or part_id
@@ -592,6 +630,20 @@ def add_multiplicity_parts(
                     win.redraw()
                     win._sync_to_repository()
         added.append(obj_dict)
+    # rename all part elements to ensure sequential numbering
+    all_objs = [
+        o
+        for o in diag.objects
+        if o.get("obj_type") == "Part"
+        and o.get("properties", {}).get("definition") == part_id
+    ]
+    for idx, obj in enumerate(all_objs):
+        elem = repo.elements.get(obj.get("element_id"))
+        if elem:
+            expected = f"{base_name}[{idx + 1}]"
+            if elem.name != expected:
+                elem.name = expected
+
     return added
 
 

--- a/tests/test_multiplicity_parts.py
+++ b/tests/test_multiplicity_parts.py
@@ -52,5 +52,40 @@ class MultiplicityPartTests(unittest.TestCase):
         ]
         self.assertEqual(names, ["P[1]", "P[2]", "P[3]"])
 
+    def test_multiplicity_decrease_removes_parts(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "3")
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "1")
+        objs = [
+            o
+            for o in ibd.objects
+            if o.get("obj_type") == "Part"
+            and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(objs), 1)
+        self.assertEqual(repo.elements[objs[0]["element_id"]].name, "Part[1]")
+
+    def test_add_parts_up_to_multiplicity(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "1..3")
+        add_multiplicity_parts(repo, whole.elem_id, part.elem_id, "1..3", count=1)
+        add_multiplicity_parts(repo, whole.elem_id, part.elem_id, "1..3", count=1)
+        add_multiplicity_parts(repo, whole.elem_id, part.elem_id, "1..3", count=1)
+        objs = [
+            o
+            for o in ibd.objects
+            if o.get("obj_type") == "Part"
+            and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(objs), 3)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow decreasing and increasing multiplicity of parts
- keep part instances in sync with multiplicity bounds
- test manual part addition and removal when multiplicity changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b06a3c57c8325a1405b6033cf741b