### PR TITLE
Add multiplicity label test

### DIFF
--- a/tests/test_part_multiplicity_label.py
+++ b/tests/test_part_multiplicity_label.py
@@ -52,5 +52,44 @@ class PartMultiplicityLabelTests(unittest.TestCase):
         lines = win._object_label_lines(obj)
         self.assertIn("Part 1 : PartB [1..*]", lines)
 
+    def test_multiple_parts_show_incrementing_range(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part_blk = repo.create_element("Block", name="PartB")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part_blk.elem_id,
+            properties={"multiplicity": "1..*"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+
+        objs = []
+        for idx in range(3):
+            elem = repo.create_element(
+                "Part",
+                name=f"Part[{idx + 1}]",
+                properties={"definition": part_blk.elem_id},
+            )
+            repo.add_element_to_diagram(ibd.diag_id, elem.elem_id)
+            obj_data = {
+                "obj_id": idx + 1,
+                "obj_type": "Part",
+                "x": 0,
+                "y": 0,
+                "element_id": elem.elem_id,
+                "width": 80.0,
+                "height": 40.0,
+                "properties": {"definition": part_blk.elem_id},
+            }
+            objs.append(obj_data)
+
+        win = DummyWindow(ibd.diag_id)
+        for idx, data in enumerate(objs):
+            obj = SysMLObject(**data)
+            lines = win._object_label_lines(obj)
+            self.assertIn(f"Part {idx + 1} : PartB [{idx + 1}..*]", lines)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- check multiplicity labels when several part instances exist

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688b6a5adbc88325aeae004c6fdfe3d1