### PR TITLE
Fix port arrow rendering

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4561,12 +4561,25 @@ class SysMLDiagramWindow(tk.Frame):
             end[0] - size * math.cos(angle + spread),
             end[1] - size * math.sin(angle + spread),
         )
-        self.canvas.create_polygon(
-            end,
-            p1,
-            p2,
-            fill=self.canvas.cget("background"),
-            outline=color,
+        # Draw the arrowhead using two lines instead of a filled triangle so
+        # the background does not show through as a white polygon. This keeps
+        # the arrow open while the center line from the connection touches the
+        # point.
+        self.canvas.create_line(
+            p1[0],
+            p1[1],
+            end[0],
+            end[1],
+            fill=color,
+            width=width,
+            tags=tags,
+        )
+        self.canvas.create_line(
+            p2[0],
+            p2[1],
+            end[0],
+            end[1],
+            fill=color,
             width=width,
             tags=tags,
         )


### PR DESCRIPTION
## Summary
- use line segments instead of polygons for open arrows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_b_688d2c8bc88c8327b5690e3313f3ea18