### PR TITLE
Fix part rename updates

### DIFF
--- a/tests/test_add_contained_parts.py
+++ b/tests/test_add_contained_parts.py
@@ -23,6 +23,20 @@ class DummyWindow:
             architecture.update_block_parts_from_ibd(self.repo, diag)
             self.repo.touch_diagram(self.diagram_id)
             architecture._sync_block_parts_from_ibd(self.repo, self.diagram_id)
+            if diag.diag_type == "Internal Block Diagram":
+                block_id = (
+                    getattr(diag, "father", None)
+                    or next(
+                        (
+                            eid
+                            for eid, did in self.repo.element_diagrams.items()
+                            if did == self.diagram_id
+                        ),
+                        None,
+                    )
+                )
+                if block_id:
+                    architecture._enforce_ibd_multiplicity(self.repo, block_id)
 
     def redraw(self):
         pass
@@ -153,6 +167,109 @@ class AddContainedPartsRenderTests(unittest.TestCase):
         with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
             InternalBlockDiagramWindow.add_contained_parts(win)
         self.assertFalse(win.objects[0].hidden)
+
+    def test_multiplicity_limit_enforced(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part.elem_id,
+            properties={"multiplicity": "2"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        win = DummyWindow(ibd)
+        architecture._sync_ibd_composite_parts(repo, whole.elem_id)
+        for obj in ibd.objects:
+            win.objects.append(SysMLObject(**obj))
+
+        class DummyDialog:
+            def __init__(self, parent, names, visible, hidden):
+                self.result = ["Part"]
+
+        with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
+            InternalBlockDiagramWindow.add_contained_parts(win)
+
+        parts = [
+            o
+            for o in repo.diagrams[ibd.diag_id].objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(parts), 2)
+        names = {repo.elements[o["element_id"]].name for o in parts}
+        self.assertIn("Part[1]", names)
+        self.assertIn("Part[2]", names)
+
+    def test_rename_part_does_not_duplicate(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part.elem_id,
+            properties={"multiplicity": "2"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        architecture.add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "2")
+        obj = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+        repo.elements[obj["element_id"]].name = "Renamed"
+        architecture.update_block_parts_from_ibd(repo, ibd)
+        architecture._sync_block_parts_from_ibd(repo, ibd.diag_id)
+        props = repo.elements[whole.elem_id].properties.get("partProperties", "")
+        self.assertEqual(props, "Part[2]")
+
+    def test_rename_part_helper_updates_properties(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part.elem_id,
+            properties={"multiplicity": "2"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        architecture.add_composite_aggregation_part(repo, whole.elem_id, part.elem_id, "2")
+        obj = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+        architecture.rename_part(repo, obj["element_id"], "New")
+        props = repo.elements[whole.elem_id].properties.get("partProperties", "")
+        self.assertEqual(props, "Part[2]")
+
+    def test_definition_change_enforces_multiplicity(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part = repo.create_element("Block", name="Part")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part.elem_id,
+            properties={"multiplicity": "2"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        win = DummyWindow(ibd)
+        elem = repo.create_element("Part", name="P")
+        repo.add_element_to_diagram(ibd.diag_id, elem.elem_id)
+        obj = SysMLObject(1, "Part", 0, 0, element_id=elem.elem_id, properties={})
+        ibd.objects.append(obj.__dict__)
+        win.objects.append(obj)
+        obj.properties["definition"] = part.elem_id
+        repo.elements[elem.elem_id].properties["definition"] = part.elem_id
+        win._sync_to_repository()
+        parts = [
+            o
+            for o in repo.diagrams[ibd.diag_id].objects
+            if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id
+        ]
+        self.assertEqual(len(parts), 2)
+        names = {repo.elements[o["element_id"]].name for o in parts}
+        self.assertIn("Part[1]", names)
+        self.assertIn("Part[2]", names)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_part_multiplicity_label.py
+++ b/tests/test_part_multiplicity_label.py
@@ -1,0 +1,56 @@
+import unittest
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+class DummyFont:
+    def measure(self, text: str) -> int:
+        return len(text)
+    def metrics(self, name: str) -> int:
+        return 1
+
+class DummyWindow:
+    _object_label_lines = SysMLDiagramWindow._object_label_lines
+    def __init__(self, diag_id):
+        self.repo = SysMLRepository.get_instance()
+        self.zoom = 1.0
+        self.font = DummyFont()
+        self.diagram_id = diag_id
+
+class PartMultiplicityLabelTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_label_shows_index_and_range(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part_blk = repo.create_element("Block", name="PartB")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part_blk.elem_id,
+            properties={"multiplicity": "1..*"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        elem = repo.create_element(
+            "Part", name="Part[1]", properties={"definition": part_blk.elem_id}
+        )
+        repo.add_element_to_diagram(ibd.diag_id, elem.elem_id)
+        obj_data = {
+            "obj_id": 1,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": elem.elem_id,
+            "width": 80.0,
+            "height": 40.0,
+            "properties": {"definition": part_blk.elem_id},
+        }
+        win = DummyWindow(ibd.diag_id)
+        obj = SysMLObject(**obj_data)
+        lines = win._object_label_lines(obj)
+        self.assertIn("Part 1 : PartB [1..*]", lines)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `rename_part` helper to sync properties when parts are renamed
- hook rename logic in architecture manager to update aggregation lists
- regression test for the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b5da3eb408325a04e3acca4fd4502