### PR TITLE
Add threat analysis window and models

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -279,6 +279,12 @@ from analysis.models import (
     StpaDoc,
     FI2TCDoc,
     TC2FIDoc,
+    DamageScenario,
+    ThreatScenario,
+    AttackPath,
+    ThreatEntry,
+    FunctionThreat,
+    ThreatDoc,
     QUALIFICATIONS,
     COMPONENT_ATTR_TEMPLATES,
     RELIABILITY_MODELS,
@@ -358,6 +364,7 @@ from gui.toolboxes import (
     RequirementsExplorerWindow,
 )
 from gui.stpa_window import StpaWindow
+from gui.threat_window import ThreatWindow
 
 
 def format_requirement(req, include_id=True):
@@ -2017,12 +2024,15 @@ class FaultTreeApp:
         self.hazop_docs = []  # list of HazopDoc
         self.hara_docs = []   # list of HaraDoc
         self.stpa_docs = []   # list of StpaDoc
+        self.threat_docs = []  # list of ThreatDoc
         self.active_hazop = None
         self.active_hara = None
         self.active_stpa = None
+        self.active_threat = None
         self.hazop_entries = []  # backwards compatibility for active doc
         self.hara_entries = []
         self.stpa_entries = []
+        self.threat_entries = []
         self.fi2tc_docs = []  # list of FI2TCDoc
         self.tc2fi_docs = []  # list of TC2FIDoc
         self.active_fi2tc = None
@@ -2153,6 +2163,7 @@ class FaultTreeApp:
             command=self.open_hara_window,
         )
         qualitative_menu.add_command(label="STPA Analysis", command=self.open_stpa_window)
+        qualitative_menu.add_command(label="Threat Analysis", command=self.open_threat_window)
         qualitative_menu.add_command(label="Hazard Explorer", command=self.show_hazard_explorer)
         qualitative_menu.add_command(label="Hazards Editor", command=self.show_hazard_editor)
         qualitative_menu.add_command(label="Malfunctions Editor", command=self.show_malfunction_editor)
@@ -2276,6 +2287,7 @@ class FaultTreeApp:
             "HAZOP Analysis": self.open_hazop_window,
             "Risk Assessment (HARA, HIRE & TARA)": self.open_hara_window,
             "STPA Analysis": self.open_stpa_window,
+            "Threat Analysis": self.open_threat_window,
             "Hazards Editor": self.show_hazard_editor,
             "Malfunctions Editor": self.show_malfunction_editor,
             "Faults Editor": self.show_fault_editor,
@@ -2305,11 +2317,12 @@ class FaultTreeApp:
         }
 
         self.tool_categories = {
-            "Hazard Analysis": [
+            "Safety & Threat Analysis": [
                 "ODD Libraries",
                 "Scenario Libraries",
                 "HAZOP Analysis",
                 "STPA Analysis",
+                "Threat Analysis",
                 "FI2TC Analysis",
                 "TC2FI Analysis",
             ],
@@ -8079,6 +8092,12 @@ class FaultTreeApp:
                 doc = self.stpa_docs[idx]
                 self._stpa_window.doc_var.set(doc.name)
                 self._stpa_window.select_doc()
+        elif kind == "threat":
+            self.open_threat_window()
+            if hasattr(self, "_threat_window"):
+                doc = self.threat_docs[idx]
+                self._threat_window.doc_var.set(doc.name)
+                self._threat_window.select_doc()
         elif kind == "fi2tc":
             self.open_fi2tc_window()
             if hasattr(self, "_fi2tc_window"):
@@ -8953,14 +8972,17 @@ class FaultTreeApp:
                 )
             tree.insert(sys_root, "end", text="Requirements", tags=("reqs", "0"))
 
-            # --- Hazard Analysis Section ---
-            haz_root = tree.insert("", "end", text="Hazard Analysis", open=True)
+            # --- Safety & Threat Analysis Section ---
+            haz_root = tree.insert("", "end", text="Safety & Threat Analysis", open=True)
             hazop_root = tree.insert(haz_root, "end", text="HAZOPs", open=True)
             for idx, doc in enumerate(self.hazop_docs):
                 tree.insert(hazop_root, "end", text=doc.name, tags=("hazop", str(idx)))
             stpa_root = tree.insert(haz_root, "end", text="STPA Analyses", open=True)
             for idx, doc in enumerate(self.stpa_docs):
                 tree.insert(stpa_root, "end", text=doc.name, tags=("stpa", str(idx)))
+            threat_root = tree.insert(haz_root, "end", text="Threat Analyses", open=True)
+            for idx, doc in enumerate(self.threat_docs):
+                tree.insert(threat_root, "end", text=doc.name, tags=("threat", str(idx)))
             fi2tc_root = tree.insert(haz_root, "end", text="FI2TC Analyses", open=True)
             for idx, doc in enumerate(self.fi2tc_docs):
                 tree.insert(fi2tc_root, "end", text=doc.name, tags=("fi2tc", str(idx)))
@@ -14059,6 +14081,13 @@ class FaultTreeApp:
         self._stpa_tab = self._new_tab("STPA")
         self._stpa_window = StpaWindow(self._stpa_tab, self)
 
+    def open_threat_window(self):
+        if hasattr(self, "_threat_tab") and self._threat_tab.winfo_exists():
+            self.doc_nb.select(self._threat_tab)
+            return
+        self._threat_tab = self._new_tab("Threat")
+        self._threat_window = ThreatWindow(self._threat_tab, self)
+
     def open_fi2tc_window(self):
         if hasattr(self, "_fi2tc_tab") and self._fi2tc_tab.winfo_exists():
             self.doc_nb.select(self._fi2tc_tab)
@@ -14781,6 +14810,10 @@ class FaultTreeApp:
                 }
                 for doc in self.stpa_docs
             ],
