### PR TITLE
Ensure vertical control flow connectors remain aligned

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2747,8 +2747,8 @@ class SysMLDiagramWindow(tk.Frame):
 
         elif diag_type == "Control Flow Diagram":
             if conn_type in ("Control Action", "Feedback"):
-                tolerance = 5 / getattr(self, "zoom", 1)
-                if abs(src.x - dst.x) > tolerance:
+                max_offset = (src.width + dst.width) / 2
+                if abs(src.x - dst.x) > max_offset:
                     return False, "Connections must be vertical"
 
         elif diag_type == "Activity Diagram":
@@ -2832,6 +2832,7 @@ class SysMLDiagramWindow(tk.Frame):
         diag = self.repo.diagrams.get(self.diagram_id)
         if not diag or diag.diag_type != "Control Flow Diagram":
             return new_x
+        adjusted_x = new_x
         for conn in self.connections:
             if conn.conn_type in ("Control Action", "Feedback") and (
                 conn.src == obj.obj_id or conn.dst == obj.obj_id
@@ -2839,8 +2840,13 @@ class SysMLDiagramWindow(tk.Frame):
                 other_id = conn.dst if conn.src == obj.obj_id else conn.src
                 for other in self.objects:
                     if other.obj_id == other_id:
-                        return other.x
-        return new_x
+                        max_diff = (obj.width + other.width) / 2
+                        diff = adjusted_x - other.x
+                        if diff > max_diff:
+                            adjusted_x = other.x + max_diff
+                        elif diff < -max_diff:
+                            adjusted_x = other.x - max_diff
+        return adjusted_x
 
     def on_left_press(self, event):
         x = self.canvas.canvasx(event.x)
@@ -5514,8 +5520,6 @@ class SysMLDiagramWindow(tk.Frame):
     ):
         axc, ayc = a.x * self.zoom, a.y * self.zoom
         bxc, byc = b.x * self.zoom, b.y * self.zoom
-        ax, ay = self.edge_point(a, bxc, byc, conn.src_pos)
-        bx, by = self.edge_point(b, axc, ayc, conn.dst_pos)
         dash = ()
         label = conn.name or None
         if conn.conn_type == "Control Action" and not label and conn.element_id:
@@ -5524,16 +5528,24 @@ class SysMLDiagramWindow(tk.Frame):
                 label = elem.name
         diag = self.repo.diagrams.get(self.diagram_id)
         if diag and diag.diag_type == "Control Flow Diagram" and conn.conn_type in ("Control Action", "Feedback"):
-            x = (ax + bx) / 2
-            top = min(ay, by)
-            bottom = max(ay, by)
+            a_left = (a.x - a.width / 2) * self.zoom
+            a_right = (a.x + a.width / 2) * self.zoom
+            b_left = (b.x - b.width / 2) * self.zoom
+            b_right = (b.x + b.width / 2) * self.zoom
+            x = (max(a_left, b_left) + min(a_right, b_right)) / 2
+            if ayc <= byc:
+                y1 = ayc + a.height / 2 * self.zoom
+                y2 = byc - b.height / 2 * self.zoom
+            else:
+                y1 = ayc - a.height / 2 * self.zoom
+                y2 = byc + b.height / 2 * self.zoom
             color = "red" if selected else "black"
             width = 2 if selected else 1
             self.canvas.create_line(
                 x,
-                bottom,
+                y1,
                 x,
-                top,
+                y2,
                 arrow=tk.LAST,
                 dash=(),
                 fill=color,
@@ -5543,14 +5555,14 @@ class SysMLDiagramWindow(tk.Frame):
             if label:
                 self.canvas.create_text(
                     x,
-                    (top + bottom) / 2 - 10 * self.zoom,
+                    (y1 + y2) / 2 - 10 * self.zoom,
                     text=label,
                     font=self.font,
                     tags="connection",
                 )
             if selected:
                 s = 3
-                for hx, hy in [(x, bottom), (x, top)]:
+                for hx, hy in [(x, y1), (x, y2)]:
                     self.canvas.create_rectangle(
                         hx - s,
                         hy - s,
@@ -5561,6 +5573,8 @@ class SysMLDiagramWindow(tk.Frame):
                         tags="connection",
                     )
             return
+        ax, ay = self.edge_point(a, bxc, byc, conn.src_pos)
+        bx, by = self.edge_point(b, axc, ayc, conn.dst_pos)
         if conn.conn_type in ("Include", "Extend"):
             dash = (4, 2)
             incl_label = f"<<{conn.conn_type.lower()}>>"

--- a/tests/test_control_flow_arrow.py
+++ b/tests/test_control_flow_arrow.py
@@ -23,6 +23,8 @@ class DummyWindow:
         self.font = None
         self.canvas = DummyCanvas()
         self.edge_point = lambda obj, _x, _y, _r: (obj.x, obj.y)
+        self.connections = []
+        self.objects = []
 
 
 def reset_repo():
@@ -45,6 +47,40 @@ class ControlFlowArrowTests(unittest.TestCase):
         x1, y1, x2, y2 = args
         self.assertEqual(x1, x2)
         self.assertGreater(y1, y2)
+
+    def test_arrow_up_offset(self):
+        win = DummyWindow()
+        a = SysMLObject(1, "Existing Element", 0, 100)
+        b = SysMLObject(2, "Existing Element", 80, 0)
+        conn = DiagramConnection(1, 2, "Control Action")
+        SysMLDiagramWindow.draw_connection(win, a, b, conn)
+        args, kwargs = win.canvas.last_line
+        self.assertEqual(kwargs.get("arrow"), tk.LAST)
+        x1, y1, x2, y2 = args
+        self.assertEqual(x1, x2)
+        self.assertEqual(x1, 40)
+        self.assertGreater(y1, y2)
+
+    def test_validate_connection_limits_offset(self):
+        win = DummyWindow()
+        a = SysMLObject(1, "Existing Element", 0, 0)
+        b = SysMLObject(2, "Existing Element", 80, 100)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, a, b, "Control Action")
+        self.assertTrue(valid)
+        b2 = SysMLObject(3, "Existing Element", 81, 100)
+        valid, msg = SysMLDiagramWindow.validate_connection(win, a, b2, "Control Action")
+        self.assertFalse(valid)
+        self.assertEqual(msg, "Connections must be vertical")
+
+    def test_constrain_horizontal_movement(self):
+        win = DummyWindow()
+        a = SysMLObject(1, "Existing Element", 0, 100)
+        b = SysMLObject(2, "Existing Element", 0, 0)
+        win.objects = [a, b]
+        conn = DiagramConnection(1, 2, "Control Action")
+        win.connections = [conn]
+        new_x = SysMLDiagramWindow._constrain_horizontal_movement(win, a, 200)
+        self.assertEqual(new_x, 80)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Allow slight horizontal offset when validating control-flow connections, using element widths
- Constrain horizontal movement to keep control-flow connectors vertical
- Draw control-flow connectors using overlapping width and height, ensuring vertical lines
- Test control-flow connectors for vertical alignment, offset handling and movement constraint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*
- `pip install networkx` *(fails: Could not find a version that satisfies the requirement networkx)*

------
https://chatgpt.com/codex/tasks/task_b_688e46643e608327966735485960d9e6