### PR TITLE
Add gradient fill to FTA diagrams

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -7869,33 +7869,9 @@ class FaultTreeApp:
         return counts
 
     def get_node_fill_color(self, node):
-        # Use the original node's properties for clones.
-        base_node = node if node.is_primary_instance else node.original
         if self.project_properties.get("black_white", False):
             return "white"
-        label = base_node.display_label  # use original's display label
-        if "Prototype Assurance Level (PAL)" in label:
-            base_type = "Prototype Assurance Level (PAL)"
-        elif "Maturity" in label:
-            base_type = "Maturity"
-        elif "Rigor" in label:
-            base_type = "Rigor"
-        elif "Confidence" in label:
-            base_type = "Confidence"
-        elif "Robustness" in label:
-            base_type = "Robustness"
-        else:
-            base_type = "Other"
-        subtype = base_node.input_subtype if base_node.input_subtype else "Default"
-        color_mapping = {
-            "Confidence": {"Function": "lightpink", "Human Task": "lightgreen", "Default": "lightpink"},
-            "Robustness": {"Function": "orange", "Human Task": "pink", "Default": "orange"},
-            "Maturity": {"Functionality": "lightyellow", "Default": "lightyellow"},
-            "Rigor": {"Capability": "turquoise", "Safety Mechanism": "yellow", "Default": "turquoise"},
-            "Prototype Assurance Level (PAL)": {"Vehicle Level Function": "pink", "Functionality": "lightyellow","Capability": "turquoise", "Safety Mechanism": "yellow"},
-            "Other": {"Default": "lightblue"}
-        }
-        return color_mapping.get(base_type, {}).get(subtype, color_mapping.get(base_type, {}).get("Default", "lightblue"))
+        return "#FAD7A0"
 
     def on_right_mouse_press(self, event):
         self.canvas.scan_mark(event.x, event.y)
@@ -8659,6 +8635,8 @@ class FaultTreeApp:
         if not hasattr(self, "canvas") or self.canvas is None or not self.canvas.winfo_exists():
             return
         self.canvas.delete("all")
+        if hasattr(self, "fta_drawing_helper"):
+            self.fta_drawing_helper.clear_cache()
         self.draw_grid()
         drawn_ids = set()
         for top_event in self.top_events:
