### PR TITLE
Add accept/cancel buttons to threat entry dialog

### DIFF
--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -568,7 +568,7 @@ class ThreatDialog(simpledialog.Dialog):
 
     # ------------------------------------------------------------------
     def buttonbox(self):
-        """Add visible Accept/Cancel buttons and resize the dialog."""
+        """Add explicit Accept/Cancel buttons and defer resizing."""
         box = ttk.Frame(self)
 
         ok_btn = ttk.Button(box, text="Accept", width=10, command=self.ok)
@@ -581,9 +581,13 @@ class ThreatDialog(simpledialog.Dialog):
         self.bind("<Return>", self.ok)
         self.bind("<Escape>", self.cancel)
 
-        # Reduce dialog height to half while keeping computed width
+        # Resize after layout so width/height are accurate
+        self.after_idle(self._set_half_height)
+
+    def _set_half_height(self):
+        """Reduce dialog height to half while keeping computed width."""
         self.update_idletasks()
-        width = self.winfo_reqwidth()
-        height = self.winfo_reqheight() // 2
+        width = self.winfo_width()
+        height = self.winfo_height() // 2
         self.geometry(f"{width}x{height}")
         self.resizable(False, False)


### PR DESCRIPTION
## Summary
- Provide explicit Accept and Cancel buttons in the threat entry editor
- Shrink the threat entry dialog height to half the original size for better usability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b505c93b4832590aa5a9181fbe146