### PR TITLE
Fix missing gca in matplotlib stub

### DIFF
--- a/matplotlib/pyplot.py
+++ b/matplotlib/pyplot.py
@@ -18,5 +18,30 @@ def text(*args, **kwargs):
 def axis(*args, **kwargs):
     pass
 
+def gca(*args, **kwargs):
+    """Return a dummy ``Axes`` object.
+
+    The real ``matplotlib.pyplot`` module exposes :func:`gca` (get current
+    axes).  The lightweight testing stub previously omitted this helper,
+    which caused attribute errors when code expected it to be present.  This
+    minimal implementation returns an object with the limited methods used by
+    the project.
+    """
+
+    class DummyAxes:
+        def annotate(self, *args, **kwargs):
+            pass
+
+        def scatter(self, *args, **kwargs):
+            pass
+
+        def text(self, *args, **kwargs):
+            return text(*args, **kwargs)
+
+        def axis(self, *args, **kwargs):
+            pass
+
+    return DummyAxes()
+
 def tight_layout(*args, **kwargs):
     pass


### PR DESCRIPTION
## Summary
- implement `gca` in the matplotlib test stub to provide a dummy Axes object

## Testing
- `pytest` *(fails: ControlFlowDragTests::test_horizontal_move_restricted, ControlFlowConnectionTests::test_non_vertical_connection_invalid)*

------
https://chatgpt.com/codex/tasks/task_b_688e7c4464b083279d48eed465b2d123