### PR TITLE
Fix STPA action combo box to list control flow actions

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -225,11 +225,12 @@ class StpaWindow(tk.Frame):
                     name = elem.name or ""
             obj_map[obj_data.get("obj_id")] = name
         for conn_data in getattr(diag, "connections", []):
-            conn_obj = (
-                DiagramConnection(**conn_data)
-                if isinstance(conn_data, dict)
-                else conn_data
-            )
+            if isinstance(conn_data, dict):
+                conn_obj = DiagramConnection(
+                    **{k: v for k, v in conn_data.items() if k in DiagramConnection.__annotations__}
+                )
+            else:
+                conn_obj = conn_data
             if getattr(conn_obj, "conn_type", "") == "Control Action":
                 label = format_control_flow_label(
                     conn_obj, repo, "Control Flow Diagram"

--- a/tests/test_stpa_actions.py
+++ b/tests/test_stpa_actions.py
@@ -4,8 +4,13 @@ from analysis.models import StpaDoc
 from sysml.sysml_repository import SysMLRepository, SysMLDiagram
 
 
+def reset_repo():
+    SysMLRepository._instance = None
+    return SysMLRepository.get_instance()
+
+
 def test_get_actions_returns_control_actions():
-    repo = SysMLRepository.get_instance()
+    repo = reset_repo()
     diag = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram")
     diag.objects = [
         {"obj_id": 1, "name": "Controller"},
@@ -14,6 +19,30 @@ def test_get_actions_returns_control_actions():
     diag.connections = [
         {"src": 1, "dst": 2, "conn_type": "Control Action", "name": "Act"},
         {"src": 2, "dst": 1, "conn_type": "Feedback", "name": "FB"},
+    ]
+    repo.diagrams[diag.diag_id] = diag
+    app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag.diag_id, []))
+    win = StpaWindow.__new__(StpaWindow)
+    win.app = app
+    actions = win._get_actions()
+    assert actions == ["Act"]
+
+
+def test_get_actions_ignores_extra_connection_fields():
+    repo = reset_repo()
+    diag = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram")
+    diag.objects = [
+        {"obj_id": 1, "name": "Controller"},
+        {"obj_id": 2, "name": "Process"},
+    ]
+    diag.connections = [
+        {
+            "src": 1,
+            "dst": 2,
+            "conn_type": "Control Action",
+            "name": "Act",
+            "id": 123,
+        }
     ]
     repo.diagrams[diag.diag_id] = diag
     app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag.diag_id, []))


### PR DESCRIPTION
## Summary
- Ensure STPA action picker reads control flow diagram connections even when extra fields are present
- Add regression test for STPA action population with additional connection data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894b8ed646c832781d7f47e081ab72d