### PR TITLE
Force cause-effect diagram redraw

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12173,6 +12173,10 @@ class FaultTreeApp:
                 )
 
             canvas.config(scrollregion=canvas.bbox("all"))
+            # Ensure the drawing appears immediately in environments where
+            # the Tk event loop has not yet run. Without this call the canvas
+            # may show up blank until the user interacts with the window.
+            canvas.update_idletasks()
 
         def on_select(event):
             sel = tree.selection()


### PR DESCRIPTION
## Summary
- Ensure cause-effect chain diagram refreshes immediately on Tk canvas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688e90f584048327b3d584db0edfa4d1