### PR TITLE
Rename HARA analysis UI to risk assessment

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -363,7 +363,7 @@ from gui.toolboxes import (
     ReliabilityWindow,
     FI2TCWindow,
     HazopWindow,
-    HaraWindow,
+    RiskAssessmentWindow,
     TC2FIWindow,
     HazardExplorerWindow,
     RequirementsExplorerWindow,
@@ -1506,7 +1506,7 @@ class EditNodeDialog(simpledialog.Dialog):
         self.update_basic_event_probabilities()
 
     def invalidate_reviews_for_hara(self, name):
-        """Reopen reviews associated with the given HARA."""
+        """Reopen reviews associated with the given risk assessment."""
         for r in self.reviews:
             if name in getattr(r, "hara_names", []):
                 r.closed = False
@@ -1543,7 +1543,7 @@ class EditNodeDialog(simpledialog.Dialog):
         self.update_requirement_statuses()
 
     def invalidate_reviews_for_hara(self, name):
-        """Reopen reviews associated with the given HARA."""
+        """Reopen reviews associated with the given risk assessment."""
         for r in self.reviews:
             if name in getattr(r, "hara_names", []):
                 r.closed = False
@@ -2162,8 +2162,8 @@ class FaultTreeApp:
         qualitative_menu = tk.Menu(menubar, tearoff=0)
         qualitative_menu.add_command(label="HAZOP Analysis", command=self.open_hazop_window)
         qualitative_menu.add_command(
-            label="Risk Assessment (HARA, HIRE & TARA)",
-            command=self.open_hara_window,
+            label="Risk Assessment",
+            command=self.open_risk_assessment_window,
         )
         qualitative_menu.add_command(label="STPA Analysis", command=self.open_stpa_window)
         qualitative_menu.add_command(label="Threat Analysis", command=self.open_threat_window)
@@ -2288,7 +2288,7 @@ class FaultTreeApp:
             "FMEDA Manager": self.show_fmeda_list,
             "FMEA Manager": self.show_fmea_list,
             "HAZOP Analysis": self.open_hazop_window,
-            "Risk Assessment (HARA, HIRE & TARA)": self.open_hara_window,
+            "Risk Assessment": self.open_risk_assessment_window,
             "STPA Analysis": self.open_stpa_window,
             "Threat Analysis": self.open_threat_window,
             "Hazards Editor": self.show_hazard_editor,
@@ -2328,7 +2328,7 @@ class FaultTreeApp:
                 "TC2FI Analysis",
             ],
             "Risk Assessment": [
-                "HARA Analysis",
+                "Risk Assessment",
                 "Product Goals Export",
                 "Product Goals Editor",
             ],
@@ -3288,7 +3288,7 @@ class FaultTreeApp:
         return None
 
     def update_hara_statuses(self):
-        """Update each HARA document's status based on linked reviews."""
+        """Update each risk assessment document's status based on linked reviews."""
         for doc in self.hara_docs:
             status = "draft"
             for review in self.reviews:
@@ -3315,7 +3315,7 @@ class FaultTreeApp:
             te.status = status
 
     def get_safety_goal_asil(self, sg_name):
-        """Return the highest ASIL level for a safety goal name across approved HARAs."""
+        """Return the highest ASIL level for a safety goal name across approved risk assessments."""
         best = "QM"
         for doc in getattr(self, "hara_docs", []):
             if not getattr(doc, "approved", False) and getattr(doc, "status", "") != "closed":
@@ -3330,7 +3330,7 @@ class FaultTreeApp:
         return best
 
     def get_hara_goal_asil(self, sg_name):
-        """Return highest ASIL from all HARA entries for the given safety goal."""
+        """Return highest ASIL from all risk assessment entries for the given safety goal."""
         best = "QM"
         for doc in getattr(self, "hara_docs", []):
             for e in doc.entries:
@@ -3705,7 +3705,7 @@ class FaultTreeApp:
         }
 
     def sync_hara_to_safety_goals(self):
-        """Propagate HARA values to top events, inheriting ASILs from HARA rows."""
+        """Propagate risk assessment values to top events, inheriting ASILs from assessment rows."""
         sg_data = {}
         sg_asil = {}
         for doc in getattr(self, "hara_docs", []):
@@ -7595,12 +7595,12 @@ class FaultTreeApp:
                 Story.append(table)
                 Story.append(Spacer(1, 12))
 
