### PR TITLE
Fix cause-effect diagram drawing and SimpleDocTemplate stub

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12079,12 +12079,7 @@ class FaultTreeApp:
             back to Tk's ``PhotoImage`` otherwise to avoid the ``TclError``
             reported on some systems.
             """
-            import matplotlib.pyplot as plt
-            import tempfile, textwrap
-            try:
-                from PIL import Image, ImageTk  # type: ignore
-            except Exception:  # Pillow may not be installed
-                Image = ImageTk = None
+            import textwrap
 
             # Build a simple graph structure without relying on external
             # drawing helpers.  We will render the diagram using basic Tk
@@ -12204,37 +12199,6 @@ class FaultTreeApp:
                     font=("TkDefaultFont", 8),
                     tags="node",
                 )
-
-            # Edge labels ("caused by") halfway between nodes
-            for u, v in edges:
-                x1, y1 = pos[u]
-                x2, y2 = pos[v]
-                ax.text((x1 + x2) / 2, (y1 + y2) / 2, "caused by", fontsize=6)
-
-            ax.axis("off")
-
-            # Save the diagram to a temporary file and let Tk load it from
-            # disk.  Using a real file keeps image handling simple and
-            # consistent with the PDF export.
-            tmp_file = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
-            tmp_path = tmp_file.name
-            tmp_file.close()
-            plt.savefig(tmp_path, format="PNG", dpi=120)
-            plt.close()
-
-            try:
-                if Image and ImageTk:
-                    pil_img = Image.open(tmp_path)
-                    photo = ImageTk.PhotoImage(pil_img)
-                else:  # Pillow not installed
-                    raise Exception
-            except Exception:
-                photo = tk.PhotoImage(file=tmp_path)
-            finally:
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
 
             canvas.config(scrollregion=canvas.bbox("all"))
             # Ensure the drawing appears immediately in environments where

--- a/reportlab/platypus/__init__.py
+++ b/reportlab/platypus/__init__.py
@@ -1,23 +1,44 @@
 class Table:
-    pass
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def setStyle(self, *args, **kwargs):
+        pass
+
 
 class TableStyle:
-    pass
+    def __init__(self, *args, **kwargs):
+        pass
+
 
 class SimpleDocTemplate:
-    pass
+    def __init__(self, filename, **kwargs):
+        self.filename = filename
+        self.kwargs = kwargs
+
+    def build(self, flowables):
+        pass
+
 
 class Paragraph:
-    pass
+    def __init__(self, *args, **kwargs):
+        pass
+
 
 class Spacer:
-    pass
+    def __init__(self, *args, **kwargs):
+        pass
+
 
 class Image:
-    pass
+    def __init__(self, *args, **kwargs):
+        pass
+
 
 class PageBreak:
-    pass
+    def __init__(self, *args, **kwargs):
+        pass
 
-class LongTable:
+
+class LongTable(Table):
     pass


### PR DESCRIPTION
## Summary
- Cleaned cause/effect chain renderer by removing leftover matplotlib/Pillow logic and relying solely on Tk canvas primitives.
- Added minimal ReportLab platypus stubs that accept initialization arguments and provide a no-op `build` method, resolving `SimpleDocTemplate` errors.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688e9a305c30832795a44ad65957099f