### PR TITLE
Fix recalc NameError on HARA row editing

### DIFF
--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -2212,6 +2212,30 @@ class HaraWindow(tk.Frame):
                 master, textvariable=self.sg_var, values=goals, state="readonly"
             ).grid(row=10, column=1)
 
+            def recalc(_=None):
+                try:
+                    s = int(self.sev_var.get())
+                    c = int(self.cont_var.get())
+                    e = int(self.exp_var.get())
+                except ValueError:
+                    self.asil_var.set("QM")
+                    return
+                self.asil_var.set(calc_asil(s, c, e))
+
+
+            sev_cb.bind("<<ComboboxSelected>>", recalc)
+            cont_cb.bind("<<ComboboxSelected>>", recalc)
+            exp_cb.bind("<<ComboboxSelected>>", recalc)
+
+            def update_exposure(_=None):
+                scen = self.scen_var.get()
+                if scen:
+                    self.exp_var.set(str(self.app.get_scenario_exposure(scen)))
+                recalc()
+
+            scen_cb.bind("<<ComboboxSelected>>", update_exposure)
+            update_exposure()
+
             def auto_hazard(_=None):
                 mal = self.mal_var.get()
                 if not mal:
@@ -2232,30 +2256,6 @@ class HaraWindow(tk.Frame):
 
             mal_cb.bind("<<ComboboxSelected>>", auto_hazard)
             auto_hazard()
-
-            def recalc(_=None):
-                try:
-                    s = int(self.sev_var.get())
-                    c = int(self.cont_var.get())
-                    e = int(self.exp_var.get())
-                except ValueError:
-                    self.asil_var.set("QM")
-                    return
-                self.asil_var.set(calc_asil(s, c, e))
-
-            sev_cb.bind("<<ComboboxSelected>>", recalc)
-            cont_cb.bind("<<ComboboxSelected>>", recalc)
-            exp_cb.bind("<<ComboboxSelected>>", recalc)
-            recalc()
-
-            def update_exposure(_=None):
-                scen = self.scen_var.get()
-                if scen:
-                    self.exp_var.set(str(self.app.get_scenario_exposure(scen)))
-                recalc()
-
-            scen_cb.bind("<<ComboboxSelected>>", update_exposure)
-            update_exposure()
 
         def apply(self):
             old_mal = self.row.malfunction


### PR DESCRIPTION
## Summary
- adjust function order in `RowDialog.body` to define `recalc` before calling it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c84a673708325a8de6ac34ab61b42