### PR TITLE
Enhance control flow connector editing

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2762,8 +2762,11 @@ class SysMLDiagramWindow(tk.Frame):
 
         elif diag_type == "Control Flow Diagram":
             if conn_type in ("Control Action", "Feedback"):
+                dx = abs(src.x - dst.x)
                 max_offset = (src.width + dst.width) / 2
-                if abs(src.x - dst.x) > max_offset:
+                tolerance_center = 10
+                tolerance_offset = 0.5
+                if dx > tolerance_center and abs(dx - max_offset) > tolerance_offset:
                     return False, "Connections must be vertical"
 
         elif diag_type == "Activity Diagram":
@@ -2853,14 +2856,16 @@ class SysMLDiagramWindow(tk.Frame):
                 conn.src == obj.obj_id or conn.dst == obj.obj_id
             ):
                 other_id = conn.dst if conn.src == obj.obj_id else conn.src
-                for other in self.objects:
-                    if other.obj_id == other_id:
-                        max_diff = (obj.width + other.width) / 2
-                        diff = adjusted_x - other.x
-                        if diff > max_diff:
-                            adjusted_x = other.x + max_diff
-                        elif diff < -max_diff:
-                            adjusted_x = other.x - max_diff
+                other = next((o for o in self.objects if o.obj_id == other_id), None)
+                if other:
+                    max_diff = (obj.width + other.width) / 2
+                    if new_x > other.x + max_diff:
+                        adjusted_x = other.x + max_diff
+                    elif new_x < other.x - max_diff:
+                        adjusted_x = other.x - max_diff
+                    else:
+                        adjusted_x = other.x
+                    break
         return adjusted_x
 
     def on_left_press(self, event):
@@ -4025,10 +4030,32 @@ class SysMLDiagramWindow(tk.Frame):
         return min(corners, key=lambda p: (p[0] - tx) ** 2 + (p[1] - ty) ** 2)
 
     def find_connection(self, x: float, y: float) -> DiagramConnection | None:
+        diag = self.repo.diagrams.get(self.diagram_id)
         for conn in self.connections:
             src = self.get_object(conn.src)
             dst = self.get_object(conn.dst)
             if not src or not dst:
