### PR TITLE
Add Control Flow diagram with guarded connectors

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -296,6 +296,7 @@ from gui.architecture import (
     ActivityDiagramWindow,
     BlockDiagramWindow,
     InternalBlockDiagramWindow,
+    ControlFlowDiagramWindow,
     ArchitectureManagerDialog,
     parse_behaviors,
 )
@@ -1926,6 +1927,7 @@ class FaultTreeApp:
             "Activity Diagram": self._create_icon("arrow", "green"),
             "Block Diagram": self._create_icon("rect", "orange"),
             "Internal Block Diagram": self._create_icon("nested", "purple"),
+            "Control Flow Diagram": self._create_icon("arrow", "red"),
         }
         self.clipboard_node = None
         self.cut_mode = False
@@ -2072,6 +2074,7 @@ class FaultTreeApp:
         architecture_menu.add_command(label="Activity Diagram", command=self.open_activity_diagram)
         architecture_menu.add_command(label="Block Diagram", command=self.open_block_diagram)
         architecture_menu.add_command(label="Internal Block Diagram", command=self.open_internal_block_diagram)
+        architecture_menu.add_command(label="Control Flow Diagram", command=self.open_control_flow_diagram)
         architecture_menu.add_separator()
         architecture_menu.add_command(label="AutoML Explorer", command=self.manage_architecture)
 
@@ -3795,6 +3798,8 @@ class FaultTreeApp:
             win = BlockDiagramWindow(temp, self, diagram_id=diagram.diag_id)
         elif diagram.diag_type == "Internal Block Diagram":
             win = InternalBlockDiagramWindow(temp, self, diagram_id=diagram.diag_id)
+        elif diagram.diag_type == "Control Flow Diagram":
+            win = ControlFlowDiagramWindow(temp, self, diagram_id=diagram.diag_id)
         else:
             temp.destroy()
             return None
@@ -13605,6 +13610,18 @@ class FaultTreeApp:
         InternalBlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
         self.update_views()
 
+    def open_control_flow_diagram(self):
+        """Prompt for a diagram name then open a new control flow diagram."""
+        name = simpledialog.askstring("New Control Flow Diagram", "Enter diagram name:")
+        if not name:
+            return
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Control Flow Diagram", name=name, package=repo.root_package.elem_id)
+        tab = self._new_tab(self._format_diag_title(diag))
+        self.diagram_tabs[diag.diag_id] = tab
+        ControlFlowDiagramWindow(tab, self, diagram_id=diag.diag_id)
+        self.update_views()
+
     def manage_architecture(self):
         if hasattr(self, "_arch_tab") and self._arch_tab.winfo_exists():
             self.doc_nb.select(self._arch_tab)
@@ -13637,6 +13654,8 @@ class FaultTreeApp:
             BlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Internal Block Diagram":
             InternalBlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
+        elif diag.diag_type == "Control Flow Diagram":
+            ControlFlowDiagramWindow(tab, self, diagram_id=diag.diag_id)
         
     def copy_node(self):
         if self.selected_node and self.selected_node != self.root_node:

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2432,6 +2432,7 @@ class DiagramConnection:
     name: str = ""
     arrow: str = "none"  # none, forward, backward, both
     mid_arrow: bool = False
+    guard: List[str] = field(default_factory=list)
     multiplicity: str = ""
 
 
@@ -2620,6 +2621,8 @@ class SysMLDiagramWindow(tk.Frame):
                     "Communication Path",
                     "Aggregation",
                     "Composite Aggregation",
+                    "Control Action",
+                    "Feedback",
                 )
                 else "tcross"
             )
@@ -2647,6 +2650,8 @@ class SysMLDiagramWindow(tk.Frame):
             "Communication Path",
             "Aggregation",
             "Composite Aggregation",
+            "Control Action",
+            "Feedback",
         ):
             if src == dst:
                 return False, "Cannot connect an element to itself"
