### PR TITLE
Display each guard on new line for control flow labels

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2477,13 +2477,14 @@ def format_control_flow_label(
         "Feedback",
     ):
         if conn.guard:
-            parts: List[str] = []
+            lines: List[str] = []
             for i, g in enumerate(conn.guard):
-                parts.append(g)
-                if i < len(conn.guard) - 1:
-                    op = conn.guard_ops[i] if i < len(conn.guard_ops) else "AND"
-                    parts.append(op)
-            guard_text = " ".join(parts)
+                if i == 0:
+                    lines.append(g)
+                else:
+                    op = conn.guard_ops[i - 1] if i - 1 < len(conn.guard_ops) else "AND"
+                    lines.append(f"{op} {g}")
+            guard_text = "\n".join(lines)
             return f"[{guard_text}] / {label}" if label else f"[{guard_text}]"
     return label
 

--- a/tests/test_control_flow_guard.py
+++ b/tests/test_control_flow_guard.py
@@ -58,7 +58,7 @@ class ControlFlowGuardTests(unittest.TestCase):
         )
         diag.connections = [conn.__dict__]
         label = format_control_flow_label(conn, repo, "Control Flow Diagram")
-        self.assertEqual(label, "[g1 AND g2 OR g3] / Do")
+        self.assertEqual(label, "[g1\nAND g2\nOR g3] / Do")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Show each guard expression on its own line for control action and feedback connections
- Update guard label test to cover multi-line formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688e7f34694c8327b77cf02a35d95f85