### PR TITLE
List control action connectors in STPA window

### DIFF
--- a/tests/test_stpa_control_actions.py
+++ b/tests/test_stpa_control_actions.py
@@ -31,3 +31,32 @@ def test_get_control_actions_returns_only_control_action_connections():
 
     labels = window._get_control_actions()
     assert labels == ["<<control action>> Do"]
+
+
+def test_get_control_actions_from_relationship_stereotype():
+    repo = SysMLRepository.reset_instance()
+    e1 = repo.create_element("Block", name="A")
+    e2 = repo.create_element("Block", name="B")
+    act = repo.create_element("Action", name="Do")
+    diag = repo.create_diagram("Control Flow Diagram", name="CF")
+    repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Existing Element", 0, 0, element_id=e1.elem_id)
+    o2 = SysMLObject(2, "Existing Element", 0, 100, element_id=e2.elem_id)
+    diag.objects = [o1.__dict__, o2.__dict__]
+    rel = repo.create_relationship(
+        "Connector",
+        e1.elem_id,
+        e2.elem_id,
+        stereotype="control action",
+        properties={"element_id": act.elem_id},
+    )
+    diag.relationships = [rel.rel_id]
+    diag.connections = []
+
+    app = types.SimpleNamespace(active_stpa=StpaDoc("doc", diag.diag_id, []))
+    window = StpaWindow.__new__(StpaWindow)
+    window.app = app
+
+    labels = window._get_control_actions()
+    assert labels == ["<<control action>> Do"]


### PR DESCRIPTION
## Summary
- Show control action labels in STPA edit row dialog by reading both diagram connections and relationships
- Support connectors using the `control action` stereotype when diagram lacks explicit connection entries
- Test that STPA dialog lists control actions from relationships with the `control action` stereotype

## Testing
- `pytest tests/test_stpa_control_actions.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68951a7d7ed48325afa002ac35bcb5be