### PR TITLE
Fix part property sync and multiplicity

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -888,7 +888,15 @@ def _sync_ibd_partproperty_parts(
         entries = [p for p in block.properties.get("partProperties", "").split(",") if p.strip()]
     else:
         entries = [n for n in names if n.strip()]
-    parsed = [parse_part_property(e) for e in entries]
+    parsed_raw = [parse_part_property(e) for e in entries]
+    seen_keys = set()
+    parsed = []
+    for prop_name, block_name in parsed_raw:
+        key = _part_prop_key(prop_name)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        parsed.append((prop_name, block_name))
     added: list[dict] = []
     boundary = next((o for o in diag.objects if o.get("obj_type") == "Block Boundary"), None)
     if boundary:
@@ -912,6 +920,28 @@ def _sync_ibd_partproperty_parts(
         )
         if not target_id:
             continue
+        # enforce multiplicity based on aggregation relationships
+        limit = None
+        for rel in repo.relationships:
+            if (
+                rel.source == block_id
+                and rel.target == target_id
+                and rel.rel_type in ("Aggregation", "Composite Aggregation")
+            ):
+                mult = rel.properties.get("multiplicity", "")
+                low, high = _parse_multiplicity_range(mult)
+                if high is not None:
+                    limit = high
+                break
+        if limit is not None:
+            current = sum(
+                1
+                for o in diag.objects
+                if o.get("obj_type") == "Part"
+                and o.get("properties", {}).get("definition") == target_id
+            )
+            if current >= limit:
+                continue
         part_elem = repo.create_element(
             "Part",
             name=prop_name,
@@ -6793,8 +6823,17 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
 
         to_add_comps = [c for c in comps if _part_prop_key(c.name) in selected_keys and _part_prop_key(c.name) not in visible and _part_prop_key(c.name) not in hidden]
         to_add_names = [n for n in part_names if _part_prop_key(n) in selected_keys and _part_prop_key(n) not in visible and _part_prop_key(n) not in hidden]
+        added_placeholders: list[dict] = []
         for def_id, mult in selected_placeholders:
-            add_multiplicity_parts(repo, block_id, def_id, mult, count=1, app=getattr(self, "app", None))
+            added_placeholders.extend(
+                add_multiplicity_parts(
+                    repo, block_id, def_id, mult, count=1, app=getattr(self, "app", None)
+                )
+            )
+        if added_placeholders and not self.app:
+            for data in added_placeholders:
+                if not any(o.obj_id == data["obj_id"] for o in self.objects):
+                    self.objects.append(SysMLObject(**data))
 
         for key, obj in visible.items():
             if key not in selected_keys:

--- a/tests/test_partproperty_multiplicity.py
+++ b/tests/test_partproperty_multiplicity.py
@@ -1,0 +1,32 @@
+import unittest
+from gui.architecture import _sync_ibd_partproperty_parts
+from sysml.sysml_repository import SysMLRepository
+
+class PartPropertyMultiplicityTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_duplicates_ignored(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "B, B"})
+        repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+        _sync_ibd_partproperty_parts(repo, blk.elem_id, visible=True)
+        parts = [o for o in ibd.objects if o.get("obj_type") == "Part"]
+        self.assertEqual(len(parts), 1)
+
+    def test_multiplicity_limit(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole", properties={"partProperties": "P, P"})
+        part = repo.create_element("Block", name="P")
+        repo.create_relationship("Composite Aggregation", whole.elem_id, part.elem_id, properties={"multiplicity": "1"})
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        _sync_ibd_partproperty_parts(repo, whole.elem_id, visible=True)
+        parts = [o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id]
+        self.assertEqual(len(parts), 1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- deduplicate part property entries before creating IBD parts
- enforce aggregation multiplicity when showing part properties in IBDs
- keep placeholder-added parts when no application object is present
- test part property multiplicity handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c407207608325911c37f3502af5eb