### PR TITLE
Support STPA and threat analysis selection for risk assessments

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14779,6 +14779,8 @@ class FaultTreeApp:
                     "entries": [asdict(e) for e in doc.entries],
                     "approved": getattr(doc, "approved", False),
                     "status": getattr(doc, "status", "draft"),
+                    "stpa": getattr(doc, "stpa", ""),
+                    "threat": getattr(doc, "threat", ""),
                 }
                 for doc in self.hara_docs
             ],
@@ -14987,6 +14989,8 @@ class FaultTreeApp:
                     entries,
                     d.get("approved", False),
                     d.get("status", "draft"),
+                    stpa=d.get("stpa", ""),
+                    threat=d.get("threat", ""),
                 )
             )
         if not self.hara_docs and "hara_entries" in data:
@@ -15013,6 +15017,8 @@ class FaultTreeApp:
                     ],
                     False,
                     "draft",
+                    stpa="",
+                    threat="",
                 )
             )
         self.active_hara = self.hara_docs[0] if self.hara_docs else None
@@ -15456,6 +15462,8 @@ class FaultTreeApp:
                     entries,
                     d.get("approved", False),
                     d.get("status", "draft"),
+                    stpa=d.get("stpa", ""),
+                    threat=d.get("threat", ""),
                 )
             )
         if not self.hara_docs and "hara_entries" in data:
@@ -15482,6 +15490,8 @@ class FaultTreeApp:
                     ],
                     False,
                     "draft",
+                    stpa="",
+                    threat="",
                 )
             )
         self.active_hara = self.hara_docs[0] if self.hara_docs else None

--- a/analysis/models.py
+++ b/analysis/models.py
@@ -159,6 +159,8 @@ class HaraDoc:
     approved: bool = False
     status: str = "draft"
     meta: Metadata = field(default_factory=Metadata)
+    stpa: str = ""
+    threat: str = ""
 
 @dataclass
 class StpaEntry:

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -2066,6 +2066,10 @@ class RiskAssessmentWindow(tk.Frame):
         self.doc_cb.bind("<<ComboboxSelected>>", self.select_doc)
         self.hazop_lbl = ttk.Label(top, text="")
         self.hazop_lbl.pack(side=tk.LEFT, padx=10)
+        self.stpa_lbl = ttk.Label(top, text="")
+        self.stpa_lbl.pack(side=tk.LEFT, padx=10)
+        self.threat_lbl = ttk.Label(top, text="")
+        self.threat_lbl.pack(side=tk.LEFT, padx=10)
         self.status_lbl = ttk.Label(top, text="")
         self.status_lbl.pack(side=tk.LEFT, padx=10)
 
@@ -2128,6 +2132,10 @@ class RiskAssessmentWindow(tk.Frame):
             self.doc_var.set(self.app.active_hara.name)
             hazops = ", ".join(getattr(self.app.active_hara, "hazops", []))
             self.hazop_lbl.config(text=f"HAZOPs: {hazops}")
+            stpa = getattr(self.app.active_hara, "stpa", "")
+            self.stpa_lbl.config(text=f"STPA: {stpa}" if stpa else "STPA: none")
+            threat = getattr(self.app.active_hara, "threat", "")
+            self.threat_lbl.config(text=f"Threat: {threat}" if threat else "Threat: none")
             self.status_lbl.config(
                 text=f"Status: {getattr(self.app.active_hara, 'status', 'draft')}"
             )
@@ -2137,6 +2145,10 @@ class RiskAssessmentWindow(tk.Frame):
             doc = self.app.hara_docs[0]
             hazops = ", ".join(getattr(doc, "hazops", []))
             self.hazop_lbl.config(text=f"HAZOPs: {hazops}")
+            stpa = getattr(doc, "stpa", "")
+            self.stpa_lbl.config(text=f"STPA: {stpa}" if stpa else "STPA: none")
+            threat = getattr(doc, "threat", "")
+            self.threat_lbl.config(text=f"Threat: {threat}" if threat else "Threat: none")
             self.app.active_hara = doc
             self.app.hara_entries = doc.entries
             self.status_lbl.config(text=f"Status: {getattr(doc, 'status', 'draft')}")
@@ -2149,6 +2161,10 @@ class RiskAssessmentWindow(tk.Frame):
                 self.app.hara_entries = d.entries
                 hazops = ", ".join(getattr(d, "hazops", []))
                 self.hazop_lbl.config(text=f"HAZOPs: {hazops}")
+                stpa = getattr(d, "stpa", "")
+                self.stpa_lbl.config(text=f"STPA: {stpa}" if stpa else "STPA: none")
+                threat = getattr(d, "threat", "")
+                self.threat_lbl.config(text=f"Threat: {threat}" if threat else "Threat: none")
                 self.status_lbl.config(text=f"Status: {getattr(d, 'status', 'draft')}")
                 break
         self.refresh()
