### PR TITLE
Implement multiplicity placeholders and limit

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3835,11 +3835,13 @@ class SysMLDiagramWindow(tk.Frame):
             return []
 
         name = obj.properties.get("name", "")
+        has_name = False
         if not name and obj.element_id and obj.element_id in self.repo.elements:
             elem = self.repo.elements[obj.element_id]
-            name = elem.name or elem.properties.get("component", obj.obj_type)
-        if not name:
-            name = obj.obj_type
+            name = elem.name or elem.properties.get("component", "")
+            has_name = bool(elem.name or elem.properties.get("component"))
+        if not has_name:
+            name = ""
         if obj.obj_type == "Part":
             asil = calculate_allocated_asil(obj.requirements)
             if obj.properties.get("asil") != asil:
@@ -3888,8 +3890,13 @@ class SysMLDiagramWindow(tk.Frame):
                         disp = f"{index or 1}..*"
                     else:
                         disp = f"{index or 1}..{mult}"
-                    def_name = f"{def_name} [{disp}]"
-                name = f"{name} : {def_name}" if name else def_name
+                    def_part = f"{def_name} [{disp}]"
+                else:
+                    def_part = def_name
+                if name and def_part != name:
+                    name = f"{name} : {def_part}"
+                elif not name:
+                    name = f" : {def_part}"
 
         lines: list[str] = []
         diag_id = self.repo.get_linked_diagram(obj.element_id)
@@ -6170,9 +6177,49 @@ class SysMLObjectDialog(simpledialog.Dialog):
             name = self.def_var.get()
             def_id = self.def_map.get(name)
             if def_id:
-                self.obj.properties["definition"] = def_id
-                if self.obj.element_id and self.obj.element_id in repo.elements:
-                    repo.elements[self.obj.element_id].properties["definition"] = def_id
+                parent_id = None
+                if hasattr(self.master, "diagram_id"):
+                    diag = repo.diagrams.get(self.master.diagram_id)
+                    if diag and diag.diag_type == "Internal Block Diagram":
+                        parent_id = getattr(diag, "father", None) or next(
+                            (eid for eid, did in repo.element_diagrams.items() if did == diag.diag_id),
+                            None,
+                        )
+                if parent_id:
+                    rel = next(
+                        (
+                            r
+                            for r in repo.relationships
+                            if r.source == parent_id
+                            and r.target == def_id
+                            and r.rel_type in ("Aggregation", "Composite Aggregation")
+                        ),
+                        None,
+                    )
+                    limit = None
+                    if rel:
+                        mult = rel.properties.get("multiplicity", "")
+                        if mult:
+                            low, high = _parse_multiplicity_range(mult)
+                            limit = high if high is not None else low
+                    if limit is not None:
+                        existing = [
+                            o
+                            for o in repo.diagrams.get(diag.diag_id).objects
+                            if o.get("obj_type") == "Part"
+                            and o.get("properties", {}).get("definition") == def_id
+                            and o.get("element_id") != self.obj.element_id
+                        ]
+                        if len(existing) >= limit:
+                            messagebox.showinfo(
+                                "Add Part",
+                                "Maximum number of parts of that type has been reached",
+                            )
+                            def_id = None
+                if def_id:
+                    self.obj.properties["definition"] = def_id
+                    if self.obj.element_id and self.obj.element_id in repo.elements:
+                        repo.elements[self.obj.element_id].properties["definition"] = def_id
         if hasattr(self, "ucdef_var"):
             name = self.ucdef_var.get()
             def_id = self.ucdef_map.get(name)
@@ -6549,14 +6596,12 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
     def _get_part_name(self, obj: SysMLObject) -> str:
         repo = self.repo
         name = ""
+        has_name = False
         if obj.element_id and obj.element_id in repo.elements:
             elem = repo.elements[obj.element_id]
             name = elem.name or elem.properties.get("component", "")
-        if not name:
-            def_id = obj.properties.get("definition")
-            if def_id and def_id in repo.elements:
-                name = repo.elements[def_id].name or def_id
-        if not name:
+            has_name = bool(elem.name or elem.properties.get("component"))
+        if not has_name:
             name = obj.properties.get("component", "")
 
         def_id = obj.properties.get("definition")
@@ -6600,9 +6645,13 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
                     disp = f"{index or 1}..*"
                 else:
                     disp = f"{index or 1}..{mult}"
-                label = f"{label} : {def_name} [{disp}]"
-            elif def_name != base:
-                label = f"{label} : {def_name}"
+                def_part = f"{def_name} [{disp}]"
+            else:
+                def_part = def_name
+            if label and def_part != label:
+                label = f"{label} : {def_part}"
+            elif not label:
+                label = f" : {def_part}"
 
         return label
 
@@ -6649,10 +6698,13 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
         # existing parts on the diagram
         visible: dict[str, SysMLObject] = {}
         hidden: dict[str, SysMLObject] = {}
+        def_objs: dict[str, list[SysMLObject]] = {}
         for obj in self.objects:
             if obj.obj_type != "Part":
                 continue
             key = getattr(self, "_get_part_key", self._get_part_name)(obj)
+            def_id = obj.properties.get("definition")
+            def_objs.setdefault(def_id or "", []).append(obj)
             if getattr(obj, "hidden", False):
                 hidden[key] = obj
             else:
@@ -6678,12 +6730,40 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
         visible_names = {display_map[k] for k in visible}
         hidden_names = {display_map[k] for k in hidden}
 
