### PR TITLE
List control actions in STPA and add toolbox shortcut for analysis

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -14,7 +14,7 @@ from sysml.sysml_repository import SysMLRepository, SysMLDiagram, SysMLElement
 from gui.style_manager import StyleManager
 
 from sysml.sysml_spec import SYSML_PROPERTIES
-from analysis.models import global_requirements, ASIL_ORDER
+from analysis.models import global_requirements, ASIL_ORDER, StpaDoc
 
 # ---------------------------------------------------------------------------
 # Appearance customization
@@ -8239,8 +8239,29 @@ class ControlFlowDiagramWindow(SysMLDiagramWindow):
             "Existing Element",
             "Control Action",
             "Feedback",
+            "STPA Analysis",
         ]
         super().__init__(master, "Control Flow Diagram", tools, diagram_id, app=app, history=history)
+
+    def select_tool(self, tool):
+        if tool == "STPA Analysis":
+            repo = SysMLRepository.get_instance()
+            self.app.open_stpa_window()
+            diag_id = self.diagram_id
+            doc = next((d for d in self.app.stpa_docs if d.diagram == diag_id), None)
+            if not doc:
+                diag = repo.diagrams.get(diag_id)
+                name = diag.name or diag.diag_id if diag else f"STPA {len(self.app.stpa_docs)+1}"
+                doc = StpaDoc(name, diag_id, [])
+                self.app.stpa_docs.append(doc)
+            self.app.active_stpa = doc
+            self.app.stpa_entries = doc.entries
+            if hasattr(self.app, "_stpa_window"):
+                self.app._stpa_window.refresh_docs()
+                self.app._stpa_window.doc_var.set(doc.name)
+                self.app._stpa_window.select_doc()
+            return
+        super().select_tool(tool)
 
 
 class NewDiagramDialog(simpledialog.Dialog):


### PR DESCRIPTION
## Summary
- Populate STPA entry action dropdown with all control actions from the chosen control flow diagram, falling back to source/destination names when unlabeled
- Add an "STPA Analysis" shortcut in Control Flow Diagram tools that opens or creates an STPA analysis for the current diagram

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894a7c559988327a2cfd947b8e57d20