### PR TITLE
Show full control action in STPA row tooltip

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -339,6 +339,14 @@ class StpaWindow(tk.Frame):
                 # Select the first control action by default so the combo box is
                 # never shown empty to the user.
                 self.action_var.set(actions[0])
+            # Add a tooltip that always shows the full control action text.
+            self._action_tt = ToolTip(action_cb, self.action_var.get())
+
+            def _update_tooltip(_event=None):
+                self._action_tt.text = self.action_var.get()
+
+            _update_tooltip()
+            action_cb.bind("<<ComboboxSelected>>", _update_tooltip)
 
             ttk.Label(master, text="Not Providing causes Hazard").grid(
                 row=1, column=0, sticky="e"

--- a/tests/test_stpa_combobox.py
+++ b/tests/test_stpa_combobox.py
@@ -81,3 +81,91 @@ def test_row_dialog_populates_control_actions(monkeypatch):
     assert cb.configured["values"] == ["Act"]
     assert dlg.action_var.get() == "Act"
 
+
+def test_row_dialog_control_action_tooltip(monkeypatch):
+    """The combo box tooltip should show the full selected action."""
+
+    app = types.SimpleNamespace()
+    parent = StpaWindow.__new__(StpaWindow)
+    parent.app = app
+    parent._get_control_actions = lambda: ["Act1", "Act2"]
+
+    class DummyWidget:
+        def __init__(self, *args, **kwargs):
+            self.configured = {}
+            self.bindings = {}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def bind(self, event, func):
+            self.bindings[event] = func
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+        def after(self, *a, **k):
+            pass
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, state=None, **k):
+            super().__init__(*a, **k)
+            self.textvariable = textvariable
+            self.state = state
+
+    combo_holder = {}
+
+    def combo_stub(*a, **k):
+        cb = DummyCombobox(*a, **k)
+        combo_holder["cb"] = cb
+        return cb
+
+    tooltip_holder = {}
+
+    class DummyToolTip:
+        def __init__(self, widget, text):
+            self.widget = widget
+            self.text = text
+            tooltip_holder["tip"] = self
+
+    monkeypatch.setattr("gui.stpa_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.stpa_window.ttk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.ttk.Frame", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.ttk.Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.tk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.tk.Listbox", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.ToolTip", DummyToolTip)
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+    monkeypatch.setattr("gui.stpa_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    dlg = StpaWindow.RowDialog.__new__(StpaWindow.RowDialog)
+    dlg.parent = parent
+    dlg.app = app
+    dlg.row = StpaEntry("", "", "", "", "", [])
+
+    dlg.body(master=DummyWidget())
+
+    tip = tooltip_holder["tip"]
+    assert tip.text == "Act1"
+    cb = combo_holder["cb"]
+    dlg.action_var.set("Act2")
+    cb.bindings["<<ComboboxSelected>>"](None)
+    assert tip.text == "Act2"
+
+


### PR DESCRIPTION
## Summary
- Add tooltip to STPA row dialog so the control action combo box always shows the full action text
- Test that tooltip text follows control action selection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68952034c01c83258bb4af7655e13e55