### PR TITLE
Fix PDF style KeyError and image scaling

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -7143,7 +7143,10 @@ class FaultTreeApp:
         def scale_image(pil_img):
             """Scale images so they fit within the doc page nicely."""
             orig_width, orig_height = pil_img.size
-            scale_factor = 0.95 * min(doc.width / orig_width, doc.height / orig_height, 1)
+            page_width, page_height = doc.pagesize
+            available_width = page_width - doc.leftMargin - doc.rightMargin
+            available_height = page_height - doc.topMargin - doc.bottomMargin
+            scale_factor = 0.95 * min(available_width / orig_width, available_height / orig_height, 1)
             return orig_width * scale_factor, orig_height * scale_factor
 
         Story = []

--- a/networkx/__init__.py
+++ b/networkx/__init__.py
@@ -1,13 +1,53 @@
 class DiGraph:
-    def __init__(self, *args, **kwargs):
-        self.nodes = []
-        self.edges = []
+    """Very small subset of :class:`networkx.DiGraph`.
 
+    The real NetworkX library exposes a rich API for storing directed graphs.
+    For the needs of this project we only implement the handful of methods
+    exercised by :func:`auto_generate_fta_diagram` in ``AutoML.py``.  The goal
+    is merely to provide enough behaviour so the surrounding code can execute
+    without pulling in the heavy NetworkX dependency.
+
+    Nodes are stored in dictionaries mapping to sets of successors and
+    predecessors which conveniently preserves insertion order in Python 3.7+
+    while giving us efficient membership checks.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Maps a node -> set of nodes with an incoming edge from ``node``
+        self._succ = {}
+        # Maps a node -> set of nodes with an outgoing edge to ``node``
+        self._pred = {}
+
+    # ------------------------------------------------------------------
+    # Basic mutation helpers
     def add_node(self, node, **kwargs):
-        self.nodes.append(node)
+        """Add *node* to the graph if it isn't present."""
+        self._succ.setdefault(node, set())
+        self._pred.setdefault(node, set())
 
     def add_edge(self, u, v, **kwargs):
-        self.edges.append((u, v))
+        """Insert a directed edge ``u -> v``."""
+        self.add_node(u)
+        self.add_node(v)
+        self._succ[u].add(v)
+        self._pred[v].add(u)
+
+    # ------------------------------------------------------------------
+    # Query helpers used by AutoML
+    def has_node(self, node):
+        return node in self._succ
+
+    def successors(self, node):
+        return list(self._succ.get(node, []))
+
+    def predecessors(self, node):
+        return list(self._pred.get(node, []))
+
+    def nodes(self):
+        return list(self._succ.keys())
+
+    def edges(self):
+        return [(u, v) for u, vs in self._succ.items() for v in vs]
 
 
 def draw_networkx_edges(*args, **kwargs):

--- a/reportlab/lib/pagesizes.py
+++ b/reportlab/lib/pagesizes.py
@@ -1,2 +1,23 @@
-letter = (0, 0)
-landscape = lambda x: x
+"""Minimal page size definitions used by the simplified ReportLab stub.
+
+The real ReportLab library defines page sizes in points (1 point = 1/72 inch).
+For our purposes we only need support for the US Letter size and the ability
+to swap dimensions for landscape orientation.  These helpers provide reasonable
+defaults so that PDF generation code can calculate available drawing areas.
+"""
+
+# Width and height of a US Letter page in points (8.5" x 11")
+letter = (612.0, 792.0)
+
+
+def landscape(pagesize):
+    """Return the dimensions for a landscape oriented page.
+
+    The real ReportLab `landscape` function simply swaps the width and height of
+    the supplied page size.  Doing the same here keeps our stub compatible with
+    code that expects this behaviour.
+    """
+
+    width, height = pagesize
+    return height, width
+

--- a/reportlab/lib/styles.py
+++ b/reportlab/lib/styles.py
@@ -1,10 +1,74 @@
-class DummyStyles(dict):
+"""Minimal styling utilities for report generation tests.
+
+This module provides a very small subset of the real ReportLab styling API
+that is sufficient for the unit tests in this repository.  The previous
+implementation returned an empty dictionary which resulted in ``KeyError``
+exceptions whenever a style such as ``"Title"`` or ``"Heading1"`` was
+requested.  The real ReportLab library ships with a sample style sheet that
+contains a number of basic styles; here we emulate only the pieces that are
+required by :mod:`AutoML` when building PDF reports.
+
+The goal of this module is not to be feature complete, but rather to provide
+just enough behaviour so that code relying on ``getSampleStyleSheet`` can run
+without raising exceptions.
+"""
+
+
+class StyleSheet(dict):
+    """Dictionary-like container for paragraph styles."""
+
     def add(self, style):
