### PR TITLE
Ensure threat entry dialog shows action buttons

### DIFF
--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -238,8 +238,6 @@ class ThreatDialog(simpledialog.Dialog):
         )
 
         self.refresh_ds()
-        self.geometry("700x500")
-        self.resizable(False, False)
         return nb
 
     # ------------------------------------------------------------------
@@ -523,3 +521,18 @@ class ThreatDialog(simpledialog.Dialog):
     def apply(self):
         self.entry.asset = self.asset_var.get()
         self.result = self.entry
+
+    # ------------------------------------------------------------------
+    def buttonbox(self):
+        """Add visible OK/Cancel buttons to the dialog."""
+        box = ttk.Frame(self)
+        ok_btn = ttk.Button(box, text="OK", width=10, command=self.ok)
+        ok_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        cancel_btn = ttk.Button(box, text="Cancel", width=10, command=self.cancel)
+        cancel_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        self.bind("<Return>", self.ok)
+        self.bind("<Escape>", self.cancel)
+        box.pack(side=tk.BOTTOM, fill=tk.X)
+        self.update_idletasks()
+        self.geometry(f"700x{self.winfo_reqheight()}")
+        self.resizable(False, False)


### PR DESCRIPTION
## Summary
- Reserve space for OK/Cancel buttons in the Edit Threat Entry dialog by resizing after packing the button box

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b17bb51248325bc86cb4404bc8ce8