### PR TITLE
Fix IBD part multiplicity enforcement

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5,6 +5,7 @@ import textwrap
 from tkinter import ttk, simpledialog, messagebox
 import json
 import math
+import re
 from dataclasses import dataclass, field, asdict
 from typing import Dict, List, Tuple
 
@@ -670,6 +671,28 @@ def add_multiplicity_parts(
     return added
 
 
+def _enforce_ibd_multiplicity(
+    repo: SysMLRepository, block_id: str, app=None
+) -> list[dict]:
+    """Ensure ``block_id``'s IBD obeys aggregation multiplicities.
+
+    Returns a list of added part object dictionaries."""
+
+    added: list[dict] = []
+    src_ids = [block_id] + _collect_generalization_parents(repo, block_id)
+    for rel in repo.relationships:
+        if (
+            rel.rel_type in ("Aggregation", "Composite Aggregation")
+            and rel.source in src_ids
+        ):
+            mult = rel.properties.get("multiplicity", "")
+            if mult:
+                added.extend(
+                    add_multiplicity_parts(repo, block_id, rel.target, mult, app=app)
+                )
+    return added
+
+
 def _sync_ibd_composite_parts(
     repo: SysMLRepository, block_id: str, app=None
 ) -> list[dict]:
@@ -1128,7 +1151,7 @@ def update_block_parts_from_ibd(repo: SysMLRepository, diagram: SysMLDiagram) ->
         return
     block = repo.elements[block_id]
     existing = [p.strip() for p in block.properties.get("partProperties", "").split(",") if p.strip()]
-    diag_names: list[str] = []
+    diag_entries: list[tuple[str, str]] = []
     diag_bases: set[str] = set()
     for obj in getattr(diagram, "objects", []):
         if obj.get("obj_type") != "Part":
@@ -1145,14 +1168,18 @@ def update_block_parts_from_ibd(repo: SysMLRepository, diagram: SysMLDiagram) ->
         if not name:
             name = obj.get("properties", {}).get("component", "")
         base = name.split("[")[0].strip() if name else ""
-        if base and base not in diag_bases:
-            diag_names.append(name or base)
-            diag_bases.add(base)
+        def_id = obj.get("properties", {}).get("definition")
+        base_def = ""
+        if def_id and def_id in repo.elements:
+            base_def = (repo.elements[def_id].name or def_id).split("[")[0].strip()
+        key = base_def or base
+        if key and key not in diag_bases:
+            diag_entries.append((key, name or key))
+            diag_bases.add(key)
 
     merged_names = list(existing)
     bases = {n.split("[")[0].strip() for n in merged_names}
-    for name in diag_names:
-        base = name.split("[")[0].strip()
+    for base, name in diag_entries:
         if base not in bases:
             merged_names.append(name)
             bases.add(base)
@@ -3807,7 +3834,12 @@ class SysMLDiagramWindow(tk.Frame):
             # Blocks and ports use custom drawing logic
             return []
 
-        name = obj.properties.get("name", obj.obj_type)
+        name = obj.properties.get("name", "")
+        if not name and obj.element_id and obj.element_id in self.repo.elements:
+            elem = self.repo.elements[obj.element_id]
+            name = elem.name or elem.properties.get("component", obj.obj_type)
+        if not name:
+            name = obj.obj_type
         if obj.obj_type == "Part":
             asil = calculate_allocated_asil(obj.requirements)
             if obj.properties.get("asil") != asil:
@@ -3815,8 +3847,48 @@ class SysMLDiagramWindow(tk.Frame):
                 if obj.element_id and obj.element_id in self.repo.elements:
                     self.repo.elements[obj.element_id].properties["asil"] = asil
             def_id = obj.properties.get("definition")
+            mult = None
             if def_id and def_id in self.repo.elements:
                 def_name = self.repo.elements[def_id].name or def_id
+                diag = self.repo.diagrams.get(self.diagram_id)
+                block_id = (
+                    getattr(diag, "father", None)
+                    or next(
+                        (
+                            eid
+                            for eid, did in self.repo.element_diagrams.items()
+                            if did == self.diagram_id
+                        ),
+                        None,
+                    )
+                )
+                if block_id:
+                    for rel in self.repo.relationships:
+                        if (
+                            rel.rel_type in ("Aggregation", "Composite Aggregation")
+                            and rel.source == block_id
+                            and rel.target == def_id
+                        ):
+                            mult = rel.properties.get("multiplicity")
+                            break
+                base = name
+                index = None
+                m = re.match(r"^(.*)\[(\d+)\]$", name)
+                if m:
+                    base = m.group(1)
+                    index = int(m.group(2))
+                if index is not None:
+                    base = f"{base} {index}"
+                name = base
+                if mult:
+                    if ".." in mult:
+                        upper = mult.split("..", 1)[1] or "*"
+                        disp = f"{index or 1}..{upper}"
+                    elif mult == "*":
+                        disp = f"{index or 1}..*"
+                    else:
+                        disp = f"{index or 1}..{mult}"
+                    def_name = f"{def_name} [{disp}]"
                 name = f"{name} : {def_name}" if name else def_name
 
         lines: list[str] = []
@@ -5135,6 +5207,28 @@ class SysMLDiagramWindow(tk.Frame):
             update_block_parts_from_ibd(self.repo, diag)
             self.repo.touch_diagram(self.diagram_id)
             _sync_block_parts_from_ibd(self.repo, self.diagram_id)
+            if diag.diag_type == "Internal Block Diagram":
+                block_id = (
+                    getattr(diag, "father", None)
+                    or next(
+                        (
+                            eid
+                            for eid, did in self.repo.element_diagrams.items()
+                            if did == self.diagram_id
+                        ),
+                        None,
+                    )
+                )
+                if block_id:
+                    added_mult = _enforce_ibd_multiplicity(
+                        self.repo, block_id, app=getattr(self, "app", None)
+                    )
+                    if added_mult and not getattr(self, "app", None):
+                        for data in added_mult:
+                            if not any(
+                                o.obj_id == data["obj_id"] for o in self.objects
+                            ):
+                                self.objects.append(SysMLObject(**data))
 
     def refresh_from_repository(self, _event=None) -> None:
         """Reload diagram objects from the repository and redraw."""
@@ -6583,6 +6677,15 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
                 for o in getattr(d, "objects", []):
                     if o.get("element_id") == block_id:
                         o.setdefault("properties", {})["partProperties"] = joined
+
+        # enforce multiplicity for aggregated parts
+        added_mult = _enforce_ibd_multiplicity(
+            repo, block_id, app=getattr(self, "app", None)
+        )
+        if added_mult and not self.app:
+            for data in added_mult:
+                if not any(o.obj_id == data["obj_id"] for o in self.objects):
+                    self.objects.append(SysMLObject(**data))
 
         boundary = getattr(self, "get_ibd_boundary", lambda: None)()
         if boundary:

--- a/tests/test_add_contained_parts.py
+++ b/tests/test_add_contained_parts.py
@@ -23,6 +23,20 @@ class DummyWindow:
             architecture.update_block_parts_from_ibd(self.repo, diag)
             self.repo.touch_diagram(self.diagram_id)
             architecture._sync_block_parts_from_ibd(self.repo, self.diagram_id)
+            if diag.diag_type == "Internal Block Diagram":
+                block_id = (
+                    getattr(diag, "father", None)
+                    or next(
+                        (
+                            eid
+                            for eid, did in self.repo.element_diagrams.items()
+                            if did == self.diagram_id
+                        ),
+                        None,
+                    )
+                )
+                if block_id:
+                    architecture._enforce_ibd_multiplicity(self.repo, block_id)
 
     def redraw(self):
         pass
@@ -153,6 +167,91 @@ class AddContainedPartsRenderTests(unittest.TestCase):
         with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
             InternalBlockDiagramWindow.add_contained_parts(win)
         self.assertFalse(win.objects[0].hidden)
+
+    def test_multiplicity_limit_enforced(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part.elem_id,
+            properties={"multiplicity": "2"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        win = DummyWindow(ibd)
+        architecture._sync_ibd_composite_parts(repo, whole.elem_id)
+        for obj in ibd.objects:
+            win.objects.append(SysMLObject(**obj))
+
+        class DummyDialog:
+            def __init__(self, parent, names, visible, hidden):
+                self.result = ["Part"]
+
+        with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
+            InternalBlockDiagramWindow.add_contained_parts(win)
+
+        parts = [
+            o
+            for o in repo.diagrams[ibd.diag_id].objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(parts), 2)
+        names = {repo.elements[o["element_id"]].name for o in parts}
+        self.assertIn("Part[1]", names)
+        self.assertIn("Part[2]", names)
+
+    def test_rename_part_does_not_duplicate(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part.elem_id,
+            properties={"multiplicity": "2"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        architecture.add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "2")
+        obj = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+        repo.elements[obj["element_id"]].name = "Renamed"
+        architecture.update_block_parts_from_ibd(repo, ibd)
+        architecture._sync_block_parts_from_ibd(repo, ibd.diag_id)
+        props = repo.elements[whole.elem_id].properties.get("partProperties", "")
+        self.assertEqual(props, "Part[2]")
+
+    def test_definition_change_enforces_multiplicity(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part.elem_id,
+            properties={"multiplicity": "2"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        win = DummyWindow(ibd)
+        elem = repo.create_element("Part", name="P")
+        repo.add_element_to_diagram(ibd.diag_id, elem.elem_id)
+        obj = SysMLObject(1, "Part", 0, 0, element_id=elem.elem_id, properties={})
+        ibd.objects.append(obj.__dict__)
+        win.objects.append(obj)
+        obj.properties["definition"] = part.elem_id
+        repo.elements[elem.elem_id].properties["definition"] = part.elem_id
+        win._sync_to_repository()
+        parts = [
+            o
+            for o in repo.diagrams[ibd.diag_id].objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(parts), 2)
+        names = {repo.elements[o["element_id"]].name for o in parts}
+        self.assertIn("Part[1]", names)
+        self.assertIn("Part[2]", names)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_part_multiplicity_label.py
+++ b/tests/test_part_multiplicity_label.py
@@ -1,0 +1,56 @@
+import unittest
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+class DummyFont:
+    def measure(self, text: str) -> int:
+        return len(text)
+    def metrics(self, name: str) -> int:
+        return 1
+
+class DummyWindow:
+    _object_label_lines = SysMLDiagramWindow._object_label_lines
+    def __init__(self, diag_id):
+        self.repo = SysMLRepository.get_instance()
+        self.zoom = 1.0
+        self.font = DummyFont()
+        self.diagram_id = diag_id
+
+class PartMultiplicityLabelTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_label_shows_index_and_range(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part_blk = repo.create_element("Block", name="PartB")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part_blk.elem_id,
+            properties={"multiplicity": "1..*"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        elem = repo.create_element(
+            "Part", name="Part[1]", properties={"definition": part_blk.elem_id}
+        )
+        repo.add_element_to_diagram(ibd.diag_id, elem.elem_id)
+        obj_data = {
+            "obj_id": 1,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": elem.elem_id,
+            "width": 80.0,
+            "height": 40.0,
+            "properties": {"definition": part_blk.elem_id},
+        }
+        win = DummyWindow(ibd.diag_id)
+        obj = SysMLObject(**obj_data)
+        lines = win._object_label_lines(obj)
+        self.assertIn("Part 1 : PartB [1..*]", lines)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce multiplicity limits when adding contained parts
- ensure multiplicity enforcement updates open diagrams
- avoid duplicate partProperties entries when part elements are renamed
- enforce multiplicity whenever diagrams are synced
- display part multiplicity range in diagram labels
- add regression tests for part rename, contained part multiplicity, and label formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b5da3eb408325a04e3acca4fd4502