### PR TITLE
Add diagram style editor and configurable styles

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -314,6 +314,7 @@ import networkx as nx
 import matplotlib.pyplot as plt
 # Import ReportLab for PDF export.
 from reportlab.platypus import Table, TableStyle, SimpleDocTemplate, Paragraph, Spacer, Image as RLImage, PageBreak
+from gui.style_editor import StyleEditor
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib import colors
@@ -2033,6 +2034,7 @@ class FaultTreeApp:
         view_menu.add_command(label="Zoom In", command=self.zoom_in, accelerator="Ctrl++")
         view_menu.add_command(label="Zoom Out", command=self.zoom_out, accelerator="Ctrl+-")
         view_menu.add_command(label="Auto Arrange", command=self.auto_arrange, accelerator="Ctrl+A")
+        view_menu.add_command(label="Style Editor", command=self.open_style_editor)
 
         requirements_menu = tk.Menu(menubar, tearoff=0)
         requirements_menu.add_command(label="Requirements Matrix", command=self.show_requirements_matrix)
@@ -2104,6 +2106,7 @@ class FaultTreeApp:
         menubar.add_cascade(label="Help", menu=help_menu)
 
         root.config(menu=menubar)
+        root.bind('<<StyleChanged>>', self.refresh_styles)
         root.bind("<Control-n>", lambda event: self.new_model())
         root.bind("<Control-s>", lambda event: self.save_model())
         root.bind("<Control-o>", lambda event: self.load_model())
@@ -12982,6 +12985,17 @@ class FaultTreeApp:
         self._fault_prio_tab = self._new_tab("Fault Prioritization")
         from gui.fault_prioritization import FaultPrioritizationWindow
         self._fault_prio_window = FaultPrioritizationWindow(self._fault_prio_tab, self)
+
+    def open_style_editor(self):
+        """Open the diagram style editor window."""
+        StyleEditor(self.root)
+
+    def refresh_styles(self, event=None):
+        """Redraw all open diagram windows using current styles."""
+        for tab in getattr(self, 'diagram_tabs', {}).values():
+            for child in tab.winfo_children():
+                if hasattr(child, 'redraw'):
+                    child.redraw()
 
     def show_hazard_explorer(self):
         if hasattr(self, "_haz_exp_window") and self._haz_exp_window.winfo_exists():

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field, asdict
 from typing import Dict, List, Tuple
 
 from sysml.sysml_repository import SysMLRepository, SysMLDiagram, SysMLElement
+from gui.style_manager import StyleManager
 
 from sysml.sysml_spec import SYSML_PROPERTIES
 from analysis.models import global_requirements, ASIL_ORDER
@@ -17,23 +18,9 @@ from analysis.models import global_requirements, ASIL_ORDER
 # ---------------------------------------------------------------------------
 # Appearance customization
 # ---------------------------------------------------------------------------
-# Basic fill colors for different AutoML object types. This provides a simple
-# color palette so diagrams appear less bland and more professional.
-OBJECT_COLORS: dict[str, str] = {
-    "Actor": "#E0F7FA",
-    "Use Case": "#FFF3E0",
-    "System Boundary": "#ECEFF1",
-    "Block Boundary": "",
-    "Action Usage": "#E8F5E9",
-    "Action": "#E8F5E9",
-    "CallBehaviorAction": "#E8F5E9",
-    "Part": "#FFFDE7",
-    "Port": "#F3E5F5",
-    "Block": "#E0E0E0",
-    "Decision": "#E1F5FE",
-    "Merge": "#E1F5FE",
-    # Fork and Join bars remain black so are not listed here
-}
+# Colors for AutoML object types come from the global StyleManager so diagrams
+# can be easily re-themed.
+OBJECT_COLORS = StyleManager.get_instance().styles
 
 
 _next_obj_id = 1
@@ -4511,7 +4498,7 @@ class SysMLDiagramWindow(tk.Frame):
         y = obj.y * self.zoom
         w = obj.width * self.zoom / 2
         h = obj.height * self.zoom / 2
-        color = OBJECT_COLORS.get(obj.obj_type, "white")
+        color = StyleManager.get_instance().get_color(obj.obj_type)
         outline = "black"
         if obj.obj_type == "Actor":
             sx = obj.width / 80.0 * self.zoom

