### PR TITLE
Fix base node probability calculation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8645,7 +8645,12 @@ class FaultTreeApp:
                 return 0.0
         if fit <= 0:
             return 0.0
-        lam = fit / 1e9
+        comp_name = self.get_component_name_for_node(fm)
+        qty = next((c.quantity for c in self.reliability_components
+                     if c.name == comp_name), 1)
+        if qty <= 0:
+            qty = 1
+        lam = (fit / qty) / 1e9
         if f == "exponential":
             return 1 - math.exp(-lam * t)
         else:

--- a/tests/test_failure_prob_quantity.py
+++ b/tests/test_failure_prob_quantity.py
@@ -1,0 +1,53 @@
+import unittest
+import types, sys
+sys.modules.setdefault('PIL', types.ModuleType('PIL'))
+sys.modules.setdefault('PIL.Image', types.ModuleType('PIL.Image'))
+sys.modules.setdefault('PIL.ImageDraw', types.ModuleType('PIL.ImageDraw'))
+sys.modules.setdefault('PIL.ImageFont', types.ModuleType('PIL.ImageFont'))
+sys.modules.setdefault('PIL.ImageTk', types.ModuleType('PIL.ImageTk'))
+from AutoML import FaultTreeNode, FaultTreeApp, GATE_NODE_TYPES
+from analysis.models import MissionProfile, ReliabilityComponent
+
+class DummyApp:
+    def __init__(self, fm_node):
+        self.mission_profiles = [MissionProfile("MP", 1.0, 0.0)]
+        self.reliability_components = [ReliabilityComponent("C1", "type", quantity=4)]
+        self.node_map = {fm_node.unique_id: fm_node}
+
+    def find_node_by_id_all(self, uid):
+        return self.node_map.get(uid)
+
+    def get_failure_mode_node(self, node):
+        ref = getattr(node, "failure_mode_ref", None)
+        if ref:
+            return self.find_node_by_id_all(ref)
+        return node
+
+    def get_component_name_for_node(self, node):
+        src = self.get_failure_mode_node(node)
+        parent = src.parents[0] if src.parents else None
+        if parent and getattr(parent, "node_type", "").upper() not in GATE_NODE_TYPES:
+            if getattr(parent, "user_name", ""):
+                return parent.user_name
+        return getattr(src, "fmea_component", "")
+
+    def get_fit_for_fault(self, _):
+        return 0.0
+
+class FailureProbabilityTests(unittest.TestCase):
+    def test_fit_divided_by_quantity(self):
+        fm = FaultTreeNode("FM", "Basic Event")
+        fm.fmea_component = "C1"
+        fm.fmeda_fit = 20.0
+
+        be = FaultTreeNode("BE", "Basic Event")
+        be.failure_mode_ref = fm.unique_id
+        be.prob_formula = "linear"
+
+        app = DummyApp(fm)
+        prob = FaultTreeApp.compute_failure_prob(app, be)
+        expected = (20.0 / 4) / 1e9
+        self.assertAlmostEqual(prob, expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- divide basic event FIT by component quantity when deriving failure probability
- cover edge case with new test

## Testing
- `pytest -q tests/test_failure_prob_quantity.py` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_b_688d29eab4fc832787eb638048884c3f