### PR TITLE
Ensure threat entry dialog shows action buttons

### DIFF
--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -523,3 +523,15 @@ class ThreatDialog(simpledialog.Dialog):
     def apply(self):
         self.entry.asset = self.asset_var.get()
         self.result = self.entry
+
+    # ------------------------------------------------------------------
+    def buttonbox(self):
+        """Add visible OK/Cancel buttons to the dialog."""
+        box = ttk.Frame(self)
+        ok_btn = ttk.Button(box, text="OK", width=10, command=self.ok)
+        ok_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        cancel_btn = ttk.Button(box, text="Cancel", width=10, command=self.cancel)
+        cancel_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        self.bind("<Return>", self.ok)
+        self.bind("<Escape>", self.cancel)
+        box.pack(side=tk.BOTTOM, fill=tk.X)


### PR DESCRIPTION
## Summary
- Add explicit OK/Cancel button box to the Edit Threat Entry dialog so changes can be confirmed or cancelled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b17bb51248325bc86cb4404bc8ce8