-        pass
+        """Store *style* in the sheet using its name as the key."""
+        self[style.name] = style
+
 
 def getSampleStyleSheet():
-    return DummyStyles()
+    """Return a very small sample style sheet.
+
+    The sheet mimics the real ReportLab ``getSampleStyleSheet`` function by
+    providing a handful of commonly used styles (``Normal``, ``Title``,
+    ``Heading1``–``Heading3``).  Additional styles can be added by client code
+    via :meth:`StyleSheet.add`.
+    """
+
+    sheet = StyleSheet()
+
+    normal = ParagraphStyle(name="Normal", fontName="Helvetica", fontSize=12, leading=14)
+    sheet.add(normal)
+    sheet.add(ParagraphStyle(name="Title", parent=normal, fontSize=24, leading=28))
+    sheet.add(ParagraphStyle(name="Heading1", parent=normal, fontSize=18, leading=22))
+    sheet.add(ParagraphStyle(name="Heading2", parent=normal, fontSize=14, leading=18))
+    sheet.add(ParagraphStyle(name="Heading3", parent=normal, fontSize=12, leading=16))
+
+    return sheet
+
 
 class ParagraphStyle:
-    def __init__(self, *args, **kwargs):
-        pass
+    """Minimal stand-in for ReportLab's :class:`ParagraphStyle`.
+
+    The class simply stores the attributes that are used throughout the tests
+    (``name``, ``parent``, ``fontName``, ``fontSize``, ``leading`` and
+    ``alignment``).  No validation or advanced behaviour is provided.
+    """
+
+    def __init__(
+        self,
+        name,
+        parent=None,
+        fontName="Helvetica",
+        fontSize=12,
+        leading=None,
+        alignment=0,
+        **kwargs,
+    ):
+        self.name = name
+        self.parent = parent
+        self.fontName = fontName
+        self.fontSize = fontSize
+        self.leading = leading if leading is not None else fontSize * 1.2
+        self.alignment = alignment
+
+        # Store any additional keyword arguments for completeness.
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+

--- a/reportlab/lib/units.py
+++ b/reportlab/lib/units.py
@@ -1,1 +1,6 @@
-inch = 1
+"""Measurement units used by the lightweight ReportLab substitute."""
+
+# One inch expressed in points.  This mirrors the real ReportLab value and
+# allows code to perform size calculations that depend on typographic points.
+inch = 72.0
+

--- a/reportlab/platypus/__init__.py
+++ b/reportlab/platypus/__init__.py
@@ -12,11 +12,26 @@ class TableStyle:
 
 
 class SimpleDocTemplate:
+    """Very small stand‑in for ReportLab's ``SimpleDocTemplate``.
+
+    The real class exposes a number of attributes used during PDF generation
+    such as ``pagesize`` and the document margins.  The application relies on
+    these for layout calculations, so this stub stores them as plain attributes
+    which can be queried by the calling code.
+    """
+
     def __init__(self, filename, **kwargs):
         self.filename = filename
-        self.kwargs = kwargs
+
+        # Basic document geometry
+        self.pagesize = kwargs.get("pagesize", (612.0, 792.0))
+        self.leftMargin = kwargs.get("leftMargin", 72.0)
+        self.rightMargin = kwargs.get("rightMargin", 72.0)
+        self.topMargin = kwargs.get("topMargin", 72.0)
+        self.bottomMargin = kwargs.get("bottomMargin", 72.0)
 
     def build(self, flowables):
+        """Placeholder build method – does nothing in this stub."""
         pass
 
 


### PR DESCRIPTION
## Summary
- Provide basic ReportLab styles to prevent missing `Title` style
- Scale images based on available page size rather than nonexistent `doc.width`/`doc.height`
- Supply minimal ReportLab geometry helpers so `SimpleDocTemplate` exposes page size and margins
- Implement adjacency-based `DiGraph` with successors and predecessors so PDF diagram generation succeeds without NetworkX

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688e9e24e8f48327930939e5b5c45685