@@ -2168,17 +2184,34 @@ class RiskAssessmentWindow(tk.Frame):
             for n in names:
                 self.hazop_lb.insert(tk.END, n)
             self.hazop_lb.grid(row=1, column=1)
+            ttk.Label(master, text="STPA").grid(row=2, column=0, sticky="e")
+            stpas = [d.name for d in self.app.stpa_docs]
+            self.stpa_var = tk.StringVar()
+            ttk.Combobox(
+                master, textvariable=self.stpa_var, values=stpas, state="readonly"
+            ).grid(row=2, column=1)
+            ttk.Label(master, text="Threat Analysis").grid(row=3, column=0, sticky="e")
+            threats = [d.name for d in self.app.threat_docs]
+            self.threat_var = tk.StringVar()
+            ttk.Combobox(
+                master, textvariable=self.threat_var, values=threats, state="readonly"
+            ).grid(row=3, column=1)
 
         def apply(self):
             sel = [self.hazop_lb.get(i) for i in self.hazop_lb.curselection()]
-            self.result = (self.name_var.get(), sel)
+            self.result = (
+                self.name_var.get(),
+                sel,
+                self.stpa_var.get(),
+                self.threat_var.get(),
+            )
 
     def new_doc(self):
         dlg = self.NewAssessmentDialog(self, self.app)
         if not getattr(dlg, "result", None):
             return
-        name, hazops = dlg.result
-        doc = HaraDoc(name, hazops, [], False, "draft")
+        name, hazops, stpa, threat = dlg.result
+        doc = HaraDoc(name, hazops, [], False, "draft", stpa=stpa, threat=threat)
         self.app.hara_docs.append(doc)
         self.app.active_hara = doc
         self.app.hara_entries = doc.entries
@@ -2286,30 +2319,42 @@ class RiskAssessmentWindow(tk.Frame):
                                     scenarios_map.setdefault(e.malfunction, []).append(
                                         scen_name
                                     )