@@ -2739,6 +2744,11 @@ class SysMLDiagramWindow(tk.Frame):
                             if ex and ex != new_dir_b:
                                 return False, "Inconsistent data flow on port"
 
+        elif diag_type == "Control Flow Diagram":
+            if conn_type in ("Control Action", "Feedback"):
+                if abs(src.x - dst.x) > 1e-6:
+                    return False, "Connections must be vertical"
+
         elif diag_type == "Activity Diagram":
             # Basic control flow rules
             allowed = {
@@ -2827,6 +2837,8 @@ class SysMLDiagramWindow(tk.Frame):
             "Communication Path",
             "Aggregation",
             "Composite Aggregation",
+            "Control Action",
+            "Feedback",
         )
         prefer = self.current_tool in conn_tools
         t = self.current_tool
@@ -2911,6 +2923,8 @@ class SysMLDiagramWindow(tk.Frame):
             "Communication Path",
             "Aggregation",
             "Composite Aggregation",
+            "Control Action",
+            "Feedback",
         ):
             if self.start is None:
                 if obj:
@@ -2924,17 +2938,20 @@ class SysMLDiagramWindow(tk.Frame):
                 if obj and obj != self.start:
                     valid, msg = self.validate_connection(self.start, obj, t)
                     if valid:
-                        arrow_default = (
-                            "forward"
-                            if t in (
-                                "Flow",
-                                "Generalize",
-                                "Generalization",
-                                "Include",
-                                "Extend",
-                            )
-                            else "none"
-                        )
+                        if t == "Control Action":
+                            arrow_default = "forward"
+                        elif t == "Feedback":
+                            arrow_default = "backward"
+                        elif t in (
+                            "Flow",
+                            "Generalize",
+                            "Generalization",
+                            "Include",
+                            "Extend",
+                        ):
+                            arrow_default = "forward"
+                        else:
+                            arrow_default = "none"
                         conn = DiagramConnection(
                             self.start.obj_id,
                             obj.obj_id,
@@ -2960,28 +2977,55 @@ class SysMLDiagramWindow(tk.Frame):
                 self.canvas.configure(cursor="arrow")
                 self.redraw()
         elif t and t != "Select":
-            if t == "Port":
-                parent_obj = (
-                    obj if obj and obj.obj_type in ("Part", "Block Boundary") else None
-                )
-                if parent_obj is None:
-                    # Default to the IBD boundary if present
-                    parent_obj = next(
-                        (o for o in self.objects if o.obj_type == "Block Boundary"),
-                        None,
-                    )
-                if parent_obj is None:
+            if t == "Existing Element":
+                names = []
+                id_map = {}
+                for eid, el in self.repo.elements.items():
+                    if el.elem_type != "Package":
+                        name = el.name or eid
+                        names.append(name)
+                        id_map[name] = eid
+                if not names:
+                    messagebox.showinfo("Add Element", "No elements available")
                     return
-            pkg = self.repo.diagrams[self.diagram_id].package
-            element = self.repo.create_element(t, owner=pkg)
-            self.repo.add_element_to_diagram(self.diagram_id, element.elem_id)
-            new_obj = SysMLObject(
-                _get_next_id(),
-                t,
-                x / self.zoom,
-                y / self.zoom,
-                element_id=element.elem_id,
-            )
+                dlg = SysMLObjectDialog.SelectElementDialog(self, names, title="Select Element")
+                selected = dlg.result
+                if not selected:
+                    return
+                elem_id = id_map[selected]
+                element = self.repo.elements.get(elem_id)
+                self.repo.add_element_to_diagram(self.diagram_id, elem_id)
+                new_obj = SysMLObject(
+                    _get_next_id(),
+                    "Existing Element",
+                    x / self.zoom,
+                    y / self.zoom,
+                    element_id=elem_id,
+                    properties={"name": element.name if element else selected},
+                )
+            else:
+                if t == "Port":
+                    parent_obj = (
+                        obj if obj and obj.obj_type in ("Part", "Block Boundary") else None
+                    )
+                    if parent_obj is None:
+                        # Default to the IBD boundary if present
+                        parent_obj = next(
+                            (o for o in self.objects if o.obj_type == "Block Boundary"),
+                            None,
+                        )
+                    if parent_obj is None:
+                        return
+                pkg = self.repo.diagrams[self.diagram_id].package
+                element = self.repo.create_element(t, owner=pkg)
+                self.repo.add_element_to_diagram(self.diagram_id, element.elem_id)
+                new_obj = SysMLObject(
+                    _get_next_id(),
+                    t,
+                    x / self.zoom,
+                    y / self.zoom,
+                    element_id=element.elem_id,
+                )
             if t == "Block":
                 new_obj.height = 140.0
                 new_obj.width = 160.0
@@ -3156,6 +3200,8 @@ class SysMLDiagramWindow(tk.Frame):
             "Communication Path",
             "Aggregation",
             "Composite Aggregation",
+            "Control Action",
+            "Feedback",
         ):
             x = self.canvas.canvasx(event.x)
             y = self.canvas.canvasy(event.y)
