### PR TITLE
Add undo support with Ctrl+Z

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2130,6 +2130,7 @@ class FaultTreeApp:
         root.bind("<Control-x>", lambda event: self.cut_node())
         root.bind("<Control-v>", lambda event: self.paste_node())
         root.bind("<Control-p>", lambda event: self.save_diagram_png())
+        root.bind("<Control-z>", lambda event: self.undo())
         root.bind("<F1>", lambda event: self.show_about())
         self.main_pane = tk.PanedWindow(root, orient=tk.HORIZONTAL)
         self.main_pane.pack(fill=tk.BOTH, expand=True)
@@ -13498,6 +13499,16 @@ class FaultTreeApp:
         """Return True if the model differs from the last saved state."""
         current_state = json.dumps(self.export_model_data(), sort_keys=True)
         return current_state != getattr(self, "last_saved_state", None)
+
+    def undo(self):
+        """Revert the repository to the previous state and refresh views."""
+        repo = SysMLRepository.get_instance()
+        if repo.undo():
+            for tab in getattr(self, "diagram_tabs", {}).values():
+                for child in tab.winfo_children():
+                    if hasattr(child, "refresh_from_repository"):
+                        child.refresh_from_repository()
+            self.update_views()
 
     def confirm_close(self):
         """Prompt to save if there are unsaved changes before closing."""

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2374,6 +2374,8 @@ class SysMLDiagramWindow(tk.Frame):
         self.bind("<Control-c>", self.copy_selected)
         self.bind("<Control-x>", self.cut_selected)
         self.bind("<Control-v>", self.paste_selected)
+        if self.app:
+            self.bind("<Control-z>", lambda e: self.app.undo())
         self.bind("<Delete>", self.delete_selected)
         # Refresh from the repository whenever the window gains focus
         self.bind("<FocusIn>", self.refresh_from_repository)
@@ -5361,6 +5363,7 @@ class SysMLDiagramWindow(tk.Frame):
 
     def _sync_to_repository(self) -> None:
         """Persist current objects and connections back to the repository."""
+        self.repo.push_undo_state()
         diag = self.repo.diagrams.get(self.diagram_id)
         if diag:
             diag.objects = [obj.__dict__ for obj in self.objects]

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -1,0 +1,21 @@
+import unittest
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from sysml.sysml_repository import SysMLRepository
+from analysis.user_config import set_current_user
+
+class UndoTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        set_current_user("Tester", "tester@example.com")
+        self.repo = SysMLRepository.get_instance()
+
+    def test_undo_creation(self):
+        elem = self.repo.create_element("Actor", name="User")
+        self.assertIn(elem.elem_id, self.repo.elements)
+        self.assertTrue(self.repo.undo())
+        self.assertNotIn(elem.elem_id, self.repo.elements)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement repository undo stack with `push_undo_state` and `undo`
- snapshot repository before changes and revert on request
- bind Ctrl+Z to undo in main app and diagrams
- refresh views after undo
- add regression test for undo

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688c50ec2cd483259846a1c55dacbd5b