### PR TITLE
Add pastel diagram style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.1.3
+version: 0.1.5
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -29,6 +29,7 @@ AutoML is an automotive modeling language. It lets you model items, operating sc
   - [Safety Goal Export](#safety-goal-export)
 - [Email Setup](#email-setup)
 - [Dependencies](#dependencies)
+- [Diagram Styles](#diagram-styles)
 - [License](#license)
 - [Building the Executable](#building-the-executable)
 - [Version History](#version-history)
@@ -956,6 +957,14 @@ bundled correctly.
 If double‑clicking `AutoML.py` closes immediately, launch it from a command
 prompt instead so any error messages remain visible.
 
+## Diagram Styles
+
+Several XML files in the `styles` directory control the colors used for
+diagram elements. The default `modern.xml` uses a Material-inspired palette.
+`pastel.xml` provides softer tones like peach actions and steel-blue nodes.
+Open the Style Editor via **View → Style Editor**, click **Load** and choose
+the desired style. All open diagrams update immediately.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.
@@ -985,6 +994,8 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.1.5 - Added a pastel style with peach actions and steel-blue nodes.
+- 0.1.4 - Initial diagram style support documented.
 - 0.1.3 - Added context menu actions to remove parts from a diagram or from the model.
 - 0.1.2 - Clarified systems safety focus in description and About dialog.
 - 0.1.1 - Updated description and About dialog.

--- a/styles/pastel.xml
+++ b/styles/pastel.xml
@@ -1,0 +1,14 @@
+<style>
+  <object type="Actor" color="#F4D698" />
+  <object type="Use Case" color="#B0E0E6" />
+  <object type="System Boundary" color="#FFFFFF" />
+  <object type="Block Boundary" color="#FFFFFF" />
+  <object type="Action Usage" color="#FAD7A0" />
+  <object type="Action" color="#FAD7A0" />
+  <object type="CallBehaviorAction" color="#FAD7A0" />
+  <object type="Part" color="#FFB6C1" />
+  <object type="Port" color="#FFA07A" />
+  <object type="Block" color="#B0C4DE" />
+  <object type="Decision" color="#FFFFFF" />
+  <object type="Merge" color="#FFFFFF" />
+</style>


### PR DESCRIPTION
## Summary
- provide `pastel.xml` with softer colors for diagrams
- document this new style in README
- drop the earlier Rhapsody and EA files
- bump version to 0.1.5

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688c54f67dd48325995e0a6263610947