@@ -3251,7 +3297,7 @@ class SysMLDiagramWindow(tk.Frame):
                 desired_w = 2 * abs(x - cx) / self.zoom
                 new_w = max(min_w, desired_w)
             if "n" in self.resize_edge or "s" in self.resize_edge:
-                if obj.obj_type not in ("Fork", "Join"):
+                if obj.obj_type not in ("Fork", "Join", "Existing Element"):
                     desired_h = 2 * abs(y - cy) / self.zoom
                     new_h = max(min_h, desired_h)
             if obj.obj_type in ("Initial", "Final"):
@@ -3335,6 +3381,8 @@ class SysMLDiagramWindow(tk.Frame):
             "Communication Path",
             "Aggregation",
             "Composite Aggregation",
+            "Control Action",
+            "Feedback",
         ):
             x = self.canvas.canvasx(event.x)
             y = self.canvas.canvasy(event.y)
@@ -3346,18 +3394,20 @@ class SysMLDiagramWindow(tk.Frame):
             if obj and obj != self.start:
                 valid, msg = self.validate_connection(self.start, obj, self.current_tool)
                 if valid:
-                    arrow_default = (
-                        "forward"
-                        if self.current_tool
-                        in (
-                            "Flow",
-                            "Generalize",
-                            "Generalization",
-                            "Include",
-                            "Extend",
-                        )
-                        else "none"
-                    )
+                    if self.current_tool == "Control Action":
+                        arrow_default = "forward"
+                    elif self.current_tool == "Feedback":
+                        arrow_default = "backward"
+                    elif self.current_tool in (
+                        "Flow",
+                        "Generalize",
+                        "Generalization",
+                        "Include",
+                        "Extend",
+                    ):
+                        arrow_default = "forward"
+                    else:
+                        arrow_default = "none"
                     conn = DiagramConnection(
                         self.start.obj_id,
                         obj.obj_id,
@@ -3606,6 +3656,8 @@ class SysMLDiagramWindow(tk.Frame):
             "Communication Path",
             "Aggregation",
             "Composite Aggregation",
+            "Control Action",
+            "Feedback",
         ):
             x = self.canvas.canvasx(event.x)
             y = self.canvas.canvasy(event.y)
@@ -3624,6 +3676,8 @@ class SysMLDiagramWindow(tk.Frame):
             "Communication Path",
             "Aggregation",
             "Composite Aggregation",
+            "Control Action",
+            "Feedback",
         ):
             x = self.canvas.canvasx(event.x)
             y = self.canvas.canvasy(event.y)
@@ -4485,7 +4539,7 @@ class SysMLDiagramWindow(tk.Frame):
         """Order objects so boundaries render behind and their ports above."""
 
         def key(o: SysMLObject) -> int:
