### PR TITLE
Enable STPA action listing and add STPA tool

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2244,6 +2244,7 @@ class FaultTreeApp:
                 "ODD Libraries",
                 "Scenario Libraries",
                 "HAZOP Analysis",
+                "STPA Analysis",
                 "FI2TC Analysis",
                 "TC2FI Analysis",
             ],

--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -213,7 +213,9 @@ class StpaWindow(tk.Frame):
         diag = repo.diagrams.get(self.app.active_stpa.diagram)
         if not diag:
             return []
-        actions = []
+        if not diag or diag.diag_type != "Control Flow Diagram":
+            return []
+        actions: set[str] = set()
         obj_map: dict[int, str] = {}
         for obj_data in getattr(diag, "objects", []):
             name = obj_data.get("name") or ""
@@ -236,7 +238,8 @@ class StpaWindow(tk.Frame):
                     src_name = obj_map.get(conn_obj.src, str(conn_obj.src))
                     dst_name = obj_map.get(conn_obj.dst, str(conn_obj.dst))
                     label = f"{src_name} -> {dst_name}"
-                actions.append(label)
+                if label:
+                    actions.add(label)
         return sorted(actions)
 
     class RowDialog(simpledialog.Dialog):

--- a/tests/test_stpa_actions.py
+++ b/tests/test_stpa_actions.py
@@ -1,0 +1,23 @@
+import types
+from gui.stpa_window import StpaWindow
+from analysis.models import StpaDoc
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+
+def test_get_actions_returns_control_actions():
+    repo = SysMLRepository.get_instance()
+    diag = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram")
+    diag.objects = [
+        {"obj_id": 1, "name": "Controller"},
+        {"obj_id": 2, "name": "Process"},
+    ]
+    diag.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Control Action", "name": "Act"},
+        {"src": 2, "dst": 1, "conn_type": "Feedback", "name": "FB"},
+    ]
+    repo.diagrams[diag.diag_id] = diag
+    app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag.diag_id, []))
+    win = StpaWindow.__new__(StpaWindow)
+    win.app = app
+    actions = win._get_actions()
+    assert actions == ["Act"]


### PR DESCRIPTION
## Summary
- List available control actions when editing STPA entries
- Expose STPA Analysis tool in the main tools panel
- Add regression test for STPA action retrieval

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6894b4bb691c83278fad60c8082297b6