### PR TITLE
Implement undo operations and shortcut

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2010,6 +2010,8 @@ class FaultTreeApp:
         fta_menu.add_command(label="Cause & Effect Chain", command=self.show_cause_effect_chain)
 
         edit_menu = tk.Menu(menubar, tearoff=0)
+        edit_menu.add_command(label="Undo", command=self.undo, accelerator="Ctrl+Z")
+        edit_menu.add_separator()
         edit_menu.add_command(label="Edit Selected", command=self.edit_selected)
         edit_menu.add_command(label="Remove Connection", command=lambda: self.remove_connection(self.selected_node) if self.selected_node else None)
         edit_menu.add_command(label="Delete Node", command=lambda: self.delete_node_and_subtree(self.selected_node) if self.selected_node else None)

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from sysml.sysml_repository import SysMLRepository
 from analysis.user_config import set_current_user
+from gui.architecture import rename_block, add_aggregation_part
 
 class UndoTests(unittest.TestCase):
     def setUp(self):
@@ -16,6 +17,27 @@ class UndoTests(unittest.TestCase):
         self.assertIn(elem.elem_id, self.repo.elements)
         self.assertTrue(self.repo.undo())
         self.assertNotIn(elem.elem_id, self.repo.elements)
+
+    def test_undo_rename_block(self):
+        blk = self.repo.create_element("Block", name="A")
+        rename_block(self.repo, blk.elem_id, "B")
+        self.assertEqual(self.repo.elements[blk.elem_id].name, "B")
+        self.assertTrue(self.repo.undo())
+        self.assertEqual(self.repo.elements[blk.elem_id].name, "A")
+
+    def test_undo_add_aggregation(self):
+        whole = self.repo.create_element("Block", name="Whole")
+        part = self.repo.create_element("Block", name="Part")
+        add_aggregation_part(self.repo, whole.elem_id, part.elem_id)
+        self.assertIn(
+            "Part",
+            self.repo.elements[whole.elem_id].properties.get("partProperties", ""),
+        )
+        self.assertTrue(self.repo.undo())
+        self.assertNotIn(
+            "Part",
+            self.repo.elements[whole.elem_id].properties.get("partProperties", ""),
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `Undo` item to the Edit menu with Ctrl+Z accelerator
- ensure architecture editing helpers push a single undo state
- cover undo for renaming blocks and adding aggregations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c5d71244883258c26908460450e91