-            # STPA unsafe control actions
-            for doc in getattr(self.app, "stpa_docs", []):
-                for entry in getattr(doc, "entries", []):
-                    for uc in (
-                        entry.not_providing,
-                        entry.providing,
-                        entry.incorrect_timing,
-                        entry.stopped_too_soon,
-                    ):
-                        if uc:
-                            malfs.add(uc)
-            # Threat scenarios from threat analysis (separate list)
-            for doc in getattr(self.app, "threat_docs", []):
-                for entry in getattr(doc, "entries", []):
-                    for func in getattr(entry, "functions", []):
-                        for dmg in getattr(func, "damage_scenarios", []):
-                            for threat in getattr(dmg, "threats", []):
-                                ts = threat.scenario
-                                threats.add(ts)
-                                paths = [ap.description for ap in threat.attack_paths]
-                                self.threat_map[ts] = {
-                                    "damage": dmg.scenario,
-                                    "paths": paths,
-                                }
+            # STPA unsafe control actions from selected STPA
+            stpa_name = getattr(getattr(self.app, "active_hara", None), "stpa", "")
+            if stpa_name:
+                stpa_doc = next(
+                    (d for d in getattr(self.app, "stpa_docs", []) if d.name == stpa_name),
+                    None,
+                )
+                if stpa_doc:
+                    for entry in getattr(stpa_doc, "entries", []):
+                        for uc in (
+                            entry.not_providing,
+                            entry.providing,
+                            entry.incorrect_timing,
+                            entry.stopped_too_soon,
+                        ):
+                            if uc:
+                                malfs.add(uc)
+            # Threat scenarios from selected threat analysis (separate list)
+            threat_name = getattr(getattr(self.app, "active_hara", None), "threat", "")
+            if threat_name:
+                threat_doc = next(
+                    (d for d in getattr(self.app, "threat_docs", []) if d.name == threat_name),
+                    None,
+                )
+                if threat_doc:
+                    for entry in getattr(threat_doc, "entries", []):
+                        for func in getattr(entry, "functions", []):
+                            for dmg in getattr(func, "damage_scenarios", []):
+                                for threat in getattr(dmg, "threats", []):
+                                    ts = threat.scenario
+                                    threats.add(ts)
+                                    paths = [ap.description for ap in threat.attack_paths]
+                                    self.threat_map[ts] = {
+                                        "damage": dmg.scenario,
+                                        "paths": paths,
+                                    }
             malfs = sorted(malfs)
             threats = sorted(threats)
             goals = [

--- a/tests/test_risk_assessment_filters.py
+++ b/tests/test_risk_assessment_filters.py
@@ -1,0 +1,222 @@
+import types
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.models import (
+    HazopDoc,
+    HazopEntry,
+    HaraDoc,
+    HaraEntry,
+    StpaDoc,
+    StpaEntry,
+    ThreatDoc,
+    ThreatEntry,
+    FunctionThreat,
+    DamageScenario,
+    ThreatScenario,
+    AttackPath,
+)
+from gui.toolboxes import RiskAssessmentWindow
+
+
+def test_row_dialog_filters_stpa_and_threat(monkeypatch):
+    """Only selected STPA UCAs and threat scenarios should appear."""
+
+    # --- Analysis documents ---
+    hazop = HazopDoc(
+        "HZ1",
+        [
+            HazopEntry(
+                "f",
+                "HZ_MALF",
+                "",
+                "",
+                "",
+                "haz",
+                True,
+                "",
+                False,
+                "",
+            )
+        ],
+    )
+    stpa_sel = StpaDoc("STPA1", "", [StpaEntry("", "UCA1", "", "", "", [])])
+    stpa_other = StpaDoc("STPA2", "", [StpaEntry("", "UCA_OTHER", "", "", "", [])])
+
+    threat_sel = ThreatDoc(
+        "TA1",
+        [
+            ThreatEntry(
+                "asset",
+                [
+                    FunctionThreat(
+                        "func",
+                        [
+                            DamageScenario(
+                                "damage",
+                                threats=[
+                                    ThreatScenario(
+                                        "S",
+                                        "TS1",
+                                        [AttackPath("p")],
+                                    )
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+    threat_other = ThreatDoc(
+        "TA2",
+        [
+            ThreatEntry(
+                "asset",
+                [
+                    FunctionThreat(
+                        "func",
+                        [
+                            DamageScenario(
+                                "damage",
+                                threats=[
+                                    ThreatScenario(
+                                        "S",
+                                        "TS_OTHER",
+                                        [AttackPath("p")],
+                                    )
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+
+    hara = HaraDoc(
+        "RA1",
+        ["HZ1"],
+        [],
+        False,
+        "draft",
+        stpa="STPA1",
+        threat="TA1",
+    )
+
+    app = types.SimpleNamespace(
+        active_hara=hara,
+        hazop_docs=[hazop],
+        stpa_docs=[stpa_sel, stpa_other],
+        threat_docs=[threat_sel, threat_other],
+        top_events=[],
+        hazard_severity={},
+        get_all_scenario_names=lambda: [],
+        get_scenario_exposure=lambda scen: 1,
+        sync_cyber_risk_to_goals=lambda: None,
+        cybersecurity_goals=[],
+    )
+
+    def get_hazop_by_name(name):
+        return hazop if name == "HZ1" else None
+
+    app.get_hazop_by_name = get_hazop_by_name
+
+    # --- Stub tkinter widgets ---
+    class DummyWidget:
+        def __init__(self, *a, textvariable=None, values=None, **k):
+            self.textvariable = textvariable
+            self.configured = {"values": values}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def bind(self, *a, **k):
+            pass
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+        config = configure
+
+        def add(self, *a, **k):
+            pass
+
+        def after(self, *a, **k):
+            pass
+
+        def delete(self, *a, **k):
+            pass
+
+    class DummyText(DummyWidget):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self.content = ""
+
+        def insert(self, index, text):
+            self.content += text
+
+        def get(self, *a, **k):
+            return self.content
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, values=None, state=None, **k):
+            super().__init__(*a, textvariable=textvariable, values=values, **k)
+            self.state = state
+
+    class DummyNotebook(DummyWidget):
+        pass
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+        def trace_add(self, *a, **k):
+            pass
+
+    combo_calls = []
+
+    def combo_stub(*a, **k):
+        cb = DummyCombobox(*a, **k)
+        combo_calls.append(cb)
+        return cb
+
+    monkeypatch.setattr("gui.toolboxes.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.toolboxes.ttk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.toolboxes.ttk.Frame", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.toolboxes.ttk.Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.toolboxes.ttk.Notebook", lambda *a, **k: DummyNotebook())
+    monkeypatch.setattr("gui.toolboxes.tk.Text", DummyText)
+    monkeypatch.setattr("gui.toolboxes.tk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.toolboxes.tk.StringVar", lambda value="": DummyVar(value))
+
+    dlg = RiskAssessmentWindow.RowDialog.__new__(RiskAssessmentWindow.RowDialog)
+    dlg.app = app
+    dlg.row = HaraEntry("", "", "", 1, "", 1, "", 1, "", "QM", "")
+    dlg.body(master=DummyWidget())
+
+    mal_values = None
+    threat_values = None
+    for cb in combo_calls:
+        if cb.textvariable is getattr(dlg, "mal_var", None):
+            mal_values = cb.configured["values"]
+        if cb.textvariable is getattr(dlg, "threat_var", None):
+            threat_values = cb.configured["values"]
+
+    assert mal_values == ["HZ_MALF", "UCA1"]
+    assert threat_values == ["TS1"]
+


### PR DESCRIPTION
## Summary
- allow choosing STPA and threat analysis as inputs when creating risk assessment
- filter malfunction list to selected STPA unsafe control actions and HAZOP malfunctions
- restrict cybersecurity threat scenarios to chosen threat analysis
- add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b4c0078f48325aede24fec8b6b8cc