### PR TITLE
Fix FMEDA base event probability calculation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9087,6 +9087,8 @@ class FaultTreeApp:
         data.pop("unique_id", None)
         data["children"] = []
         new_node = FaultTreeNode.from_dict(data, parent_node)
+        if hasattr(selected, "unique_id"):
+            new_node.failure_mode_ref = selected.unique_id
         parent_node.children.append(new_node)
         new_node.parents.append(parent_node)
         self.update_views()
@@ -9127,6 +9129,8 @@ class FaultTreeApp:
         data.pop("unique_id", None)
         data["children"] = []
         new_node = FaultTreeNode.from_dict(data, parent_node)
+        if hasattr(selected, "unique_id"):
+            new_node.failure_mode_ref = selected.unique_id
         parent_node.children.append(new_node)
         new_node.parents.append(parent_node)
         self.update_views()
@@ -9167,6 +9171,8 @@ class FaultTreeApp:
         data.pop("unique_id", None)
         data["children"] = []
         new_node = FaultTreeNode.from_dict(data, parent_node)
+        if hasattr(selected, "unique_id"):
+            new_node.failure_mode_ref = selected.unique_id
         parent_node.children.append(new_node)
         new_node.parents.append(parent_node)
         self.update_views()


### PR DESCRIPTION
## Summary
- ensure newly created base events from FMEDA rows keep a reference to the FMEDA entry
- update all `add_basic_event_from_fmea` helpers so probabilities recompute correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688d033f9d908327be1e373c1ccb3183