### PR TITLE
Auto-populate validation target probabilities from risk assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,27 @@ Use **Export Product Goal Requirements** in the Requirements menu to generate a 
 
 The **Safety Performance Indicators** tab in the Requirements menu lists each product goal's validation target and acceptance criteria with their descriptions for quick reference.
 
+### Acceptance Criteria and Validation Targets
+
+ISO 21448 provides a method to derive a validation target from an acceptance
+criterion by analysing the rate of the hazardous behaviour :math:`R_{HB}`.
+Given an acceptance criterion for a harm :math:`A_H` and conditional
+probabilities for exposure :math:`P_{E|HB}`, uncontrollability
+:math:`P_{C|E}` and severity :math:`P_{S|C}`, the acceptable rate of the
+hazardous behaviour is computed as:
+
+```
+R_HB = A_H / (P_{E|HB} * P_{C|E} * P_{S|C})
+```
+
+This value can serve as a validation target when planning tests. For example,
+an acceptance criterion of ``1e-8/h`` with ``P_{E|HB}=0.05``,
+``P_{C|E}=0.1`` and ``P_{S|C}=0.01`` yields ``R_HB = 2e-4/h``.
+The product goal editor derives exposure, controllability and severity
+probabilities from their risk assessment ratings and shows them as read-only
+fields. Only the acceptance rate is editable; the validation target is then
+computed automatically.
+
 ## Email Setup
 
 When sending review summaries, the application asks for SMTP settings and login details. If you use Gmail with two-factor authentication enabled, create an **app password** and enter it instead of your normal account password. Authentication failures will prompt you to re-enter these settings.

