### PR TITLE
Include all Control Flow Diagram connections

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -231,20 +231,23 @@ class StpaWindow(tk.Frame):
         for conn_data in getattr(diag, "connections", []):
             if isinstance(conn_data, dict):
                 conn_obj = DiagramConnection(
-                    **{k: v for k, v in conn_data.items() if k in DiagramConnection.__annotations__}
+                    **{
+                        k: v
+                        for k, v in conn_data.items()
+                        if k in DiagramConnection.__annotations__
+                    }
                 )
             else:
                 conn_obj = conn_data
-            if getattr(conn_obj, "conn_type", "") == "Control Action":
-                label = format_control_flow_label(
-                    conn_obj, repo, "Control Flow Diagram"
-                )
-                if not label:
-                    src_name = obj_map.get(conn_obj.src, str(conn_obj.src))
-                    dst_name = obj_map.get(conn_obj.dst, str(conn_obj.dst))
-                    label = f"{src_name} -> {dst_name}"
-                if label:
-                    actions.add(label)
+            label = format_control_flow_label(
+                conn_obj, repo, "Control Flow Diagram"
+            )
+            if not label:
+                src_name = obj_map.get(conn_obj.src, str(conn_obj.src))
+                dst_name = obj_map.get(conn_obj.dst, str(conn_obj.dst))
+                label = f"{src_name} -> {dst_name}"
+            if label:
+                actions.add(label)
         return sorted(actions)
 
     class RowDialog(simpledialog.Dialog):

--- a/tests/test_stpa_actions.py
+++ b/tests/test_stpa_actions.py
@@ -9,7 +9,7 @@ def reset_repo():
     return SysMLRepository.get_instance()
 
 
-def test_get_actions_returns_control_actions():
+def test_get_actions_returns_all_connections():
     repo = reset_repo()
     diag = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram")
     diag.objects = [
@@ -25,7 +25,7 @@ def test_get_actions_returns_control_actions():
     win = StpaWindow.__new__(StpaWindow)
     win.app = app
     actions = win._get_actions()
-    assert actions == ["Act"]
+    assert actions == ["Act", "FB"]
 
 
 def test_get_actions_ignores_extra_connection_fields():


### PR DESCRIPTION
## Summary
- expose every connection from the active Control Flow Diagram in STPA window
- support building labels via `format_control_flow_label`
- update tests for all connection types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894c32643508327a4025bd2421b94bb