+                continue
+            if (
+                diag
+                and diag.diag_type == "Control Flow Diagram"
+                and conn.conn_type in ("Control Action", "Feedback")
+            ):
+                a_left = (src.x - src.width / 2) * self.zoom
+                a_right = (src.x + src.width / 2) * self.zoom
+                b_left = (dst.x - dst.width / 2) * self.zoom
+                b_right = (dst.x + dst.width / 2) * self.zoom
+                vx = (max(a_left, b_left) + min(a_right, b_right)) / 2
+                ayc = src.y * self.zoom
+                byc = dst.y * self.zoom
+                if ayc <= byc:
+                    y1 = ayc + src.height / 2 * self.zoom
+                    y2 = byc - dst.height / 2 * self.zoom
+                else:
+                    y1 = ayc - src.height / 2 * self.zoom
+                    y2 = byc + dst.height / 2 * self.zoom
+                if self._dist_to_segment((x, y), (vx, y1), (vx, y2)) <= CONNECTION_SELECT_RADIUS:
+                    return conn
                 continue
             sx, sy = self.edge_point(
                 src,
@@ -7393,11 +7420,40 @@ class ConnectionDialog(simpledialog.Dialog):
         row = 4
         if self.connection.conn_type == "Control Action":
             repo = SysMLRepository.get_instance()
-            elems = [
-                e
-                for e in repo.elements.values()
-                if e.elem_type in ("Action", "Activity", "Operation")
-            ]
+            diag = repo.diagrams.get(self.master.diagram_id)
+            blk_id = None
+            if diag:
+                blk_id = diag.father or next(
+                    (eid for eid, did in repo.element_diagrams.items() if did == diag.diag_id),
+                    None,
+                )
+            elems: list[SysMLElement] = []
+            if blk_id:
+                blk = repo.elements.get(blk_id)
+                beh_diags = {
+                    b.diagram for b in parse_behaviors(blk.properties.get("behaviors", ""))
+                }
+                beh_elem_ids: set[str] = set()
+                for d_id in beh_diags:
+                    d_obj = repo.diagrams.get(d_id)
+                    if d_obj:
+                        beh_elem_ids.update(d_obj.elements)
+                elems = [
+                    repo.elements[eid]
+                    for eid in beh_elem_ids
+                    if repo.elements[eid].elem_type in ("Action", "Activity")
+                ]
+                elems += [
+                    e
+                    for e in repo.elements.values()
+                    if e.elem_type == "Operation" and e.owner == blk_id
+                ]
+            else:
+                elems = [
+                    e
+                    for e in repo.elements.values()
+                    if e.elem_type in ("Action", "Activity", "Operation")
+                ]
             self.elem_map = {e.name or e.elem_id: e.elem_id for e in elems}
             ttk.Label(master, text="Element:").grid(row=row, column=0, sticky="e", padx=4, pady=4)
             cur_name = next(
@@ -7422,8 +7478,10 @@ class ConnectionDialog(simpledialog.Dialog):
             ttk.Button(gbtn, text="Remove", command=self.remove_guard).pack(side=tk.TOP)
             row += 1
             ttk.Label(master, text="Guard Ops:").grid(row=row, column=0, sticky="e", padx=4, pady=4)
-            self.guard_ops_var = tk.StringVar(value=", ".join(self.connection.guard_ops))
-            ttk.Entry(master, textvariable=self.guard_ops_var).grid(row=row, column=1, padx=4, pady=4, sticky="we")
+            self.guard_ops_frame = ttk.Frame(master)
+            self.guard_ops_frame.grid(row=row, column=1, padx=4, pady=4, sticky="w")
+            self.guard_ops_vars: list[tk.StringVar] = []
+            self.refresh_guard_ops_controls()
             row += 1
 
         if self.connection.conn_type in ("Aggregation", "Composite Aggregation"):
@@ -7450,11 +7508,33 @@ class ConnectionDialog(simpledialog.Dialog):
         txt = simpledialog.askstring("Guard", "Condition:", parent=self)
         if txt:
             self.guard_list.insert(tk.END, txt)
+            self.refresh_guard_ops_controls()
 
     def remove_guard(self):
         sel = list(self.guard_list.curselection())
         for idx in reversed(sel):
             self.guard_list.delete(idx)
+        self.refresh_guard_ops_controls()
+
+    def refresh_guard_ops_controls(self):
+        if not hasattr(self, "guard_ops_frame"):
+            return
+        for child in self.guard_ops_frame.winfo_children():
+            child.destroy()
+        self.guard_ops_vars = []
+        needed = max(self.guard_list.size() - 1, 0) if hasattr(self, "guard_list") else 0
+        for i in range(needed):
+            val = (
+                self.connection.guard_ops[i]
+                if i < len(self.connection.guard_ops)
+                else "AND"
+            )
+            var = tk.StringVar(value=val)
+            cb = ttk.Combobox(
+                self.guard_ops_frame, textvariable=var, values=["AND", "OR"], width=5
+            )
+            cb.pack(side=tk.LEFT, padx=2)
+            self.guard_ops_vars.append(var)
 
     def apply(self):
         self.connection.name = self.name_var.get()
@@ -7474,11 +7554,8 @@ class ConnectionDialog(simpledialog.Dialog):
             self.connection.multiplicity = self.mult_var.get()
         if hasattr(self, "guard_list"):
             self.connection.guard = [self.guard_list.get(i) for i in range(self.guard_list.size())]
-        if hasattr(self, "guard_ops_var"):
-            txt = self.guard_ops_var.get()
-            self.connection.guard_ops = [
-                op.strip().upper() for op in txt.split(",") if op.strip()
-            ]
+        if hasattr(self, "guard_ops_vars"):
+            self.connection.guard_ops = [var.get().upper() or "AND" for var in self.guard_ops_vars]
         if hasattr(self, "elem_var"):
             sel = self.elem_var.get()
             self.connection.element_id = self.elem_map.get(sel, "")

--- a/tests/test_control_flow_select.py
+++ b/tests/test_control_flow_select.py
@@ -1,0 +1,37 @@
+import unittest
+from gui.architecture import SysMLDiagramWindow, SysMLObject, DiagramConnection
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+class DummyWindow:
+    def __init__(self):
+        self.repo = SysMLRepository.get_instance()
+        diag = SysMLDiagram(diag_id="d", diag_type="Control Flow Diagram")
+        self.repo.diagrams[diag.diag_id] = diag
+        self.diagram_id = diag.diag_id
+        self.zoom = 1.0
+        self.objects = [
+            SysMLObject(1, "Existing Element", 0, 0),
+            SysMLObject(2, "Existing Element", 60, 100),
+        ]
+        self.connections = [DiagramConnection(1, 2, "Control Action")]
+
+    def get_object(self, oid):
+        return next((o for o in self.objects if o.obj_id == oid), None)
+
+    def edge_point(self, obj, tx, ty, rel, apply_radius=True):
+        return SysMLDiagramWindow.edge_point(self, obj, tx, ty, rel, apply_radius)
+
+    def _dist_to_segment(self, p, a, b):
+        return SysMLDiagramWindow._dist_to_segment(self, p, a, b)
+
+class ControlFlowSelectTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+
+    def test_vertical_connection_selectable(self):
+        win = DummyWindow()
+        conn = SysMLDiagramWindow.find_connection(win, 30, 50)
+        self.assertIs(conn, win.connections[0])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_control_flow_vertical.py
+++ b/tests/test_control_flow_vertical.py
@@ -21,6 +21,13 @@ class ControlFlowConnectionTests(unittest.TestCase):
         valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Control Action")
         self.assertTrue(valid)
 
+    def test_slight_offset_still_valid(self):
+        win = DummyWindow()
+        src = SysMLObject(1, "Existing Element", 0, 0)
+        dst = SysMLObject(2, "Existing Element", 5, 100)
+        valid, _ = SysMLDiagramWindow.validate_connection(win, src, dst, "Control Action")
+        self.assertTrue(valid)
+
     def test_non_vertical_connection_invalid(self):
         win = DummyWindow()
         src = SysMLObject(1, "Existing Element", 0, 0)


### PR DESCRIPTION
## Summary
- add guard operator combo boxes allowing only AND/OR
- filter control action elements to behaviors of owning block
- enable selection of control flow connectors and tighten vertical validation
- relax vertical alignment check to tolerate small offsets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688e72e15a288327b48ad54f7b6c0581