@@ -8781,78 +8759,148 @@ class FaultTreeApp:
             # For clones, draw them in a “clone” style.
             if source.is_page:
                 fta_drawing_helper.draw_triangle_shape(
-                    self.canvas, eff_x, eff_y, scale=40 * self.zoom,
-                    top_text=top_text, bottom_text=bottom_text,
-                    fill=fill_color, outline_color=outline_color,
-                    line_width=line_width, font_obj=font_obj
+                    self.canvas,
+                    eff_x,
+                    eff_y,
+                    scale=40 * self.zoom,
+                    top_text=top_text,
+                    bottom_text=bottom_text,
+                    fill=fill_color,
+                    outline_color=outline_color,
+                    line_width=line_width,
+                    font_obj=font_obj,
+                    obj_id=node.unique_id,
                 )
             elif node_type_upper in GATE_NODE_TYPES:
                 if source.gate_type.upper() == "OR":
                     fta_drawing_helper.draw_rotated_or_gate_clone_shape(
-                        self.canvas, eff_x, eff_y, scale=40 * self.zoom,
-                        top_text=top_text, bottom_text=bottom_text,
-                        fill=fill_color, outline_color=outline_color,
-                        line_width=line_width, font_obj=font_obj
+                        self.canvas,
+                        eff_x,
+                        eff_y,
+                        scale=40 * self.zoom,
+                        top_text=top_text,
+                        bottom_text=bottom_text,
+                        fill=fill_color,
+                        outline_color=outline_color,
+                        line_width=line_width,
+                        font_obj=font_obj,
+                        obj_id=node.unique_id,
                     )
                 else:
                     fta_drawing_helper.draw_rotated_and_gate_clone_shape(
-                        self.canvas, eff_x, eff_y, scale=40 * self.zoom,
-                        top_text=top_text, bottom_text=bottom_text,
-                        fill=fill_color, outline_color=outline_color,
-                        line_width=line_width, font_obj=font_obj
+                        self.canvas,
+                        eff_x,
+                        eff_y,
+                        scale=40 * self.zoom,
+                        top_text=top_text,
+                        bottom_text=bottom_text,
+                        fill=fill_color,
+                        outline_color=outline_color,
+                        line_width=line_width,
+                        font_obj=font_obj,
+                        obj_id=node.unique_id,
                     )
             elif node_type_upper in ["CONFIDENCE LEVEL", "ROBUSTNESS SCORE"]:
                 fta_drawing_helper.draw_circle_event_shape(
-                    self.canvas, eff_x, eff_y, 45 * self.zoom,
-                    top_text=top_text, bottom_text=bottom_text,
-                    fill=fill_color, outline_color=outline_color,
-                    line_width=line_width, font_obj=font_obj
+                    self.canvas,
+                    eff_x,
+                    eff_y,
+                    45 * self.zoom,
+                    top_text=top_text,
+                    bottom_text=bottom_text,
+                    fill=fill_color,
+                    outline_color=outline_color,
+                    line_width=line_width,
+                    font_obj=font_obj,
+                    obj_id=node.unique_id,
                 )
             else:
                 fta_drawing_helper.draw_circle_event_shape(
-                    self.canvas, eff_x, eff_y, 45 * self.zoom,
-                    top_text=top_text, bottom_text=bottom_text,
-                    fill=fill_color, outline_color=outline_color,
-                    line_width=line_width, font_obj=font_obj
+                    self.canvas,
+                    eff_x,
+                    eff_y,
+                    45 * self.zoom,
+                    top_text=top_text,
+                    bottom_text=bottom_text,
+                    fill=fill_color,
+                    outline_color=outline_color,
+                    line_width=line_width,
+                    font_obj=font_obj,
+                    obj_id=node.unique_id,
                 )
         else:
             # Primary node: use normal drawing routines.
             if node_type_upper in GATE_NODE_TYPES:
                 if source.is_page and source != self.root_node:
                     fta_drawing_helper.draw_triangle_shape(
-                        self.canvas, eff_x, eff_y, scale=40 * self.zoom,
-                        top_text=top_text, bottom_text=bottom_text,
-                        fill=fill_color, outline_color=outline_color,
-                        line_width=line_width, font_obj=font_obj
+                        self.canvas,
+                        eff_x,
+                        eff_y,
+                        scale=40 * self.zoom,
+                        top_text=top_text,
+                        bottom_text=bottom_text,
+                        fill=fill_color,
+                        outline_color=outline_color,
+                        line_width=line_width,
+                        font_obj=font_obj,
+                        obj_id=node.unique_id,
                     )
                 else:
                     if source.gate_type.upper() == "OR":
                         fta_drawing_helper.draw_rotated_or_gate_shape(
-                            self.canvas, eff_x, eff_y, scale=40 * self.zoom,
-                            top_text=top_text, bottom_text=bottom_text,
-                            fill=fill_color, outline_color=outline_color,
-                            line_width=line_width, font_obj=font_obj
+                            self.canvas,
+                            eff_x,
+                            eff_y,
+                            scale=40 * self.zoom,
+                            top_text=top_text,
+                            bottom_text=bottom_text,
+                            fill=fill_color,
+                            outline_color=outline_color,
+                            line_width=line_width,
+                            font_obj=font_obj,
+                            obj_id=node.unique_id,
                         )
                     else:
                         fta_drawing_helper.draw_rotated_and_gate_shape(
-                            self.canvas, eff_x, eff_y, scale=40 * self.zoom,
-                            top_text=top_text, bottom_text=bottom_text,
-                            fill=fill_color, outline_color=outline_color,
-                            line_width=line_width, font_obj=font_obj
+                            self.canvas,
+                            eff_x,
+                            eff_y,
+                            scale=40 * self.zoom,
+                            top_text=top_text,
+                            bottom_text=bottom_text,
+                            fill=fill_color,
+                            outline_color=outline_color,
+                            line_width=line_width,
+                            font_obj=font_obj,
+                            obj_id=node.unique_id,
                         )
             elif node_type_upper in ["CONFIDENCE LEVEL", "ROBUSTNESS SCORE"]:
                 fta_drawing_helper.draw_circle_event_shape(
-                    self.canvas, eff_x, eff_y, 45 * self.zoom,
-                    top_text=top_text, bottom_text=bottom_text,
-                    fill=fill_color, outline_color=outline_color,
-                    line_width=line_width, font_obj=font_obj
+                    self.canvas,
+                    eff_x,
+                    eff_y,
+                    45 * self.zoom,
+                    top_text=top_text,
+                    bottom_text=bottom_text,
+                    fill=fill_color,
+                    outline_color=outline_color,
+                    line_width=line_width,
+                    font_obj=font_obj,
+                    obj_id=node.unique_id,
                 )
             else:
                 fta_drawing_helper.draw_circle_event_shape(
-                    self.canvas, eff_x, eff_y, 45 * self.zoom,
-                    top_text=top_text, bottom_text=bottom_text,
-                    fill=fill_color, outline_color=outline_color,
-                    line_width=line_width, font_obj=font_obj
+                    self.canvas,
+                    eff_x,
+                    eff_y,
+                    45 * self.zoom,
+                    top_text=top_text,
+                    bottom_text=bottom_text,
+                    fill=fill_color,
+                    outline_color=outline_color,
+                    line_width=line_width,
+                    font_obj=font_obj,
+                    obj_id=node.unique_id,
                 )
 
         # Draw any additional text (such as equations) from the source.
