### PR TITLE
Draw diagrams directly on Tk canvas

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -310,7 +310,6 @@ except ModuleNotFoundError:
     Image = ImageDraw = ImageFont = None
 import os
 import types
-import tempfile
 os.environ["GS_EXECUTABLE"] = r"C:\Program Files\gs\gs10.04.0\bin\gswin64c.exe"
 import networkx as nx
 import matplotlib.pyplot as plt
@@ -12072,15 +12071,19 @@ class FaultTreeApp:
             row_map[iid] = row
 
         def draw_row(row):
-            """Render a small network diagram for *row* on the canvas."""
-            import matplotlib.pyplot as plt
+            """Render a small network diagram for *row* directly on the Tk canvas.
+
+            Earlier versions rendered diagrams to a temporary PNG and then loaded
+            that image with ``tk.PhotoImage``.  On some systems the image loader
+            would raise ``TclError`` and crash the GUI.  The current approach
+            avoids image files entirely by drawing basic shapes straight onto the
+            canvas using Tk primitives.
+            """
             import textwrap
 
-            # Build a simple graph structure without relying on the external
-            # ``networkx`` package.  The lightweight stub bundled with the
-            # repository does not implement the drawing helpers used
-            # previously, so we assemble the diagram manually using
-            # matplotlib primitives.
+            # Build a simple graph structure without relying on external
+            # drawing helpers.  We will render the diagram using basic Tk
+            # canvas primitives such as lines and rectangles.
             nodes: dict[str, str] = {}
             edges: list[tuple[str, str]] = []
 
@@ -12123,55 +12126,74 @@ class FaultTreeApp:
                 pos[tc] = (2, y_tc)
                 y_tc -= 2
 
+            # Use hexadecimal color codes so the palette works on all Tk
+            # platforms.  Some Windows installs reject X11 color names (e.g.
+            # ``lightcoral``) which previously resulted in only the arrows
+            # being drawn.  Hex codes are universally recognised and ensure
+            # that every node receives a visible fill colour.
             color_map = {
-                "hazard": "lightcoral",
-                "malfunction": "lightblue",
-                "failure_mode": "orange",
-                "fault": "lightgray",
-                "fi": "lightyellow",
-                "tc": "lightgreen",
+                "hazard": "#F08080",       # light coral
+                "malfunction": "#ADD8E6",  # light blue
+                "failure_mode": "#FFA500",  # orange
+                "fault": "#D3D3D3",        # light gray
+                "fi": "#FFFFE0",           # light yellow
+                "tc": "#90EE90",           # light green
             }
 
-            plt.figure(figsize=(6, 4))
-            ax = plt.gca()
+            # Clear any existing drawing
+            canvas.delete("all")
 
-            # Draw arrows for each edge
+            # Scaling factors to convert the logical layout coordinates to
+            # pixels on the canvas.
+            scale = 80
+            x_off = 50
+            y_off = 50
+            box_w = 80
+            box_h = 40
+
+            def to_canvas(x: float, y: float) -> tuple[float, float]:
+                return x_off + scale * x, y_off + scale * y
+
+            # Draw connections with arrows and labels
             for u, v in edges:
-                x1, y1 = pos[u]
-                x2, y2 = pos[v]
-                ax.annotate("", xy=(x2, y2), xytext=(x1, y1),
-                            arrowprops=dict(arrowstyle="->"))
+                x1, y1 = to_canvas(*pos[u])
+                x2, y2 = to_canvas(*pos[v])
+                canvas.create_line(x1, y1, x2, y2, arrow=tk.LAST, tags="edge")
+                canvas.create_text(
+                    (x1 + x2) / 2,
+                    (y1 + y2) / 2,
+                    text="caused by",
+                    font=("TkDefaultFont", 8),
+                    tags="edge",
+                )
 
-            # Draw the nodes with labels
+            # Draw the nodes as rectangles with wrapped text
             for n, (x, y) in pos.items():
                 kind = nodes.get(n, "")
                 color = color_map.get(kind, "white")
-                ax.scatter([x], [y], s=1200, c=color, edgecolors="black")
+                cx, cy = to_canvas(x, y)
+                canvas.create_rectangle(
+                    cx - box_w / 2,
+                    cy - box_h / 2,
+                    cx + box_w / 2,
+                    cy + box_h / 2,
+                    fill=color,
+                    outline="black",
+                    tags="node",
+                )
                 label = textwrap.fill(str(n), 20)
-                ax.text(x, y, label, fontsize=6, ha="center", va="center")
+                canvas.create_text(
+                    cx,
+                    cy,
+                    text=label,
+                    width=box_w - 10,
+                    font=("TkDefaultFont", 8),
+                    tags="node",
+                )
 
-            # Edge labels ("caused by") halfway between nodes
-            for u, v in edges:
-                x1, y1 = pos[u]
-                x2, y2 = pos[v]
-                ax.text((x1 + x2) / 2, (y1 + y2) / 2, "caused by", fontsize=6)
+            # Ensure nodes are drawn above connecting lines
+            canvas.tag_raise("node")
 
-            ax.axis("off")
-
-            # Save the diagram to a temporary file and let Tk load it from
-            # disk.  This avoids in-memory image format quirks and uses only
-            # the standard ``tk.PhotoImage`` loader.
-            tmp_file = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
-            tmp_path = tmp_file.name
-            tmp_file.close()
-            plt.savefig(tmp_path, format="PNG", dpi=120)
-            plt.close()
-            photo = tk.PhotoImage(file=tmp_path)
-            os.unlink(tmp_path)
-
-            canvas.delete("all")
-            canvas.image = photo  # keep reference
-            canvas.create_image(0, 0, image=photo, anchor="nw")
             canvas.config(scrollregion=canvas.bbox("all"))
 
         def on_select(event):


### PR DESCRIPTION
## Summary
- Render cause-and-effect nodes with universal hex colors and raise them above edges so they no longer disappear, even on Windows Tk installs that reject X11 color names
- Display edge labels using Tk's `text` keyword to prevent 'unknown option' errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688e8c59d69c83278b77e8be5f9c1dec