### PR TITLE
Fix port movement in IBD boundary drag

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3286,7 +3286,13 @@ class SysMLDiagramWindow(tk.Frame):
                     if o.obj_type == "Part":
                         o.x += dx
                         o.y += dy
-                        update_ports_for_part(o, self.objects)
+                        for p in self.objects:
+                            if (
+                                p.obj_type == "Port"
+                                and p.properties.get("parent") == str(o.obj_id)
+                            ):
+                                p.x += dx
+                                p.y += dy
             if self.selected_obj.obj_type == "System Boundary":
                 for o in self.objects:
                     if o.properties.get("boundary") == str(self.selected_obj.obj_id):


### PR DESCRIPTION
## Summary
- ensure IBD boundary drags only translate part ports

## Testing
- `pytest tests/test_boundary_size.py::TestBoundarySize -q` *(fails: ModuleNotFoundError: No module named 'gui')*

------
https://chatgpt.com/codex/tasks/task_b_688d62802c5c832784bd1845e0b38cef