-            if o.obj_type in ("System Boundary", "Block Boundary"):
+            if o.obj_type in ("System Boundary", "Block Boundary", "Existing Element"):
                 return 0
             if o.obj_type == "Port":
                 parent_id = o.properties.get("parent")
@@ -4591,6 +4645,8 @@ class SysMLDiagramWindow(tk.Frame):
                 "Communication Path",
                 "Aggregation",
                 "Composite Aggregation",
+                "Control Action",
+                "Feedback",
             )
         ):
             sx, sy = self.edge_point(self.start, *self.temp_line_end)
@@ -5042,7 +5098,7 @@ class SysMLDiagramWindow(tk.Frame):
                     anchor="s",
                     font=self.font,
                 )
-        elif obj.obj_type == "Block Boundary":
+        elif obj.obj_type in ("Block Boundary", "Existing Element"):
             self._create_round_rect(
                 x - w,
                 y - h,
@@ -6140,6 +6196,27 @@ class SysMLObjectDialog(simpledialog.Dialog):
         def apply(self):
             self.result = [n for n, var in self.selected.items() if var.get()]
 
+    class SelectElementDialog(simpledialog.Dialog):
+        """Dialog to choose a single existing element."""
+
+        def __init__(self, parent, names, title="Select Element"):
+            self.names = names
+            self.result = None
+            super().__init__(parent, title=title)
+
+        def body(self, master):
+            ttk.Label(master, text="Select element:").pack(padx=5, pady=5)
+            self.listbox = tk.Listbox(master)
+            for name in self.names:
+                self.listbox.insert(tk.END, name)
+            self.listbox.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+            return self.listbox
+
+        def apply(self):
+            sel = self.listbox.curselection()
+            if sel:
+                self.result = self.names[sel[0]]
+
     class ManagePartsDialog(simpledialog.Dialog):
         """Dialog to toggle visibility of contained parts."""
 
@@ -7191,15 +7268,27 @@ class ConnectionDialog(simpledialog.Dialog):
         ):
             self.arrow_cb.configure(state="disabled")
             self.mid_check.configure(state="disabled")
+        row = 4
+        if self.connection.conn_type == "Control Action":
+            ttk.Label(master, text="Guard:").grid(row=row, column=0, sticky="ne", padx=4, pady=4)
+            self.guard_list = tk.Listbox(master, height=4)
+            for g in self.connection.guard:
+                self.guard_list.insert(tk.END, g)
+            self.guard_list.grid(row=row, column=1, padx=4, pady=4, sticky="we")
+            gbtn = ttk.Frame(master)
+            gbtn.grid(row=row, column=2, padx=2)
+            ttk.Button(gbtn, text="Add", command=self.add_guard).pack(side=tk.TOP)
+            ttk.Button(gbtn, text="Remove", command=self.remove_guard).pack(side=tk.TOP)
+            row += 1
 
         if self.connection.conn_type in ("Aggregation", "Composite Aggregation"):
-            ttk.Label(master, text="Multiplicity:").grid(row=4, column=0, sticky="e", padx=4, pady=4)
+            ttk.Label(master, text="Multiplicity:").grid(row=row, column=0, sticky="e", padx=4, pady=4)
             self.mult_var = tk.StringVar(value=self.connection.multiplicity)
             ttk.Combobox(
                 master,
                 textvariable=self.mult_var,
                 values=["1", "0..1", "1..*", "0..*", "2", "3", "4", "5"],
-            ).grid(row=4, column=1, padx=4, pady=4, sticky="we")
+            ).grid(row=row, column=1, padx=4, pady=4, sticky="we")
 
     def add_point(self):
         x = simpledialog.askfloat("Point", "X:", parent=self)
@@ -7211,6 +7300,16 @@ class ConnectionDialog(simpledialog.Dialog):
         sel = list(self.point_list.curselection())
         for idx in reversed(sel):
             self.point_list.delete(idx)
