### PR TITLE
Enhance cause and effect chain view

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -11917,13 +11917,22 @@ class FaultTreeApp:
         return sorted(rows.values(), key=lambda r: (r["hazard"].lower(), r["malfunction"].lower()))
 
     def show_cause_effect_chain(self):
-        """Display a table linking hazards to downstream events."""
+        """Display a table linking hazards to downstream events with an optional diagram."""
         data = self.build_cause_effect_data()
         if not data:
             messagebox.showinfo("Cause & Effect", "No data available")
             return
+
         win = tk.Toplevel(self.root)
         win.title("Cause & Effect Chain")
+
+        # --- Layout: tree on the left, diagram canvas on the right ---
+        container = ttk.Frame(win)
+        container.pack(fill=tk.BOTH, expand=True)
+        container.columnconfigure(0, weight=1)
+        container.columnconfigure(1, weight=1)
+        container.rowconfigure(0, weight=1)
+
         cols = (
             "Hazard",
             "Malfunction",
@@ -11932,14 +11941,19 @@ class FaultTreeApp:
             "FIs",
             "TCs",
         )
-        tree = ttk.Treeview(win, columns=cols, show="headings")
-        for c in cols:
-            tree.heading(c, text=c)
-            tree.column(c, width=180 if c in ("Hazard", "Malfunction") else 150)
-        tree.pack(fill=tk.BOTH, expand=True)
 
+        tree = ttk.Treeview(container, columns=cols, show="headings")
+        vsb = ttk.Scrollbar(container, orient="vertical", command=tree.yview)
+        tree.configure(yscrollcommand=vsb.set)
+        tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=0, sticky="nse")
+
+        canvas = tk.Canvas(container, bg="white")
+        canvas.grid(row=0, column=1, sticky="nsew")
+
+        row_map = {}
         for row in data:
-            tree.insert(
+            iid = tree.insert(
                 "",
                 "end",
                 values=(
@@ -11951,6 +11965,69 @@ class FaultTreeApp:
                     ", ".join(sorted(row["tcs"])),
                 ),
             )
+            row_map[iid] = row
+
+        def draw_row(row):
+            """Render a small network diagram for *row* on the canvas."""
+            import matplotlib.pyplot as plt
+            from io import BytesIO
+            G = nx.DiGraph()
+            haz = row["hazard"]
+            mal = row["malfunction"]
+            G.add_node(haz, kind="hazard")
+            G.add_node(mal, kind="malfunction")
+            G.add_edge(haz, mal)
+            for fm in sorted(row["failure_modes"]):
+                G.add_node(fm, kind="failure_mode")
+                G.add_edge(mal, fm)
+            for fault in sorted(row["faults"]):
+                G.add_node(fault, kind="fault")
+                G.add_edge(mal, fault)
+            for fi in sorted(row["fis"]):
+                G.add_node(fi, kind="fi")
+                G.add_edge(haz, fi)
+            for tc in sorted(row["tcs"]):
+                G.add_node(tc, kind="tc")
+                G.add_edge(haz, tc)
+
+            pos = nx.spring_layout(G, seed=42)
+            color_map = {
+                "hazard": "lightcoral",
+                "malfunction": "lightblue",
+                "failure_mode": "orange",
+                "fault": "lightgray",
+                "fi": "lightyellow",
+                "tc": "lightgreen",
+            }
+            node_colors = [color_map.get(G.nodes[n].get("kind"), "white") for n in G.nodes()]
+            plt.figure(figsize=(6, 4))
+            nx.draw(G, pos, with_labels=True, node_color=node_colors, node_size=1500, font_size=8, arrows=True)
+            plt.axis("off")
+            buf = BytesIO()
+            plt.savefig(buf, format="PNG", dpi=120)
+            plt.close()
+            buf.seek(0)
+            img = Image.open(buf)
+
+            canvas.delete("all")
+            photo = ImageTk.PhotoImage(img)
+            canvas.image = photo  # keep reference
+            canvas.create_image(0, 0, image=photo, anchor="nw")
+            canvas.config(scrollregion=canvas.bbox("all"))
+
+        def on_select(event):
+            sel = tree.selection()
+            if sel:
+                row = row_map.get(sel[0])
+                if row:
+                    draw_row(row)
+
+        tree.bind("<<TreeviewSelect>>", on_select)
+
+        if row_map:
+            first_iid = next(iter(row_map))
+            tree.selection_set(first_iid)
+            draw_row(row_map[first_iid])
 
         def export_csv():
             path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV", "*.csv")])


### PR DESCRIPTION
## Summary
- add a diagram canvas beside the cause & effect chain table
- generate a small networkx graph for the selected row
- draw and display the graph in the window

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_b_688d4371b6d08327940721343d8aecc7