+            "threat_docs": [
+                {"name": doc.name, "entries": [asdict(e) for e in doc.entries]}
+                for doc in self.threat_docs
+            ],
             "fi2tc_docs": [
                 {"name": doc.name, "entries": doc.entries}
                 for doc in self.fi2tc_docs
@@ -15041,6 +15074,51 @@ class FaultTreeApp:
             self.stpa_docs.append(StpaDoc("Default", "", entries))
         self.active_stpa = self.stpa_docs[0] if self.stpa_docs else None
         self.stpa_entries = self.active_stpa.entries if self.active_stpa else []
+
+        self.threat_docs = []
+        for d in data.get("threat_docs", []):
+            entries = []
+            for e in d.get("entries", []):
+                funcs = []
+                fn_data = e.get("functions", [])
+                if fn_data and isinstance(fn_data[0], dict):
+                    for f in fn_data:
+                        dmg_list = []
+                        for ds in f.get("damage_scenarios", []):
+                            threats = []
+                            for t in ds.get("threats", []):
+                                paths = [AttackPath(**p) for p in t.get("attack_paths", [])]
+                                threats.append(
+                                    ThreatScenario(
+                                        t.get("stride", ""), t.get("scenario", ""), paths
+                                    )
+                                )
+                            dmg_list.append(
+                                DamageScenario(
+                                    ds.get("scenario", ""), ds.get("dtype", ""), threats
+                                )
+                            )
+                        funcs.append(FunctionThreat(f.get("function", ""), dmg_list))
+                else:
+                    dmg_list = []
+                    for ds in e.get("damage_scenarios", []):
+                        threats = []
+                        for t in ds.get("threats", []):
+                            paths = [AttackPath(**p) for p in t.get("attack_paths", [])]
+                            threats.append(
+                                ThreatScenario(t.get("stride", ""), t.get("scenario", ""), paths)
+                            )
+                        dmg_list.append(
+                            DamageScenario(ds.get("scenario", ""), ds.get("dtype", ""), threats)
+                        )
+                    for fn in fn_data or []:
+                        funcs.append(FunctionThreat(fn, dmg_list))
+                entries.append(ThreatEntry(e.get("asset", ""), funcs))
+            self.threat_docs.append(
+                ThreatDoc(d.get("name", f"Threat {len(self.threat_docs)+1}"), entries)
+            )
+        self.active_threat = self.threat_docs[0] if self.threat_docs else None
+        self.threat_entries = self.active_threat.entries if self.active_threat else []
 
         self.fi2tc_docs = []
         for d in data.get("fi2tc_docs", []):
@@ -15455,6 +15533,51 @@ class FaultTreeApp:
             self.stpa_docs.append(StpaDoc("Default", "", entries))
         self.active_stpa = self.stpa_docs[0] if self.stpa_docs else None
         self.stpa_entries = self.active_stpa.entries if self.active_stpa else []
+
+        self.threat_docs = []
+        for d in data.get("threat_docs", []):
+            entries = []
+            for e in d.get("entries", []):
+                funcs = []
+                fn_data = e.get("functions", [])
+                if fn_data and isinstance(fn_data[0], dict):
+                    for f in fn_data:
+                        dmg_list = []
+                        for ds in f.get("damage_scenarios", []):
+                            threats = []
+                            for t in ds.get("threats", []):
+                                paths = [AttackPath(**p) for p in t.get("attack_paths", [])]
+                                threats.append(
+                                    ThreatScenario(
+                                        t.get("stride", ""), t.get("scenario", ""), paths
+                                    )
+                                )
+                            dmg_list.append(
+                                DamageScenario(
+                                    ds.get("scenario", ""), ds.get("dtype", ""), threats
+                                )
+                            )
+                        funcs.append(FunctionThreat(f.get("function", ""), dmg_list))
+                else:
+                    dmg_list = []
+                    for ds in e.get("damage_scenarios", []):
+                        threats = []
+                        for t in ds.get("threats", []):
+                            paths = [AttackPath(**p) for p in t.get("attack_paths", [])]
+                            threats.append(
+                                ThreatScenario(t.get("stride", ""), t.get("scenario", ""), paths)
+                            )
+                        dmg_list.append(
+                            DamageScenario(ds.get("scenario", ""), ds.get("dtype", ""), threats)
+                        )
+                    for fn in fn_data or []:
+                        funcs.append(FunctionThreat(fn, dmg_list))
+                entries.append(ThreatEntry(e.get("asset", ""), funcs))
+            self.threat_docs.append(
+                ThreatDoc(d.get("name", f"Threat {len(self.threat_docs)+1}"), entries)
+            )
+        self.active_threat = self.threat_docs[0] if self.threat_docs else None
+        self.threat_entries = self.active_threat.entries if self.active_threat else []
 
         self.fi2tc_docs = []
         for d in data.get("fi2tc_docs", []):

--- a/analysis/models.py
+++ b/analysis/models.py
@@ -230,6 +230,56 @@ class CybersecurityGoal:
                 highest = cal
         self.cal = highest
 
+
+@dataclass
+class AttackPath:
+    """Single attack path description."""
+
+    description: str
+
+
+@dataclass
+class ThreatScenario:
+    """Threat scenario organized by STRIDE category."""
+
+    stride: str
+    scenario: str
+    attack_paths: list[AttackPath] = field(default_factory=list)
+
+
+@dataclass
+class DamageScenario:
+    """Potential damage scenario for a given asset/function."""
+
+    scenario: str
+    dtype: str = ""
+    threats: list[ThreatScenario] = field(default_factory=list)
+
+
+@dataclass
+class FunctionThreat:
+    """Group damage scenarios under a specific function."""
+
+    function: str
+    damage_scenarios: list[DamageScenario] = field(default_factory=list)
+
+
+@dataclass
+class ThreatEntry:
+    """Single row in a threat analysis table."""
+
+    asset: str
+    functions: list[FunctionThreat] = field(default_factory=list)
+
+
+@dataclass
+class ThreatDoc:
+    """Container for a threat analysis document."""
+
+    name: str
+    entries: list[ThreatEntry]
+    meta: Metadata = field(default_factory=Metadata)
+
 COMPONENT_ATTR_TEMPLATES = {
     "capacitor": {
         "dielectric": ["ceramic", "electrolytic", "tantalum"],

--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -1,0 +1,503 @@
+# Author: ChatGPT
+import tkinter as tk
+from tkinter import ttk, simpledialog
+
+from gui import messagebox
+from gui.toolboxes import configure_table_style
+from analysis.models import (
+    AttackPath,
+    DamageScenario,
+    ThreatScenario,
+    ThreatEntry,
+    FunctionThreat,
+)
+from sysml.sysml_repository import SysMLRepository
+
+
+class ThreatDialog(simpledialog.Dialog):
+    """Dialog for creating or editing a threat analysis entry."""
+
+    def __init__(self, parent, app, entry=None):
+        self.app = app
+        self.entry = entry if entry else ThreatEntry("", [])
+        super().__init__(parent, title="Edit Threat Entry")
+
+    # ------------------------------------------------------------------
+    def body(self, master):
+        nb = ttk.Notebook(master)
+        nb.pack(fill=tk.BOTH, expand=True)
+
+        # Asset Identification tab --------------------------------------
+        asset_tab = ttk.Frame(nb)
+        nb.add(asset_tab, text="Asset Identification")
+
+        ai_top = ttk.Frame(asset_tab)
+        ai_top.pack(fill=tk.X)
+        ttk.Label(ai_top, text="Asset:").pack(side=tk.LEFT)
+        self.asset_var = tk.StringVar(value=self.entry.asset)
+        self.asset_cb = ttk.Combobox(
+            ai_top,
+            textvariable=self.asset_var,
+            values=self._get_assets(),
+            state="readonly",
+        )
+        self.asset_cb.pack(side=tk.LEFT, padx=2)
+
+        func_frame = ttk.Frame(asset_tab)
+        func_frame.pack(fill=tk.X, pady=2)
+        ttk.Label(func_frame, text="Function:").pack(side=tk.LEFT)
+        self.func_var = tk.StringVar()
+        self.func_cb = ttk.Combobox(
+            func_frame,
+            textvariable=self.func_var,
+            values=self._get_functions(),
+            state="readonly",
+            width=25,
+        )
+        self.func_cb.pack(side=tk.LEFT, padx=2)
+        ttk.Button(func_frame, text="Add", command=self.add_function).pack(side=tk.LEFT)
+
+        self.func_list = tk.Listbox(asset_tab, height=4)
+        self.func_list.pack(fill=tk.X, padx=2)
+        self.func_list.bind("<<ListboxSelect>>", self.on_function_select)
+        ttk.Button(asset_tab, text="Remove Function", command=self.remove_function).pack(
+            anchor="w", padx=2, pady=2
+        )
+        for fn in self.entry.functions:
+            self.func_list.insert(tk.END, fn.function)
+        if self.entry.functions:
+            self.func_list.selection_set(0)
+
+        ds_frame = ttk.Frame(asset_tab)
+        ds_frame.pack(fill=tk.BOTH, expand=True)
+        configure_table_style("Threat.Damage.Treeview")
+        self.ds_tree = ttk.Treeview(
+            ds_frame,
+            columns=("scenario", "type"),
+            show="headings",
+            style="Threat.Damage.Treeview",
+            height=4,
+        )
+        self.ds_tree.heading("scenario", text="Damage Scenario")
+        self.ds_tree.heading("type", text="Type")
+        self.ds_tree.column("scenario", width=250)
+        self.ds_tree.column("type", width=100)
+        self.ds_tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        ds_scroll = ttk.Scrollbar(ds_frame, orient="vertical", command=self.ds_tree.yview)
+        self.ds_tree.configure(yscrollcommand=ds_scroll.set)
+        ds_scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        self.ds_tree.bind("<<TreeviewSelect>>", self.on_ds_select)
+
+        ds_edit = ttk.Frame(asset_tab)
+        ds_edit.pack(fill=tk.X, pady=2)
+        ttk.Label(ds_edit, text="Damage Scenario:").pack(side=tk.LEFT)
+        self.ds_scenario_var = tk.StringVar()
+        ttk.Entry(ds_edit, textvariable=self.ds_scenario_var, width=30).pack(side=tk.LEFT, padx=2)
+        ttk.Label(ds_edit, text="Type:").pack(side=tk.LEFT)
+        self.ds_type_var = tk.StringVar()
+        self.ds_type_cb = ttk.Combobox(
+            ds_edit,
+            textvariable=self.ds_type_var,
+            values=["Confidentiality", "Integrity", "Availability"],
+            state="readonly",
+            width=18,
+        )
+        self.ds_type_cb.pack(side=tk.LEFT, padx=2)
+
+        ds_btn = ttk.Frame(asset_tab)
+        ds_btn.pack(fill=tk.X)
+        ttk.Button(ds_btn, text="Add", command=self.add_damage_scenario).pack(
+            side=tk.LEFT, padx=2, pady=2
+        )
+        ttk.Button(ds_btn, text="Update", command=self.update_damage_scenario).pack(
+            side=tk.LEFT, padx=2, pady=2
+        )
+        ttk.Button(ds_btn, text="Delete", command=self.del_damage_scenario).pack(
+            side=tk.LEFT, padx=2, pady=2
+        )
+
+        # Threat Analysis tab -------------------------------------------
+        threat_tab = ttk.Frame(nb)
+        nb.add(threat_tab, text="Threat Analysis")
+
+        ta_frame = ttk.Frame(threat_tab)
+        ta_frame.pack(fill=tk.BOTH, expand=True)
+        configure_table_style("Threat.Scenarios.Treeview")
+        self.threat_tree = ttk.Treeview(
+            ta_frame,
+            columns=("stride", "scenario"),
+            show="headings",
+            style="Threat.Scenarios.Treeview",
+            height=4,
+        )
+        self.threat_tree.heading("stride", text="STRIDE")
+        self.threat_tree.heading("scenario", text="Threat Scenario")
+        self.threat_tree.column("stride", width=100)
+        self.threat_tree.column("scenario", width=250)
+        self.threat_tree.bind("<<TreeviewSelect>>", self.on_threat_select)
+        self.threat_tree.grid(row=0, column=0, sticky="nsew")
+        tscroll = ttk.Scrollbar(ta_frame, orient="vertical", command=self.threat_tree.yview)
+        self.threat_tree.configure(yscrollcommand=tscroll.set)
+        tscroll.grid(row=0, column=1, sticky="ns")
+
+        configure_table_style("Threat.Paths.Treeview")
+        self.path_tree = ttk.Treeview(
+            ta_frame,
+            columns=("path",),
+            show="headings",
+            style="Threat.Paths.Treeview",
+            height=3,
+        )
+        self.path_tree.heading("path", text="Attack Path")
+        self.path_tree.column("path", width=350)
+        self.path_tree.grid(row=1, column=0, sticky="nsew")
+        pscroll = ttk.Scrollbar(ta_frame, orient="vertical", command=self.path_tree.yview)
+        self.path_tree.configure(yscrollcommand=pscroll.set)
+        pscroll.grid(row=1, column=1, sticky="ns")
+        self.path_tree.bind("<<TreeviewSelect>>", self.on_path_select)
+
+        ta_frame.columnconfigure(0, weight=1)
+        ta_frame.rowconfigure(0, weight=1)
+        ta_frame.rowconfigure(1, weight=1)
+
+        ts_edit = ttk.Frame(threat_tab)
+        ts_edit.pack(fill=tk.X, pady=2)
+        ttk.Label(ts_edit, text="STRIDE:").pack(side=tk.LEFT)
+        self.threat_stride_var = tk.StringVar()
+        self.threat_stride_cb = ttk.Combobox(
+            ts_edit,
+            textvariable=self.threat_stride_var,
+            values=[
+                "Spoofing",
+                "Tampering",
+                "Repudiation",
+                "Information disclosure",
+                "Denial of service",
+                "Elevation of privilege",
+            ],
+            state="readonly",
+            width=20,
+        )
+        self.threat_stride_cb.pack(side=tk.LEFT, padx=2)
+        ttk.Label(ts_edit, text="Threat Scenario:").pack(side=tk.LEFT)
+        self.threat_scenario_var = tk.StringVar()
+        ttk.Entry(ts_edit, textvariable=self.threat_scenario_var, width=30).pack(
+            side=tk.LEFT, padx=2
+        )
+
+        ts_btn = ttk.Frame(threat_tab)
+        ts_btn.pack(fill=tk.X)
+        ttk.Button(ts_btn, text="Add", command=self.add_threat_scenario).pack(
+            side=tk.LEFT, padx=2, pady=2
+        )
+        ttk.Button(ts_btn, text="Update", command=self.update_threat_scenario).pack(
+            side=tk.LEFT, padx=2, pady=2
+        )
+        ttk.Button(ts_btn, text="Delete", command=self.del_threat_scenario).pack(
+            side=tk.LEFT, padx=2, pady=2
+        )
+
+        path_edit = ttk.Frame(threat_tab)
+        path_edit.pack(fill=tk.X, pady=2)
+        ttk.Label(path_edit, text="Attack Path:").pack(side=tk.LEFT)
+        self.path_var = tk.StringVar()
+        ttk.Entry(path_edit, textvariable=self.path_var, width=40).pack(
+            side=tk.LEFT, padx=2
+        )
+
+        path_btn = ttk.Frame(threat_tab)
+        path_btn.pack(fill=tk.X)
+        ttk.Button(path_btn, text="Add", command=self.add_attack_path).pack(
+            side=tk.LEFT, padx=2, pady=2
+        )
+        ttk.Button(path_btn, text="Update", command=self.update_attack_path).pack(
+            side=tk.LEFT, padx=2, pady=2
+        )
+        ttk.Button(path_btn, text="Delete", command=self.del_attack_path).pack(
+            side=tk.LEFT, padx=2, pady=2
+        )
+
+        self.refresh_ds()
+        self.geometry("700x500")
+        self.resizable(False, False)
+        return nb
+
+    # ------------------------------------------------------------------
+    # Data helpers
+    # ------------------------------------------------------------------
+    def _get_assets(self):
+        repo = SysMLRepository.get_instance()
+        names = set()
+        for elem in repo.elements.values():
+            if elem.elem_type in {"Part", "Port", "Flow", "Connector"} and elem.name:
+                names.add(elem.name)
+        for diag in repo.diagrams.values():
+            for obj in getattr(diag, "objects", []):
+                typ = obj.get("obj_type") or obj.get("type")
+                if typ in {"Part", "Port", "Flow", "Connector"}:
+                    name = obj.get("properties", {}).get("name")
+                    if not name:
+                        elem_id = obj.get("element_id")
+                        if elem_id and elem_id in repo.elements:
+                            name = repo.elements[elem_id].name
+                    if name:
+                        names.add(name)
+        return sorted(names)
+
+    def _get_functions(self):
+        return self.app.get_all_action_names()
+
+    # ------------------------------------------------------------------
+    # Function helpers
+    # ------------------------------------------------------------------
+    def add_function(self):
+        func = self.func_var.get().strip()
+        if not func:
+            return
+        if func in self.func_list.get(0, tk.END):
+            self.func_var.set("")
+            return
+        self.entry.functions.append(FunctionThreat(func))
+        self.func_list.insert(tk.END, func)
+        self.func_var.set("")
+        if self.func_list.size() == 1:
+            self.func_list.selection_set(0)
+            self.refresh_ds()
+
+    def remove_function(self):
+        sel = self.func_list.curselection()
+        if not sel:
+            return
+        idx = int(sel[0])
+        self.func_list.delete(idx)
+        del self.entry.functions[idx]
+        self.refresh_ds()
+
+    def on_function_select(self, *_):
+        self.refresh_ds()
+
+    # ------------------------------------------------------------------
+    def on_ds_select(self, *_):
+        sel = self.ds_tree.selection()
+        fn_sel = self.func_list.curselection()
+        if sel and fn_sel:
+            fn = self.entry.functions[fn_sel[0]]
+            ds = fn.damage_scenarios[int(sel[0])]
+            self.ds_scenario_var.set(ds.scenario)
+            self.ds_type_var.set(ds.dtype)
+        else:
+            self.ds_scenario_var.set("")
+            self.ds_type_var.set("")
+        self.refresh_threats()
+
+    def on_threat_select(self, *_):
+        sel = self.threat_tree.selection()
+        ds_sel = self.ds_tree.selection()
+        fn_sel = self.func_list.curselection()
+        if sel and ds_sel and fn_sel:
+            fn = self.entry.functions[fn_sel[0]]
+            ds = fn.damage_scenarios[int(ds_sel[0])]
+            ts = ds.threats[int(sel[0])]
+            self.threat_stride_var.set(ts.stride)
+            self.threat_scenario_var.set(ts.scenario)
+        else:
+            self.threat_stride_var.set("")
+            self.threat_scenario_var.set("")
+        self.refresh_paths()
+
+    def on_path_select(self, *_):
+        fn_sel = self.func_list.curselection()
+        ds_sel = self.ds_tree.selection()
+        ts_sel = self.threat_tree.selection()
+        ap_sel = self.path_tree.selection()
+        if fn_sel and ds_sel and ts_sel and ap_sel:
+            fn = self.entry.functions[fn_sel[0]]
+            ds = fn.damage_scenarios[int(ds_sel[0])]
+            ts = ds.threats[int(ts_sel[0])]
+            ap = ts.attack_paths[int(ap_sel[0])]
+            self.path_var.set(ap.description)
+        else:
+            self.path_var.set("")
+
+    def refresh_ds(self):
+        self.ds_tree.delete(*self.ds_tree.get_children())
+        fn_sel = self.func_list.curselection()
+        if not fn_sel:
+            self.on_ds_select()
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        for idx, ds in enumerate(fn.damage_scenarios):
+            self.ds_tree.insert("", "end", iid=str(idx), values=(ds.scenario, ds.dtype))
+        self.on_ds_select()
+
+    def refresh_threats(self):
+        self.threat_tree.delete(*self.threat_tree.get_children())
+        self.path_tree.delete(*self.path_tree.get_children())
+        fn_sel = self.func_list.curselection()
+        ds_sel = self.ds_tree.selection()
+        if not fn_sel or not ds_sel:
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        ds = fn.damage_scenarios[int(ds_sel[0])]
+        for idx, ts in enumerate(ds.threats):
+            self.threat_tree.insert("", "end", iid=str(idx), values=(ts.stride, ts.scenario))
+        self.on_threat_select()
+
+    def refresh_paths(self):
+        self.path_tree.delete(*self.path_tree.get_children())
+        fn_sel = self.func_list.curselection()
+        ds_sel = self.ds_tree.selection()
+        ts_sel = self.threat_tree.selection()
+        if not fn_sel or not ds_sel or not ts_sel:
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        ds = fn.damage_scenarios[int(ds_sel[0])]
+        ts = ds.threats[int(ts_sel[0])]
+        for idx, ap in enumerate(ts.attack_paths):
+            self.path_tree.insert("", "end", iid=str(idx), values=(ap.description,))
+        self.on_path_select()
+
+    # ------------------------------------------------------------------
+    # Damage Scenarios
+    # ------------------------------------------------------------------
+    def add_damage_scenario(self):
+        fn_sel = self.func_list.curselection()
+        if not fn_sel:
+            messagebox.showwarning("Add", "Select a function first")
+            return
+        scenario = self.ds_scenario_var.get().strip()
+        if not scenario:
+            messagebox.showwarning("Add", "Enter a damage scenario")
+            return
+        stype = self.ds_type_var.get().strip()
+        fn = self.entry.functions[fn_sel[0]]
+        fn.damage_scenarios.append(DamageScenario(scenario, stype))
+        self.ds_scenario_var.set("")
+        self.ds_type_var.set("")
+        self.refresh_ds()
+
+    def update_damage_scenario(self):
+        fn_sel = self.func_list.curselection()
+        sel = self.ds_tree.selection()
+        if not fn_sel or not sel:
+            messagebox.showwarning("Update", "Select a damage scenario")
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        ds = fn.damage_scenarios[int(sel[0])]
+        ds.scenario = self.ds_scenario_var.get()
+        ds.dtype = self.ds_type_var.get()
+        self.refresh_ds()
+
+    def del_damage_scenario(self):
+        fn_sel = self.func_list.curselection()
+        sel = self.ds_tree.selection()
+        if not fn_sel or not sel:
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        del fn.damage_scenarios[int(sel[0])]
+        self.refresh_ds()
+        self.ds_scenario_var.set("")
+        self.ds_type_var.set("")
+
+    # ------------------------------------------------------------------
+    # Threat Scenarios
+    # ------------------------------------------------------------------
+    def add_threat_scenario(self):
+        fn_sel = self.func_list.curselection()
+        ds_sel = self.ds_tree.selection()
+        if not fn_sel or not ds_sel:
+            messagebox.showwarning("Add", "Select a damage scenario first")
+            return
+        stride = self.threat_stride_var.get().strip()
+        scenario = self.threat_scenario_var.get().strip()
+        if not stride or not scenario:
+            messagebox.showwarning("Add", "Enter STRIDE and scenario")
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        ds = fn.damage_scenarios[int(ds_sel[0])]
+        ds.threats.append(ThreatScenario(stride, scenario))
+        self.threat_stride_var.set("")
+        self.threat_scenario_var.set("")
+        self.refresh_threats()
+
+    def update_threat_scenario(self):
+        fn_sel = self.func_list.curselection()
+        ds_sel = self.ds_tree.selection()
+        ts_sel = self.threat_tree.selection()
+        if not fn_sel or not ds_sel or not ts_sel:
+            messagebox.showwarning("Update", "Select a threat scenario")
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        ds = fn.damage_scenarios[int(ds_sel[0])]
+        ts = ds.threats[int(ts_sel[0])]
+        ts.stride = self.threat_stride_var.get()
+        ts.scenario = self.threat_scenario_var.get()
+        self.refresh_threats()
+
+    def del_threat_scenario(self):
+        fn_sel = self.func_list.curselection()
+        ds_sel = self.ds_tree.selection()
+        ts_sel = self.threat_tree.selection()
+        if not fn_sel or not ds_sel or not ts_sel:
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        ds = fn.damage_scenarios[int(ds_sel[0])]
+        del ds.threats[int(ts_sel[0])]
+        self.refresh_threats()
+        self.threat_stride_var.set("")
+        self.threat_scenario_var.set("")
+
+    # ------------------------------------------------------------------
+    # Attack Paths
+    # ------------------------------------------------------------------
+    def add_attack_path(self):
+        fn_sel = self.func_list.curselection()
+        ds_sel = self.ds_tree.selection()
+        ts_sel = self.threat_tree.selection()
+        if not fn_sel or not ds_sel or not ts_sel:
+            messagebox.showwarning("Add", "Select a threat scenario first")
+            return
+        path = self.path_var.get().strip()
+        if not path:
+            messagebox.showwarning("Add", "Enter an attack path")
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        ds = fn.damage_scenarios[int(ds_sel[0])]
+        ts = ds.threats[int(ts_sel[0])]
+        ts.attack_paths.append(AttackPath(path))
+        self.path_var.set("")
+        self.refresh_paths()
+
+    def update_attack_path(self):
+        fn_sel = self.func_list.curselection()
+        ds_sel = self.ds_tree.selection()
+        ts_sel = self.threat_tree.selection()
+        ap_sel = self.path_tree.selection()
+        if not fn_sel or not ds_sel or not ts_sel or not ap_sel:
+            messagebox.showwarning("Update", "Select an attack path")
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        ds = fn.damage_scenarios[int(ds_sel[0])]
+        ts = ds.threats[int(ts_sel[0])]
+        ap = ts.attack_paths[int(ap_sel[0])]
+        ap.description = self.path_var.get()
+        self.refresh_paths()
+
+    def del_attack_path(self):
+        fn_sel = self.func_list.curselection()
+        ds_sel = self.ds_tree.selection()
+        ts_sel = self.threat_tree.selection()
+        ap_sel = self.path_tree.selection()
+        if not fn_sel or not ds_sel or not ts_sel or not ap_sel:
+            return
+        fn = self.entry.functions[fn_sel[0]]
+        ds = fn.damage_scenarios[int(ds_sel[0])]
+        ts = ds.threats[int(ts_sel[0])]
+        del ts.attack_paths[int(ap_sel[0])]
+        self.refresh_paths()
+        self.path_var.set("")
+
+    # ------------------------------------------------------------------
+    def apply(self):
+        self.entry.asset = self.asset_var.get()
+        self.result = self.entry

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -1,0 +1,211 @@
+# Author: ChatGPT
+import tkinter as tk
+from tkinter import ttk, simpledialog
+
+from gui import messagebox
+from gui.toolboxes import ToolTip, configure_table_style
+from analysis.models import ThreatDoc, ThreatEntry
+from .threat_dialog import ThreatDialog
+
+
+class ThreatWindow(tk.Frame):
+    """Main window for Threat Analysis documents."""
+
+    def __init__(self, master, app):
+        super().__init__(master)
+        self.app = app
+        if isinstance(master, tk.Toplevel):
+            master.title("Threat Analysis")
+            master.geometry("700x350")
+            master.resizable(False, False)
+
+        top = ttk.Frame(self)
+        top.pack(fill=tk.X)
+        ttk.Label(top, text="Threat:").pack(side=tk.LEFT)
+        self.doc_var = tk.StringVar()
+        self.doc_cb = ttk.Combobox(top, textvariable=self.doc_var, state="readonly")
+        self.doc_cb.pack(side=tk.LEFT, padx=2)
+        ToolTip(self.doc_cb, "Select a Threat Analysis document to edit.")
+        ttk.Button(top, text="New", command=self.new_doc).pack(side=tk.LEFT)
+        ttk.Button(top, text="Rename", command=self.rename_doc).pack(side=tk.LEFT)
+        ttk.Button(top, text="Delete", command=self.delete_doc).pack(side=tk.LEFT)
+        self.doc_cb.bind("<<ComboboxSelected>>", self.select_doc)
+
+        columns = (
+            "asset",
+            "functions",
+            "damage",
+            "damage_type",
+            "threat",
+            "path",
+        )
+        content = ttk.Frame(self)
+        content.pack(fill=tk.BOTH, expand=True)
+        configure_table_style("Threat.Treeview")
+        self.tree = ttk.Treeview(
+            content,
+            columns=columns,
+            show="headings",
+            style="Threat.Treeview",
+            height=8,
+        )
+        self.tree.heading("asset", text="Asset")
+        self.tree.heading("functions", text="Functions")
+        self.tree.heading("damage", text="Damage Scenario")
+        self.tree.heading("damage_type", text="Damage Scenario Type")
+        self.tree.heading("threat", text="Threat Scenario (STRIDE)")
+        self.tree.heading("path", text="Attack Paths")
+        self.tree.column("asset", width=120)
+        self.tree.column("functions", width=120)
+        self.tree.column("damage", width=200)
+        self.tree.column("damage_type", width=150)
+        self.tree.column("threat", width=200)
+        self.tree.column("path", width=200)
+        vsb = ttk.Scrollbar(content, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=vsb.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        content.columnconfigure(0, weight=1)
+        content.rowconfigure(0, weight=1)
+        self.tree.bind("<Double-1>", self.on_double_click)
+
+        btn = ttk.Frame(self)
+        btn.pack(fill=tk.X)
+        add_btn = ttk.Button(btn, text="Add", command=self.add_row)
+        add_btn.pack(side=tk.LEFT, padx=2, pady=2)
+        ToolTip(add_btn, "Insert a new Threat Analysis entry.")
+        edit_btn = ttk.Button(btn, text="Edit", command=self.edit_row)
+        edit_btn.pack(side=tk.LEFT, padx=2, pady=2)
+        ToolTip(edit_btn, "Edit the selected Threat Analysis entry.")
+        del_btn = ttk.Button(btn, text="Delete", command=self.del_row)
+        del_btn.pack(side=tk.LEFT, padx=2, pady=2)
+        ToolTip(del_btn, "Remove the selected Threat Analysis entry.")
+
+        self.refresh_docs()
+        self.refresh()
+        if not isinstance(master, tk.Toplevel):
+            self.pack(fill=tk.BOTH, expand=True)
+
+    # ------------------------------------------------------------------
+    # Document management
+    # ------------------------------------------------------------------
+    def refresh_docs(self):
+        names = [d.name for d in self.app.threat_docs]
+        self.doc_cb["values"] = names
+        if self.app.active_threat:
+            self.doc_var.set(self.app.active_threat.name)
+        elif names:
+            self.doc_var.set(names[0])
+            self.select_doc()
+
+    def select_doc(self, *_):
+        name = self.doc_var.get()
+        for d in self.app.threat_docs:
+            if d.name == name:
+                self.app.active_threat = d
+                self.app.threat_entries = d.entries
+                break
+        self.refresh()
+
+    def new_doc(self):
+        name = simpledialog.askstring("New Threat Analysis", "Name:")
+        if not name:
+            return
+        doc = ThreatDoc(name, [])
+        self.app.threat_docs.append(doc)
+        self.app.active_threat = doc
+        self.app.threat_entries = doc.entries
+        self.refresh_docs()
+        self.refresh()
+        self.app.update_views()
+
+    def rename_doc(self):
+        if not self.app.active_threat:
+            return
+        name = simpledialog.askstring(
+            "Rename Threat Analysis", "Name:", initialvalue=self.app.active_threat.name
+        )
+        if not name:
+            return
+        self.app.active_threat.name = name
+        self.refresh_docs()
+        self.app.update_views()
+
+    def delete_doc(self):
+        doc = self.app.active_threat
+        if not doc:
+            return
+        if not messagebox.askyesno("Delete", f"Delete Threat '{doc.name}'?"):
+            return
+        self.app.threat_docs.remove(doc)
+        if self.app.threat_docs:
+            self.app.active_threat = self.app.threat_docs[0]
+            self.app.threat_entries = self.app.active_threat.entries
+        else:
+            self.app.active_threat = None
+            self.app.threat_entries = []
+        self.refresh_docs()
+        self.refresh()
+        self.app.update_views()
+
+    # ------------------------------------------------------------------
+    # Table actions
+    # ------------------------------------------------------------------
+    def refresh(self):
+        self.tree.delete(*self.tree.get_children())
+        for idx, entry in enumerate(self.app.threat_entries):
+            fn_names = []
+            damages = []
+            types = []
+            threats = []
+            paths = []
+            for fn in entry.functions:
+                fn_names.append(fn.function)
+                for ds in fn.damage_scenarios:
+                    damages.append(ds.scenario)
+                    types.append(ds.dtype)
+                    for ts in ds.threats:
+                        threats.append(ts.scenario)
+                        for ap in ts.attack_paths:
+                            paths.append(ap.description)
+            self.tree.insert(
+                "",
+                "end",
+                iid=str(idx),
+                values=(
+                    entry.asset,
+                    "; ".join(fn_names),
+                    "; ".join(damages),
+                    "; ".join(types),
+                    "; ".join(threats),
+                    "; ".join(paths),
+                ),
+            )
+
+    def on_double_click(self, *_):
+        self.edit_row()
+
+    def add_row(self):
+        dlg = ThreatDialog(self, self.app)
+        if dlg.result:
+            self.app.threat_entries.append(dlg.result)
+            self.refresh()
+
+    def edit_row(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        idx = int(sel[0])
+        entry = self.app.threat_entries[idx]
+        dlg = ThreatDialog(self, self.app, entry)
+        if dlg.result:
+            self.app.threat_entries[idx] = dlg.result
+            self.refresh()
+
+    def del_row(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        idx = int(sel[0])
+        del self.app.threat_entries[idx]
+        self.refresh()


### PR DESCRIPTION
## Summary
- nest damage scenarios under each function in threat entries
- clarify threat dialog with fixed-size window and "Damage Scenario" labels
- make threat analysis window fixed size with explicit columns for damage scenario, type, threat scenario (STRIDE), and attack paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689af5e05850832593d264620e20bfc1