### PR TITLE
Fix SGDialog float validation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -11448,11 +11448,11 @@ class FaultTreeApp:
 
                 ttk.Label(master, text="FTTI:").grid(row=3, column=0, sticky="e")
                 self.ftti_var = tk.StringVar(value=getattr(self.initial, "ftti", ""))
-                tk.Entry(master, textvariable=self.ftti_var, validate="key", validatecommand=(master.register(parent.validate_float), "%P")).grid(row=3, column=1, padx=5, pady=5)
+                tk.Entry(master, textvariable=self.ftti_var, validate="key", validatecommand=(master.register(self.parent.validate_float), "%P")).grid(row=3, column=1, padx=5, pady=5)
 
                 ttk.Label(master, text="Acceptance Prob:").grid(row=4, column=0, sticky="e")
                 self.prob_var = tk.StringVar(value=str(getattr(self.initial, "acceptance_prob", 1.0)))
-                tk.Entry(master, textvariable=self.prob_var, validate="key", validatecommand=(master.register(parent.validate_float), "%P")).grid(row=4, column=1, padx=5, pady=5)
+                tk.Entry(master, textvariable=self.prob_var, validate="key", validatecommand=(master.register(self.parent.validate_float), "%P")).grid(row=4, column=1, padx=5, pady=5)
 
                 ttk.Label(master, text="Acceptance Criteria:").grid(row=5, column=0, sticky="ne")
                 self.acc_text = tk.Text(master, width=30, height=3, wrap="word")


### PR DESCRIPTION
## Summary
- fix reference to parent dialog in SGDialog validation commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c51c83f588325a11a8b8083eecd4b