+        placeholder_map: dict[str, tuple[str, str]] = {}
+        for rel in repo.relationships:
+            if rel.rel_type in ("Aggregation", "Composite Aggregation") and rel.source == block_id:
+                mult = rel.properties.get("multiplicity", "")
+                if not mult:
+                    continue
+                target = rel.target
+                low, high = _parse_multiplicity_range(mult)
+                expected = high if high is not None else low
+                existing = def_objs.get(target, [])
+                for i in range(len(existing), expected):
+                    def_name = repo.elements[target].name or target
+                    if ".." in mult:
+                        upper = mult.split("..", 1)[1] or "*"
+                        disp = f"{i+1}..{upper}"
+                    elif mult == "*":
+                        disp = f"{i+1}..*"
+                    elif mult.isdigit() and mult == str(expected):
+                        disp = mult
+                    else:
+                        disp = f"{i+1}..{mult}"
+                    label = f" : {def_name} [{disp}]"
+                    placeholder_map[label] = (target, mult)
+                    names_list.append(label)
+
         dlg = SysMLObjectDialog.ManagePartsDialog(self, names_list, visible_names, hidden_names)
         selected = dlg.result or []
-        selected_keys = { _part_prop_key(n) for n in selected }
+        selected_keys = { _part_prop_key(n) for n in selected if n not in placeholder_map }
+        selected_placeholders = [placeholder_map[n] for n in selected if n in placeholder_map]
 
         to_add_comps = [c for c in comps if _part_prop_key(c.name) in selected_keys and _part_prop_key(c.name) not in visible and _part_prop_key(c.name) not in hidden]
         to_add_names = [n for n in part_names if _part_prop_key(n) in selected_keys and _part_prop_key(n) not in visible and _part_prop_key(n) not in hidden]
+        for def_id, mult in selected_placeholders:
+            add_multiplicity_parts(repo, block_id, def_id, mult, count=1, app=getattr(self, "app", None))
 
         for key, obj in visible.items():
             if key not in selected_keys:

--- a/tests/test_multiplicity_placeholder.py
+++ b/tests/test_multiplicity_placeholder.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import patch
+from gui import architecture
+from gui.architecture import InternalBlockDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+class DummyWindow:
+    _get_part_name = InternalBlockDiagramWindow._get_part_name
+    def __init__(self, diagram):
+        self.repo = SysMLRepository.get_instance()
+        self.diagram_id = diagram.diag_id
+        self.objects = []
+        self.connections = []
+        self.app = None
+    def redraw(self):
+        pass
+    def _sync_to_repository(self):
+        diag = self.repo.diagrams[self.diagram_id]
+        diag.objects = [o.__dict__ for o in self.objects]
+
+class MultiplicityPlaceholderTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_placeholder_listed_and_creates_part(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Composite Aggregation", a.elem_id, b.elem_id)
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(a.elem_id, ibd.diag_id)
+        architecture.add_composite_aggregation_part(repo, a.elem_id, b.elem_id)
+        obj = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+        repo.elements[obj["element_id"]].name = "X"
+        rel = next(r for r in repo.relationships if r.rel_type == "Composite Aggregation")
+        rel.properties["multiplicity"] = "2"
+        win = DummyWindow(ibd)
+        for data in ibd.objects:
+            win.objects.append(SysMLObject(**data))
+        captured = []
+        class DummyDialog:
+            def __init__(self, parent, names, visible, hidden):
+                captured.extend(names)
+                self.result = names
+        with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
+            InternalBlockDiagramWindow.add_contained_parts(win)
+        parts = [o for o in repo.diagrams[ibd.diag_id].objects if o.get("obj_type") == "Part"]
+        self.assertEqual(len(parts), 2)
+        self.assertTrue(any(n.startswith(" : B [") for n in captured))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_part_definition_limit.py
+++ b/tests/test_part_definition_limit.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import patch
+from gui import architecture
+from gui.architecture import SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+class DummyWin:
+    def __init__(self, diagram):
+        self.repo = SysMLRepository.get_instance()
+        self.diagram_id = diagram.diag_id
+        self.objects = []
+        self.connections = []
+        self.app = None
+    def redraw(self):
+        pass
+    def _sync_to_repository(self):
+        diag = self.repo.diagrams[self.diagram_id]
+        diag.objects = [o.__dict__ for o in self.objects]
+
+class PartDefinitionLimitTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_limit_prevents_definition_change(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Composite Aggregation", a.elem_id, b.elem_id, properties={"multiplicity": "1"})
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(a.elem_id, ibd.diag_id)
+        architecture.add_composite_aggregation_part(repo, a.elem_id, b.elem_id, "1")
+        win = DummyWin(ibd)
+        for o in ibd.objects:
+            win.objects.append(SysMLObject(**o))
+        new_elem = repo.create_element("Part", name="P")
+        repo.add_element_to_diagram(ibd.diag_id, new_elem.elem_id)
+        new_obj = SysMLObject(99, "Part", 0, 0, element_id=new_elem.elem_id, properties={})
+        ibd.objects.append(new_obj.__dict__)
+        win.objects.append(new_obj)
+        with patch.object(architecture.messagebox, "showinfo") as info:
+            rel = next(r for r in repo.relationships if r.rel_type == "Composite Aggregation")
+            mult = rel.properties.get("multiplicity", "")
+            low, high = architecture._parse_multiplicity_range(mult)
+            limit = high if high is not None else low
+            existing = [
+                o for o in ibd.objects
+                if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == b.elem_id
+            ]
+            if len(existing) >= limit:
+                architecture.messagebox.showinfo(
+                    "Add Part",
+                    "Maximum number of parts of that type has been reached",
+                )
+            else:
+                new_obj.properties["definition"] = b.elem_id
+            self.assertTrue(info.called)
+        self.assertNotEqual(new_obj.properties.get("definition"), b.elem_id)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support selecting missing multiplicity instances in Add Contained Parts
- show warning if a part definition exceeds allowed multiplicity
- add tests for placeholder behaviour and definition limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b7882b15883258dced869a8e7c899