### PR TITLE
Recursively gather control actions for STPA

### DIFF
--- a/tests/test_stpa_actions.py
+++ b/tests/test_stpa_actions.py
@@ -68,3 +68,38 @@ def test_get_control_actions_matches_diagram_by_name():
     win.app = app
     actions = win._get_control_actions()
     assert actions == ["Act"]
+
+
+def test_get_control_actions_recurses_into_linked_diagrams():
+    repo = reset_repo()
+    # Top-level diagram with a control action and an object linked to a subdiagram
+    diag1 = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram")
+    elem = repo.create_element("ActionUsage", name="Sub")
+    diag1.objects = [
+        {"obj_id": 1, "name": "Controller"},
+        {"obj_id": 2, "name": "Process"},
+        {"obj_id": 3, "element_id": elem.elem_id},
+    ]
+    diag1.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Control Action", "name": "Act"},
+    ]
+
+    # Subdiagram linked from elem with another control action
+    diag2 = SysMLDiagram(diag_id="d2", diag_type="Control Flow Diagram")
+    diag2.objects = [
+        {"obj_id": 10, "name": "SubController"},
+        {"obj_id": 11, "name": "SubProcess"},
+    ]
+    diag2.connections = [
+        {"src": 10, "dst": 11, "conn_type": "Control Action", "name": "SubAct"},
+    ]
+
+    repo.diagrams[diag1.diag_id] = diag1
+    repo.diagrams[diag2.diag_id] = diag2
+    repo.link_diagram(elem.elem_id, diag2.diag_id)
+
+    app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag1.diag_id, []))
+    win = StpaWindow.__new__(StpaWindow)
+    win.app = app
+    actions = win._get_control_actions()
+    assert actions == ["Act", "SubAct"]


### PR DESCRIPTION
## Summary
- Collect control actions recursively across linked control flow diagrams for STPA combo box
- Add regression test covering recursive control action retrieval

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894d2cb00308325a448894754e534fb