### PR TITLE
Fix STPA control action combobox population

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -340,10 +340,16 @@ class StpaWindow(tk.Frame):
             ttk.Label(master, text="Control Action").grid(row=0, column=0, sticky="e")
             actions = self.parent._get_control_actions()
             self.action_var = tk.StringVar(value=self.row.action)
-            action_cb = ttk.Combobox(
-                master, textvariable=self.action_var, values=actions, state="readonly"
-            )
+            action_cb = ttk.Combobox(master, textvariable=self.action_var, state="readonly")
             action_cb.grid(row=0, column=1, padx=5, pady=5)
+            # Explicitly configure the combobox values so Tkinter updates its list
+            # correctly. Passing ``values`` during construction can sometimes
+            # result in an empty drop-down on some platforms.
+            action_cb.configure(values=actions)
+            if not self.row.action and actions:
+                # Select the first control action by default so the combo box is
+                # never shown empty to the user.
+                self.action_var.set(actions[0])
 
             ttk.Label(master, text="Not Providing causes Hazard").grid(
                 row=1, column=0, sticky="e"

--- a/tests/test_stpa_combobox.py
+++ b/tests/test_stpa_combobox.py
@@ -1,0 +1,90 @@
+import types
+
+from analysis.models import StpaDoc, StpaEntry
+from gui.stpa_window import StpaWindow
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+
+def test_row_dialog_populates_control_actions(monkeypatch):
+    """The control action combo box should list actions and preselect one."""
+
+    repo = SysMLRepository.reset_instance()
+    diag = SysMLDiagram(diag_id="d1", diag_type="Control Flow Diagram")
+    diag.objects = [
+        {"obj_id": 1, "name": "Controller"},
+        {"obj_id": 2, "name": "Process"},
+    ]
+    diag.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Control Action", "name": "Act"}
+    ]
+    repo.diagrams[diag.diag_id] = diag
+
+    app = types.SimpleNamespace(active_stpa=StpaDoc("Doc", diag.diag_id, []))
+    parent = StpaWindow.__new__(StpaWindow)
+    parent.app = app
+
+    # ------------------------------------------------------------------
+    # Stub tkinter widgets so the dialog can be created without a display
+    # ------------------------------------------------------------------
+    class DummyWidget:
+        def __init__(self, *args, **kwargs):
+            self.configured = {}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def bind(self, *a, **k):
+            pass
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, state=None, **k):
+            super().__init__(*a, **k)
+            self.textvariable = textvariable
+            self.state = state
+
+    combo_holder = {}
+
+    def combo_stub(*a, **k):
+        cb = DummyCombobox(*a, **k)
+        combo_holder["cb"] = cb
+        return cb
+
+    monkeypatch.setattr("gui.stpa_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.stpa_window.ttk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.ttk.Frame", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.ttk.Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.tk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.tk.Listbox", lambda *a, **k: DummyWidget())
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+    monkeypatch.setattr("gui.stpa_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    dlg = StpaWindow.RowDialog.__new__(StpaWindow.RowDialog)
+    dlg.parent = parent
+    dlg.app = app
+    dlg.row = StpaEntry("", "", "", "", "", [])
+
+    dlg.body(master=DummyWidget())
+
+    cb = combo_holder["cb"]
+    assert cb.configured["values"] == ["Act"]
+    assert dlg.action_var.get() == "Act"
+


### PR DESCRIPTION
## Summary
- ensure STPA row dialog explicitly configures combobox values and preselects first action
- add regression test for control action combobox population

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894dd60eaf88325aee6bd03cf148f2e