### PR TITLE
Fix duplicate parts when inheriting with BOM

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -972,6 +972,7 @@ def _sync_ibd_partproperty_parts(
         for o in diag.objects
         if o.get("obj_type") == "Part" and o.get("element_id") in repo.elements
     }
+    existing_keys = {_part_prop_key(n) for n in existing_props}
     if names is None:
         entries = [p for p in block.properties.get("partProperties", "").split(",") if p.strip()]
     else:
@@ -996,7 +997,7 @@ def _sync_ibd_partproperty_parts(
         base_x = 50.0
         base_y = 50.0 + 60.0 * len(existing_props)
     for prop_name, block_name in parsed:
-        if prop_name in existing_props:
+        if _part_prop_key(prop_name) in existing_keys:
             continue
         target_id = next(
             (
@@ -1052,6 +1053,7 @@ def _sync_ibd_partproperty_parts(
         diag.objects.append(obj_dict)
         added.append(obj_dict)
         existing_props.add(prop_name)
+        existing_keys.add(_part_prop_key(prop_name))
         existing_defs.add(target_id)
         if app:
             for win in getattr(app, "ibd_windows", []):

--- a/tests/test_partproperty_multiplicity.py
+++ b/tests/test_partproperty_multiplicity.py
@@ -28,5 +28,23 @@ class PartPropertyMultiplicityTests(unittest.TestCase):
         parts = [o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part.elem_id]
         self.assertEqual(len(parts), 1)
 
+    def test_skip_existing_bracketed_parts(self):
+        repo = self.repo
+        blk = repo.create_element("Block", name="A", properties={"partProperties": "B"})
+        part_blk = repo.create_element("Block", name="B")
+        ibd = repo.create_diagram("Internal Block Diagram")
+        repo.link_diagram(blk.elem_id, ibd.diag_id)
+
+        p1 = repo.create_element("Part", name="B[1]", properties={"definition": part_blk.elem_id})
+        p2 = repo.create_element("Part", name="B[2]", properties={"definition": part_blk.elem_id})
+        repo.add_element_to_diagram(ibd.diag_id, p1.elem_id)
+        repo.add_element_to_diagram(ibd.diag_id, p2.elem_id)
+        ibd.objects.append({"obj_id": 1, "obj_type": "Part", "x": 0, "y": 0, "element_id": p1.elem_id, "properties": {"definition": part_blk.elem_id}})
+        ibd.objects.append({"obj_id": 2, "obj_type": "Part", "x": 0, "y": 0, "element_id": p2.elem_id, "properties": {"definition": part_blk.elem_id}})
+
+        _sync_ibd_partproperty_parts(repo, blk.elem_id, visible=True)
+        parts = [o for o in ibd.objects if o.get("obj_type") == "Part" and o.get("properties", {}).get("definition") == part_blk.elem_id]
+        self.assertEqual(len(parts), 2)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle existing part property names using base key to skip duplicates
- add regression test for bracketed part names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688cc776efbc8325b9a47170ede9974d