### PR TITLE
Add block import button

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6900,6 +6900,113 @@ class BlockDiagramWindow(SysMLDiagramWindow):
             "Composite Aggregation",
         ]
         super().__init__(master, "Block Diagram", tools, diagram_id, app=app, history=history)
+        ttk.Button(
+            self.toolbox,
+            text="Add Blocks",
+            command=self.add_blocks,
+        ).pack(fill=tk.X, padx=2, pady=2)
+
+    def _add_block_relationships(self) -> None:
+        """Add connections for any existing relationships between blocks."""
+        repo = self.repo
+        diag = repo.diagrams.get(self.diagram_id)
+        if not diag:
+            return
+        obj_map = {
+            o.element_id: o.obj_id
+            for o in self.objects
+            if o.obj_type == "Block" and o.element_id
+        }
+        existing = {
+            (c.src, c.dst, c.conn_type)
+            for c in self.connections
+        } | {
+            (c.dst, c.src, c.conn_type)
+            for c in self.connections
+        }
+        for rel in repo.relationships:
+            if rel.rel_type not in (
+                "Association",
+                "Generalization",
+                "Aggregation",
+                "Composite Aggregation",
+            ):
+                continue
+            if rel.source in obj_map and rel.target in obj_map:
+                src_id = obj_map[rel.source]
+                dst_id = obj_map[rel.target]
+                if (src_id, dst_id, rel.rel_type) in existing:
+                    continue
+                if (dst_id, src_id, rel.rel_type) in existing:
+                    continue
+                conn = DiagramConnection(
+                    src_id,
+                    dst_id,
+                    rel.rel_type,
+                    arrow="forward" if rel.rel_type == "Generalization" else "none",
+                )
+                self.connections.append(conn)
+                diag.connections.append(conn.__dict__)
+                repo.add_relationship_to_diagram(self.diagram_id, rel.rel_id)
+        
+    def add_blocks(self) -> None:
+        repo = self.repo
+        diag = repo.diagrams.get(self.diagram_id)
+        if not diag:
+            return
+        existing = {
+            o.element_id
+            for o in self.objects
+            if o.obj_type == "Block" and o.element_id
+        }
+        candidates = set()
+        for d in repo.diagrams.values():
+            if d.diag_type != "Block Diagram" or d.diag_id == self.diagram_id:
+                continue
+            for obj in getattr(d, "objects", []):
+                if obj.get("obj_type") == "Block" and obj.get("element_id"):
+                    candidates.add(obj["element_id"])
+        names = []
+        id_map = {}
+        for bid in candidates:
+            if bid in existing or bid not in repo.elements:
+                continue
+            name = repo.elements[bid].name or bid
+            names.append(name)
+            id_map[name] = bid
+        if not names:
+            messagebox.showinfo("Add Blocks", "No blocks available")
+            return
+        dlg = SysMLObjectDialog.SelectNamesDialog(self, names, title="Add Blocks")
+        selected = dlg.result or []
+        if not selected:
+            return
+        base_x = 50.0
+        base_y = 50.0
+        offset = 180.0
+        for idx, name in enumerate(selected):
+            blk_id = id_map.get(name)
+            if not blk_id:
+                continue
+            repo.add_element_to_diagram(self.diagram_id, blk_id)
+            elem = repo.elements.get(blk_id)
+            props = elem.properties.copy() if elem else {}
+            props["name"] = elem.name if elem else blk_id
+            obj = SysMLObject(
+                _get_next_id(),
+                "Block",
+                base_x,
+                base_y + offset * idx,
+                element_id=blk_id,
+                width=160.0,
+                height=140.0,
+                properties=props,
+            )
+            diag.objects.append(obj.__dict__)
+            self.objects.append(obj)
+        self._add_block_relationships()
+        self.redraw()
+        self._sync_to_repository()
 
 
 class InternalBlockDiagramWindow(SysMLDiagramWindow):

