### PR TITLE
Add Control Flow diagram with colored element boundaries

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -296,6 +296,7 @@ from gui.architecture import (
     ActivityDiagramWindow,
     BlockDiagramWindow,
     InternalBlockDiagramWindow,
+    ControlFlowDiagramWindow,
     ArchitectureManagerDialog,
     parse_behaviors,
 )
@@ -1926,6 +1927,7 @@ class FaultTreeApp:
             "Activity Diagram": self._create_icon("arrow", "green"),
             "Block Diagram": self._create_icon("rect", "orange"),
             "Internal Block Diagram": self._create_icon("nested", "purple"),
+            "Control Flow Diagram": self._create_icon("arrow", "red"),
         }
         self.clipboard_node = None
         self.cut_mode = False
@@ -2072,6 +2074,7 @@ class FaultTreeApp:
         architecture_menu.add_command(label="Activity Diagram", command=self.open_activity_diagram)
         architecture_menu.add_command(label="Block Diagram", command=self.open_block_diagram)
         architecture_menu.add_command(label="Internal Block Diagram", command=self.open_internal_block_diagram)
+        architecture_menu.add_command(label="Control Flow Diagram", command=self.open_control_flow_diagram)
         architecture_menu.add_separator()
         architecture_menu.add_command(label="AutoML Explorer", command=self.manage_architecture)
 
@@ -3795,6 +3798,8 @@ class FaultTreeApp:
             win = BlockDiagramWindow(temp, self, diagram_id=diagram.diag_id)
         elif diagram.diag_type == "Internal Block Diagram":
             win = InternalBlockDiagramWindow(temp, self, diagram_id=diagram.diag_id)
+        elif diagram.diag_type == "Control Flow Diagram":
+            win = ControlFlowDiagramWindow(temp, self, diagram_id=diagram.diag_id)
         else:
             temp.destroy()
             return None
@@ -13605,6 +13610,18 @@ class FaultTreeApp:
         InternalBlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
         self.update_views()
 
+    def open_control_flow_diagram(self):
+        """Prompt for a diagram name then open a new control flow diagram."""
+        name = simpledialog.askstring("New Control Flow Diagram", "Enter diagram name:")
+        if not name:
+            return
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Control Flow Diagram", name=name, package=repo.root_package.elem_id)
+        tab = self._new_tab(self._format_diag_title(diag))
+        self.diagram_tabs[diag.diag_id] = tab
+        ControlFlowDiagramWindow(tab, self, diagram_id=diag.diag_id)
+        self.update_views()
+
     def manage_architecture(self):
         if hasattr(self, "_arch_tab") and self._arch_tab.winfo_exists():
             self.doc_nb.select(self._arch_tab)
@@ -13637,6 +13654,8 @@ class FaultTreeApp:
             BlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Internal Block Diagram":
             InternalBlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
+        elif diag.diag_type == "Control Flow Diagram":
+            ControlFlowDiagramWindow(tab, self, diagram_id=diag.diag_id)
         
     def copy_node(self):
         if self.selected_node and self.selected_node != self.root_node:

--- a/tests/test_control_flow_guard.py
+++ b/tests/test_control_flow_guard.py
@@ -1,0 +1,37 @@
+import unittest
+from gui.architecture import SysMLObject, DiagramConnection
+from sysml.sysml_repository import SysMLRepository
+
+class ControlFlowGuardTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def test_guard_persistence(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="A")
+        e2 = repo.create_element("Block", name="B")
+        act = repo.create_element("Action", name="Do")
+        diag = repo.create_diagram("Control Flow Diagram", name="CF")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(1, "Existing Element", 0, 0, element_id=e1.elem_id)
+        o2 = SysMLObject(2, "Existing Element", 0, 100, element_id=e2.elem_id)
+        diag.objects = [o1.__dict__, o2.__dict__]
+        conn = DiagramConnection(
+            o1.obj_id,
+            o2.obj_id,
+            "Control Action",
+            guard=["g1", "g2"],
+            element_id=act.elem_id,
+        )
+        diag.connections = [conn.__dict__]
+        data = repo.to_dict()
+        repo2 = SysMLRepository.reset_instance()
+        repo2.from_dict(data)
+        loaded = repo2.diagrams[diag.diag_id].connections[0]
+        self.assertEqual(loaded.get("guard"), ["g1", "g2"])
+        self.assertEqual(loaded.get("element_id"), act.elem_id)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_control_flow_label.py
+++ b/tests/test_control_flow_label.py
@@ -1,0 +1,28 @@
+import unittest
+
+from gui.architecture import format_control_flow_label
+
+
+class ControlFlowLabelTests(unittest.TestCase):
+    def test_format_with_name_and_guard(self):
+        self.assertEqual(
+            format_control_flow_label("Do", ["g1", "g2"]),
+            "[g1 and g2] {Do}",
+        )
+
+    def test_format_with_only_guard(self):
+        self.assertEqual(
+            format_control_flow_label("", ["cond"]),
+            "[cond]",
+        )
+
+    def test_format_with_only_name(self):
+        self.assertEqual(
+            format_control_flow_label("Act", []),
+            "{Act}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_control_flow_vertical.py
+++ b/tests/test_control_flow_vertical.py
@@ -1,0 +1,33 @@
+import unittest
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+class DummyWindow:
+    def __init__(self):
+        self.repo = SysMLRepository.get_instance()
+        diag = SysMLDiagram(diag_id="d", diag_type="Control Flow Diagram")
+        self.repo.diagrams[diag.diag_id] = diag
+        self.diagram_id = diag.diag_id
+
+class ControlFlowConnectionTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_vertical_connection_valid(self):
+        win = DummyWindow()
+        src = SysMLObject(1, "Existing Element", 0, 0)
+        dst = SysMLObject(2, "Existing Element", 1, 100)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Control Action")
+        self.assertTrue(valid)
+
+    def test_non_vertical_connection_invalid(self):
+        win = DummyWindow()
+        src = SysMLObject(1, "Existing Element", 0, 0)
+        dst = SysMLObject(2, "Existing Element", 20, 100)
+        valid, msg = SysMLDiagramWindow.validate_connection(win, src, dst, "Control Action")
+        self.assertFalse(valid)
+        self.assertEqual(msg, "Connections must be vertical")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- render existing elements with solid, gradient boundaries matching referenced element colors and hide their external labels
- show control connectors with guard conditions and names formatted like state-machine transitions
- add tests for control-flow connector label formatting

## Testing
- `PYTHONPATH=. pytest tests/test_control_flow_guard.py tests/test_control_flow_vertical.py tests/test_control_flow_label.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*


------
https://chatgpt.com/codex/tasks/task_b_688e3205f1e48327b19591ad77b4ab10