@@ -14222,6 +14270,7 @@ class FaultTreeApp:
                 outline_color=outline_color,
                 line_width=line_width,
                 font_obj=self.diagram_font,
+                obj_id=node.unique_id,
             )
         else:
             node_type_upper = node.node_type.upper()
@@ -14237,6 +14286,7 @@ class FaultTreeApp:
                         fill=fill_color,
                         outline_color=outline_color,
                         line_width=line_width,
+                        obj_id=node.unique_id,
                     )
                 else:
                     fta_drawing_helper.draw_rotated_and_gate_shape(
@@ -14249,6 +14299,7 @@ class FaultTreeApp:
                         fill=fill_color,
                         outline_color=outline_color,
                         line_width=line_width,
+                        obj_id=node.unique_id,
                     )
             elif node_type_upper in ["CONFIDENCE LEVEL", "ROBUSTNESS SCORE"]:
                 fta_drawing_helper.draw_circle_event_shape(
@@ -14261,6 +14312,7 @@ class FaultTreeApp:
                     fill=fill_color,
                     outline_color=outline_color,
                     line_width=line_width,
+                    obj_id=node.unique_id,
                 )
             else:
                 fta_drawing_helper.draw_circle_event_shape(
@@ -14273,6 +14325,7 @@ class FaultTreeApp:
                     fill=fill_color,
                     outline_color=outline_color,
                     line_width=line_width,
+                    obj_id=node.unique_id,
                 )
 
         if self.review_data:
@@ -15648,6 +15701,8 @@ class PageDiagram:
         if not hasattr(self, "canvas") or self.canvas is None or not self.canvas.winfo_exists():
             return
         self.canvas.delete("all")
+        if hasattr(self.app, "fta_drawing_helper"):
+            self.app.fta_drawing_helper.clear_cache()
         self.draw_grid()
         
         # Use the page's root node as the sole top-level event.

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -1,6 +1,7 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 import math
 import tkinter.font as tkFont
+from PIL import Image, ImageDraw, ImageTk
 
 class FTADrawingHelper:
     """
@@ -9,7 +10,60 @@ class FTADrawingHelper:
     onto a tkinter Canvas.
     """
     def __init__(self):
