### PR TITLE
Ensure unique diagram names across types

### DIFF
--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -217,14 +217,36 @@ class SysMLRepository:
         if package is None:
             package = self.root_package.elem_id
         if name:
-            existing = {
-                d.name
-                for d in self.diagrams.values()
-                if d.diag_type == diag_type and d.name
-            }
+            same_name_diagrams = [d for d in self.diagrams.values() if d.name == name]
+            if same_name_diagrams:
+                if any(d.diag_type != diag_type for d in same_name_diagrams):
+                    for d in same_name_diagrams:
+                        existing_names = {
+                            dd.name for dd in self.diagrams.values() if dd.diag_id != d.diag_id
+                        }
+                        base_existing = f"{name} {d.diag_type}"
+                        new_existing = base_existing
+                        suffix = 1
+                        while new_existing in existing_names:
+                            new_existing = f"{base_existing}_{suffix}"
+                            suffix += 1
+                        d.name = new_existing
+                    name = f"{name} {diag_type}"
+                else:
+                    existing = {
+                        d.name
+                        for d in self.diagrams.values()
+                        if d.diag_type == diag_type and d.name
+                    }
+                    base = name
+                    suffix = 1
+                    while name in existing:
+                        name = f"{base}_{suffix}"
+                        suffix += 1
+            existing_all = {d.name for d in self.diagrams.values()}
             base = name
             suffix = 1
-            while name in existing:
+            while name in existing_all:
                 name = f"{base}_{suffix}"
                 suffix += 1
         diagram = SysMLDiagram(

--- a/tests/test_diagram_name_unique.py
+++ b/tests/test_diagram_name_unique.py
@@ -1,0 +1,20 @@
+import unittest
+from sysml.sysml_repository import SysMLRepository
+
+
+class DiagramNameUniqueTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_names_include_type_when_conflict(self):
+        repo = self.repo
+        bdd = repo.create_diagram("Block Definition Diagram", name="Main")
+        ibd = repo.create_diagram("Internal Block Diagram", name="Main")
+        self.assertIn(bdd.diag_type, bdd.name)
+        self.assertIn(ibd.diag_type, ibd.name)
+        self.assertNotEqual(bdd.name, ibd.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stpa_control_actions.py
+++ b/tests/test_stpa_control_actions.py
@@ -67,7 +67,7 @@ def test_diagram_lookup_prefers_control_flow_diagrams():
     e1 = repo.create_element("Block", name="A")
     e2 = repo.create_element("Block", name="B")
     act = repo.create_element("Action", name="Do")
-    # Create diagrams with the same name but different types
+    # Create diagrams with the same base name but different types
     activity = repo.create_diagram("Activity Diagram", name="Same")
     cf = repo.create_diagram("Control Flow Diagram", name="Same")
 
@@ -95,7 +95,7 @@ def test_diagram_lookup_prefers_control_flow_diagrams():
 
     class DummyNewDialog:
         def __init__(self, parent, app):
-            self.result = ("doc", "Same")
+            self.result = ("doc", cf.name)
 
     window.NewStpaDialog = DummyNewDialog
     window.new_doc()
@@ -107,7 +107,7 @@ def test_diagram_lookup_prefers_control_flow_diagrams():
 
     class DummyEditDialog:
         def __init__(self, parent, app):
-            self.result = "Same"
+            self.result = cf.name
 
     window.EditStpaDialog = DummyEditDialog
     window.edit_doc()


### PR DESCRIPTION
## Summary
- prevent diagrams with identical names across different types by appending the diagram type and ensuring uniqueness
- cover new behavior with a dedicated unit test and adjust STPA control actions test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68951fb316588325880df423c38aedf8