### PR TITLE
Remove part properties editing option

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6736,6 +6736,10 @@ class ElementPropertiesDialog(simpledialog.Dialog):
         key = f"{self.element.elem_type.replace(' ', '')}Usage"
         row = 1
         for prop in SYSML_PROPERTIES.get(key, []):
+            if prop == "partProperties":
+                # Part properties are configured through dedicated dialogs.
+                # Skip them in the generic properties window.
+                continue
             ttk.Label(master, text=f"{prop}:").grid(row=row, column=0, sticky="e", padx=4, pady=2)
             var = tk.StringVar(value=self.element.properties.get(prop, ""))
             ttk.Entry(master, textvariable=var).grid(row=row, column=1, padx=4, pady=2)


### PR DESCRIPTION
## Summary
- skip `partProperties` when constructing `ElementPropertiesDialog`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b65f23408832590986acdeeb73e87