--- a/analysis/risk_assessment.py
+++ b/analysis/risk_assessment.py
@@ -1,4 +1,6 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
+from .utils import derive_validation_target
+
 # Derived Maturity Table: (avg_confidence, avg_robustness) → maturity level
 DERIVED_MATURITY_TABLE = {
     (1, 1): 1, (1, 2): 1, (1, 3): 1, (1, 4): 2, (1, 5): 2,
@@ -30,6 +32,19 @@ OR_DECOMPOSITION_TABLE = {
     4: [(2, 2)],
     5: [(1, 1)]
 }
+
+
+def calculate_validation_target(acceptance_rate,
+                                exposure_given_hb,
+                                uncontrollable_given_exposure,
+                                severity_given_uncontrollable):
+    """Wrapper to derive a validation target for risk assessments."""
+    return derive_validation_target(
+        acceptance_rate,
+        exposure_given_hb,
+        uncontrollable_given_exposure,
+        severity_given_uncontrollable,
+    )
     
 def boolify(value, default):
     if isinstance(value, str):

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -4,6 +4,31 @@
 from typing import List
 
 
+# Mapping tables from risk assessment ratings to probabilities.
+#
+# The values provide a simple heuristic for converting ISO 26262 / ISO 21448
+# levels into conditional probabilities used in the validation target
+# calculation. They can be refined as better field data becomes available.
+EXPOSURE_PROBABILITIES = {1: 1e-4, 2: 1e-3, 3: 1e-2, 4: 5e-2}
+CONTROLLABILITY_PROBABILITIES = {1: 1e-3, 2: 1e-2, 3: 1e-1}
+SEVERITY_PROBABILITIES = {1: 1e-3, 2: 1e-2, 3: 1e-1}
+
+
+def exposure_to_probability(level: int) -> float:
+    """Return ``P(E|HB)`` for the given exposure rating."""
+    return EXPOSURE_PROBABILITIES.get(int(level), 1.0)
+
+
+def controllability_to_probability(level: int) -> float:
+    """Return ``P(C|E)`` for the given controllability rating."""
+    return CONTROLLABILITY_PROBABILITIES.get(int(level), 1.0)
+
+
+def severity_to_probability(level: int) -> float:
+    """Return ``P(S|C)`` for the given severity rating."""
+    return SEVERITY_PROBABILITIES.get(int(level), 1.0)
+
+
 def append_unique_insensitive(items: List[str], name: str) -> None:
     """Append ``name`` to ``items`` if not already present (case-insensitive)."""
     if not name:
@@ -16,3 +41,60 @@ def append_unique_insensitive(items: List[str], name: str) -> None:
         if existing.lower() == lower:
             return
     items.append(name)
+
+
+def derive_validation_target(acceptance_rate: float,
+                             exposure_given_hb: float,
+                             uncontrollable_given_exposure: float,
+                             severity_given_uncontrollable: float) -> float:
+    """Derive a validation target from an acceptance criterion.
+
+    This implements the ISO 21448 relationship for the rate of hazardous
+    behaviour :math:`R_{HB}`.
+
+    The acceptance criterion :math:`A_H` is decomposed into conditional
+    probabilities for exposure (``exposure_given_hb``), lack of
+    controllability (``uncontrollable_given_exposure``) and severity
+    (``severity_given_uncontrollable``). The resulting validation target is
+    calculated using:
+
+    ``R_HB = A_H / (P_E|HB * P_C|E * P_S|C)``
+
+    Parameters
+    ----------
+    acceptance_rate:
+        Acceptance criterion for the harm :math:`A_H`.
+    exposure_given_hb:
+        Conditional probability of being exposed to the scenario given the
+        hazardous behaviour, :math:`P_{E|HB}`.
+    uncontrollable_given_exposure:
+        Probability that the hazardous behaviour is not controllable once
+        exposure occurs, :math:`P_{C|E}`.
+    severity_given_uncontrollable:
+        Probability of the relevant severity assuming the control action
+        fails, :math:`P_{S|C}`.
+
+    Returns
+    -------
+    float
+        The acceptable rate of the hazardous behaviour ``R_HB`` that can be
+        used as a validation target.
+
+    Raises
+    ------
+    ValueError
+        If any of the probability terms is less than or equal to zero.
+    """
+
+    denominator = (
+        exposure_given_hb *
+        uncontrollable_given_exposure *
+        severity_given_uncontrollable
+    )
+
+    if denominator <= 0:
+        raise ValueError(
+            "Probability factors must be positive to derive a validation target"
+        )
+
+    return acceptance_rate / denominator

--- a/tests/test_validation_target.py
+++ b/tests/test_validation_target.py
@@ -1,0 +1,41 @@
+import unittest
+from analysis.utils import (
+    derive_validation_target,
+    exposure_to_probability,
+    controllability_to_probability,
+    severity_to_probability,
+)
+from analysis.risk_assessment import calculate_validation_target
+from AutoML import FaultTreeNode
+
+
+class ValidationTargetTests(unittest.TestCase):
+    def test_derive_validation_target_example(self):
+        rate = derive_validation_target(1e-8, 0.05, 0.1, 0.01)
+        self.assertAlmostEqual(rate, 2e-4)
+
+    def test_invalid_probabilities(self):
+        with self.assertRaises(ValueError):
+            derive_validation_target(1e-8, 0.0, 0.1, 0.01)
+
+    def test_wrapper(self):
+        rate = calculate_validation_target(1e-8, 0.05, 0.1, 0.01)
+        self.assertAlmostEqual(rate, 2e-4)
+
+    def test_fault_tree_node_update(self):
+        node = FaultTreeNode("SG1", "TOP EVENT")
+        node.acceptance_rate = 1e-8
+        node.exposure = 4
+        node.controllability = 3
+        node.severity = 2
+        node.update_validation_target()
+        self.assertAlmostEqual(node.validation_target, 2e-4)
+
+    def test_probability_mappings(self):
+        self.assertAlmostEqual(exposure_to_probability(4), 5e-2)
+        self.assertAlmostEqual(controllability_to_probability(3), 1e-1)
+        self.assertAlmostEqual(severity_to_probability(2), 1e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- map exposure, controllability and severity ratings to conditional probabilities
- auto-fill read-only probability and validation target fields in product goal editor
- document that probabilities are derived from risk assessment ratings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b4b1f38d883258df43a2d46e88197