--- a/tests/test_add_block_relationships.py
+++ b/tests/test_add_block_relationships.py
@@ -1,0 +1,78 @@
+import unittest
+from gui.architecture import BlockDiagramWindow, SysMLObject, _get_next_id
+from sysml.sysml_repository import SysMLRepository
+
+class DummyWindow:
+    _add_block_relationships = BlockDiagramWindow._add_block_relationships
+    def __init__(self, diagram):
+        self.repo = SysMLRepository.get_instance()
+        self.diagram_id = diagram.diag_id
+        self.objects = []
+        self.connections = []
+
+    def redraw(self):
+        pass
+
+    def _sync_to_repository(self):
+        diag = self.repo.diagrams.get(self.diagram_id)
+        if diag:
+            diag.objects = [o.__dict__ for o in self.objects]
+            diag.connections = [c.__dict__ for c in self.connections]
+
+class AddBlockRelationshipsTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_relationships_added_when_blocks_imported(self):
+        repo = self.repo
+        d1 = repo.create_diagram("Block Diagram", name="D1")
+        d2 = repo.create_diagram("Block Diagram", name="D2")
+        a = repo.create_element("Block", name="A")
+        b = repo.create_element("Block", name="B")
+        c = repo.create_element("Block", name="C")
+
+        repo.add_element_to_diagram(d2.diag_id, a.elem_id)
+        repo.add_element_to_diagram(d2.diag_id, b.elem_id)
+        repo.add_element_to_diagram(d2.diag_id, c.elem_id)
+        d2.objects = [
+            {"obj_id": 1, "obj_type": "Block", "x": 0, "y": 0, "element_id": a.elem_id},
+            {"obj_id": 2, "obj_type": "Block", "x": 0, "y": 0, "element_id": b.elem_id},
+            {"obj_id": 3, "obj_type": "Block", "x": 0, "y": 0, "element_id": c.elem_id},
+        ]
+
+        rel_ab = repo.create_relationship("Association", a.elem_id, b.elem_id)
+        repo.add_relationship_to_diagram(d2.diag_id, rel_ab.rel_id)
+        rel_bc = repo.create_relationship("Association", b.elem_id, c.elem_id)
+        repo.add_relationship_to_diagram(d2.diag_id, rel_bc.rel_id)
+
+        win = DummyWindow(d1)
+
+        # add A
+        repo.add_element_to_diagram(d1.diag_id, a.elem_id)
+        obj_a = SysMLObject(_get_next_id(), "Block", 0, 0, element_id=a.elem_id)
+        d1.objects.append(obj_a.__dict__)
+        win.objects.append(obj_a)
+        win._add_block_relationships()
+        self.assertEqual(len(win.connections), 0)
+
+        # add B
+        repo.add_element_to_diagram(d1.diag_id, b.elem_id)
+        obj_b = SysMLObject(_get_next_id(), "Block", 0, 0, element_id=b.elem_id)
+        d1.objects.append(obj_b.__dict__)
+        win.objects.append(obj_b)
+        win._add_block_relationships()
+        self.assertEqual(len(win.connections), 1)
+        self.assertIn(rel_ab.rel_id, repo.diagrams[d1.diag_id].relationships)
+
+        # add C
+        repo.add_element_to_diagram(d1.diag_id, c.elem_id)
+        obj_c = SysMLObject(_get_next_id(), "Block", 0, 0, element_id=c.elem_id)
+        d1.objects.append(obj_c.__dict__)
+        win.objects.append(obj_c)
+        win._add_block_relationships()
+        self.assertEqual(len(win.connections), 2)
+        self.assertIn(rel_bc.rel_id, repo.diagrams[d1.diag_id].relationships)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_block_import_shared.py
+++ b/tests/test_block_import_shared.py
@@ -1,0 +1,53 @@
+import unittest
+
+from gui.architecture import rename_block
+from sysml.sysml_repository import SysMLRepository
+
+
+class BlockImportSharedTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_imported_block_shares_element(self):
+        repo = self.repo
+        d1 = repo.create_diagram("Block Diagram")
+        d2 = repo.create_diagram("Block Diagram")
+        blk = repo.create_element("Block", name="A", properties={"ports": "p1"})
+
+        repo.add_element_to_diagram(d1.diag_id, blk.elem_id)
+        d1.objects = [
+            {
+                "obj_id": 1,
+                "obj_type": "Block",
+                "x": 0,
+                "y": 0,
+                "element_id": blk.elem_id,
+                "properties": {"name": blk.name, **blk.properties},
+            }
+        ]
+
+        repo.add_element_to_diagram(d2.diag_id, blk.elem_id)
+        d2.objects = [
+            {
+                "obj_id": 2,
+                "obj_type": "Block",
+                "x": 0,
+                "y": 0,
+                "element_id": blk.elem_id,
+                "properties": {"name": blk.name, **blk.properties},
+            }
+        ]
+
+        d1.objects.clear()
+        d1.elements.remove(blk.elem_id)
+
+        rename_block(repo, blk.elem_id, "B")
+
+        self.assertEqual(repo.elements[blk.elem_id].name, "B")
+        self.assertEqual(d2.objects[0]["properties"]["name"], "B")
+        self.assertEqual(d2.objects[0]["properties"]["ports"], "p1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow importing of existing blocks into a block diagram
- include a new "Add Blocks" button in BlockDiagramWindow
- automatically create connections for existing relationships when blocks are imported
- when blocks are imported they now copy all element properties so each diagram references the same model element
- add regression tests for block relationship import and shared element behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688c8124deb083259472041e967f0337