### PR TITLE
Fix reliability window initialization

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -7004,7 +7004,8 @@ class BlockDiagramWindow(SysMLDiagramWindow):
             )
             diag.objects.append(obj.__dict__)
             self.objects.append(obj)
-        self._add_block_relationships()
+        if hasattr(self, "_add_block_relationships"):
+            self._add_block_relationships()
         self.redraw()
         self._sync_to_repository()
 

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -331,7 +331,6 @@ class ReliabilityWindow(tk.Frame):
         )
         self.analysis_combo.pack(anchor="w", fill="x")
         self.analysis_combo.bind("<<ComboboxSelected>>", self.load_selected_analysis)
-        self.refresh_analysis_list()
 
         configure_table_style("Reliability.Treeview")
         column_opts = {
@@ -413,6 +412,10 @@ class ReliabilityWindow(tk.Frame):
         ToolTip(del_btn, "Remove the selected analysis from the project.")
         self.formula_label = ttk.Label(self, text="")
         self.formula_label.pack(anchor="w", padx=5, pady=5)
+
+        # populate analysis list after tree initialization to avoid missing
+        # widgets during early callbacks
+        self.refresh_analysis_list()
 
     def add_component(self):
         dialog = tk.Toplevel(self)


### PR DESCRIPTION
## Summary
- avoid calling refresh_analysis_list before tree exists
- refresh analysis list at end of ReliabilityWindow setup
- guard add_blocks against missing `_add_block_relationships`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688cc4c6a1bc83259bce857ea745ed15