### PR TITLE
Handle passive component failure modes as unique faults

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8326,6 +8326,19 @@ class FaultTreeApp:
                 failures.append(eff)
         self.failures = failures
 
+    def update_fault_list(self) -> None:
+        """Ensure faults include failure modes of passive components."""
+        faults = list(self.faults)
+        for fm in self.get_all_failure_modes():
+            desc = getattr(fm, "description", "").strip()
+            if not desc:
+                continue
+            comp = self.get_component_name_for_node(fm)
+            if self.is_passive_component(comp):
+                label = self.format_failure_mode_label(fm)
+                append_unique_insensitive(faults, label)
+        self.faults = faults
+
     def update_triggering_condition_list(self):
         """Aggregate triggering conditions from docs and FTAs."""
         names: list[str] = []
@@ -8438,6 +8451,23 @@ class FaultTreeApp:
                 return parent.user_name
         return getattr(src, "fmea_component", "")
 
+    def is_passive_component(self, comp_name: str) -> bool:
+        """Return True if ``comp_name`` matches a passive component."""
+        for c in self.reliability_components:
+            if c.name == comp_name and c.is_passive:
+                return True
+        return False
+
+    def find_passive_failure_mode(self, label: str):
+        """Return the failure mode node matching ``label`` for a passive component."""
+        target = label.lower().strip()
+        for fm in self.get_all_failure_modes():
+            comp = self.get_component_name_for_node(fm)
+            if self.is_passive_component(comp):
+                if self.format_failure_mode_label(fm).lower() == target:
+                    return fm
+        return None
+
     def format_failure_mode_label(self, node):
         comp = self.get_component_name_for_node(node)
         label = node.description if node.description else (node.user_name or f"Node {node.unique_id}")
@@ -8462,12 +8492,26 @@ class FaultTreeApp:
                 fault = getattr(be, "fault_ref", "") or getattr(be, "description", "")
                 if fault:
                     faults.append(fault)
+        comp = self.get_component_name_for_node(fm_node)
+        if self.is_passive_component(comp):
+            label = self.format_failure_mode_label(fm_node)
+            if label:
+                faults.append(label)
         return sorted(set(faults))
 
     def get_fit_for_fault(self, fault_name: str) -> float:
         """Return total FIT for FMEDA entries referencing ``fault_name``."""
         comp_fit = component_fit_map(self.reliability_components)
         total = 0.0
+
+        # First check if this fault corresponds to a passive failure mode label
+        for fm in self.get_all_failure_modes():
+            comp = self.get_component_name_for_node(fm)
+            if self.is_passive_component(comp):
+                label = self.format_failure_mode_label(fm)
+                if label.lower() == fault_name.lower():
+                    return getattr(fm, "fmeda_fit", 0.0)
+
         for fm in self.get_all_fmea_entries():
             causes = [c.strip() for c in getattr(fm, "fmea_cause", "").split(";") if c.strip()]
             if fault_name in causes:
@@ -8478,6 +8522,13 @@ class FaultTreeApp:
                     frac /= 100.0
                 value = base * frac if base is not None else getattr(fm, "fmeda_fit", 0.0)
                 total += value
+        if total == 0.0:
+            for fm in self.get_all_fmea_entries():
+                desc = getattr(fm, "description", "").strip()
+                if desc == fault_name:
+                    comp = self.get_component_name_for_node(fm)
+                    if self.is_passive_component(comp):
+                        total += getattr(fm, "fmeda_fit", 0.0)
         return total
 
 
@@ -9350,17 +9401,34 @@ class FaultTreeApp:
         new_node.failure_prob = 0.0
         new_node.fault_ref = fault
         new_node.description = fault