-        pass
+        # Cache PhotoImage objects so Tkinter doesn't garbage collect them
+        self.gradient_cache: dict[str, ImageTk.PhotoImage] = {}
+
+    def clear_cache(self):
+        """Clear cached gradient images."""
+        self.gradient_cache.clear()
+
+    def _create_gradient_image(self, width: int, height: int, color: str) -> Image.Image:
+        """Return a Pillow Image with a left-to-right gradient from white to *color*."""
+        width = max(1, int(width))
+        height = max(1, int(height))
+        img = Image.new("RGB", (width, height), "white")
+        draw = ImageDraw.Draw(img)
+        r = int(color[1:3], 16)
+        g = int(color[3:5], 16)
+        b = int(color[5:7], 16)
+        for x in range(width):
+            ratio = x / (width - 1) if width > 1 else 1
+            nr = int(255 * (1 - ratio) + r * ratio)
+            ng = int(255 * (1 - ratio) + g * ratio)
+            nb = int(255 * (1 - ratio) + b * ratio)
+            draw.line([(x, 0), (x, height)], fill=(nr, ng, nb))
+        return img
+
+    def _draw_gradient_polygon(self, canvas, points, color: str, obj_id: str) -> None:
+        """Draw a gradient filled polygon on *canvas*."""
+        xs = [p[0] for p in points]
+        ys = [p[1] for p in points]
+        min_x = int(min(xs))
+        min_y = int(min(ys))
+        width = int(max(xs) - min_x)
+        height = int(max(ys) - min_y)
+        gradient = self._create_gradient_image(width, height, color)
+        mask = Image.new("L", (width, height), 0)
+        mdraw = ImageDraw.Draw(mask)
+        shifted = [(x - min_x, y - min_y) for x, y in points]
+        mdraw.polygon(shifted, fill=255)
+        gradient.putalpha(mask)
+        tk_img = ImageTk.PhotoImage(gradient)
+        canvas.create_image(min_x, min_y, anchor="nw", image=tk_img)
+        self.gradient_cache[obj_id] = tk_img
+
+    def _draw_gradient_oval(self, canvas, x1: float, y1: float, x2: float, y2: float, color: str, obj_id: str) -> None:
+        """Draw a gradient filled oval bounded by (x1, y1, x2, y2)."""
+        width = int(abs(x2 - x1))
+        height = int(abs(y2 - y1))
+        gradient = self._create_gradient_image(width, height, color)
+        mask = Image.new("L", (width, height), 0)
+        mdraw = ImageDraw.Draw(mask)
+        mdraw.ellipse((0, 0, width, height), fill=255)
+        gradient.putalpha(mask)
+        tk_img = ImageTk.PhotoImage(gradient)
+        canvas.create_image(min(x1, x2), min(y1, y2), anchor="nw", image=tk_img)
+        self.gradient_cache[obj_id] = tk_img
 
     def get_text_size(self, text, font_obj):
         """Return the (width, height) in pixels needed to render the text with the given font."""
@@ -18,15 +72,34 @@ class FTADrawingHelper:
         height = font_obj.metrics("linespace") * len(lines)
         return max_width, height
 
-    def draw_page_clone_shape(self, canvas, x, y, scale=40.0,
-                              top_text="Desc:\n\nRationale:", bottom_text="Node",
-                              fill="lightgray", outline_color="dimgray",
-                              line_width=1, font_obj=None):
+    def draw_page_clone_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=40.0,
+        top_text="Desc:\n\nRationale:",
+        bottom_text="Node",
+        fill="lightgray",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
         # First, draw the main triangle using the existing triangle routine.
-        self.draw_triangle_shape(canvas, x, y, scale=scale,
-                                 top_text=top_text, bottom_text=bottom_text,
-                                 fill=fill, outline_color=outline_color,
-                                 line_width=line_width, font_obj=font_obj)
+        self.draw_triangle_shape(
+            canvas,
+            x,
+            y,
+            scale=scale,
+            top_text=top_text,
+            bottom_text=bottom_text,
+            fill=fill,
+            outline_color=outline_color,
+            line_width=line_width,
+            font_obj=font_obj,
+            obj_id=obj_id,
+        )
         # Determine a baseline for the bottom of the triangle.
         # (You may need to adjust this value to match your triangle's dimensions.)
         bottom_y = y + scale * 0.75  
@@ -160,11 +233,20 @@ class FTADrawingHelper:
         scaled = [(vx * scale, vy * scale) for (vx, vy) in translated]
         return scaled
 
-    def draw_rotated_and_gate_shape(self, canvas, x, y, scale=40.0,
-                                      top_text="Desc:\n\nRationale:",
-                                      bottom_text="Event",
-                                      fill="lightgray", outline_color="dimgray",
-                                      line_width=1, font_obj=None):
+    def draw_rotated_and_gate_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=40.0,
+        top_text="Desc:\n\nRationale:",
+        bottom_text="Event",
+        fill="lightgray",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
         """Draw a rotated AND gate shape with top and bottom text labels."""
         if font_obj is None:
             font_obj = tkFont.Font(family="Arial", size=10)
