### PR TITLE
Fix multiplicity enforcement for new parts

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -252,6 +252,130 @@ def _parse_multiplicity_range(mult: str) -> tuple[int, int | None]:
     return 1, None
 
 
+def _is_default_part_name(def_name: str, part_name: str) -> bool:
+    """Return ``True`` if *part_name* is derived from ``def_name``."""
+
+    if not part_name:
+        return True
+    if part_name == def_name:
+        return True
+    pattern = re.escape(def_name) + r"\[\d+\]$"
+    return re.fullmatch(pattern, part_name) is not None
+
+
+def _multiplicity_limit_exceeded(
+    repo: SysMLRepository,
+    parent_id: str,
+    def_id: str,
+    diagram_objects: list,
+    self_elem_id: str | None = None,
+) -> bool:
+    """Return ``True`` if assigning *def_id* would exceed multiplicity."""
+
+    rels = [
+        r
+        for r in repo.relationships
+        if r.source == parent_id
+        and r.target == def_id
+        and r.rel_type in ("Aggregation", "Composite Aggregation")
+    ]
+    if not rels:
+        return False
+
+    limit: int | None = 0
+    for rel in rels:
+        mult = rel.properties.get("multiplicity", "1")
+        low, high = _parse_multiplicity_range(mult)
+        if high is None:
+            limit = None
+            break
+        limit += high
+
+    if limit is None:
+        return False
+
+    # gather all diagrams containing parts for this block
+    diag_ids: set[str] = set()
+    linked = repo.get_linked_diagram(parent_id)
+    if linked:
+        diag_ids.add(linked)
+    for d in repo.diagrams.values():
+        if d.diag_type != "Internal Block Diagram":
+            continue
+        for o in getattr(d, "objects", []):
+            if o.get("obj_type") == "Block Boundary" and o.get("element_id") == parent_id:
+                diag_ids.add(d.diag_id)
+                break
+
+    seen: set[str] = set()
+    count = 0
+    for did in diag_ids:
+        diag = repo.diagrams.get(did)
+        if not diag:
+            continue
+        for o in getattr(diag, "objects", []):
+            if (
+                o.get("obj_type") == "Part"
+                and o.get("properties", {}).get("definition") == def_id
+            ):
+                elem_id = o.get("element_id")
+                if elem_id != self_elem_id and elem_id not in seen:
+                    seen.add(elem_id)
+                    count += 1
+
+    for obj in diagram_objects:
+        data = obj.__dict__ if hasattr(obj, "__dict__") else obj
+        if (
+            data.get("obj_type") == "Part"
+            and data.get("properties", {}).get("definition") == def_id
+        ):
+            elem_id = data.get("element_id")
+            if elem_id != self_elem_id and elem_id not in seen:
+                seen.add(elem_id)
+                count += 1
+
+    return count >= limit
+
+
+def _part_name_exists(
+    repo: SysMLRepository,
+    parent_id: str,
+    name: str,
+    self_elem_id: str | None = None,
+) -> bool:
+    """Return ``True`` if another part with ``name`` already exists."""
+
+    if not name:
+        return False
+
+    diag_ids: set[str] = set()
+    linked = repo.get_linked_diagram(parent_id)
+    if linked:
+        diag_ids.add(linked)
+    for d in repo.diagrams.values():
+        if d.diag_type != "Internal Block Diagram":
+            continue
+        for o in getattr(d, "objects", []):
+            if o.get("obj_type") == "Block Boundary" and o.get("element_id") == parent_id:
+                diag_ids.add(d.diag_id)
+                break
+
+    for did in diag_ids:
+        diag = repo.diagrams.get(did)
+        if not diag:
+            continue
+        for obj in getattr(diag, "objects", []):
+            if obj.get("obj_type") != "Part":
+                continue
+            if obj.get("element_id") == self_elem_id:
+                continue
+            elem_id = obj.get("element_id")
+            if elem_id in repo.elements and repo.elements[elem_id].name == name:
+                return True
+
+    return False
+
+
 def _find_generalization_children(repo: SysMLRepository, parent_id: str) -> set[str]:
     """Return all blocks that generalize ``parent_id``."""
     children: set[str] = set()
@@ -414,7 +538,24 @@ def add_aggregation_part(
         ),
         None,
     )
