### PR TITLE
feat: rename action combo to control action

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -63,7 +63,8 @@ class StpaWindow(tk.Frame):
         hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
         self.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
         for c in self.COLS:
-            self.tree.heading(c, text=c.replace("_", " ").title())
+            heading = "Control Action" if c == "action" else c.replace("_", " ").title()
+            self.tree.heading(c, text=heading)
             width = 200 if c == "safety_constraints" else 150
             self.tree.column(c, width=width)
         self.tree.grid(row=0, column=0, sticky="nsew")
@@ -253,7 +254,7 @@ class StpaWindow(tk.Frame):
             ]
             self.tree.insert("", "end", values=vals)
 
-    def _get_actions(self):
+    def _get_control_actions(self):
         if not self.app.active_stpa:
             return []
         repo = SysMLRepository.get_instance()
@@ -307,8 +308,8 @@ class StpaWindow(tk.Frame):
             super().__init__(parent, title="Edit STPA Row")
 
         def body(self, master):
-            ttk.Label(master, text="Action").grid(row=0, column=0, sticky="e")
-            actions = self.parent._get_actions()
+            ttk.Label(master, text="Control Action").grid(row=0, column=0, sticky="e")
+            actions = self.parent._get_control_actions()
             self.action_var = tk.StringVar(value=self.row.action)
             action_cb = ttk.Combobox(
                 master, textvariable=self.action_var, values=actions, state="readonly"

--- a/tests/test_stpa_actions.py
+++ b/tests/test_stpa_actions.py
@@ -9,7 +9,7 @@ def reset_repo():
     return SysMLRepository.get_instance()
 
 
-def test_get_actions_returns_control_actions_only():
+def test_get_control_actions_returns_control_actions_only():
     repo = reset_repo()
     diag = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram")
     diag.objects = [
@@ -24,11 +24,11 @@ def test_get_actions_returns_control_actions_only():
     app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag.diag_id, []))
     win = StpaWindow.__new__(StpaWindow)
     win.app = app
-    actions = win._get_actions()
+    actions = win._get_control_actions()
     assert actions == ["Act"]
 
 
-def test_get_actions_ignores_extra_connection_fields():
+def test_get_control_actions_ignores_extra_connection_fields():
     repo = reset_repo()
     diag = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram")
     diag.objects = [
@@ -48,11 +48,11 @@ def test_get_actions_ignores_extra_connection_fields():
     app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag.diag_id, []))
     win = StpaWindow.__new__(StpaWindow)
     win.app = app
-    actions = win._get_actions()
+    actions = win._get_control_actions()
     assert actions == ["Act"]
 
 
-def test_get_actions_matches_diagram_by_name():
+def test_get_control_actions_matches_diagram_by_name():
     repo = reset_repo()
     diag = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram", name="CF")
     diag.objects = [
@@ -66,5 +66,5 @@ def test_get_actions_matches_diagram_by_name():
     app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag.name, []))
     win = StpaWindow.__new__(StpaWindow)
     win.app = app
-    actions = win._get_actions()
+    actions = win._get_control_actions()
     assert actions == ["Act"]


### PR DESCRIPTION
## Summary
- display STPA "Action" column and dialog label as "Control Action"
- populate combo box with Control Action connections from the selected diagram
- adjust tests for renamed helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894cdaf35b48325b8a930374d72eda3