@@ -174,8 +256,23 @@ class FTADrawingHelper:
         ys = [v[1] for v in flipped]
         cx, cy = (sum(xs) / len(xs), sum(ys) / len(ys))
         final_points = [(vx - cx + x, vy - cy + y) for (vx, vy) in flipped]
-        canvas.create_polygon(final_points, fill=fill, outline=outline_color,
-                                width=line_width, smooth=False)
+        if obj_id:
+            self._draw_gradient_polygon(canvas, final_points, fill, obj_id)
+            canvas.create_polygon(
+                final_points,
+                fill="",
+                outline=outline_color,
+                width=line_width,
+                smooth=False,
+            )
+        else:
+            canvas.create_polygon(
+                final_points,
+                fill=fill,
+                outline=outline_color,
+                width=line_width,
+                smooth=False,
+            )
 
         # Draw the top label box
         t_width, t_height = self.get_text_size(top_text, font_obj)
@@ -184,11 +281,15 @@ class FTADrawingHelper:
         top_box_height = t_height + 2 * padding
         top_y = min(pt[1] for pt in final_points) - top_box_height - 5
         top_box_x = x - top_box_width / 2
-        canvas.create_rectangle(top_box_x, top_y,
-                                top_box_x + top_box_width,
-                                top_y + top_box_height,
-                                fill="lightblue", outline=outline_color,
-                                width=line_width)
+        canvas.create_rectangle(
+            top_box_x,
+            top_y,
+            top_box_x + top_box_width,
+            top_y + top_box_height,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+        )
         canvas.create_text(top_box_x + top_box_width / 2,
                            top_y + top_box_height / 2,
                            text=top_text,
@@ -203,11 +304,15 @@ class FTADrawingHelper:
         shape_lowest_y = max(pt[1] for pt in final_points)
         bottom_y = shape_lowest_y - (2 * bottom_box_height)
         bottom_box_x = x - bottom_box_width / 2
-        canvas.create_rectangle(bottom_box_x, bottom_y,
-                                bottom_box_x + bottom_box_width,
-                                bottom_y + bottom_box_height,
-                                fill="lightblue", outline=outline_color,
-                                width=line_width)
+        canvas.create_rectangle(
+            bottom_box_x,
+            bottom_y,
+            bottom_box_x + bottom_box_width,
+            bottom_y + bottom_box_height,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+        )
         canvas.create_text(bottom_box_x + bottom_box_width / 2,
                            bottom_y + bottom_box_height / 2,
                            text=bottom_text,
@@ -215,11 +320,20 @@ class FTADrawingHelper:
                            anchor="center",
                            width=bottom_box_width)
 
-    def draw_rotated_or_gate_shape(self, canvas, x, y, scale=40.0,
-                                     top_text="Desc:\n\nRationale:",
-                                     bottom_text="Event",
-                                     fill="lightgray", outline_color="dimgray",
-                                     line_width=1, font_obj=None):
+    def draw_rotated_or_gate_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=40.0,
+        top_text="Desc:\n\nRationale:",
+        bottom_text="Event",
+        fill="lightgray",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
         """Draw a rotated OR gate shape with text labels."""
         if font_obj is None:
             font_obj = tkFont.Font(family="Arial", size=10)
@@ -242,8 +356,23 @@ class FTADrawingHelper:
         ys = [p[1] for p in flipped]
         cx, cy = (sum(xs) / len(xs), sum(ys) / len(ys))
         final_points = [(vx - cx + x, vy - cy + y) for (vx, vy) in flipped]
-        canvas.create_polygon(final_points, fill=fill, outline=outline_color,
-                                width=line_width, smooth=True)
+        if obj_id:
+            self._draw_gradient_polygon(canvas, final_points, fill, obj_id)
+            canvas.create_polygon(
+                final_points,
+                fill="",
+                outline=outline_color,
+                width=line_width,
+                smooth=True,
+            )
+        else:
+            canvas.create_polygon(
+                final_points,
+                fill=fill,
+                outline=outline_color,
+                width=line_width,
+                smooth=True,
+            )
 
         # Draw the top label box
         padding = 6
@@ -252,10 +381,15 @@ class FTADrawingHelper:
         top_box_height = t_height + 2 * padding
         top_y = min(pt[1] for pt in final_points) - top_box_height - 5
         top_box_x = x - top_box_width / 2
-        canvas.create_rectangle(top_box_x, top_y,
-                                top_box_x + top_box_width,
-                                top_y + top_box_height,
-                                fill="lightblue", outline=outline_color, width=line_width)
+        canvas.create_rectangle(
+            top_box_x,
+            top_y,
+            top_box_x + top_box_width,
+            top_y + top_box_height,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+        )
         canvas.create_text(top_box_x + top_box_width / 2,
                            top_y + top_box_height / 2,
                            text=top_text, font=font_obj, anchor="center",
@@ -268,25 +402,48 @@ class FTADrawingHelper:
         shape_lowest_y = max(pt[1] for pt in final_points)
         bottom_y = shape_lowest_y - (2 * bottom_box_height)
         bottom_box_x = x - bottom_box_width / 2
-        canvas.create_rectangle(bottom_box_x, bottom_y,
-                                bottom_box_x + bottom_box_width,
-                                bottom_y + bottom_box_height,
-                                fill="lightblue", outline=outline_color,
-                                width=line_width)
+        canvas.create_rectangle(
+            bottom_box_x,
+            bottom_y,
+            bottom_box_x + bottom_box_width,
+            bottom_y + bottom_box_height,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+        )
         canvas.create_text(bottom_box_x + bottom_box_width / 2,
                            bottom_y + bottom_box_height / 2,
                            text=bottom_text, font=font_obj,
                            anchor="center", width=bottom_box_width)
 
-    def draw_rotated_and_gate_clone_shape(self, canvas, x, y, scale=40.0,
-                                            top_text="Desc:\n\nRationale:", bottom_text="Node",
-                                            fill="lightgray", outline_color="dimgray",
-                                            line_width=1, font_obj=None):
+    def draw_rotated_and_gate_clone_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=40.0,
+        top_text="Desc:\n\nRationale:",
+        bottom_text="Node",
+        fill="lightgray",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
         """Draw a rotated AND gate shape with additional clone details."""
-        self.draw_rotated_and_gate_shape(canvas, x, y, scale=scale,
-                                         top_text=top_text, bottom_text=bottom_text,
-                                         fill=fill, outline_color=outline_color,
-                                         line_width=line_width, font_obj=font_obj)
+        self.draw_rotated_and_gate_shape(
+            canvas,
+            x,
+            y,
+            scale=scale,
+            top_text=top_text,
+            bottom_text=bottom_text,
+            fill=fill,
+            outline_color=outline_color,
+            line_width=line_width,
+            font_obj=font_obj,
+            obj_id=obj_id,
+        )
         bottom_y = y + scale * 1.5
         line_offset1 = scale * 0.05
         line_offset2 = scale * 0.1
@@ -310,15 +467,34 @@ class FTADrawingHelper:
                            x + scale/2, bottom_y + final_line_offset,
                            fill=outline_color, width=line_width)
 
-    def draw_rotated_or_gate_clone_shape(self, canvas, x, y, scale=40.0,
-                                           top_text="Desc:\n\nRationale:", bottom_text="Node",
-                                           fill="lightgray", outline_color="dimgray",
-                                           line_width=1, font_obj=None):
+    def draw_rotated_or_gate_clone_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=40.0,
+        top_text="Desc:\n\nRationale:",
+        bottom_text="Node",
+        fill="lightgray",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
         """Draw a rotated OR gate shape with additional clone details."""
-        self.draw_rotated_or_gate_shape(canvas, x, y, scale=scale,
-                                        top_text=top_text, bottom_text=bottom_text,
-                                        fill=fill, outline_color=outline_color,
-                                        line_width=line_width, font_obj=font_obj)
+        self.draw_rotated_or_gate_shape(
+            canvas,
+            x,
+            y,
+            scale=scale,
+            top_text=top_text,
+            bottom_text=bottom_text,
+            fill=fill,
+            outline_color=outline_color,
+            line_width=line_width,
+            font_obj=font_obj,
+            obj_id=obj_id,
+        )
         bottom_y = y + scale * 1.5
         line_offset1 = scale * 0.05
         line_offset2 = scale * 0.1
@@ -342,11 +518,20 @@ class FTADrawingHelper:
                            x + scale/2, bottom_y + final_line_offset,
                            fill=outline_color, width=line_width)
 
