### PR TITLE
Align connectors with port surfaces

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4255,8 +4255,6 @@ class SysMLDiagramWindow(tk.Frame):
     ) -> Tuple[float, float]:
         cx = obj.x * self.zoom
         cy = obj.y * self.zoom
-        if obj.obj_type == "Port":
-            return cx, cy
 
         def _intersect(vx: float, vy: float, w: float, h: float, r: float) -> Tuple[float, float]:
             """Return intersection of a ray from the origin with a rounded rectangle."""
@@ -4302,6 +4300,21 @@ class SysMLDiagramWindow(tk.Frame):
 
             t, ix, iy = min(candidates, key=lambda c: c[0])
             return ix, iy
+
+        if obj.obj_type == "Port":
+            # Ports are drawn as 12x12 squares regardless of object width/height.
+            # Compute the intersection with this square so connectors touch its edge
+            # rather than reaching the center.
+            w = h = 6 * self.zoom
+            if rel is not None:
+                rx, ry = rel
+                vx = rx * w
+                vy = ry * h
+            else:
+                vx = tx - cx
+                vy = ty - cy
+            ix, iy = _intersect(vx, vy, w, h, 0.0)
+            return cx + ix, cy + iy
 
         w = obj.width * self.zoom / 2
         h = obj.height * self.zoom / 2

--- a/tests/test_port_connector_endpoint.py
+++ b/tests/test_port_connector_endpoint.py
@@ -1,0 +1,22 @@
+import pytest
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+
+class DummyWindow:
+    def __init__(self):
+        self.zoom = 1.0
+
+@pytest.mark.parametrize(
+    "tx, ty, expected",
+    [
+        (10, 0, (6, 0)),   # right side
+        (-10, 0, (-6, 0)), # left side
+        (0, 10, (0, 6)),   # bottom side (positive y)
+        (0, -10, (0, -6)), # top side
+    ],
+)
+def test_edge_point_on_port(tx, ty, expected):
+    win = DummyWindow()
+    port = SysMLObject(1, "Port", 0, 0)
+    x, y = SysMLDiagramWindow.edge_point(win, port, tx, ty)
+    assert abs(x - expected[0]) < 1e-6
+    assert abs(y - expected[1]) < 1e-6


### PR DESCRIPTION
## Summary
- ensure connection endpoints intersect port borders instead of port centers
- add regression test for port connector edge calculation

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ae28ab8dc8325b2a075c07ac6fce2