+
+    def add_guard(self):
+        txt = simpledialog.askstring("Guard", "Condition:", parent=self)
+        if txt:
+            self.guard_list.insert(tk.END, txt)
+
+    def remove_guard(self):
+        sel = list(self.guard_list.curselection())
+        for idx in reversed(sel):
+            self.guard_list.delete(idx)
 
     def apply(self):
         self.connection.name = self.name_var.get()
@@ -7228,6 +7327,8 @@ class ConnectionDialog(simpledialog.Dialog):
         self.connection.mid_arrow = self.mid_var.get()
         if hasattr(self, "mult_var"):
             self.connection.multiplicity = self.mult_var.get()
+        if hasattr(self, "guard_list"):
+            self.connection.guard = [self.guard_list.get(i) for i in range(self.guard_list.size())]
         if hasattr(self.master, "_sync_to_repository"):
             self.master._sync_to_repository()
         if self.connection.conn_type in ("Aggregation", "Composite Aggregation"):
@@ -7804,6 +7905,17 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
         if self.app:
             self.app.update_views()
 
+
+class ControlFlowDiagramWindow(SysMLDiagramWindow):
+    def __init__(self, master, app, diagram_id: str | None = None, history=None):
+        tools = [
+            "Existing Element",
+            "Control Action",
+            "Feedback",
+        ]
+        super().__init__(master, "Control Flow Diagram", tools, diagram_id, app=app, history=history)
+
+
 class NewDiagramDialog(simpledialog.Dialog):
     """Dialog to create a new diagram and assign a name and type."""
 
@@ -7826,6 +7938,7 @@ class NewDiagramDialog(simpledialog.Dialog):
                 "Activity Diagram",
                 "Block Diagram",
                 "Internal Block Diagram",
+                "Control Flow Diagram",
             ],
         ).grid(row=1, column=1, padx=4, pady=4)
 

--- a/styles/pastel.xml
+++ b/styles/pastel.xml
@@ -3,6 +3,7 @@
   <object type="Use Case" color="#B0E0E6" />
   <object type="System Boundary" color="#CFD8DC" />
   <object type="Block Boundary" color="#F5F5F5" />
+  <object type="Existing Element" color="#F5F5F5" />
   <object type="Action Usage" color="#FAD7A0" />
   <object type="Action" color="#FAD7A0" />
   <object type="CallBehaviorAction" color="#FAD7A0" />

--- a/tests/test_control_flow_guard.py
+++ b/tests/test_control_flow_guard.py
@@ -1,0 +1,29 @@
+import unittest
+from gui.architecture import SysMLObject, DiagramConnection
+from sysml.sysml_repository import SysMLRepository
+
+class ControlFlowGuardTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def test_guard_persistence(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="A")
+        e2 = repo.create_element("Block", name="B")
+        diag = repo.create_diagram("Control Flow Diagram", name="CF")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(1, "Existing Element", 0, 0, element_id=e1.elem_id)
+        o2 = SysMLObject(2, "Existing Element", 0, 100, element_id=e2.elem_id)
+        diag.objects = [o1.__dict__, o2.__dict__]
+        conn = DiagramConnection(o1.obj_id, o2.obj_id, "Control Action", guard=["g1", "g2"])
+        diag.connections = [conn.__dict__]
+        data = repo.to_dict()
+        repo2 = SysMLRepository.reset_instance()
+        repo2.from_dict(data)
+        loaded = repo2.diagrams[diag.diag_id].connections[0]
+        self.assertEqual(loaded.get("guard"), ["g1", "g2"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce Control Flow diagram type with tools for adding existing elements and vertical connectors
- support Control Action connector guards with multiple conditions
- ensure existing elements render as boundaries and are horizontally resizable only

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'networkx')*
- `pip install networkx` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_b_688e3205f1e48327b19591ad77b4ab10