-    def draw_triangle_shape(self, canvas, x, y, scale=40.0,
-                              top_text="Desc:\n\nRationale:",
-                              bottom_text="Event",
-                              fill="lightgray", outline_color="dimgray",
-                              line_width=1, font_obj=None):
+    def draw_triangle_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=40.0,
+        top_text="Desc:\n\nRationale:",
+        bottom_text="Event",
+        fill="lightgray",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
         if font_obj is None:
             font_obj = tkFont.Font(family="Arial", size=10)
         effective_scale = scale * 2  
@@ -354,10 +539,16 @@ class FTADrawingHelper:
         v1 = (0, -2 * h / 3)
         v2 = (-effective_scale / 2, h / 3)
         v3 = (effective_scale / 2, h / 3)
-        vertices = [(x + v1[0], y + v1[1]),
-                    (x + v2[0], y + v2[1]),
-                    (x + v3[0], y + v3[1])]
-        canvas.create_polygon(vertices, fill=fill, outline=outline_color, width=line_width)
+        vertices = [
+            (x + v1[0], y + v1[1]),
+            (x + v2[0], y + v2[1]),
+            (x + v3[0], y + v3[1]),
+        ]
+        if obj_id:
+            self._draw_gradient_polygon(canvas, vertices, fill, obj_id)
+            canvas.create_polygon(vertices, fill="", outline=outline_color, width=line_width)
+        else:
+            canvas.create_polygon(vertices, fill=fill, outline=outline_color, width=line_width)
         
         t_width, t_height = self.get_text_size(top_text, font_obj)
         padding = 6
