### PR TITLE
Give elements default names

### DIFF
--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -154,6 +154,8 @@ class SysMLRepository:
     def create_element(self, elem_type: str, name: str = "", properties: Optional[Dict[str, str]] = None, owner: Optional[str] = None) -> SysMLElement:
         self.push_undo_state()
         elem_id = str(uuid.uuid4())
+        if not name and elem_type != "Part":
+            name = elem_type
         unique_name = self.ensure_unique_element_name(name) if name else name
         elem = SysMLElement(
             elem_id,


### PR DESCRIPTION
## Summary
- assign a default name when creating a new element if none is specified

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c7d893dcc83258ee871ec69028250