### PR TITLE
Fix invalid aggregation cases

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -523,6 +523,12 @@ def add_aggregation_part(
     part = repo.elements.get(part_id)
     if not whole or not part:
         return
+    if part_id == whole_id:
+        return
+    if part_id in _collect_generalization_parents(repo, whole_id):
+        return
+    if _reverse_aggregation_exists(repo, whole_id, part_id):
+        return
     name = part.name or part_id
     entry = f"{name}[{multiplicity}]" if multiplicity else name
     parts = [p.strip() for p in whole.properties.get("partProperties", "").split(",") if p.strip()]


### PR DESCRIPTION
## Summary
- prevent `add_aggregation_part` from creating self or ancestor relationships
- cover these cases with unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_b_688d5777e4d483279b2aa2ec9c465027