### PR TITLE
Color-code log messages

### DIFF
--- a/gui/logger.py
+++ b/gui/logger.py
@@ -4,12 +4,23 @@ from tkinter.scrolledtext import ScrolledText
 
 log_widget = None
 
+# Mapping of log levels to the tag name that will be used for colouring
+_LEVEL_TAGS = {
+    "INFO": "info",
+    "WARNING": "warning",
+    "ERROR": "error",
+}
+
 
 def init_log_window(root, height=8):
     """Create and return a log window packed in *root*."""
     global log_widget
     frame = ttk.Frame(root)
     log_widget = ScrolledText(frame, height=height, state="disabled", font=("Arial", 9))
+    # Define tags for different log levels with appropriate colours
+    log_widget.tag_configure("error", foreground="red")
+    log_widget.tag_configure("warning", foreground="orange")
+    log_widget.tag_configure("info", foreground="blue")
     log_widget.pack(fill=tk.BOTH, expand=True)
     return frame
 
@@ -19,6 +30,7 @@ def log_message(message: str, level: str = "INFO") -> None:
     if not log_widget:
         return
     log_widget.configure(state="normal")
-    log_widget.insert(tk.END, f"[{level}] {message}\n")
+    tag = _LEVEL_TAGS.get(level.upper(), "info")
+    log_widget.insert(tk.END, f"[{level}] {message}\n", tag)
     log_widget.see(tk.END)
     log_widget.configure(state="disabled")


### PR DESCRIPTION
## Summary
- color-code log messages by level in the GUI logger

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_b_688d3536af888327969cdb9ee95f7a02