### PR TITLE
Fix control action recursion for STPA

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -300,17 +300,22 @@ class StpaWindow(tk.Frame):
                     )
                 else:
                     conn_obj = conn_data
-                if conn_obj.conn_type != "Control Action":
-                    continue
-                label = format_control_flow_label(
-                    conn_obj, repo, "Control Flow Diagram"
-                )
-                if not label:
-                    src_name = obj_map.get(conn_obj.src, str(conn_obj.src))
-                    dst_name = obj_map.get(conn_obj.dst, str(conn_obj.dst))
-                    label = f"{src_name} -> {dst_name}"
-                if label:
-                    results.add(label)
+                elem_id = getattr(conn_obj, "element_id", "")
+                if conn_obj.conn_type == "Control Action":
+                    label = format_control_flow_label(
+                        conn_obj, repo, "Control Flow Diagram"
+                    )
+                    if not label:
+                        src_name = obj_map.get(conn_obj.src, str(conn_obj.src))
+                        dst_name = obj_map.get(conn_obj.dst, str(conn_obj.dst))
+                        label = f"{src_name} -> {dst_name}"
+                    if label:
+                        results.add(label)
+                if elem_id:
+                    sub_id = repo.get_linked_diagram(elem_id)
+                    sub_diag = repo.diagrams.get(sub_id)
+                    if sub_diag:
+                        results.update(collect_actions(sub_diag))
 
             for obj_data in getattr(diagram, "objects", []):
                 elem_id = obj_data.get("element_id")

--- a/tests/test_stpa_actions.py
+++ b/tests/test_stpa_actions.py
@@ -103,3 +103,37 @@ def test_get_control_actions_recurses_into_linked_diagrams():
     win.app = app
     actions = win._get_control_actions()
     assert actions == ["Act", "SubAct"]
+
+
+def test_get_control_actions_recurses_from_connection_links():
+    repo = reset_repo()
+    # Top-level diagram with a non-control connection linked to a subdiagram
+    diag1 = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram")
+    elem = repo.create_element("ActionUsage", name="Sub")
+    diag1.objects = [
+        {"obj_id": 1, "name": "Controller"},
+        {"obj_id": 2, "name": "Process"},
+    ]
+    diag1.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Feedback", "element_id": elem.elem_id},
+    ]
+
+    # Subdiagram linked from the connection with a control action
+    diag2 = SysMLDiagram(diag_id="d2", diag_type="Control Flow Diagram")
+    diag2.objects = [
+        {"obj_id": 10, "name": "SubController"},
+        {"obj_id": 11, "name": "SubProcess"},
+    ]
+    diag2.connections = [
+        {"src": 10, "dst": 11, "conn_type": "Control Action", "name": "SubAct"},
+    ]
+
+    repo.diagrams[diag1.diag_id] = diag1
+    repo.diagrams[diag2.diag_id] = diag2
+    repo.link_diagram(elem.elem_id, diag2.diag_id)
+
+    app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag1.diag_id, []))
+    win = StpaWindow.__new__(StpaWindow)
+    win.app = app
+    actions = win._get_control_actions()
+    assert actions == ["SubAct"]


### PR DESCRIPTION
## Summary
- recurse through diagrams linked from connections when gathering control actions
- add regression test covering connection-linked diagrams

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894d46d0f748325a39c45d665f8efbf