-    if rel and not rel.properties.get("part_elem"):
+    if not rel:
+        rel = next(
+            (
+                r
+                for r in repo.relationships
+                if r.rel_type == "Composite Aggregation"
+                and r.source == whole_id
+                and r.target == part_id
+            ),
+            None,
+        )
+    if not rel:
+        rel = repo.create_relationship("Aggregation", whole_id, part_id)
+    if multiplicity:
+        rel.properties["multiplicity"] = multiplicity
+    else:
+        rel.properties.pop("multiplicity", None)
+    if not rel.properties.get("part_elem"):
         part_elem = repo.create_element(
             "Part",
             name=repo.elements.get(part_id).name or part_id,
@@ -455,6 +596,12 @@ def add_composite_aggregation_part(
         ),
         None,
     )
+    if not rel:
+        rel = repo.create_relationship("Composite Aggregation", whole_id, part_id)
+    if multiplicity:
+        rel.properties["multiplicity"] = multiplicity
+    else:
+        rel.properties.pop("multiplicity", None)
     if not diag or diag.diag_type != "Internal Block Diagram":
         if rel and not rel.properties.get("part_elem"):
             part_elem = repo.create_element(
@@ -556,45 +703,6 @@ def add_multiplicity_parts(
         if high is not None and target_total > high:
             target_total = high
 
-    if total > target_total:
-        # remove excess parts starting from the end of the list
-        for obj in existing[target_total:]:
-            diag.objects.remove(obj)
-            elem_id = obj.get("element_id")
-            if elem_id in repo.elements:
-                repo.delete_element(elem_id)
-            if app:
-                for win in getattr(app, "ibd_windows", []):
-                    if getattr(win, "diagram_id", None) == diag.diag_id:
-                        win.objects = [
-                            o
-                            for o in win.objects
-                            if getattr(o, "obj_id", None) != obj.get("obj_id")
-                        ]
-                        win.redraw()
-                        win._sync_to_repository()
-        existing = existing[:target_total]
-        total = len(existing)
-
-    if total > target_total:
-        # remove excess parts starting from the end of the list
-        for obj in existing[target_total:]:
-            diag.objects.remove(obj)
-            elem_id = obj.get("element_id")
-            if elem_id in repo.elements:
-                repo.delete_element(elem_id)
-            if app:
-                for win in getattr(app, "ibd_windows", []):
-                    if getattr(win, "diagram_id", None) == diag.diag_id:
-                        win.objects = [
-                            o
-                            for o in win.objects
-                            if getattr(o, "obj_id", None) != obj.get("obj_id")
-                        ]
-                        win.redraw()
-                        win._sync_to_repository()
-        existing = existing[:target_total]
-        total = len(existing)
 
     added: list[dict] = []
     base_name = repo.elements.get(part_id).name or part_id
@@ -616,13 +724,23 @@ def add_multiplicity_parts(
         ]
         existing = existing[:target_total]
         total = target_total
+        if app:
+            for win in getattr(app, "ibd_windows", []):
+                if getattr(win, "diagram_id", None) == diag.diag_id:
+                    win.objects = [
+                        o
+                        for o in win.objects
+                        if getattr(o, "obj_id", None) not in remove_ids
+                    ]
+                    win.redraw()
+                    win._sync_to_repository()
 
-    # rename remaining part elements so their names follow the indexing scheme
+    # rename remaining part elements if they still have default names
     for idx, obj in enumerate(existing):
         elem = repo.elements.get(obj.get("element_id"))
         if elem:
             expected = f"{base_name}[{idx + 1}]"
-            if elem.name != expected:
+            if _is_default_part_name(base_name, elem.name) and elem.name != expected:
                 elem.name = expected
 
     base_x = 50.0
@@ -665,7 +783,7 @@ def add_multiplicity_parts(
         elem = repo.elements.get(obj.get("element_id"))
         if elem:
             expected = f"{base_name}[{idx + 1}]"
-            if elem.name != expected:
+            if _is_default_part_name(base_name, elem.name) and elem.name != expected:
                 elem.name = expected
 
     return added
@@ -3835,11 +3953,18 @@ class SysMLDiagramWindow(tk.Frame):
             return []
 
         name = obj.properties.get("name", "")
-        if not name and obj.element_id and obj.element_id in self.repo.elements:
+        has_name = False
+        def_id = obj.properties.get("definition")
+        if obj.element_id and obj.element_id in self.repo.elements:
             elem = self.repo.elements[obj.element_id]
-            name = elem.name or elem.properties.get("component", obj.obj_type)
-        if not name:
-            name = obj.obj_type
+            name = elem.name or elem.properties.get("component", "")
+            def_id = def_id or elem.properties.get("definition")
+            def_name = ""
+            if def_id and def_id in self.repo.elements:
+                def_name = self.repo.elements[def_id].name or def_id
+            has_name = bool(name) and not _is_default_part_name(def_name, name)
+        if not has_name:
+            name = ""
         if obj.obj_type == "Part":
             asil = calculate_allocated_asil(obj.requirements)
             if obj.properties.get("asil") != asil:
@@ -3848,6 +3973,7 @@ class SysMLDiagramWindow(tk.Frame):
                     self.repo.elements[obj.element_id].properties["asil"] = asil
             def_id = obj.properties.get("definition")
             mult = None
+            comp = obj.properties.get("component", "")
             if def_id and def_id in self.repo.elements:
                 def_name = self.repo.elements[def_id].name or def_id
                 diag = self.repo.diagrams.get(self.diagram_id)
@@ -3869,7 +3995,9 @@ class SysMLDiagramWindow(tk.Frame):
                             and rel.source == block_id
                             and rel.target == def_id
                         ):
-                            mult = rel.properties.get("multiplicity")
+                            mult = rel.properties.get("multiplicity", "1")
+                            if mult in ("", "1"):
+                                mult = None
                             break
                 base = name
                 index = None
@@ -3880,6 +4008,10 @@ class SysMLDiagramWindow(tk.Frame):
                 if index is not None:
                     base = f"{base} {index}"
                 name = base
+                if obj.element_id and obj.element_id in self.repo.elements and not comp:
+                    comp = self.repo.elements[obj.element_id].properties.get("component", "")
+                if comp and comp == def_name:
+                    comp = ""
                 if mult:
                     if ".." in mult:
                         upper = mult.split("..", 1)[1] or "*"
@@ -3888,8 +4020,15 @@ class SysMLDiagramWindow(tk.Frame):
                         disp = f"{index or 1}..*"
                     else:
                         disp = f"{index or 1}..{mult}"
-                    def_name = f"{def_name} [{disp}]"
-                name = f"{name} : {def_name}" if name else def_name
+                    def_part = f"{def_name} [{disp}]"
+                else:
+                    def_part = def_name
+                if comp:
+                    def_part = f"{comp} / {def_part}"
+                if name and def_part != name:
+                    name = f"{name} : {def_part}"
+                elif not name:
+                    name = f" : {def_part}"
 
         lines: list[str] = []
         diag_id = self.repo.get_linked_diagram(obj.element_id)
@@ -5766,9 +5905,12 @@ class SysMLObjectDialog(simpledialog.Dialog):
             cur_id = self.obj.properties.get("definition", "")
             cur_name = next((n for n, i in idmap.items() if i == cur_id), "")
             self.def_var = tk.StringVar(value=cur_name)
-            ttk.Combobox(link_frame, textvariable=self.def_var, values=list(idmap.keys())).grid(
-                row=link_row, column=1, padx=4, pady=2
+            self.def_cb = ttk.Combobox(
+                link_frame, textvariable=self.def_var, values=list(idmap.keys())
             )
+            self.def_cb.grid(row=link_row, column=1, padx=4, pady=2)
+            self.def_cb.bind("<<ComboboxSelected>>", self._on_def_selected)
+            self._current_def_id = cur_id
             link_row += 1
 
         # Requirement allocation section
@@ -6007,10 +6149,59 @@ class SysMLObjectDialog(simpledialog.Dialog):
                         modes.add(label)
         return ", ".join(sorted(modes))
 
+    def _on_def_selected(self, event=None):
+        """Callback when the definition combobox is changed."""
+        repo = SysMLRepository.get_instance()
+        name = self.def_var.get()
+        def_id = self.def_map.get(name)
+        if not def_id:
+            self._current_def_id = ""
+            return
+
+        parent_id = None
+        if hasattr(self.master, "diagram_id"):
+            diag = repo.diagrams.get(self.master.diagram_id)
+            if diag and diag.diag_type == "Internal Block Diagram":
+                parent_id = getattr(diag, "father", None) or next(
+                    (eid for eid, did in repo.element_diagrams.items() if did == diag.diag_id),
+                    None,
+                )
+
+        if parent_id and _multiplicity_limit_exceeded(
+            repo,
+            parent_id,
+            def_id,
+            getattr(self.master, "objects", []),
+            self.obj.element_id,
+        ):
+            messagebox.showinfo(
+                "Add Part",
+                "Maximum number of parts of that type has been reached",
+            )
+            prev_name = next(
+                (n for n, i in self.def_map.items() if i == self._current_def_id),
+                "",
+            )
+            self.def_var.set(prev_name)
+            return
+
+        self._current_def_id = def_id
+
     def apply(self):
         new_name = self.name_var.get()
-        self.obj.properties["name"] = new_name
         repo = SysMLRepository.get_instance()
+        parent_id = None
+        if self.obj.obj_type == "Part" and hasattr(self.master, "diagram_id"):
+            diag = repo.diagrams.get(self.master.diagram_id)
+            if diag and diag.diag_type == "Internal Block Diagram":
+                parent_id = getattr(diag, "father", None) or next(
+                    (eid for eid, did in repo.element_diagrams.items() if did == diag.diag_id),
+                    None,
+                )
+        if parent_id and _part_name_exists(repo, parent_id, new_name, self.obj.element_id):
+            messagebox.showinfo("Add Part", "A part with that name already exists")
+            new_name = self.obj.properties.get("name", "")
+        self.obj.properties["name"] = new_name
         if self.obj.element_id and self.obj.element_id in repo.elements:
             elem = repo.elements[self.obj.element_id]
             if self.obj.obj_type in ("Block", "Block Boundary") and elem.elem_type == "Block":
@@ -6170,9 +6361,42 @@ class SysMLObjectDialog(simpledialog.Dialog):
             name = self.def_var.get()
             def_id = self.def_map.get(name)
             if def_id:
-                self.obj.properties["definition"] = def_id
-                if self.obj.element_id and self.obj.element_id in repo.elements:
-                    repo.elements[self.obj.element_id].properties["definition"] = def_id
+                parent_id = None
+                if hasattr(self.master, "diagram_id"):
+                    diag = repo.diagrams.get(self.master.diagram_id)
+                    if diag and diag.diag_type == "Internal Block Diagram":
+                        parent_id = getattr(diag, "father", None) or next(
+                            (eid for eid, did in repo.element_diagrams.items() if did == diag.diag_id),
+                            None,
+                        )
+                if parent_id:
+                    rel = next(
+                        (
+                            r
+                            for r in repo.relationships
+                            if r.source == parent_id
+                            and r.target == def_id
+                            and r.rel_type in ("Aggregation", "Composite Aggregation")
+                        ),
+                        None,
+                    )
+                    limit_exceeded = _multiplicity_limit_exceeded(
+                        repo,
+                        parent_id,
+                        def_id,
+                        getattr(self.master, "objects", []),
+                        self.obj.element_id,
+                    )
+                    if limit_exceeded:
+                        messagebox.showinfo(
+                            "Add Part",
+                            "Maximum number of parts of that type has been reached",
+                        )
+                        def_id = None
+                if def_id:
+                    self.obj.properties["definition"] = def_id
+                    if self.obj.element_id and self.obj.element_id in repo.elements:
+                        repo.elements[self.obj.element_id].properties["definition"] = def_id
         if hasattr(self, "ucdef_var"):
             name = self.ucdef_var.get()
             def_id = self.ucdef_map.get(name)
@@ -6549,19 +6773,23 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
     def _get_part_name(self, obj: SysMLObject) -> str:
         repo = self.repo
         name = ""
+        has_name = False
+        def_id = obj.properties.get("definition")
         if obj.element_id and obj.element_id in repo.elements:
             elem = repo.elements[obj.element_id]
             name = elem.name or elem.properties.get("component", "")
-        if not name:
-            def_id = obj.properties.get("definition")
+            def_id = def_id or elem.properties.get("definition")
+            def_name = ""
             if def_id and def_id in repo.elements:
-                name = repo.elements[def_id].name or def_id
-        if not name:
+                def_name = repo.elements[def_id].name or def_id
+            has_name = bool(name) and not _is_default_part_name(def_name, name)
+        if not has_name:
             name = obj.properties.get("component", "")
 
         def_id = obj.properties.get("definition")
         def_name = ""
         mult = ""
+        comp = obj.properties.get("component", "")
         if def_id and def_id in repo.elements:
             def_name = repo.elements[def_id].name or def_id
             diag = repo.diagrams.get(self.diagram_id)
@@ -6579,8 +6807,15 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
                         and rel.source == block_id
                         and rel.target == def_id
                     ):
-                        mult = rel.properties.get("multiplicity", "")
+                        mult = rel.properties.get("multiplicity", "1")
+                        if mult in ("", "1"):
+                            mult = ""
                         break
+
+        if obj.element_id and obj.element_id in repo.elements and not comp:
+            comp = repo.elements[obj.element_id].properties.get("component", "")
+        if comp and comp == def_name:
+            comp = ""
 
         base = name
         index = None
@@ -6600,9 +6835,15 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
                     disp = f"{index or 1}..*"
                 else:
                     disp = f"{index or 1}..{mult}"
-                label = f"{label} : {def_name} [{disp}]"
-            elif def_name != base:
-                label = f"{label} : {def_name}"
+                def_part = f"{def_name} [{disp}]"
+            else:
+                def_part = def_name
+            if comp:
+                def_part = f"{comp} / {def_part}"
+            if label and def_part != label:
+                label = f"{label} : {def_part}"
+            elif not label:
+                label = f" : {def_part}"
 
         return label
 
@@ -6649,10 +6890,13 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
         # existing parts on the diagram
         visible: dict[str, SysMLObject] = {}
         hidden: dict[str, SysMLObject] = {}
+        def_objs: dict[str, list[SysMLObject]] = {}
         for obj in self.objects:
             if obj.obj_type != "Part":
                 continue
             key = getattr(self, "_get_part_key", self._get_part_name)(obj)
+            def_id = obj.properties.get("definition")
+            def_objs.setdefault(def_id or "", []).append(obj)
             if getattr(obj, "hidden", False):
                 hidden[key] = obj
             else:
@@ -6678,12 +6922,40 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
         visible_names = {display_map[k] for k in visible}
         hidden_names = {display_map[k] for k in hidden}
 
+        placeholder_map: dict[str, tuple[str, str]] = {}
+        for rel in repo.relationships:
+            if rel.rel_type in ("Aggregation", "Composite Aggregation") and rel.source == block_id:
+                mult = rel.properties.get("multiplicity", "")
+                if not mult:
+                    continue
+                target = rel.target
+                low, high = _parse_multiplicity_range(mult)
+                expected = high if high is not None else low
+                existing = def_objs.get(target, [])
+                for i in range(len(existing), expected):
+                    def_name = repo.elements[target].name or target
+                    if ".." in mult:
+                        upper = mult.split("..", 1)[1] or "*"
+                        disp = f"{i+1}..{upper}"
+                    elif mult == "*":
+                        disp = f"{i+1}..*"
+                    elif mult.isdigit() and mult == str(expected):
+                        disp = mult
+                    else:
+                        disp = f"{i+1}..{mult}"
+                    label = f" : {def_name} [{disp}]"
+                    placeholder_map[label] = (target, mult)
+                    names_list.append(label)
+
         dlg = SysMLObjectDialog.ManagePartsDialog(self, names_list, visible_names, hidden_names)
         selected = dlg.result or []
-        selected_keys = { _part_prop_key(n) for n in selected }
+        selected_keys = { _part_prop_key(n) for n in selected if n not in placeholder_map }
+        selected_placeholders = [placeholder_map[n] for n in selected if n in placeholder_map]
 
         to_add_comps = [c for c in comps if _part_prop_key(c.name) in selected_keys and _part_prop_key(c.name) not in visible and _part_prop_key(c.name) not in hidden]
         to_add_names = [n for n in part_names if _part_prop_key(n) in selected_keys and _part_prop_key(n) not in visible and _part_prop_key(n) not in hidden]
+        for def_id, mult in selected_placeholders:
+            add_multiplicity_parts(repo, block_id, def_id, mult, count=1, app=getattr(self, "app", None))
 
         for key, obj in visible.items():
             if key not in selected_keys:

--- a/tests/test_add_contained_parts.py
+++ b/tests/test_add_contained_parts.py
@@ -7,6 +7,7 @@ from sysml.sysml_repository import SysMLRepository
 
 class DummyWindow:
     _get_part_name = InternalBlockDiagramWindow._get_part_name
+    _get_part_key = InternalBlockDiagramWindow._get_part_key
 
     def __init__(self, diagram):
         self.repo = SysMLRepository.get_instance()
@@ -140,7 +141,7 @@ class AddContainedPartsRenderTests(unittest.TestCase):
             win.objects.append(SysMLObject(**obj_dict))
         class DummyDialog:
             def __init__(self, parent, names, visible, hidden):
-                self.result = ["B"]
+                self.result = [names[0]]
         with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
             InternalBlockDiagramWindow.add_contained_parts(win)
         self.assertFalse(win.objects[0].hidden)
@@ -163,7 +164,7 @@ class AddContainedPartsRenderTests(unittest.TestCase):
             win.objects.append(SysMLObject(**obj_dict))
         class DummyDialog:
             def __init__(self, parent, names, visible, hidden):
-                self.result = ["B"]
+                self.result = [names[0]]
         with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
             InternalBlockDiagramWindow.add_contained_parts(win)
         self.assertFalse(win.objects[0].hidden)
@@ -187,7 +188,7 @@ class AddContainedPartsRenderTests(unittest.TestCase):
 
         class DummyDialog:
             def __init__(self, parent, names, visible, hidden):
-                self.result = ["Part"]
+                self.result = [names[0]]
 
         with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
             InternalBlockDiagramWindow.add_contained_parts(win)
@@ -250,7 +251,7 @@ class AddContainedPartsRenderTests(unittest.TestCase):
         ]
         self.assertEqual(len(parts), 2)
         names = {repo.elements[o["element_id"]].name for o in parts}
-        self.assertIn("Part[1]", names)
+        self.assertIn("P", names)
         self.assertIn("Part[2]", names)
 
 if __name__ == '__main__':

--- a/tests/test_multiplicity_across_boundary.py
+++ b/tests/test_multiplicity_across_boundary.py
@@ -1,0 +1,62 @@
+import unittest
+from gui import architecture
+from gui.architecture import SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+class MultiplicityAcrossBoundaryTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_limit_counts_parts_in_all_diagrams(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship(
+            "Composite Aggregation",
+            a.elem_id,
+            b.elem_id,
+            properties={"multiplicity": "1"},
+        )
+        ibd_a = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(a.elem_id, ibd_a.diag_id)
+        architecture.add_composite_aggregation_part(repo, a.elem_id, b.elem_id, "1")
+
+        ibd_b = repo.create_diagram("Internal Block Diagram")
+        boundary = {
+            "obj_id": 1,
+            "obj_type": "Block Boundary",
+            "x": 0,
+            "y": 0,
+            "width": 100.0,
+            "height": 80.0,
+            "element_id": a.elem_id,
+            "properties": {},
+        }
+        ibd_b.objects.append(boundary)
+
+        new_elem = repo.create_element("Part", name="X")
+        repo.add_element_to_diagram(ibd_b.diag_id, new_elem.elem_id)
+        obj = {
+            "obj_id": 2,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": new_elem.elem_id,
+            "properties": {"definition": b.elem_id},
+        }
+
+        exceeded = architecture._multiplicity_limit_exceeded(
+            repo,
+            a.elem_id,
+            b.elem_id,
+            [obj],
+            new_elem.elem_id,
+        )
+        self.assertTrue(exceeded)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_multiplicity_default.py
+++ b/tests/test_multiplicity_default.py
@@ -1,0 +1,30 @@
+import unittest
+from gui import architecture
+from gui.architecture import SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+class MultiplicityDefaultTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_default_multiplicity_enforced(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Composite Aggregation", a.elem_id, b.elem_id)
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(a.elem_id, ibd.diag_id)
+        architecture.add_composite_aggregation_part(repo, a.elem_id, b.elem_id)
+        elem = repo.create_element("Part")
+        repo.add_element_to_diagram(ibd.diag_id, elem.elem_id)
+        obj = SysMLObject(99, "Part", 0, 0, element_id=elem.elem_id, properties={})
+        ibd.objects.append(obj.__dict__)
+        exceeded = architecture._multiplicity_limit_exceeded(
+            repo,
+            a.elem_id,
+            b.elem_id,
+            ibd.objects,
+            obj.element_id,
+        )
+        self.assertTrue(exceeded)

--- a/tests/test_multiplicity_placeholder.py
+++ b/tests/test_multiplicity_placeholder.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import patch
+from gui import architecture
+from gui.architecture import InternalBlockDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+class DummyWindow:
+    _get_part_name = InternalBlockDiagramWindow._get_part_name
+    def __init__(self, diagram):
+        self.repo = SysMLRepository.get_instance()
+        self.diagram_id = diagram.diag_id
+        self.objects = []
+        self.connections = []
+        self.app = None
+    def redraw(self):
+        pass
+    def _sync_to_repository(self):
+        diag = self.repo.diagrams[self.diagram_id]
+        diag.objects = [o.__dict__ for o in self.objects]
+
+class MultiplicityPlaceholderTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_placeholder_listed_and_creates_part(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Composite Aggregation", a.elem_id, b.elem_id)
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(a.elem_id, ibd.diag_id)
+        architecture.add_composite_aggregation_part(repo, a.elem_id, b.elem_id)
+        obj = next(o for o in ibd.objects if o.get("obj_type") == "Part")
+        repo.elements[obj["element_id"]].name = "X"
+        rel = next(r for r in repo.relationships if r.rel_type == "Composite Aggregation")
+        rel.properties["multiplicity"] = "2"
+        win = DummyWindow(ibd)
+        for data in ibd.objects:
+            win.objects.append(SysMLObject(**data))
+        captured = []
+        class DummyDialog:
+            def __init__(self, parent, names, visible, hidden):
+                captured.extend(names)
+                self.result = names
+        with patch.object(architecture.SysMLObjectDialog, 'ManagePartsDialog', DummyDialog):
+            InternalBlockDiagramWindow.add_contained_parts(win)
+        parts = [o for o in repo.diagrams[ibd.diag_id].objects if o.get("obj_type") == "Part"]
+        self.assertEqual(len(parts), 2)
+        self.assertTrue(any(n.startswith(" : B [") for n in captured))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_part_definition_limit.py
+++ b/tests/test_part_definition_limit.py
@@ -1,0 +1,60 @@
+import unittest
+from unittest.mock import patch
+from gui import architecture
+from gui.architecture import SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+class DummyWin:
+    def __init__(self, diagram):
+        self.repo = SysMLRepository.get_instance()
+        self.diagram_id = diagram.diag_id
+        self.objects = []
+        self.connections = []
+        self.app = None
+    def redraw(self):
+        pass
+    def _sync_to_repository(self):
+        diag = self.repo.diagrams[self.diagram_id]
+        diag.objects = [o.__dict__ for o in self.objects]
+
+class PartDefinitionLimitTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_limit_prevents_definition_change(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Composite Aggregation", a.elem_id, b.elem_id, properties={"multiplicity": "1"})
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(a.elem_id, ibd.diag_id)
+        architecture.add_composite_aggregation_part(repo, a.elem_id, b.elem_id, "1")
+        win = DummyWin(ibd)
+        for o in ibd.objects:
+            win.objects.append(SysMLObject(**o))
+        new_elem = repo.create_element("Part", name="P")
+        repo.add_element_to_diagram(ibd.diag_id, new_elem.elem_id)
+        new_obj = SysMLObject(99, "Part", 0, 0, element_id=new_elem.elem_id, properties={})
+        ibd.objects.append(new_obj.__dict__)
+        win.objects.append(new_obj)
+        with patch.object(architecture.messagebox, "showinfo") as info:
+            exceeded = architecture._multiplicity_limit_exceeded(
+                repo,
+                a.elem_id,
+                b.elem_id,
+                win.objects,
+                new_obj.element_id,
+            )
+            if exceeded:
+                architecture.messagebox.showinfo(
+                    "Add Part",
+                    "Maximum number of parts of that type has been reached",
+                )
+            else:
+                new_obj.properties["definition"] = b.elem_id
+            self.assertTrue(info.called)
+        self.assertNotEqual(new_obj.properties.get("definition"), b.elem_id)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_part_label_component.py
+++ b/tests/test_part_label_component.py
@@ -1,0 +1,65 @@
+import unittest
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+
+class DummyFont:
+    def measure(self, text: str) -> int:
+        return len(text)
+
+    def metrics(self, name: str) -> int:
+        return 1
+
+
+class DummyWindow:
+    _object_label_lines = SysMLDiagramWindow._object_label_lines
+
+    def __init__(self, diag_id):
+        self.repo = SysMLRepository.get_instance()
+        self.zoom = 1.0
+        self.font = DummyFont()
+        self.diagram_id = diag_id
+
+
+class PartLabelComponentTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_label_includes_component_and_multiplicity(self):
+        repo = self.repo
+        whole = repo.create_element("Block", name="Whole")
+        part_blk = repo.create_element("Block", name="PartB")
+        repo.create_relationship(
+            "Composite Aggregation",
+            whole.elem_id,
+            part_blk.elem_id,
+            properties={"multiplicity": "2"},
+        )
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(whole.elem_id, ibd.diag_id)
+        elem = repo.create_element(
+            "Part",
+            name="Part[1]",
+            properties={"definition": part_blk.elem_id, "component": "Comp"},
+        )
+        repo.add_element_to_diagram(ibd.diag_id, elem.elem_id)
+        obj_data = {
+            "obj_id": 1,
+            "obj_type": "Part",
+            "x": 0,
+            "y": 0,
+            "element_id": elem.elem_id,
+            "width": 80.0,
+            "height": 40.0,
+            "properties": {"definition": part_blk.elem_id, "component": "Comp"},
+        }
+        win = DummyWindow(ibd.diag_id)
+        obj = SysMLObject(**obj_data)
+        lines = win._object_label_lines(obj)
+        self.assertIn("Part 1 : Comp / PartB [1..2]", lines)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_part_name_unique.py
+++ b/tests/test_part_name_unique.py
@@ -1,0 +1,41 @@
+import unittest
+from gui import architecture
+from sysml.sysml_repository import SysMLRepository
+
+
+class PartNameUniqueTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_detect_duplicate_name_across_diagrams(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        repo.create_relationship("Composite Aggregation", a.elem_id, b.elem_id)
+        ibd_a = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(a.elem_id, ibd_a.diag_id)
+        architecture.add_composite_aggregation_part(repo, a.elem_id, b.elem_id)
+        obj = next(o for o in ibd_a.objects if o.get("obj_type") == "Part")
+        repo.elements[obj["element_id"]].name = "P"
+
+        ibd_b = repo.create_diagram("Internal Block Diagram")
+        boundary = {
+            "obj_id": 1,
+            "obj_type": "Block Boundary",
+            "x": 0,
+            "y": 0,
+            "width": 80.0,
+            "height": 40.0,
+            "element_id": a.elem_id,
+            "properties": {},
+        }
+        ibd_b.objects.append(boundary)
+
+        exists = architecture._part_name_exists(repo, a.elem_id, "P")
+        self.assertTrue(exists)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_relationship_multiplicity_update.py
+++ b/tests/test_relationship_multiplicity_update.py
@@ -1,0 +1,18 @@
+import unittest
+from gui import architecture
+from sysml.sysml_repository import SysMLRepository
+
+class RelationMultiplicityUpdateTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_update_relationship_multiplicity(self):
+        repo = self.repo
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        rel = repo.create_relationship("Composite Aggregation", a.elem_id, b.elem_id)
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(a.elem_id, ibd.diag_id)
+        architecture.add_composite_aggregation_part(repo, a.elem_id, b.elem_id, "2")
+        self.assertEqual(rel.properties.get("multiplicity"), "2")


### PR DESCRIPTION
## Summary
- enforce default multiplicity of 1 when relationship lacks a multiplicity property
- update aggregation/composite relationships with multiplicity changes
- hide `[1]` in part labels
- regression tests for default multiplicity and relationship update

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688b7882b15883258dced869a8e7c899