### PR TITLE
Fix STPA action combo box missing control actions

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -210,9 +210,13 @@ class StpaWindow(tk.Frame):
         if not self.app.active_stpa:
             return []
         repo = SysMLRepository.get_instance()
-        diag = repo.diagrams.get(self.app.active_stpa.diagram)
+        diag_id = self.app.active_stpa.diagram
+        diag = repo.diagrams.get(diag_id)
         if not diag:
-            return []
+            diag = next(
+                (d for d in repo.diagrams.values() if (d.name or d.diag_id) == diag_id),
+                None,
+            )
         if not diag or diag.diag_type != "Control Flow Diagram":
             return []
         actions: set[str] = set()

--- a/tests/test_stpa_actions.py
+++ b/tests/test_stpa_actions.py
@@ -50,3 +50,21 @@ def test_get_actions_ignores_extra_connection_fields():
     win.app = app
     actions = win._get_actions()
     assert actions == ["Act"]
+
+
+def test_get_actions_matches_diagram_by_name():
+    repo = reset_repo()
+    diag = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram", name="CF")
+    diag.objects = [
+        {"obj_id": 1, "name": "Controller"},
+        {"obj_id": 2, "name": "Process"},
+    ]
+    diag.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Control Action", "name": "Act"},
+    ]
+    repo.diagrams[diag.diag_id] = diag
+    app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag.name, []))
+    win = StpaWindow.__new__(StpaWindow)
+    win.app = app
+    actions = win._get_actions()
+    assert actions == ["Act"]


### PR DESCRIPTION
## Summary
- Ensure STPA action dropdown finds the diagram by ID or name so control actions populate
- Test retrieving actions when STPA doc stores diagram name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894bda68ba083279792f2d18b6b9899