### PR TITLE
Enhance FMEDA fault handling

### DIFF
--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -422,7 +422,9 @@ class ReliabilityWindow(tk.Frame):
         dialog.title("New Component")
         ttk.Label(dialog, text="Name").grid(row=0, column=0, padx=5, pady=5, sticky="e")
         name_var = tk.StringVar()
-        ttk.Entry(dialog, textvariable=name_var).grid(row=0, column=1, padx=5, pady=5)
+        part_names = self.app.get_all_part_names()
+        name_cb = ttk.Combobox(dialog, textvariable=name_var, values=part_names)
+        name_cb.grid(row=0, column=1, padx=5, pady=5)
         ttk.Label(dialog, text="Type").grid(row=1, column=0, padx=5, pady=5, sticky="e")
         type_var = tk.StringVar(value="capacitor")
         type_cb = ttk.Combobox(


### PR DESCRIPTION
## Summary
- auto-populate faults in the FMEARow dialog based on component and mode
- rename "Potential Cause" field to "Related Fault"
- offer IBD part names as component choices and reuse them in reliability analyses
- include part components when listing all components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688d2573b1948327b9dad8a0f5bd5a7d