### PR TITLE
Implement global undo and redo with shortcuts

### DIFF
--- a/analysis/risk_assessment.py
+++ b/analysis/risk_assessment.py
@@ -373,6 +373,8 @@ class AutoMLHelper:
         return max(1, min(5, round(inverted)))
 
     def calculate_assurance_recursive(self, node, all_top_events, visited=None):
+        if node is None:
+            return 1
         if visited is None:
             visited = set()
         if node.unique_id in visited:

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -39,5 +39,20 @@ class UndoTests(unittest.TestCase):
             self.repo.elements[whole.elem_id].properties.get("partProperties", ""),
         )
 
+    def test_redo_creation(self):
+        elem = self.repo.create_element("Actor", name="User")
+        self.repo.undo()
+        self.assertNotIn(elem.elem_id, self.repo.elements)
+        self.assertTrue(self.repo.redo())
+        self.assertIn(elem.elem_id, self.repo.elements)
+
+    def test_redo_rename_block(self):
+        blk = self.repo.create_element("Block", name="A")
+        rename_block(self.repo, blk.elem_id, "B")
+        self.repo.undo()
+        self.assertEqual(self.repo.elements[blk.elem_id].name, "A")
+        self.assertTrue(self.repo.redo())
+        self.assertEqual(self.repo.elements[blk.elem_id].name, "B")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add redo stack and redo() to SysMLRepository
- track redo state in the main app and expose a redo command
- bind Ctrl+Y and add Redo menu entry
- expand undo tests to cover redo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c629c95288325b2cad5f570074b57