-        # Pull FIT data from any FMEDA entries using this fault
-        fit_total = 0.0
-        for entry in self.get_all_fmea_entries():
-            causes = [c.strip() for c in getattr(entry, "fmea_cause", "").split(";") if c.strip()]
-            if fault in causes:
-                fit_total += getattr(entry, "fmeda_fit", 0.0)
-                if not getattr(new_node, "prob_formula", None):
-                    new_node.prob_formula = getattr(entry, "prob_formula", "linear")
-        if fit_total > 0:
-            new_node.fmeda_fit = fit_total
-            new_node.failure_prob = self.compute_failure_prob(new_node)
+
+        fm_entry = self.find_passive_failure_mode(fault)
+        if fm_entry is not None:
+            new_node.failure_mode_ref = fm_entry.unique_id
+            new_node.prob_formula = getattr(fm_entry, "prob_formula", "linear")
+            new_node.fmeda_fit = getattr(fm_entry, "fmeda_fit", 0.0)
+            new_node.failure_prob = self.compute_failure_prob(new_node, failure_mode_ref=fm_entry.unique_id)
+        else:
+            # Pull FIT data from any FMEDA entries using this fault
+            fit_total = 0.0
+            for entry in self.get_all_fmea_entries():
+                causes = [c.strip() for c in getattr(entry, "fmea_cause", "").split(";") if c.strip()]
+                if fault in causes:
+                    fit_total += getattr(entry, "fmeda_fit", 0.0)
+                    if not getattr(new_node, "prob_formula", None):
+                        new_node.prob_formula = getattr(entry, "prob_formula", "linear")
+            if fit_total == 0.0:
+                for entry in self.get_all_fmea_entries():
+                    desc = getattr(entry, "description", "").strip()
+                    if desc == fault:
+                        comp = self.get_component_name_for_node(entry)
+                        if self.is_passive_component(comp):
+                            fit_total += getattr(entry, "fmeda_fit", 0.0)
+                            if not getattr(new_node, "prob_formula", None):
+                                new_node.prob_formula = getattr(entry, "prob_formula", "linear")
+            if fit_total > 0:
+                new_node.fmeda_fit = fit_total
+                new_node.failure_prob = self.compute_failure_prob(new_node)
         new_node.x = parent_node.x + 100
         new_node.y = parent_node.y + 100
         parent_node.children.append(new_node)
@@ -10103,6 +10171,10 @@ class FaultTreeApp:
 
     def show_fault_list(self):
         """Open a tab to manage the list of faults."""
+        # Make sure the fault list includes any failure modes from passive
+        # components before displaying the editor so the list stays in sync.
+        self.update_fault_list()
+
         if hasattr(self, "_fault_tab") and self._fault_tab.winfo_exists():
             self.doc_nb.select(self._fault_tab)
             return
@@ -10613,6 +10685,11 @@ class FaultTreeApp:
                 self.node.parents[0].user_name = comp
             # Always store the component name so it can be restored on load
             self.node.fmea_component = comp
+            if self.app.is_passive_component(comp):
+                desc = self.mode_var.get().strip()
+                if desc:
+                    label = f"{comp}: {desc}" if comp else desc
+                    append_unique_insensitive(self.app.faults, label)
             self.node.description = self.mode_var.get()
             new_effect = self.effect_text.get("1.0", "end-1c")
             if self.node.fmea_effect and self.node.fmea_effect != new_effect:
@@ -13917,6 +13994,7 @@ class FaultTreeApp:
             })
 
         self.update_failure_list()
+        self.update_fault_list()
 
         node_map = {}
         for te in self.top_events:
@@ -14290,6 +14368,7 @@ class FaultTreeApp:
             })
 
         self.update_failure_list()
+        self.update_fault_list()
 
         # Link FMEA entries to the fault tree nodes so edits propagate
         node_map = {}