-        # --- Risk Assessment (HARA, HIRE & TARA) ---
+        # --- Risk Assessment ---
         if self.hara_docs:
             Story.append(PageBreak())
             Story.append(
                 Paragraph(
-                    "Risk Assessment (HARA, HIRE & TARA)",
+                    "Risk Assessment",
                     pdf_styles["Heading2"],
                 )
             )
@@ -8080,11 +8080,11 @@ class FaultTreeApp:
                 self._hazop_window.doc_var.set(doc.name)
                 self._hazop_window.select_doc()
         elif kind == "hara":
-            self.open_hara_window()
-            if hasattr(self, "_hara_window"):
+            self.open_risk_assessment_window()
+            if hasattr(self, "_risk_window"):
                 doc = self.hara_docs[idx]
-                self._hara_window.doc_var.set(doc.name)
-                self._hara_window.select_doc()
+                self._risk_window.doc_var.set(doc.name)
+                self._risk_window.select_doc()
         elif kind == "stpa":
             self.open_stpa_window()
             if hasattr(self, "_stpa_window"):
@@ -8738,7 +8738,7 @@ class FaultTreeApp:
             self.odd_elements.extend(lib.get("elements", []))
 
     def update_hazard_list(self):
-        """Aggregate hazards from HARA and HAZOP documents."""
+        """Aggregate hazards from risk assessment and HAZOP documents."""
         hazards: list[str] = []
         for doc in self.hara_docs:
             for e in doc.entries:
@@ -8991,9 +8991,9 @@ class FaultTreeApp:
 
             # --- Risk Assessment Section ---
             risk_root = tree.insert("", "end", text="Risk Assessment", open=True)
-            hara_root = tree.insert(risk_root, "end", text="HARAs", open=True)
+            assessment_root = tree.insert(risk_root, "end", text="Risk Assessments", open=True)
             for idx, doc in enumerate(self.hara_docs):
-                tree.insert(hara_root, "end", text=doc.name, tags=("hara", str(idx)))
+                tree.insert(assessment_root, "end", text=doc.name, tags=("hara", str(idx)))
             tree.insert(risk_root, "end", text="Product Goals", tags=("sg", "0"))
 
             # --- Safety Analysis Section ---
@@ -12347,7 +12347,7 @@ class FaultTreeApp:
     def build_cause_effect_data(self):
         """Collect cause and effect chain information."""
         rows = {}
-        # Map hazards to malfunctions from HARA entries
+        # Map hazards to malfunctions from risk assessment entries
         for doc in self.hara_docs:
             for e in doc.entries:
                 haz = e.hazard.strip()
@@ -13950,12 +13950,12 @@ class FaultTreeApp:
         self._hazop_tab = self._new_tab("HAZOP")
         self._hazop_window = HazopWindow(self._hazop_tab, self)
 
-    def open_hara_window(self):
-        if hasattr(self, "_hara_tab") and self._hara_tab.winfo_exists():
-            self.doc_nb.select(self._hara_tab)
+    def open_risk_assessment_window(self):
+        if hasattr(self, "_risk_tab") and self._risk_tab.winfo_exists():
+            self.doc_nb.select(self._risk_tab)
             return
-        self._hara_tab = self._new_tab("HARA")
-        self._hara_window = HaraWindow(self._hara_tab, self)
+        self._risk_tab = self._new_tab("Risk Assessment")
+        self._risk_window = RiskAssessmentWindow(self._risk_tab, self)
 
     def open_stpa_window(self):
         if hasattr(self, "_stpa_tab") and self._stpa_tab.winfo_exists():
@@ -14483,13 +14483,13 @@ class FaultTreeApp:
     def edit_severity(self):
         messagebox.showinfo(
             "Severity",
-            "Severity is determined from the HARA and cannot be edited here.",
+            "Severity is determined from the risk assessment and cannot be edited here.",
         )
 
     def edit_controllability(self):
         messagebox.showinfo(
             "Controllability",
-            "Controllability is determined from the HARA and cannot be edited here.",
+            "Controllability is determined from the risk assessment and cannot be edited here.",
         )
 
     def edit_page_flag(self):
