### PR TITLE
Fix cause-effect diagram missing nodes in PDF

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -6674,62 +6674,160 @@ class FaultTreeApp:
         """
         nodes = []
         edges = []
-        
+
+        visited = set()
+
         def traverse(node):
+            if node.unique_id in visited:
+                return
+            visited.add(node.unique_id)
+
             node_type_up = node.node_type.upper()
-            if node_type_up in GATE_NODE_TYPES:
-                final_gate_type = node.gate_type  # e.g. "AND" or "OR"
+            node_info = {
+                "id": str(node.unique_id),
+                "label": node.name,
+                # Preserve the on-screen coordinates so exported diagrams can
+                # mirror the layout used inside the application.  If a node
+                # lacks explicit positions, default to ``0`` so the diagram
+                # generator can still function.
+                "x": getattr(node, "x", 0),
+                "y": getattr(node, "y", 0),
+            }
 
-                node_info = {
-                    "id": str(node.unique_id),
-                    "label": node.name,
-                    "gate_type": final_gate_type,   # store it only if not all children are base
-                }
-                if node.input_subtype:
-                    node_info["subtype"] = node.input_subtype
-                
-                nodes.append(node_info)
+            # Include gate type only when the node itself is a gate and it has
+            # at least one non-base child.  Previously only gate nodes were
+            # added to the model which meant that basic events—the actual
+            # causes in the chain—were omitted from the generated diagram. As a
+            # result the PDF report often displayed just the top event with no
+            # contributing causes.  By recording every node and linking it to
+            # its parent, all causes now appear in the output.
+            if node_type_up in GATE_NODE_TYPES and not self.all_children_are_base_events(node):
+                node_info["gate_type"] = node.gate_type
+            if getattr(node, "input_subtype", ""):
+                node_info["subtype"] = node.input_subtype
 
-                # Only traverse children that are also gates or top events
-                for child in node.children:
-                    child_type = child.node_type.upper()
-                    if child_type in GATE_NODE_TYPES:
-                        edges.append({"source": str(node.unique_id), "target": str(child.unique_id)})
-                        traverse(child)
+            nodes.append(node_info)
+
+            for child in getattr(node, "children", []):
+                edges.append({"source": str(node.unique_id), "target": str(child.unique_id)})
+                traverse(child)
 
         traverse(top_event)
         return {"nodes": nodes, "edges": edges}
 
     @staticmethod
     def auto_generate_fta_diagram(fta_model, output_path):
-        """
-        Generate a cause-and-effect diagram with a layered (hierarchical) layout,
-        but draw the arrows in reverse (child -> parent).
-        """
-        import networkx as nx
+        """Generate a cause-and-effect diagram for inclusion in the PDF
+        report.  If the simplified FTA model provides explicit ``x`` and ``y``
+        coordinates for every node, those positions are used directly so the
+        exported image matches the diagram shown inside the tool.  Otherwise a
+        simple layered layout is computed as a fallback."""
         from PIL import Image, ImageDraw, ImageFont
-        import numpy as np
         import math
 
-        # --- 1) Build the directed graph (parent->child) ---
+        nodes = fta_model.get("nodes", [])
+        edges = fta_model.get("edges", [])
+
+        # ------------------------------------------------------------------
+        # 1) Use stored coordinates when available
+        # ------------------------------------------------------------------
+        if nodes and all("x" in n and "y" in n for n in nodes):
+            node_w, node_h = 120, 60
+            xs = [n["x"] for n in nodes]
+            ys = [n["y"] for n in nodes]
+            min_x, max_x = min(xs), max(xs)
+            min_y, max_y = min(ys), max(ys)
+            margin_x = int(node_w / 2) + 20
+            margin_y = int(node_h / 2) + 20
+            width = int(max_x - min_x) + node_w + 2 * margin_x
+            height = int(max_y - min_y) + node_h + 2 * margin_y
+
+            img = Image.new("RGB", (width, height), "white")
+            draw = ImageDraw.Draw(img)
+            font = ImageFont.load_default()
+
+            node_colors = {}
+            node_labels = {}
+            pos = {}
+            for n in nodes:
+                node_id = n["id"]
+                label = n.get("label", f"Node {node_id}")
+                gate_type = n.get("gate_type", "")
+                if gate_type:
+                    label += f"\n({gate_type.upper()})"
+                node_labels[node_id] = label
+
+                subtype = n.get("subtype", "").lower()
+                if "vehicle level function" in subtype:
+                    node_colors[node_id] = "lightcoral"
+                elif "safety mechanism" in subtype:
+                    node_colors[node_id] = "lightyellow"
+                elif "capability" in subtype:
+                    node_colors[node_id] = "lightblue"
+                else:
+                    node_colors[node_id] = "white"
+
+                x = n["x"] - min_x + margin_x + node_w / 2
+                y = n["y"] - min_y + margin_y + node_h / 2
+                pos[node_id] = (x, y)
+
+            for edge in edges:
+                src = edge["source"]
+                tgt = edge["target"]
+                if src in pos and tgt in pos:
+                    start = pos[tgt]
+                    end = pos[src]
+                    draw.line([start, end], fill="gray", width=2)
+                    dx = end[0] - start[0]
+                    dy = end[1] - start[1]
+                    length = math.hypot(dx, dy)
+                    if length:
+                        ux, uy = dx / length, dy / length
+                        arrow = 10
+                        left = (end[0] - ux * arrow - uy * arrow / 2,
+                                end[1] - uy * arrow + ux * arrow / 2)
+                        right = (end[0] - ux * arrow + uy * arrow / 2,
+                                 end[1] - uy * arrow - ux * arrow / 2)
+                        draw.polygon([end, left, right], fill="gray")
+
+            for node_id, (x, y) in pos.items():
+                left = x - node_w / 2
+                top = y - node_h / 2
+                right = x + node_w / 2
+                bottom = y + node_h / 2
+                draw.rectangle([left, top, right, bottom],
+                               fill=node_colors[node_id], outline="black")
+                lbl = node_labels[node_id]
+                bbox = draw.multiline_textbbox((0, 0), lbl, font=font,
+                                               align="center")
+                tw = bbox[2] - bbox[0]
+                th = bbox[3] - bbox[1]
+                draw.multiline_text((x - tw/2, y - th/2), lbl, font=font,
+                                    fill="black", align="center")
+
+            img.save(output_path)
+            return
+
+        # ------------------------------------------------------------------
+        # 2) Fallback: compute a layered layout similar to the previous
+        #    implementation when coordinates are not provided.
+        # ------------------------------------------------------------------
+        import networkx as nx
+        import numpy as np
+
         G = nx.DiGraph()
         node_labels = {}
         node_colors = {}
 
-        for node in fta_model["nodes"]:
+        for node in nodes:
             node_id = node["id"]
-            label   = node.get("label", f"Node {node_id}")
-
-            # If there's a gate_type, append it to the label
+            label = node.get("label", f"Node {node_id}")
             gate_type = node.get("gate_type", "")
             if gate_type:
-                # e.g. label = "Node 1\n(AND)"
                 label += f"\n({gate_type.upper()})"
-
             G.add_node(node_id)
             node_labels[node_id] = label
 
-            # Keep your color logic based on "subtype":
             subtype = node.get("subtype", "").lower()
             if "vehicle level function" in subtype:
                 node_colors[node_id] = "lightcoral"
@@ -6738,19 +6836,16 @@ class FaultTreeApp:
             elif "capability" in subtype:
                 node_colors[node_id] = "lightblue"
             else:
-                node_colors[node_id] = "white"  # clone
+                node_colors[node_id] = "white"
 
-        # Add edges
-        for edge in fta_model["edges"]:
+        for edge in edges:
             src = edge["source"]
             tgt = edge["target"]
-            if not G.has_node(src) or not G.has_node(tgt):
-                continue
-            G.add_edge(src, tgt)
+            if G.has_node(src) and G.has_node(tgt):
+                G.add_edge(src, tgt)
 
-        # --- 2) Identify the top event as 'root' (layer 0) ---
-        if fta_model["nodes"]:
-            top_event_id = fta_model["nodes"][0]["id"]
+        if nodes:
+            top_event_id = nodes[0]["id"]
         else:
             img = Image.new("RGB", (400, 300), "white")
             draw = ImageDraw.Draw(img)
@@ -6758,11 +6853,9 @@ class FaultTreeApp:
             img.save(output_path)
             return
 
-        # --- 3) BFS layering from top_event to find each node's layer ---
-        layers = {}
-        layers[top_event_id] = 0
+        layers = {top_event_id: 0}
         queue = [top_event_id]
-        visited = set([top_event_id])
+        visited = {top_event_id}
 
         while queue:
             current = queue.pop(0)
@@ -6773,44 +6866,35 @@ class FaultTreeApp:
                     layers[child] = current_layer + 1
                     queue.append(child)
 
-        # Any node not reached gets placed in a higher layer
         max_layer = max(layers.values()) if layers else 0
         for n in G.nodes():
             if n not in layers:
                 max_layer += 1
                 layers[n] = max_layer
 
-        # Group nodes by layer
         layer_dict = {}
         for node_id, layer in layers.items():
             layer_dict.setdefault(layer, []).append(node_id)
 
-        # --- 4) Assign (x, y) by layer ---
         horizontal_gap = 2.0
-        vertical_gap   = 1.0
+        vertical_gap = 1.0
         pos = {}
-
         for layer in sorted(layer_dict.keys()):
             node_list = layer_dict[layer]
 
-            # Sort siblings by average parent index (optional)
             def avg_parent_position(n):
                 parents = list(G.predecessors(n))
                 if not parents:
                     return 0
-                # we assume all parents are in a smaller layer
                 return sum(layer_dict[layers[p]].index(p) for p in parents) / len(parents)
 
             node_list.sort(key=avg_parent_position)
-
-            # Place them at x = layer*gap, y around 0
             middle = (len(node_list) - 1) / 2.0
             for i, n in enumerate(node_list):
                 x = layer * horizontal_gap
                 y = (i - middle) * vertical_gap
                 pos[n] = (x, y)
 
-        # --- 5) Light collision-avoidance pass (optional) ---
         def get_node_bbox(p, box_size=0.3):
             return (p[0] - box_size, p[1] - box_size, p[0] + box_size, p[1] + box_size)
 
@@ -6830,26 +6914,26 @@ class FaultTreeApp:
                         delta = p1 - p2
                         dist = np.linalg.norm(delta) + 1e-9
                         push = 0.02
-                        shift = (delta/dist)*push
+                        shift = (delta / dist) * push
                         pos[n1] = tuple(p1 + shift)
                         pos[n2] = tuple(p2 - shift)
 
-        # --- 6) Draw the diagram with REVERSED edges (child->parent) ---
-        # Convert layout coordinates to image pixels
         xs = [p[0] for p in pos.values()]
         ys = [p[1] for p in pos.values()]
         min_x, max_x = min(xs), max(xs)
         min_y, max_y = min(ys), max(ys)
 
+        node_w, node_h = 120, 60
         scale = 150
-        margin = 50
-        width = int((max_x - min_x) * scale) + 2 * margin
-        height = int((max_y - min_y) * scale) + 2 * margin
+        margin_x = int(node_w / 2) + 20
+        margin_y = int(node_h / 2) + 20
+        width = int((max_x - min_x) * scale) + 2 * margin_x
+        height = int((max_y - min_y) * scale) + 2 * margin_y
 
         def to_px(pt):
             x, y = pt
-            px = int((x - min_x) * scale) + margin
-            py = int((max_y - y) * scale) + margin
+            px = int((x - min_x) * scale) + margin_x
+            py = int((max_y - y) * scale) + margin_y
             return px, py
 
         px_pos = {n: to_px(pos[n]) for n in pos}
@@ -6858,12 +6942,10 @@ class FaultTreeApp:
         draw = ImageDraw.Draw(img)
         font = ImageFont.load_default()
 
-        # Draw reversed edges (child -> parent)
         for src, tgt in G.edges():
             start = px_pos[tgt]
             end = px_pos[src]
             draw.line([start, end], fill="gray", width=2)
-
             dx = end[0] - start[0]
             dy = end[1] - start[1]
             length = math.hypot(dx, dy)
@@ -6876,8 +6958,6 @@ class FaultTreeApp:
                          end[1] - uy * arrow - ux * arrow / 2)
                 draw.polygon([end, left, right], fill="gray")
 
-        # Draw nodes
-        node_w, node_h = 120, 60
         for n, (x, y) in px_pos.items():
             left = x - node_w / 2
             top = y - node_h / 2

--- a/tests/test_cause_effect_diagram.py
+++ b/tests/test_cause_effect_diagram.py
@@ -1,0 +1,166 @@
+import os
+import sys
+import types
+import unittest
+
+# ---------------------------------------------------------------------------
+# Provide a light-weight stub of the Pillow API used by AutoML.  The real
+# Pillow package isn't available in the execution environment, but the
+# cause-and-effect diagram generator relies on a few classes from it.  The
+# stub records the size of images that would have been created so tests can
+# verify the canvas is large enough to contain all nodes.
+# ---------------------------------------------------------------------------
+created_sizes = []
+
+class _FakeImage:
+    def __init__(self, size):
+        self.size = size
+
+    def save(self, *_args, **_kwargs):
+        pass
+
+def _image_new(_mode, size, _color):
+    created_sizes.append(size)
+    return _FakeImage(size)
+
+class _FakeDraw:
+    def __init__(self, _img):
+        pass
+
+    def line(self, *_a, **_k):
+        pass
+
+    def polygon(self, *_a, **_k):
+        pass
+
+    def rectangle(self, *_a, **_k):
+        pass
+
+    def multiline_textbbox(self, *_a, **_k):
+        # Return a dummy bounding box
+        return (0, 0, 10, 10)
+
+    def multiline_text(self, *_a, **_k):
+        pass
+
+class _FakeFontModule:
+    @staticmethod
+    def load_default():
+        return object()
+
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace(new=_image_new)
+PIL_stub.ImageDraw = types.SimpleNamespace(Draw=lambda img: _FakeDraw(img))
+PIL_stub.ImageFont = _FakeFontModule
+PIL_stub.ImageTk = object
+sys.modules.setdefault("PIL", PIL_stub)
+
+# ---------------------------------------------------------------------------
+# Minimal numpy stub supporting the features required by auto_generate_fta_diagram
+# ---------------------------------------------------------------------------
+class _Vector:
+    def __init__(self, data):
+        self.x, self.y = data
+
+    def __sub__(self, other):
+        return _Vector((self.x - other.x, self.y - other.y))
+
+    def __add__(self, other):
+        return _Vector((self.x + other.x, self.y + other.y))
+
+    def __truediv__(self, scalar):
+        return _Vector((self.x / scalar, self.y / scalar))
+
+    def __mul__(self, scalar):
+        return _Vector((self.x * scalar, self.y * scalar))
+
+    __rmul__ = __mul__
+
+    def __iter__(self):
+        yield self.x
+        yield self.y
+
+def _array(data):
+    return _Vector(data)
+
+def _norm(vec):
+    return (vec.x ** 2 + vec.y ** 2) ** 0.5
+
+numpy_stub = types.ModuleType("numpy")
+numpy_stub.array = _array
+numpy_stub.linalg = types.SimpleNamespace(norm=_norm)
+sys.modules.setdefault("numpy", numpy_stub)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import FaultTreeApp
+
+
+class DummyNode:
+    def __init__(self, unique_id, node_type, name, gate_type=None,
+                 children=None, input_subtype="", x=0, y=0):
+        self.unique_id = unique_id
+        self.node_type = node_type
+        self.name = name
+        self.gate_type = gate_type
+        self.children = children or []
+        self.input_subtype = input_subtype
+        # The real application stores pixel coordinates for each node so the
+        # exported diagram matches the on-screen layout.  Include ``x`` and
+        # ``y`` here so tests can verify the positions are propagated through
+        # the simplified model.
+        self.x = x
+        self.y = y
+
+
+class CauseEffectDiagramTests(unittest.TestCase):
+    def setUp(self):
+        # Create a minimal FaultTreeApp instance without initialising Tk
+        self.app = FaultTreeApp.__new__(FaultTreeApp)
+
+    def test_build_simplified_fta_model_includes_basic_events(self):
+        be1 = DummyNode(2, "BASIC EVENT", "Cause 1", x=100, y=100)
+        be2 = DummyNode(3, "BASIC EVENT", "Cause 2", x=200, y=100)
+        top = DummyNode(1, "TOP EVENT", "Hazard", gate_type="AND",
+                        children=[be1, be2], x=150, y=0)
+
+        model = self.app.build_simplified_fta_model(top)
+
+        node_ids = {n["id"] for n in model["nodes"]}
+        self.assertEqual(node_ids, {"1", "2", "3"})
+
+        # Positions from the nodes should be carried over to the model so the
+        # exported diagram mirrors the application's layout.
+        node_map = {n["id"]: n for n in model["nodes"]}
+        self.assertEqual(node_map["1"]["x"], 150)
+        self.assertEqual(node_map["2"]["y"], 100)
+
+        edge_pairs = {(e["source"], e["target"]) for e in model["edges"]}
+        self.assertEqual(edge_pairs, {("1", "2"), ("1", "3")})
+
+    def test_auto_generate_diagram_canvas_large_enough(self):
+        """Ensure generated diagram is not clipped when only one node exists."""
+        created_sizes.clear()
+        top = DummyNode(1, "TOP EVENT", "Hazard", x=10, y=20)
+        model = self.app.build_simplified_fta_model(top)
+        FaultTreeApp.auto_generate_fta_diagram(model, "out.png")
+        self.assertTrue(created_sizes, "Image.new was not called")
+        width, height = created_sizes[0]
+        self.assertGreaterEqual(width, 120)
+        self.assertGreaterEqual(height, 60)
+
+    def test_auto_generate_diagram_respects_coordinates(self):
+        """Nodes positioned far apart should produce a correspondingly
+        large canvas, proving the coordinates from the model are used."""
+        created_sizes.clear()
+        be = DummyNode(2, "BASIC EVENT", "Cause", x=1000, y=1000)
+        top = DummyNode(1, "TOP EVENT", "Hazard", children=[be], x=0, y=0)
+        model = self.app.build_simplified_fta_model(top)
+        FaultTreeApp.auto_generate_fta_diagram(model, "out.png")
+        width, height = created_sizes[0]
+        self.assertGreater(width, 1000)
+        self.assertGreater(height, 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure build_simplified_fta_model includes basic events so cause & effect PDFs show all causes
- expand margins in auto_generate_fta_diagram so entire diagram is visible
- add regression test for cause-effect diagram including basic events and verifying canvas size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688ee5765e9c8327905d90b09b7918dc