### PR TITLE
Add Rhapsody/EA style options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.1.3
+version: 0.1.4
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -29,6 +29,7 @@ AutoML is an automotive modeling language. It lets you model items, operating sc
   - [Safety Goal Export](#safety-goal-export)
 - [Email Setup](#email-setup)
 - [Dependencies](#dependencies)
+- [Diagram Styles](#diagram-styles)
 - [License](#license)
 - [Building the Executable](#building-the-executable)
 - [Version History](#version-history)
@@ -956,6 +957,15 @@ bundled correctly.
 If double‑clicking `AutoML.py` closes immediately, launch it from a command
 prompt instead so any error messages remain visible.
 
+## Diagram Styles
+
+Several XML files in the `styles` directory control the colors used for
+diagram elements. The default `modern.xml` uses a Material-inspired palette.
+For a look similar to IBM Rhapsody load `rhapsody.xml` from the Style Editor.
+Likewise, `ea.xml` gives the appearance of Enterprise Architect. Open the
+editor via **View → Style Editor**, click **Load** and choose the desired
+style. All open diagrams update immediately.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.
@@ -985,6 +995,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.1.4 - Added Rhapsody and Enterprise Architect style files and documentation.
 - 0.1.3 - Added context menu actions to remove parts from a diagram or from the model.
 - 0.1.2 - Clarified systems safety focus in description and About dialog.
 - 0.1.1 - Updated description and About dialog.

--- a/styles/ea.xml
+++ b/styles/ea.xml
@@ -1,0 +1,14 @@
+<style>
+  <object type="Actor" color="#FFD966" />
+  <object type="Use Case" color="#FFE699" />
+  <object type="System Boundary" color="#C8C8C8" />
+  <object type="Block Boundary" color="#F2F2F2" />
+  <object type="Action Usage" color="#C9DAF8" />
+  <object type="Action" color="#C9DAF8" />
+  <object type="CallBehaviorAction" color="#C9DAF8" />
+  <object type="Part" color="#FFF2CC" />
+  <object type="Port" color="#D5A6BD" />
+  <object type="Block" color="#9FC5E8" />
+  <object type="Decision" color="#CFE2F3" />
+  <object type="Merge" color="#CFE2F3" />
+</style>

--- a/styles/rhapsody.xml
+++ b/styles/rhapsody.xml
@@ -1,0 +1,14 @@
+<style>
+  <object type="Actor" color="#F1C232" />
+  <object type="Use Case" color="#F9CB9C" />
+  <object type="System Boundary" color="#B7B7B7" />
+  <object type="Block Boundary" color="#FFFFFF" />
+  <object type="Action Usage" color="#93C47D" />
+  <object type="Action" color="#93C47D" />
+  <object type="CallBehaviorAction" color="#93C47D" />
+  <object type="Part" color="#F9CB9C" />
+  <object type="Port" color="#B4A7D6" />
+  <object type="Block" color="#6FA8DC" />
+  <object type="Decision" color="#A4C2F4" />
+  <object type="Merge" color="#A4C2F4" />
+</style>


### PR DESCRIPTION
## Summary
- document how to load alternative diagram styles
- provide `rhapsody.xml` and `ea.xml` style files with colors similar to IBM Rhapsody and Enterprise Architect
- bump version to 0.1.4

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c54f67dd48325995e0a6263610947