### PR TITLE
Restrict STPA diagram lookup to control flow diagrams

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -175,7 +175,12 @@ class StpaWindow(tk.Frame):
         name, diag_name = dlg.result
         repo = SysMLRepository.get_instance()
         diag_id = next(
-            (d.diag_id for d in repo.diagrams.values() if (d.name or d.diag_id) == diag_name),
+            (
+                d.diag_id
+                for d in repo.diagrams.values()
+                if d.diag_type == "Control Flow Diagram"
+                and (d.name or d.diag_id) == diag_name
+            ),
             "",
         )
         doc = StpaDoc(name, diag_id, [])
@@ -207,7 +212,12 @@ class StpaWindow(tk.Frame):
         repo = SysMLRepository.get_instance()
         diag_name = dlg.result
         diag_id = next(
-            (d.diag_id for d in repo.diagrams.values() if (d.name or d.diag_id) == diag_name),
+            (
+                d.diag_id
+                for d in repo.diagrams.values()
+                if d.diag_type == "Control Flow Diagram"
+                and (d.name or d.diag_id) == diag_name
+            ),
             "",
         )
         self.app.active_stpa.diagram = diag_id

--- a/tests/test_stpa_control_actions.py
+++ b/tests/test_stpa_control_actions.py
@@ -60,3 +60,56 @@ def test_get_control_actions_from_relationship_stereotype():
 
     labels = window._get_control_actions()
     assert labels == ["<<control action>> Do"]
+
+
+def test_diagram_lookup_prefers_control_flow_diagrams():
+    repo = SysMLRepository.reset_instance()
+    e1 = repo.create_element("Block", name="A")
+    e2 = repo.create_element("Block", name="B")
+    act = repo.create_element("Action", name="Do")
+    # Create diagrams with the same name but different types
+    activity = repo.create_diagram("Activity Diagram", name="Same")
+    cf = repo.create_diagram("Control Flow Diagram", name="Same")
+
+    # Add elements and a control action connection to the control flow diagram
+    repo.add_element_to_diagram(cf.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(cf.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Existing Element", 0, 0, element_id=e1.elem_id)
+    o2 = SysMLObject(2, "Existing Element", 0, 100, element_id=e2.elem_id)
+    cf.objects = [o1.__dict__, o2.__dict__]
+    ca_conn = DiagramConnection(o1.obj_id, o2.obj_id, "Control Action", element_id=act.elem_id)
+    cf.connections = [ca_conn.__dict__]
+
+    # Prepare StpaWindow instance with stubbed dialogs and widgets
+    app = types.SimpleNamespace(
+        stpa_docs=[],
+        active_stpa=None,
+        stpa_entries=[],
+        update_views=lambda: None,
+    )
+    window = StpaWindow.__new__(StpaWindow)
+    window.app = app
+    window.refresh_docs = lambda: None
+    window.refresh = lambda: None
+    window.diag_lbl = types.SimpleNamespace(config=lambda **kwargs: None)
+
+    class DummyNewDialog:
+        def __init__(self, parent, app):
+            self.result = ("doc", "Same")
+
+    window.NewStpaDialog = DummyNewDialog
+    window.new_doc()
+    assert window.app.active_stpa.diagram == cf.diag_id
+    assert window._get_control_actions() == ["<<control action>> Do"]
+
+    # Change to the activity diagram and ensure edit_doc switches back to the CF diagram
+    window.app.active_stpa.diagram = activity.diag_id
+
+    class DummyEditDialog:
+        def __init__(self, parent, app):
+            self.result = "Same"
+
+    window.EditStpaDialog = DummyEditDialog
+    window.edit_doc()
+    assert window.app.active_stpa.diagram == cf.diag_id
+    assert window._get_control_actions() == ["<<control action>> Do"]


### PR DESCRIPTION
## Summary
- Avoid picking diagrams of other types when creating or editing STPA documents by filtering for Control Flow Diagrams during name lookup
- Add regression test ensuring Control Flow Diagram connectors are returned when another diagram shares the same name

## Testing
- `pytest tests/test_stpa_control_actions.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68951d60c1688325a1642fa3f3cef6ed