--- a/tests/test_passive_failure_modes_faults.py
+++ b/tests/test_passive_failure_modes_faults.py
@@ -1,0 +1,131 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import unittest
+from dataclasses import dataclass, field
+from analysis.models import ReliabilityComponent
+
+@dataclass
+class SimpleNode:
+    user_name: str
+    node_type: str
+    description: str = ""
+    parents: list = field(default_factory=list)
+    fmea_component: str = ""
+    fmeda_fit: float = 0.0
+    failure_mode_ref: int | None = None
+    fault_ref: str = ""
+    unique_id: int = field(default_factory=lambda: SimpleNode._next_id())
+
+    _id_counter = 1
+
+    @classmethod
+    def _next_id(cls):
+        i = cls._id_counter
+        cls._id_counter += 1
+        return i
+
+class DummyApp:
+    def __init__(self):
+        self.reliability_components = []
+        self._basic_events = []
+
+    def get_all_basic_events(self):
+        return self._basic_events
+
+    def get_all_failure_modes(self):
+        return self._basic_events
+
+    def get_all_fmea_entries(self):
+        return self._basic_events
+
+    def get_failure_mode_node(self, node):
+        ref = getattr(node, "failure_mode_ref", None)
+        if ref:
+            for n in self._basic_events:
+                if n.unique_id == ref:
+                    return n
+        return node
+
+    def get_component_name_for_node(self, node):
+        parent = node.parents[0] if node.parents else None
+        if parent and parent.node_type.upper() not in {"GATE", "TOP EVENT", "RIGOR LEVEL"}:
+            return parent.user_name
+        return getattr(node, "fmea_component", "")
+
+    def format_failure_mode_label(self, node):
+        comp = self.get_component_name_for_node(node)
+        label = node.description if node.description else node.user_name
+        return f"{comp}: {label}" if comp else label
+
+    def is_passive_component(self, comp_name):
+        return any(c.name == comp_name and c.is_passive for c in self.reliability_components)
+
+    def find_passive_failure_mode(self, label):
+        target = label.lower().strip()
+        for fm in self.get_all_failure_modes():
+            comp = self.get_component_name_for_node(fm)
+            if self.is_passive_component(comp):
+                if self.format_failure_mode_label(fm).lower() == target:
+                    return fm
+        return None
+
+    # Methods under test - simplified versions of AutoML logic
+    def get_faults_for_failure_mode(self, failure_mode_node):
+        fm_node = self.get_failure_mode_node(failure_mode_node)
+        fm_id = fm_node.unique_id
+        faults = []
+        for be in self.get_all_basic_events():
+            if getattr(be, "failure_mode_ref", None) == fm_id:
+                fault = getattr(be, "fault_ref", "") or getattr(be, "description", "")
+                if fault:
+                    faults.append(fault)
+        comp = self.get_component_name_for_node(fm_node)
+        if self.is_passive_component(comp):
+            label = self.format_failure_mode_label(fm_node)
+            if label:
+                faults.append(label)
+        return sorted(set(faults))
+
+    def get_fit_for_fault(self, fault_name):
+        for fm in self.get_all_failure_modes():
+            comp = self.get_component_name_for_node(fm)
+            if self.is_passive_component(comp):
+                if self.format_failure_mode_label(fm).lower() == fault_name.lower():
+                    return fm.fmeda_fit
+        return 0.0
+
+class PassiveFailureModeTests(unittest.TestCase):
+    def test_passive_mode_returns_as_fault(self):
+        app = DummyApp()
+        comp = ReliabilityComponent("C1", "resistor", is_passive=True)
+        app.reliability_components.append(comp)
+        fm = SimpleNode("FM", "Basic Event", description="open", fmea_component="C1")
+        app._basic_events.append(fm)
+        faults = app.get_faults_for_failure_mode(fm)
+        self.assertEqual(faults, [app.format_failure_mode_label(fm)])
+
+    def test_get_fit_for_passive_label(self):
+        app = DummyApp()
+        comp = ReliabilityComponent("C1", "resistor", is_passive=True)
+        app.reliability_components.append(comp)
+        fm = SimpleNode("FM", "Basic Event", description="open", fmea_component="C1", fmeda_fit=5.0)
+        app._basic_events.append(fm)
+        label = app.format_failure_mode_label(fm)
+        fit = app.get_fit_for_fault(label)
+        self.assertEqual(fit, 5.0)
+
+    def test_active_mode_no_extra_fault(self):
+        app = DummyApp()
+        comp = ReliabilityComponent("C1", "ic", is_passive=False)
+        app.reliability_components.append(comp)
+        fm = SimpleNode("FM", "Basic Event", description="stuck", fmea_component="C1")
+        fault_event = SimpleNode("Fault", "Basic Event", description="short", fault_ref="short")
+        fault_event.failure_mode_ref = fm.unique_id
+        app._basic_events.extend([fm, fault_event])
+        faults = app.get_faults_for_failure_mode(fm)
+        self.assertEqual(faults, ["short"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- treat passive component failure modes as distinct faults
- map fault labels back to their failure mode to compute FIT
- show faults for passive modes using `component: mode` labels
- refresh fault list when opening the editor
- test passive failure mode faults mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688d13cfa4b08327b859952989814feb