### PR TITLE
Add default names for created elements

### DIFF
--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -151,10 +151,27 @@ class SysMLRepository:
             suffix += 1
         return name
 
+    def _default_name(self, elem_type: str) -> str:
+        """Return a generated default name for ``elem_type``."""
+        base = elem_type.replace(" ", "") or "Element"
+        existing = {
+            e.name
+            for e in self.elements.values()
+            if e.name and e.name.startswith(base)
+        }
+        suffix = 1
+        name = f"{base}{suffix}"
+        while name in existing:
+            suffix += 1
+            name = f"{base}{suffix}"
+        return name
+
     def create_element(self, elem_type: str, name: str = "", properties: Optional[Dict[str, str]] = None, owner: Optional[str] = None) -> SysMLElement:
         self.push_undo_state()
         elem_id = str(uuid.uuid4())
-        unique_name = self.ensure_unique_element_name(name) if name else name
+        if not name:
+            name = self._default_name(elem_type)
+        unique_name = self.ensure_unique_element_name(name)
         elem = SysMLElement(
             elem_id,
             elem_type,

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -26,6 +26,16 @@ class RepositoryTests(unittest.TestCase):
         self.assertEqual(rel.source, a.elem_id)
         self.assertEqual(rel.target, b.elem_id)
 
+    def test_default_element_names(self):
+        blk1 = self.repo.create_element("Block")
+        blk2 = self.repo.create_element("Block")
+        part = self.repo.create_element("Part")
+        act = self.repo.create_element("Action")
+        self.assertTrue(blk1.name)
+        self.assertTrue(part.name)
+        self.assertTrue(act.name)
+        self.assertNotEqual(blk1.name, blk2.name)
+
     def test_author_metadata(self):
         elem = self.repo.create_element("Block", name="Engine")
         diag = self.repo.create_diagram("Block Diagram", name="BD")


### PR DESCRIPTION
## Summary
- generate a default name when creating repository elements
- ensure default names are unique
- test default name generation for blocks, parts and actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c7ef763048325835ec3ef865d933f