--- a/gui/style_editor.py
+++ b/gui/style_editor.py
@@ -1,0 +1,62 @@
+import tkinter as tk
+from tkinter import colorchooser, filedialog, messagebox
+from .style_manager import StyleManager
+
+class StyleEditor(tk.Toplevel):
+    """Simple editor for diagram style colors."""
+
+    def __init__(self, master=None):
+        super().__init__(master)
+        self.title("Style Editor")
+        self.manager = StyleManager.get_instance()
+        self.entries = {}
+        row = 0
+        for obj_type in sorted(self.manager.styles.keys()):
+            tk.Label(self, text=obj_type).grid(row=row, column=0, sticky="w", padx=4, pady=2)
+            ent = tk.Entry(self)
+            ent.insert(0, self.manager.styles[obj_type])
+            ent.grid(row=row, column=1, padx=4, pady=2)
+            btn = tk.Button(self, text="...", command=lambda t=obj_type: self.choose_color(t))
+            btn.grid(row=row, column=2, padx=2)
+            self.entries[obj_type] = ent
+            row += 1
+        btn_frame = tk.Frame(self)
+        btn_frame.grid(row=row, columnspan=3, pady=8)
+        tk.Button(btn_frame, text="Save As...", command=self.save).pack(side=tk.LEFT, padx=4)
+        tk.Button(btn_frame, text="Load", command=self.load).pack(side=tk.LEFT, padx=4)
+        tk.Button(btn_frame, text="Apply", command=self.apply).pack(side=tk.LEFT, padx=4)
+        tk.Button(btn_frame, text="Close", command=self.destroy).pack(side=tk.LEFT, padx=4)
+
+    def choose_color(self, obj_type):
+        cur = self.entries[obj_type].get()
+        color = colorchooser.askcolor(color=cur, parent=self)[1]
+        if color:
+            self.entries[obj_type].delete(0, tk.END)
+            self.entries[obj_type].insert(0, color)
+
+    def apply(self):
+        for t, ent in self.entries.items():
+            self.manager.styles[t] = ent.get()
+        if hasattr(self.master, 'redraw'):
+            self.master.redraw()
+        if self.master:
+            self.master.event_generate('<<StyleChanged>>', when='tail')
+
+    def save(self):
+        self.apply()
+        path = filedialog.asksaveasfilename(defaultextension='.xml', filetypes=[('Style XML', '*.xml')])
+        if path:
+            self.manager.save_style(path)
+            messagebox.showinfo('Style Editor', 'Style saved to ' + path)
+
+    def load(self):
+        path = filedialog.askopenfilename(filetypes=[('Style XML', '*.xml')])
+        if path:
+            self.manager.load_style(path)
+            for t, ent in self.entries.items():
+                ent.delete(0, tk.END)
+                ent.insert(0, self.manager.styles.get(t, ''))
+            if hasattr(self.master, 'redraw'):
+                self.master.redraw()
+            if self.master:
+                self.master.event_generate('<<StyleChanged>>', when='tail')

--- a/gui/style_manager.py
+++ b/gui/style_manager.py
@@ -1,0 +1,45 @@
+import os
+import xml.etree.ElementTree as ET
+
+_DEFAULT_STYLE = os.path.join(os.path.dirname(__file__), '..', 'styles', 'modern.xml')
+
+class StyleManager:
+    """Singleton manager for diagram styles loaded from XML files."""
+
+    _instance = None
+
+    def __init__(self):
+        self.styles = {}
+        try:
+            self.load_style(_DEFAULT_STYLE)
+        except Exception:
+            # fallback to hard coded white style
+            self.styles = {}
+
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            cls._instance = StyleManager()
+        return cls._instance
+
+    def load_style(self, path: str) -> None:
+        if not os.path.isfile(path):
+            return
+        tree = ET.parse(path)
+        root = tree.getroot()
+        self.styles.clear()
+        for obj in root.findall('object'):
+            typ = obj.get('type')
+            color = obj.get('color')
+            if typ and color:
+                self.styles[typ] = color
+
+    def save_style(self, path: str) -> None:
+        root = ET.Element('style')
+        for typ, color in self.styles.items():
+            ET.SubElement(root, 'object', type=typ, color=color)
+        tree = ET.ElementTree(root)
+        tree.write(path)
+
+    def get_color(self, obj_type: str) -> str:
+        return self.styles.get(obj_type, '#FFFFFF')

--- a/styles/modern.xml
+++ b/styles/modern.xml
@@ -1,0 +1,14 @@
+<style>
+  <object type="Actor" color="#B3E5FC" />
+  <object type="Use Case" color="#FFECB3" />
+  <object type="System Boundary" color="#CFD8DC" />
+  <object type="Block Boundary" color="#F5F5F5" />
+  <object type="Action Usage" color="#C8E6C9" />
+  <object type="Action" color="#C8E6C9" />
+  <object type="CallBehaviorAction" color="#C8E6C9" />
+  <object type="Part" color="#FFF9C4" />
+  <object type="Port" color="#E1BEE7" />
+  <object type="Block" color="#B0BEC5" />
+  <object type="Decision" color="#B2EBF2" />
+  <object type="Merge" color="#B2EBF2" />
+</style>


### PR DESCRIPTION
## Summary
- load object colors from a new `StyleManager`
- implement a `StyleEditor` window to edit and save styles
- add a modern default style in XML format
- hook Style Editor into the View menu and refresh open diagrams on change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c4eb6107c83258e993a00827f6aec