### PR TITLE
List STPA control actions from selected diagram

### DIFF
--- a/tests/test_stpa_combobox.py
+++ b/tests/test_stpa_combobox.py
@@ -11,9 +11,10 @@ from gui.stpa_window import StpaWindow
 def test_row_dialog_populates_control_actions(monkeypatch):
     """The control action combo box should list actions and preselect one."""
 
-    app = types.SimpleNamespace(get_all_action_labels=lambda: ["Act"])
+    app = types.SimpleNamespace()
     parent = StpaWindow.__new__(StpaWindow)
     parent.app = app
+    parent._get_control_actions = lambda: ["Act"]
 
     # ------------------------------------------------------------------
     # Stub tkinter widgets so the dialog can be created without a display

--- a/tests/test_stpa_control_actions.py
+++ b/tests/test_stpa_control_actions.py
@@ -1,0 +1,33 @@
+import types
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.models import StpaDoc
+from gui.stpa_window import StpaWindow
+from gui.architecture import SysMLObject, DiagramConnection
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_get_control_actions_returns_only_control_action_connections():
+    repo = SysMLRepository.reset_instance()
+    e1 = repo.create_element("Block", name="A")
+    e2 = repo.create_element("Block", name="B")
+    act = repo.create_element("Action", name="Do")
+    diag = repo.create_diagram("Control Flow Diagram", name="CF")
+    repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Existing Element", 0, 0, element_id=e1.elem_id)
+    o2 = SysMLObject(2, "Existing Element", 0, 100, element_id=e2.elem_id)
+    diag.objects = [o1.__dict__, o2.__dict__]
+    ca_conn = DiagramConnection(o1.obj_id, o2.obj_id, "Control Action", element_id=act.elem_id)
+    fb_conn = DiagramConnection(o2.obj_id, o1.obj_id, "Feedback")
+    diag.connections = [ca_conn.__dict__, fb_conn.__dict__]
+
+    app = types.SimpleNamespace(active_stpa=StpaDoc("doc", diag.diag_id, []))
+    window = StpaWindow.__new__(StpaWindow)
+    window.app = app
+
+    labels = window._get_control_actions()
+    assert labels == ["<<control action>> Do"]


### PR DESCRIPTION
## Summary
- populate STPA row dialog with control action connections from the chosen control flow diagram
- ensure RowDialog uses helper to gather control action connection labels
- add unit test to verify only control action connectors are returned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68951664967483258d960d17137f7225