@@ -365,10 +556,15 @@ class FTADrawingHelper:
         top_box_height = t_height + 2 * padding
         top_box_x = x - top_box_width / 2
         top_box_y = min(v[1] for v in vertices) - top_box_height
-        canvas.create_rectangle(top_box_x, top_box_y,
-                                top_box_x + top_box_width,
-                                top_box_y + top_box_height,
-                                fill="lightblue", outline=outline_color, width=line_width)
+        canvas.create_rectangle(
+            top_box_x,
+            top_box_y,
+            top_box_x + top_box_width,
+            top_box_y + top_box_height,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+        )
         canvas.create_text(top_box_x + top_box_width / 2,
                            top_box_y + top_box_height / 2,
                            text=top_text,
@@ -379,23 +575,35 @@ class FTADrawingHelper:
         bottom_box_height = b_height + 2 * padding
         bottom_box_x = x - bottom_box_width / 2
         bottom_box_y = max(v[1] for v in vertices) + padding - 2 * bottom_box_height
-        canvas.create_rectangle(bottom_box_x, bottom_box_y,
-                                bottom_box_x + bottom_box_width,
-                                bottom_box_y + bottom_box_height,
-                                fill="lightblue", outline=outline_color, width=line_width)
+        canvas.create_rectangle(
+            bottom_box_x,
+            bottom_box_y,
+            bottom_box_x + bottom_box_width,
+            bottom_box_y + bottom_box_height,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+        )
         canvas.create_text(bottom_box_x + bottom_box_width / 2,
                            bottom_box_y + bottom_box_height / 2,
                            text=bottom_text,
                            font=font_obj, anchor="center", width=bottom_box_width)
                            
-    def draw_circle_event_shape(self, canvas, x, y, radius,
-                                top_text="",
-                                bottom_text="",
-                                fill="lightyellow",
-                                outline_color="dimgray",
-                                line_width=1,
-                                font_obj=None,
-                                base_event=False):
+    def draw_circle_event_shape(
+        self,
+        canvas,
+        x,
+        y,
+        radius,
+        top_text="",
+        bottom_text="",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        base_event=False,
+        obj_id: str = "",
+    ):
         """Draw a circular event shape with optional text labels."""
         if font_obj is None:
             font_obj = tkFont.Font(family="Arial", size=10)
@@ -403,19 +611,42 @@ class FTADrawingHelper:
         top = y - radius
         right = x + radius
         bottom = y + radius
-        canvas.create_oval(left, top, right, bottom, fill=fill,
-                           outline=outline_color, width=line_width)
+        if obj_id:
+            self._draw_gradient_oval(canvas, left, top, right, bottom, fill, obj_id)
+            canvas.create_oval(
+                left,
+                top,
+                right,
+                bottom,
+                fill="",
+                outline=outline_color,
+                width=line_width,
+            )
+        else:
+            canvas.create_oval(
+                left,
+                top,
+                right,
+                bottom,
+                fill=fill,
+                outline=outline_color,
+                width=line_width,
+            )
         t_width, t_height = self.get_text_size(top_text, font_obj)
         padding = 6
         top_box_width = t_width + 2 * padding
         top_box_height = t_height + 2 * padding
         top_box_x = x - top_box_width / 2
         top_box_y = top - top_box_height
-        canvas.create_rectangle(top_box_x, top_box_y,
-                                top_box_x + top_box_width,
-                                top_box_y + top_box_height,
-                                fill="lightblue", outline=outline_color,
-                                width=line_width)
+        canvas.create_rectangle(
+            top_box_x,
+            top_box_y,
+            top_box_x + top_box_width,
+            top_box_y + top_box_height,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+        )
         canvas.create_text(top_box_x + top_box_width / 2,
                            top_box_y + top_box_height / 2,
                            text=top_text,
@@ -426,21 +657,35 @@ class FTADrawingHelper:
         bottom_box_height = b_height + 2 * padding
         bottom_box_x = x - bottom_box_width / 2
         bottom_box_y = bottom - 2 * bottom_box_height
-        canvas.create_rectangle(bottom_box_x, bottom_box_y,
-                                bottom_box_x + bottom_box_width,
-                                bottom_box_y + bottom_box_height,
-                                fill="lightblue", outline=outline_color,
-                                width=line_width)
+        canvas.create_rectangle(
+            bottom_box_x,
+            bottom_box_y,
+            bottom_box_x + bottom_box_width,
+            bottom_box_y + bottom_box_height,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+        )
         canvas.create_text(bottom_box_x + bottom_box_width / 2,
                            bottom_box_y + bottom_box_height / 2,
                            text=bottom_text,
                            font=font_obj, anchor="center",
                            width=bottom_box_width)
                            
-    def draw_triangle_clone_shape(self, canvas, x, y, scale=40.0,
-                                  top_text="Desc:\n\nRationale:", bottom_text="Node",
-                                  fill="lightgray", outline_color="dimgray",
-                                  line_width=1, font_obj=None):
+    def draw_triangle_clone_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=40.0,
+        top_text="Desc:\n\nRationale:",
+        bottom_text="Node",
+        fill="lightgray",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
         """
         Draws the same triangle as draw_triangle_shape but then adds two horizontal lines
         at the bottom and a small triangle on the right side as clone indicators.
@@ -450,10 +695,19 @@ class FTADrawingHelper:
         if font_obj is None:
             font_obj = tkFont.Font(family="Arial", size=10)
         # Draw the base triangle.
-        self.draw_triangle_shape(canvas, x, y, scale=scale,
-                                 top_text=top_text, bottom_text=bottom_text,
-                                 fill=fill, outline_color=outline_color,
-                                 line_width=line_width, font_obj=font_obj)
+        self.draw_triangle_shape(
+            canvas,
+            x,
+            y,
+            scale=scale,
+            top_text=top_text,
+            bottom_text=bottom_text,
+            fill=fill,
+            outline_color=outline_color,
+            line_width=line_width,
+            font_obj=font_obj,
+            obj_id=obj_id,
+        )
         # Compute the vertices of the big triangle.
         effective_scale = scale * 2  
         h = effective_scale * math.sqrt(3) / 2


### PR DESCRIPTION
## Summary
- implement gradient utilities and caching in `FTADrawingHelper`
- draw FTA shapes using gradient backgrounds
- clear gradient cache on redraw
- set FTA node color to `#FAD7A0`
- ensure FTA node text boxes use the selected color

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688c5ea3a2788325b21d43f6d6ca2408