@@ -14885,7 +14885,7 @@ class FaultTreeApp:
                 hazops = [hazop] if hazop else []
             self.hara_docs.append(
                 HaraDoc(
-                    d.get("name", f"HARA {len(self.hara_docs)+1}"),
+                    d.get("name", f"Risk Assessment {len(self.hara_docs)+1}"),
                     hazops,
                     entries,
                     d.get("approved", False),
@@ -15354,7 +15354,7 @@ class FaultTreeApp:
                 hazops = [hazop] if hazop else []
             self.hara_docs.append(
                 HaraDoc(
-                    d.get("name", f"HARA {len(self.hara_docs)+1}"),
+                    d.get("name", f"Risk Assessment {len(self.hara_docs)+1}"),
                     hazops,
                     entries,
                     d.get("approved", False),
@@ -15539,7 +15539,7 @@ class FaultTreeApp:
         for event in self.top_events:
             self.update_global_requirements_from_nodes(event)
 
-        # Propagate ASIL values from HARA entries to loaded safety goals
+        # Propagate ASIL values from risk assessment entries to loaded safety goals
         if hasattr(self, "hara_entries"):
             self.sync_hara_to_safety_goals()
         
@@ -16101,7 +16101,7 @@ class FaultTreeApp:
                 lines.append(f" - {name}")
             lines.append("")
         if getattr(review, 'hara_names', []):
-            lines.append("HARAs:")
+            lines.append("Risk Assessments:")
             for name in review.hara_names:
                 lines.append(f" - {name}")
             lines.append("")
@@ -16489,7 +16489,7 @@ class FaultTreeApp:
                     global_requirements[rid]["asil"] = asil
 
     def ensure_asil_consistency(self):
-        """Sync safety goal ASILs from HARAs and update requirement ASILs."""
+        """Sync safety goal ASILs from risk assessments and update requirement ASILs."""
         self.update_fta_statuses()
         self.sync_hara_to_safety_goals()
         self.update_hazard_list()
@@ -16497,7 +16497,7 @@ class FaultTreeApp:
         self.update_all_validation_criteria()
 
     def invalidate_reviews_for_hara(self, name):
-        """Reopen reviews associated with the given HARA."""
+        """Reopen reviews associated with the given risk assessment."""
         for r in self.reviews:
             if name in getattr(r, "hara_names", []):
                 r.closed = False
@@ -16738,7 +16738,7 @@ class FaultTreeNode:
         self.x = 50
         self.y = 50
         # Severity and controllability now use a 1-3 scale
-        # Default to the lowest level until linked to a HARA entry
+        # Default to the lowest level until linked to a risk assessment entry
         self.severity = 1 if node_type.upper() == "TOP EVENT" else None
         self.controllability = 1 if node_type.upper() == "TOP EVENT" else None
         self.input_subtype = None

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AutoML is an automotive modeling language. It lets you model items, operating sc
 
 - [Workflow Overview](#workflow-overview)
 - [HAZOP Analysis](#hazop-analysis)
-- [Risk Assessment (HARA, HIRE & TARA)](#risk-assessment-hara-hire--tara)
+- [Risk Assessment](#risk-assessment)
 - [Requirements Creation and Management](#requirements-creation-and-management)
 - [AutoML Diagrams and Safety Analyses](#automl-diagrams-and-safety-analyses)
 - [Metamodel Overview](#metamodel-overview)
@@ -46,7 +46,7 @@ flowchart TD
     X --> R([Reliability analysis<br/>inputs: BOM<br/>outputs: FIT rates & parts])
     A([System functions & architecture]) --> B([HAZOP<br/>inputs: functions<br/>outputs: malfunctions])
     A --> S([FI2TC / TC2FI<br/>inputs: functions<br/>outputs: hazards, FIs & TCs, severity])
-    B --> C([HARA<br/>inputs: malfunctions & SOTIF severity<br/>outputs: hazards, ASIL, safety goals])
+    B --> C([Risk Assessment<br/>inputs: malfunctions & SOTIF severity<br/>outputs: hazards, ASIL, safety goals])
     S --> C
     A --> D([FMEA / FMEDA<br/>inputs: architecture, malfunctions, reliability<br/>outputs: failure modes])
     R --> D
@@ -58,20 +58,20 @@ flowchart TD
     G --> H([ASIL propagation to SGs, FMEAs and FTAs])
 ```
 
-The workflow begins by entering system functions and architecture elements. A **BOM** is imported into a **Reliability analysis** which produces FIT rates and component lists used by the **FMEA/FMEDA** tables. A **HAZOP** analysis identifies malfunctions while the **FI2TC/TC2FI** tables capture SOTIF hazards, functional insufficiencies and triggering conditions along with their severities. The **HARA** inherits these severities and assigns hazards and ASIL ratings to safety goals which then inform FMEDAs and **FTA** diagrams. Fault trees and failure modes generate safety requirements that go through peer or joint **reviews**. When a review is approved any changes to requirements or analyses automatically update the ASIL values traced back to the safety goals, FMEAs and FTAs.
+The workflow begins by entering system functions and architecture elements. A **BOM** is imported into a **Reliability analysis** which produces FIT rates and component lists used by the **FMEA/FMEDA** tables. A **HAZOP** analysis identifies malfunctions while the **FI2TC/TC2FI** tables capture SOTIF hazards, functional insufficiencies and triggering conditions along with their severities. The **risk assessment** inherits these severities and assigns hazards and ASIL ratings to safety goals which then inform FMEDAs and **FTA** diagrams. Fault trees and failure modes generate safety requirements that go through peer or joint **reviews**. When a review is approved any changes to requirements or analyses automatically update the ASIL values traced back to the safety goals, FMEAs and FTAs.
 
 ## HAZOP Analysis
 
 The **HAZOP Analysis** window lets you list system functions with one or more associated malfunctions. Each entry records the malfunction guideword (*No/Not*, *Unintended*, *Excessive*, *Insufficient* or *Reverse*), the related scenario, driving conditions and hazard, and whether it is safety relevant. Covered malfunctions may reference other entries as mitigation. When a function is allocated to an active component in a reliability analysis, its malfunctions become selectable failure modes in the FMEDA table.
 
-## Risk Assessment (HARA, HIRE & TARA)
+## Risk Assessment
 
-The **Risk Assessment (HARA, HIRE & TARA)** view builds on the safety relevant malfunctions from one or more selected HAZOPs. When creating a new HARA you can pick multiple HAZOP documents; only malfunctions from those selections appear in the table. Each HARA table contains the following columns:
+The **Risk Assessment** view builds on the safety relevant malfunctions from one or more selected HAZOPs. When creating a new assessment you can pick multiple HAZOP documents; only malfunctions from those selections appear in the table. Each assessment table contains the following columns:
 
 1. **Malfunction** – combo box listing malfunctions flagged as safety relevant in the chosen HAZOP documents.
 2. **Hazard** – textual description of the resulting hazard.
 3. **Severity** – ISO&nbsp;26262 severity level (1–3). Values from FI2TC and
-   TC2FI analyses are inherited here so the HARA reflects SOTIF hazards.
+   TC2FI analyses are inherited here so the risk assessment reflects SOTIF hazards.
 4. **Severity Rationale** – free text explanation for the chosen severity.
 5. **Controllability** – ISO&nbsp;26262 controllability level (1–3).
 6. **Controllability Rationale** – free text explanation for the chosen controllability.
@@ -82,7 +82,7 @@ The **Risk Assessment (HARA, HIRE & TARA)** view builds on the safety relevant m
 
 The calculated ASIL from each row is propagated to the referenced safety goal so that inherited ASIL levels appear consistently in all analyses and documentation, including FTA top level events.
 
-The **Hazard Explorer** window lists all hazards from every HARA in a read-only table for quick review or CSV export. A **Requirements Explorer** window lets you query global requirements with filters for text, type, ASIL and status.
+The **Hazard Explorer** window lists all hazards from every risk assessment in a read-only table for quick review or CSV export. A **Requirements Explorer** window lets you query global requirements with filters for text, type, ASIL and status.
 
 ## Requirements Creation and Management
 
@@ -98,7 +98,7 @@ Activity diagrams list individual **actions** that describe the expected behavio
 
 Elements on a diagram may reference reliability analyses. Choosing an **analysis** or **component** automatically fills the **fit**, **qualification** and **failureModes** fields using data from FMEA and FMEDA tables. These values show up in a *Reliability* compartment for blocks or below parts. When a block references an analysis, the components from that analysis BOM can be inserted as parts in the linked internal block diagram with their failure modes already listed.
 
-Requirements can also be attached to diagram elements to keep architecture and safety analyses synchronized. The same safety goals referenced in HAZOP or HARA tables can therefore be traced directly to the blocks and parts that implement them.
+Requirements can also be attached to diagram elements to keep architecture and safety analyses synchronized. The same safety goals referenced in HAZOP or risk assessment tables can therefore be traced directly to the blocks and parts that implement them.
 
 ## Metamodel Overview
 
@@ -233,7 +233,7 @@ classDiagram
 AutoML builds on this base by introducing domain specific stereotypes for safety
 analysis. Hazards, faults and scenarios are stored using explicit types such as
 `Hazard`, `Scenario`, `Scenery`, `SafetyGoal` and `FaultTreeNode`. Tables like
-HAZOP or HARA reference these elements so analyses remain linked to the
+HAZOP or risk assessment reference these elements so analyses remain linked to the
 architecture.
 
 ```mermaid
@@ -417,8 +417,8 @@ instances capture on/off times and temperature ranges used when converting FIT
 rates to probabilities. `MechanismLibrary` collections hold
 `DiagnosticMechanism` entries from ISO 26262 Annex D so FMEDAs can select the
 appropriate diagnostic coverage. `ScenarioLibrary` and `OddLibrary` objects
-group reusable scenarios and ODD elements so HAZOP, HARA and FI2TC/TC2FI tables
-share a consistent context. HAZOP and HARA tables use `HazopDoc`/`HazopEntry`
+group reusable scenarios and ODD elements so HAZOP, risk assessment and FI2TC/TC2FI tables
+share a consistent context. HAZOP and risk assessment tables use `HazopDoc`/`HazopEntry`
 and `HaraDoc`/`HaraEntry` pairs to store their rows. FMEA and FMEDA tables are
 stored as `FmeaDoc` and `FmedaDoc` with lists of generic `FmeaEntry`
 dictionaries capturing the failure mode, cause, detection rating and diagnostic
@@ -557,7 +557,7 @@ the names or IDs of the analyses being evaluated.
   listing applicable `failureModes` and storing the assigned `asil` level.
 - **SafetyGoal** – specialization of `Requirement` holding a textual
   `description`, `asil` rating and quantitative targets `spfm`, `lpfm` and `dc`.
-- **Hazard** – extends `SysMLElement` with a hazard `description` and HARA
+- **Hazard** – extends `SysMLElement` with a hazard `description` and risk assessment
   `severity` plus the related `scenarios`.
 - **Scenario** – extends `SysMLElement` to include a short `description`, linked
   `scenery` context and traced `hazards`.
@@ -612,7 +612,7 @@ Key attributes are:
 - **SafetyGoal** – textual `description`, assigned `asil` level and quantitative
   targets `spfm`, `lpfm` and `dc`. Each goal also lists allocated safety
   `requirements`.
-- **Hazard** – hazard `description`, HARA `severity` and the related
+- **Hazard** – hazard `description`, risk assessment `severity` and the related
   `scenarios` that can lead to it.
 - **Scenario** – short `description`, linked `scenery` context and traced
   `hazards`.
@@ -711,7 +711,7 @@ classDiagram
     Requirement <|-- SafetyGoal
 ```
 
-**Hazard** – extends `SysMLElement` to store the hazard `description` and HARA `severity`.
+**Hazard** – extends `SysMLElement` to store the hazard `description` and risk assessment `severity`.
 
 ```mermaid
 classDiagram
@@ -1044,9 +1044,9 @@ Two additional tables support tracing between these elements:
   **functional_insufficiencies** fields mirror those in the FI2TC table to keep
   the relationships consistent.
 
-Severity recorded in FI2TC and TC2FI entries is inherited by the HARA so the risk graph reflects the SOTIF findings. Other HARA values such as the associated safety goal flow into these tables so SOTIF considerations remain connected to the overall risk assessment. Minimal cut sets calculated from the FTAs highlight combinations of FIs and TCs that form *CTAs*. From a CTA entry you can generate a functional modification requirement describing how the design must change to avoid the unsafe behaviour.
+Severity recorded in FI2TC and TC2FI entries is inherited by the risk assessment so the risk graph reflects the SOTIF findings. Other risk assessment values such as the associated safety goal flow into these tables so SOTIF considerations remain connected to the overall risk assessment. Minimal cut sets calculated from the FTAs highlight combinations of FIs and TCs that form *CTAs*. From a CTA entry you can generate a functional modification requirement describing how the design must change to avoid the unsafe behaviour.
 
-All FI2TC and TC2FI documents appear in the *Hazard Analysis* section of the **Analyses** tab so they can be opened alongside HARA tables, FTAs and CTAs for a complete view of functional safety and SOTIF issues.
+All FI2TC and TC2FI documents appear in the *Hazard Analysis* section of the **Analyses** tab so they can be opened alongside risk assessment tables, FTAs and CTAs for a complete view of functional safety and SOTIF issues.
 
 ### SOTIF Traceability
 
@@ -1225,10 +1225,10 @@ Steps to reproduce:
 |----------|-------------|----------|--------|-----------|
 | Stop at Intersection | Does not stop at intersection | Pedestrians crossing | Run over VRUs | If the vehicle fails to stop when pedestrians are crossing, it may run over vulnerable road users. |
 
-### Risk Assessment (HARA, HIRE & TARA)
+### Risk Assessment
 
 Steps to reproduce:
-1. Open **Safety → Risk Assessment (HARA, HIRE & TARA)** and create a new document linked to the HAZOP entry.
+1. Open **Safety → Risk Assessment** and create a new document linked to the HAZOP entry.
 2. Set Severity = 3, Controllability = 3, Exposure = 4; AutoML computes ASIL D.
 3. Export or save to view the table.
 
@@ -1274,5 +1274,5 @@ Steps to reproduce:
 | resistor | resistor | 20 | 297.505 |
 | capacitor | capacitor | 10 | 961.17 |
 
-This end-to-end flow links HAZOP findings to HARA ratings, fault trees and FMEDA metrics for a coherent safety case.
+This end-to-end flow links HAZOP findings to risk assessment ratings, fault trees and FMEDA metrics for a coherent safety case.
 

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -292,7 +292,7 @@ class ReviewScopeDialog(simpledialog.Dialog):
             cb = tk.Checkbutton(hazop_frame, text=d.name, variable=var, anchor="w")
             cb.pack(fill=tk.X, anchor="w")
             self.hazop_vars.append((var, d.name))
-        tk.Label(master, text="HARAs:").grid(row=0, column=4, padx=5, pady=5, sticky="w")
+        tk.Label(master, text="Risk Assessments:").grid(row=0, column=4, padx=5, pady=5, sticky="w")
         self.hara_vars = []
         hara_frame = tk.Frame(master)
         hara_frame.grid(row=1, column=4, padx=5, pady=5, sticky="nsew")
@@ -742,8 +742,8 @@ class ReviewToolbox(tk.Frame):
                 self.app.update_hara_statuses()
                 self.app.update_fta_statuses()
                 self.app.update_requirement_statuses()
-                if hasattr(self.app, "_hara_window") and self.app._hara_window.winfo_exists():
-                    self.app._hara_window.refresh_docs()
+                if hasattr(self.app, "_risk_window") and self.app._risk_window.winfo_exists():
+                    self.app._risk_window.refresh_docs()
                 self.refresh_reviews()
         else:
             approvers = [p for p in r.participants if p.role == 'approver']
@@ -762,8 +762,8 @@ class ReviewToolbox(tk.Frame):
                 if not was_closed and r.closed:
                     self.app.ensure_asil_consistency()
                     self.app.update_base_event_requirement_asil()
-                if hasattr(self.app, "_hara_window") and self.app._hara_window.winfo_exists():
-                    self.app._hara_window.refresh_docs()
+                if hasattr(self.app, "_risk_window") and self.app._risk_window.winfo_exists():
+                    self.app._risk_window.refresh_docs()
                 self.refresh_reviews()
 
     def refresh_targets(self):
@@ -1443,7 +1443,7 @@ class ReviewDocumentDialog(tk.Frame):
             new_entries = new_hara.get(name, [])
             if not old_entries and not new_entries:
                 continue
-            tk.Label(self.inner, text=f"HARA: {name}", font=heading_font).grid(row=row, column=0, sticky='w', padx=5, pady=5)
+            tk.Label(self.inner, text=f"Risk Assessment: {name}", font=heading_font).grid(row=row, column=0, sticky='w', padx=5, pady=5)
             row += 1
             frame = tk.Frame(self.inner)
             frame.grid(row=row, column=0, sticky='nsew', padx=5, pady=5)
@@ -1652,7 +1652,7 @@ class VersionCompareDialog(tk.Frame):
         self.hazop_tree.tag_configure("existing", background="#e2e3e5")
 
         columns_hara = [
-            "HARA",
+            "Assessment",
             "Malfunction",
             "Hazard",
             "Severity",
@@ -2434,7 +2434,7 @@ class VersionCompareDialog(tk.Frame):
                     # Insert removed HAZOP entry
                     self.hazop_tree.insert("", "end", values=row, tags=("removed",))
 
-        # ----- HARA diff -----
+        # ----- Risk Assessment diff -----
         self.hara_tree.delete(*self.hara_tree.get_children())
         hr1 = {d["name"]: d for d in data1.get("haras", [])}
         hr2 = {d["name"]: d for d in data2.get("haras", [])}

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -1633,13 +1633,13 @@ class HazopWindow(tk.Frame):
         btn.pack(fill=tk.X)
         hara_add_btn = ttk.Button(btn, text="Add", command=self.add_row)
         hara_add_btn.pack(side=tk.LEFT, padx=2, pady=2)
-        ToolTip(hara_add_btn, "Insert a new HARA entry.")
+        ToolTip(hara_add_btn, "Insert a new risk assessment entry.")
         hara_edit_btn = ttk.Button(btn, text="Edit", command=self.edit_row)
         hara_edit_btn.pack(side=tk.LEFT, padx=2, pady=2)
-        ToolTip(hara_edit_btn, "Edit the selected HARA row.")
+        ToolTip(hara_edit_btn, "Edit the selected risk assessment row.")
         hara_del_btn = ttk.Button(btn, text="Delete", command=self.del_row)
         hara_del_btn.pack(side=tk.LEFT, padx=2, pady=2)
-        ToolTip(hara_del_btn, "Delete the selected HARA row.")
+        ToolTip(hara_del_btn, "Delete the selected risk assessment row.")
 
         self.refresh_docs()
         self.refresh()
@@ -2023,7 +2023,7 @@ class HazopWindow(tk.Frame):
         messagebox.showinfo("Save", "Analysis saved")
 
 
-class HaraWindow(tk.Frame):
+class RiskAssessmentWindow(tk.Frame):
     COLS = [
         "malfunction",
         "hazard",
@@ -2042,19 +2042,19 @@ class HaraWindow(tk.Frame):
         super().__init__(master)
         self.app = app
         if isinstance(master, tk.Toplevel):
-            master.title("Risk Assessment (HARA, HIRE & TARA)")
+            master.title("Risk Assessment")
         top = ttk.Frame(self)
         top.pack(fill=tk.X)
-        hara_lbl = ttk.Label(top, text="HARA:")
-        hara_lbl.pack(side=tk.LEFT)
-        ToolTip(hara_lbl, "Select a HARA document to work on.")
+        assessment_lbl = ttk.Label(top, text="Assessment:")
+        assessment_lbl.pack(side=tk.LEFT)
+        ToolTip(assessment_lbl, "Select a risk assessment document to work on.")
         self.doc_var = tk.StringVar()
         self.doc_cb = ttk.Combobox(top, textvariable=self.doc_var, state="readonly")
         self.doc_cb.pack(side=tk.LEFT, padx=2)
-        ToolTip(self.doc_cb, "Only HARAs defined in the project appear here.")
-        new_hara_btn = ttk.Button(top, text="New", command=self.new_doc)
-        new_hara_btn.pack(side=tk.LEFT)
-        ToolTip(new_hara_btn, "Create a new HARA document.")
+        ToolTip(self.doc_cb, "Only risk assessments defined in the project appear here.")
+        new_assessment_btn = ttk.Button(top, text="New", command=self.new_doc)
+        new_assessment_btn.pack(side=tk.LEFT)
+        ToolTip(new_assessment_btn, "Create a new risk assessment document.")
         edit_btn = ttk.Button(top, text="Rename", command=self.rename_doc)
         edit_btn.pack(side=tk.LEFT)
         del_btn = ttk.Button(top, text="Delete", command=self.delete_doc)
@@ -2065,14 +2065,14 @@ class HaraWindow(tk.Frame):
         self.status_lbl = ttk.Label(top, text="")
         self.status_lbl.pack(side=tk.LEFT, padx=10)
 
-        configure_table_style("Hara.Treeview")
+        configure_table_style("Risk.Treeview")
         table_frame = ttk.Frame(self)
         table_frame.pack(fill=tk.BOTH, expand=True)
         self.tree = EditableTreeview(
             table_frame,
             columns=self.COLS,
             show="headings",
-            style="Hara.Treeview",
+            style="Risk.Treeview",
             edit_callback=self.on_cell_edit,
             height=8,
         )
@@ -2149,10 +2149,10 @@ class HaraWindow(tk.Frame):
                 break
         self.refresh()
 
-    class NewHaraDialog(simpledialog.Dialog):
+    class NewAssessmentDialog(simpledialog.Dialog):
         def __init__(self, parent, app):
             self.app = app
-            super().__init__(parent, title="New HARA")
+            super().__init__(parent, title="New Risk Assessment")
 
         def body(self, master):
             ttk.Label(master, text="Name").grid(row=0, column=0, sticky="e")
@@ -2170,7 +2170,7 @@ class HaraWindow(tk.Frame):
             self.result = (self.name_var.get(), sel)
 
     def new_doc(self):
-        dlg = self.NewHaraDialog(self, self.app)
+        dlg = self.NewAssessmentDialog(self, self.app)
         if not getattr(dlg, "result", None):
             return
         name, hazops = dlg.result
@@ -2187,7 +2187,7 @@ class HaraWindow(tk.Frame):
         if not self.app.active_hara:
             return
         name = simpledialog.askstring(
-            "Rename HARA", "Name:", initialvalue=self.app.active_hara.name
+            "Rename Risk Assessment", "Name:", initialvalue=self.app.active_hara.name
         )
         if not name:
             return
@@ -2199,7 +2199,7 @@ class HaraWindow(tk.Frame):
         doc = self.app.active_hara
         if not doc:
             return
-        if not messagebox.askyesno("Delete", f"Delete HARA '{doc.name}'?"):
+        if not messagebox.askyesno("Delete", f"Delete risk assessment '{doc.name}'?"):
             return
         self.app.hara_docs.remove(doc)
         if self.app.hara_docs:
@@ -2241,7 +2241,7 @@ class HaraWindow(tk.Frame):
         def __init__(self, parent, app, row=None):
             self.app = app
             self.row = row or HaraEntry("", "", "", 1, "", 1, "", 1, "", "QM", "")
-            super().__init__(parent, title="Edit HARA Row")
+            super().__init__(parent, title="Edit Risk Assessment Row")
 
         def body(self, master):
             hazop_names = []
@@ -2425,7 +2425,7 @@ class HaraWindow(tk.Frame):
 
     def add_row(self):
         if not self.app.active_hara:
-            messagebox.showwarning("Add", "Create a HARA first")
+            messagebox.showwarning("Add", "Create a risk assessment first")
             return
         dlg = self.RowDialog(self, self.app)
         self.app.hara_entries.append(dlg.row)
@@ -2495,7 +2495,7 @@ class HaraWindow(tk.Frame):
         self.app.update_hara_statuses()
         self.app.ensure_asil_consistency()
         self.app.update_views()
-        messagebox.showinfo("HARA", "HARA approved")
+        messagebox.showinfo("Risk Assessment", "Risk assessment approved")
 
 
 class TC2FIWindow(tk.Frame):
@@ -3149,14 +3149,14 @@ class TC2FIWindow(tk.Frame):
 
 
 class HazardExplorerWindow(tk.Toplevel):
-    """Read-only list of hazards per HARA."""
+    """Read-only list of hazards per risk assessment."""
 
     def __init__(self, app):
         super().__init__(app.root)
         self.app = app
         self.title("Hazard Explorer")
 
-        columns = ("HARA", "Malfunction", "Hazard", "Severity")
+        columns = ("Assessment", "Malfunction", "Hazard", "Severity")
         configure_table_style("HazExp.Treeview")
         self.tree = EditableTreeview(
             self,
@@ -3194,14 +3194,14 @@ class HazardExplorerWindow(tk.Toplevel):
             return
         with open(path, "w", newline="") as f:
             w = csv.writer(f)
-            w.writerow(["HARA", "Malfunction", "Hazard", "Severity"])
+            w.writerow(["Assessment", "Malfunction", "Hazard", "Severity"])
             for iid in self.tree.get_children():
                 w.writerow(self.tree.item(iid, "values"))
         messagebox.showinfo("Export", "Hazards exported")
 
     def on_cell_edit(self, row: int, column: str, value: str) -> None:
         values = list(self.tree.item(self.tree.get_children()[row], "values"))
-        idx = ("HARA", "Malfunction", "Hazard", "Severity").index(column)
+        idx = ("Assessment", "Malfunction", "Hazard", "Severity").index(column)
         values[idx] = value
         self.tree.item(self.tree.get_children()[row], values=values)
 


### PR DESCRIPTION
## Summary
- rename HARA analysis UI to "Risk Assessment" across menus and analysis tree
- replace HaraWindow with RiskAssessmentWindow and update related tooltips and dialog labels
- update README and hazard explorer docs to the new terminology

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b3986334c83259c14de72a5fe9968