### PR TITLE
Auto-populate validation target probabilities from risk assessment

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -357,7 +357,13 @@ styles.add(preformatted_style)
 
 # Characters used to display pass/fail status in metrics labels.
 from analysis.constants import CHECK_MARK, CROSS_MARK
-from analysis.utils import append_unique_insensitive
+from analysis.utils import (
+    append_unique_insensitive,
+    derive_validation_target,
+    exposure_to_probability,
+    controllability_to_probability,
+    severity_to_probability,
+)
 
 from gui.toolboxes import (
     ReliabilityWindow,
@@ -1828,12 +1834,33 @@ class EditNodeDialog(simpledialog.Dialog):
         return "break"
 
     def validate_float(self, value):
-        if value in ("", "-", "+", ".", "-.", "+."):
+        """Validation helper that accepts scientific notation.
+
+        Tk's ``validatecommand`` fires on every keystroke, so this method
+        permits intermediate states such as ``"1e"`` or ``"1e-"`` that are
+        part of entering a number in scientific notation. The final value is
+        still checked via ``float`` for correctness.
+        """
+
+        if value in ("", "-", "+", ".", "-.", "+.", "e", "E", "e-", "e+", "E-", "E+"):
             return True
         try:
             float(value)
             return True
         except ValueError:
+            lower = value.lower()
+            if lower.endswith("e"):
+                try:
+                    float(lower[:-1])
+                    return True
+                except ValueError:
+                    return False
+            if lower.endswith(("e-", "e+")):
+                try:
+                    float(lower[:-2])
+                    return True
+                except ValueError:
+                    return False
             return False
 
     def update_probability(self, *_):
@@ -3740,7 +3767,7 @@ class FaultTreeApp:
                     continue
                 data = sg_data.setdefault(
                     mal,
-                    {"asil": "QM", "severity": 1, "cont": 1, "sg": "", "approved": False},
+                    {"asil": "QM", "severity": 1, "cont": 1, "exp": 1, "sg": "", "approved": False},
                 )
                 if ASIL_ORDER.get(e.asil, 0) > ASIL_ORDER.get(data["asil"], 0):
                     data["asil"] = e.asil
@@ -3749,6 +3776,8 @@ class FaultTreeApp:
                     data["severity"] = e.severity
                 if e.controllability > data["cont"]:
                     data["cont"] = e.controllability
+                if e.exposure > data["exp"]:
+                    data["exp"] = e.exposure
                 if approved:
                     data["approved"] = True
                 if e.safety_goal:
@@ -3771,6 +3800,8 @@ class FaultTreeApp:
                     te.safety_goal_description = data["sg"]
                     te.severity = data["severity"]
                     te.controllability = data["cont"]
+                    te.exposure = data["exp"]
+                    te.update_validation_target()
             sg_name = te.safety_goal_description
             asil = sg_asil.get(sg_name)
             if asil and ASIL_ORDER.get(asil, 0) > ASIL_ORDER.get(te.safety_goal_asil or "QM", 0):
@@ -9071,15 +9102,32 @@ class FaultTreeApp:
             be.failure_prob = self.compute_failure_prob(be)
 
     def validate_float(self, value):
-        """Return ``True`` if ``value`` can be parsed as a float or is an
-        intermediate input allowed by Tk validation."""
+        """Return ``True`` if ``value`` resembles a float.
 
-        if value in ("", "-", "+", ".", "-.", "+."):
+        This validator is tolerant of scientific-notation inputs that are
+        entered incrementally (e.g. ``"1e"`` or ``"1e-"``) to keep the entry
+        widget from rejecting keystrokes during editing.
+        """
+
+        if value in ("", "-", "+", ".", "-.", "+.", "e", "E", "e-", "e+", "E-", "E+"):
             return True
         try:
             float(value)
             return True
         except ValueError:
+            lower = value.lower()
+            if lower.endswith("e"):
+                try:
+                    float(lower[:-1])
+                    return True
+                except ValueError:
+                    return False
+            if lower.endswith(("e-", "e+")):
+                try:
+                    float(lower[:-2])
+                    return True
+                except ValueError:
+                    return False
             return False
 
     def compute_failure_prob(self, node, failure_mode_ref=None, formula=None):
@@ -12089,6 +12137,7 @@ class FaultTreeApp:
             "ASIL",
             "Safe State",
             "FTTI",
+            "Acc Rate",
             "Val Target",
             "Val Desc",
             "Acceptance",
@@ -12105,7 +12154,6 @@ class FaultTreeApp:
             for sg in self.top_events:
                 name = sg.safety_goal_description or (sg.user_name or f"SG {sg.unique_id}")
                 sg.safety_goal_asil = self.get_hara_goal_asil(name)
-                cal = self.get_cyber_goal_cal(sg.user_name or f"SG {sg.unique_id}")
                 tree.insert(
                     "",
                     "end",
@@ -12113,9 +12161,9 @@ class FaultTreeApp:
                     values=[
                         sg.user_name or f"SG {sg.unique_id}",
                         sg.safety_goal_asil,
-                        cal,
                         sg.safe_state,
                         getattr(sg, "ftti", ""),
+                        str(getattr(sg, "acceptance_rate", "")),
                         getattr(sg, "validation_target", ""),
                         getattr(sg, "validation_desc", ""),
                         getattr(sg, "acceptance_criteria", ""),
@@ -12156,29 +12204,63 @@ class FaultTreeApp:
                     validatecommand=(master.register(self.app.validate_float), "%P"),
                 ).grid(row=4, column=1, padx=5, pady=5)
 
-                ttk.Label(master, text="Validation Target:").grid(row=4, column=0, sticky="e")
-                self.val_var = tk.StringVar(value=str(getattr(self.initial, "validation_target", 1.0)))
+                ttk.Label(master, text="Acceptance Rate:").grid(row=5, column=0, sticky="e")
+                self.accept_rate_var = tk.StringVar(value=str(getattr(self.initial, "acceptance_rate", 0.0)))
                 tk.Entry(
                     master,
-                    textvariable=self.val_var,
+                    textvariable=self.accept_rate_var,
                     validate="key",
                     validatecommand=(master.register(self.app.validate_float), "%P"),
                 ).grid(row=5, column=1, padx=5, pady=5)
 
-                ttk.Label(master, text="Val Target Desc:").grid(row=5, column=0, sticky="ne")
+                exp = exposure_to_probability(getattr(self.initial, "exposure", 1))
+                ctrl = controllability_to_probability(getattr(self.initial, "controllability", 1))
+                sev = severity_to_probability(getattr(self.initial, "severity", 1))
+
+                ttk.Label(master, text="P(E|HB):").grid(row=6, column=0, sticky="e")
+                self.pehb_var = tk.StringVar(value=str(exp))
+                tk.Entry(master, textvariable=self.pehb_var, state="readonly").grid(row=6, column=1, padx=5, pady=5)
+
+                ttk.Label(master, text="P(C|E):").grid(row=7, column=0, sticky="e")
+                self.pce_var = tk.StringVar(value=str(ctrl))
+                tk.Entry(master, textvariable=self.pce_var, state="readonly").grid(row=7, column=1, padx=5, pady=5)
+
+                ttk.Label(master, text="P(S|C):").grid(row=8, column=0, sticky="e")
+                self.psc_var = tk.StringVar(value=str(sev))
+                tk.Entry(master, textvariable=self.psc_var, state="readonly").grid(row=8, column=1, padx=5, pady=5)
+
+                ttk.Label(master, text="Validation Target:").grid(row=9, column=0, sticky="e")
+                try:
+                    val = derive_validation_target(float(self.accept_rate_var.get() or 0.0), exp, ctrl, sev)
+                except Exception:
+                    val = 1.0
+                self.val_var = tk.StringVar(value=str(val))
+                tk.Entry(master, textvariable=self.val_var, state="readonly").grid(row=9, column=1, padx=5, pady=5)
+
+                def _update_val(*_):
+                    try:
+                        acc = float(self.accept_rate_var.get())
+                        v = derive_validation_target(acc, float(self.pehb_var.get()), float(self.pce_var.get()), float(self.psc_var.get()))
+                    except Exception:
+                        v = 1.0
+                    self.val_var.set(str(v))
+
+                self.accept_rate_var.trace_add("write", _update_val)
+
+                ttk.Label(master, text="Val Target Desc:").grid(row=10, column=0, sticky="ne")
                 self.val_desc_text = tk.Text(master, width=30, height=3, wrap="word")
                 self.val_desc_text.insert("1.0", getattr(self.initial, "validation_desc", ""))
-                self.val_desc_text.grid(row=5, column=1, padx=5, pady=5)
+                self.val_desc_text.grid(row=10, column=1, padx=5, pady=5)
 
-                ttk.Label(master, text="Acceptance Criteria:").grid(row=6, column=0, sticky="ne")
+                ttk.Label(master, text="Acceptance Criteria:").grid(row=11, column=0, sticky="ne")
                 self.acc_text = tk.Text(master, width=30, height=3, wrap="word")
                 self.acc_text.insert("1.0", getattr(self.initial, "acceptance_criteria", ""))
-                self.acc_text.grid(row=6, column=1, padx=5, pady=5)
+                self.acc_text.grid(row=11, column=1, padx=5, pady=5)
 
-                ttk.Label(master, text="Description:").grid(row=7, column=0, sticky="ne")
+                ttk.Label(master, text="Description:").grid(row=12, column=0, sticky="ne")
                 self.desc_text = tk.Text(master, width=30, height=3, wrap="word")
                 self.desc_text.insert("1.0", getattr(self.initial, "safety_goal_description", ""))
-                self.desc_text.grid(row=7, column=1, padx=5, pady=5)
+                self.desc_text.grid(row=12, column=1, padx=5, pady=5)
                 return master
 
             def apply(self):
@@ -12190,6 +12272,10 @@ class FaultTreeApp:
                     "asil": asil,
                     "state": self.state_var.get().strip(),
                     "ftti": self.ftti_var.get().strip(),
+                    "accept_rate": self.accept_rate_var.get().strip(),
+                    "pehb": self.pehb_var.get().strip(),
+                    "pce": self.pce_var.get().strip(),
+                    "psc": self.psc_var.get().strip(),
                     "val": self.val_var.get().strip(),
                     "val_desc": self.val_desc_text.get("1.0", "end-1c"),
                     "accept": self.acc_text.get("1.0", "end-1c"),
@@ -12203,10 +12289,8 @@ class FaultTreeApp:
                 node.safety_goal_asil = dlg.result["asil"]
                 node.safe_state = dlg.result["state"]
                 node.ftti = dlg.result["ftti"]
-                try:
-                    node.validation_target = float(dlg.result["val"])
-                except Exception:
-                    node.validation_target = 1.0
+                node.acceptance_rate = float(dlg.result.get("accept_rate", 0.0) or 0.0)
+                node.update_validation_target()
                 node.validation_desc = dlg.result["val_desc"]
                 node.acceptance_criteria = dlg.result["accept"]
                 node.safety_goal_description = dlg.result["desc"]
@@ -12226,10 +12310,8 @@ class FaultTreeApp:
                 sg.safety_goal_asil = dlg.result["asil"]
                 sg.safe_state = dlg.result["state"]
                 sg.ftti = dlg.result["ftti"]
-                try:
-                    sg.validation_target = float(dlg.result["val"])
-                except Exception:
-                    sg.validation_target = 1.0
+                sg.acceptance_rate = float(dlg.result.get("accept_rate", 0.0) or 0.0)
+                sg.update_validation_target()
                 sg.validation_desc = dlg.result["val_desc"]
                 sg.acceptance_criteria = dlg.result["accept"]
                 sg.safety_goal_description = dlg.result["desc"]
@@ -16838,6 +16920,7 @@ class FaultTreeNode:
         # Default to the lowest level until linked to a risk assessment entry
         self.severity = 1 if node_type.upper() == "TOP EVENT" else None
         self.controllability = 1 if node_type.upper() == "TOP EVENT" else None
+        self.exposure = 1 if node_type.upper() == "TOP EVENT" else None
         self.input_subtype = None
         self.display_label = ""
         self.equation = ""
@@ -16856,6 +16939,10 @@ class FaultTreeNode:
         self.validation_target = 1.0
         self.validation_desc = ""
         self.acceptance_criteria = ""
+        self.acceptance_rate = 0.0
+        self.exposure_given_hb = 1.0
+        self.uncontrollable_given_exposure = 1.0
+        self.severity_given_uncontrollable = 1.0
         self.status = "draft"
         self.approved = False
         # Targets for safety goal metrics
@@ -16900,6 +16987,19 @@ class FaultTreeNode:
         # Review status for top events
         self.status = "draft"
 
+    def update_validation_target(self):
+        """Recalculate validation target from current risk ratings."""
+        self.exposure_given_hb = exposure_to_probability(getattr(self, "exposure", 1))
+        self.uncontrollable_given_exposure = controllability_to_probability(getattr(self, "controllability", 1))
+        self.severity_given_uncontrollable = severity_to_probability(getattr(self, "severity", 1))
+        self.validation_target = derive_validation_target(
+            self.acceptance_rate,
+            self.exposure_given_hb,
+            self.uncontrollable_given_exposure,
+            self.severity_given_uncontrollable,
+        )
+        return self.validation_target
+
     @property
     def name(self):
         orig = getattr(self, "original", self)
@@ -16923,6 +17023,7 @@ class FaultTreeNode:
             "y": self.y,
             "severity": self.severity,
             "controllability": self.controllability,
+            "exposure": self.exposure,
             "input_subtype": self.input_subtype,
             "is_page": self.is_page,
             "is_primary_instance": self.is_primary_instance,
@@ -16933,6 +17034,10 @@ class FaultTreeNode:
             "validation_target": self.validation_target,
             "validation_desc": self.validation_desc,
             "acceptance_criteria": self.acceptance_criteria,
+            "acceptance_rate": self.acceptance_rate,
+            "exposure_given_hb": self.exposure_given_hb,
+            "uncontrollable_given_exposure": self.uncontrollable_given_exposure,
+            "severity_given_uncontrollable": self.severity_given_uncontrollable,
             "status": self.status,
             "approved": self.approved,
             "sg_dc_target": self.sg_dc_target,
@@ -16987,6 +17092,7 @@ class FaultTreeNode:
         node.y = data.get("y", 50)
         node.severity = data.get("severity", 1) if node.node_type.upper() == "TOP EVENT" else None
         node.controllability = data.get("controllability", 1) if node.node_type.upper() == "TOP EVENT" else None
+        node.exposure = data.get("exposure", 1) if node.node_type.upper() == "TOP EVENT" else None
         node.input_subtype = data.get("input_subtype", None)
         node.is_page = boolify(data.get("is_page", False), False)
         node.is_primary_instance = boolify(data.get("is_primary_instance", True), True)
@@ -16997,6 +17103,10 @@ class FaultTreeNode:
         node.validation_target = data.get("validation_target", 1.0)
         node.validation_desc = data.get("validation_desc", "")
         node.acceptance_criteria = data.get("acceptance_criteria", "")
+        node.acceptance_rate = data.get("acceptance_rate", 0.0)
+        node.exposure_given_hb = data.get("exposure_given_hb", 1.0)
+        node.uncontrollable_given_exposure = data.get("uncontrollable_given_exposure", 1.0)
+        node.severity_given_uncontrollable = data.get("severity_given_uncontrollable", 1.0)
         node.status = data.get("status", "draft")
         node.approved = data.get("approved", False)
         node.sg_dc_target = data.get("sg_dc_target", 0.0)

--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,27 @@ Use **Export Product Goal Requirements** in the Requirements menu to generate a 
 
 The **Safety Performance Indicators** tab in the Requirements menu lists each product goal's validation target and acceptance criteria with their descriptions for quick reference.
 
+### Acceptance Criteria and Validation Targets
+
+ISO 21448 provides a method to derive a validation target from an acceptance
+criterion by analysing the rate of the hazardous behaviour :math:`R_{HB}`.
+Given an acceptance criterion for a harm :math:`A_H` and conditional
+probabilities for exposure :math:`P_{E|HB}`, uncontrollability
+:math:`P_{C|E}` and severity :math:`P_{S|C}`, the acceptable rate of the
+hazardous behaviour is computed as:
+
+```
+R_HB = A_H / (P_{E|HB} * P_{C|E} * P_{S|C})
+```
+
+This value can serve as a validation target when planning tests. For example,
+an acceptance criterion of ``1e-8/h`` with ``P_{E|HB}=0.05``,
+``P_{C|E}=0.1`` and ``P_{S|C}=0.01`` yields ``R_HB = 2e-4/h``.
+The product goal editor derives exposure, controllability and severity
+probabilities from their risk assessment ratings and shows them as read-only
+fields. Only the acceptance rate is editable; the validation target is then
+computed automatically.
+
 ## Email Setup
 
 When sending review summaries, the application asks for SMTP settings and login details. If you use Gmail with two-factor authentication enabled, create an **app password** and enter it instead of your normal account password. Authentication failures will prompt you to re-enter these settings.

--- a/analysis/risk_assessment.py
+++ b/analysis/risk_assessment.py
@@ -1,4 +1,6 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
+from .utils import derive_validation_target
+
 # Derived Maturity Table: (avg_confidence, avg_robustness) → maturity level
 DERIVED_MATURITY_TABLE = {
     (1, 1): 1, (1, 2): 1, (1, 3): 1, (1, 4): 2, (1, 5): 2,
@@ -30,6 +32,19 @@ OR_DECOMPOSITION_TABLE = {
     4: [(2, 2)],
     5: [(1, 1)]
 }
+
+
+def calculate_validation_target(acceptance_rate,
+                                exposure_given_hb,
+                                uncontrollable_given_exposure,
+                                severity_given_uncontrollable):
+    """Wrapper to derive a validation target for risk assessments."""
+    return derive_validation_target(
+        acceptance_rate,
+        exposure_given_hb,
+        uncontrollable_given_exposure,
+        severity_given_uncontrollable,
+    )
     
 def boolify(value, default):
     if isinstance(value, str):

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -4,6 +4,31 @@
 from typing import List
 
 
+# Mapping tables from risk assessment ratings to probabilities.
+#
+# The values provide a simple heuristic for converting ISO 26262 / ISO 21448
+# levels into conditional probabilities used in the validation target
+# calculation. They can be refined as better field data becomes available.
+EXPOSURE_PROBABILITIES = {1: 1e-4, 2: 1e-3, 3: 1e-2, 4: 5e-2}
+CONTROLLABILITY_PROBABILITIES = {1: 1e-3, 2: 1e-2, 3: 1e-1}
+SEVERITY_PROBABILITIES = {1: 1e-3, 2: 1e-2, 3: 1e-1}
+
+
+def exposure_to_probability(level: int) -> float:
+    """Return ``P(E|HB)`` for the given exposure rating."""
+    return EXPOSURE_PROBABILITIES.get(int(level), 1.0)
+
+
+def controllability_to_probability(level: int) -> float:
+    """Return ``P(C|E)`` for the given controllability rating."""
+    return CONTROLLABILITY_PROBABILITIES.get(int(level), 1.0)
+
+
+def severity_to_probability(level: int) -> float:
+    """Return ``P(S|C)`` for the given severity rating."""
+    return SEVERITY_PROBABILITIES.get(int(level), 1.0)
+
+
 def append_unique_insensitive(items: List[str], name: str) -> None:
     """Append ``name`` to ``items`` if not already present (case-insensitive)."""
     if not name:
@@ -16,3 +41,60 @@ def append_unique_insensitive(items: List[str], name: str) -> None:
         if existing.lower() == lower:
             return
     items.append(name)
+
+
+def derive_validation_target(acceptance_rate: float,
+                             exposure_given_hb: float,
+                             uncontrollable_given_exposure: float,
+                             severity_given_uncontrollable: float) -> float:
+    """Derive a validation target from an acceptance criterion.
+
+    This implements the ISO 21448 relationship for the rate of hazardous
+    behaviour :math:`R_{HB}`.
+
+    The acceptance criterion :math:`A_H` is decomposed into conditional
+    probabilities for exposure (``exposure_given_hb``), lack of
+    controllability (``uncontrollable_given_exposure``) and severity
+    (``severity_given_uncontrollable``). The resulting validation target is
+    calculated using:
+
+    ``R_HB = A_H / (P_E|HB * P_C|E * P_S|C)``
+
+    Parameters
+    ----------
+    acceptance_rate:
+        Acceptance criterion for the harm :math:`A_H`.
+    exposure_given_hb:
+        Conditional probability of being exposed to the scenario given the
+        hazardous behaviour, :math:`P_{E|HB}`.
+    uncontrollable_given_exposure:
+        Probability that the hazardous behaviour is not controllable once
+        exposure occurs, :math:`P_{C|E}`.
+    severity_given_uncontrollable:
+        Probability of the relevant severity assuming the control action
+        fails, :math:`P_{S|C}`.
+
+    Returns
+    -------
+    float
+        The acceptable rate of the hazardous behaviour ``R_HB`` that can be
+        used as a validation target.
+
+    Raises
+    ------
+    ValueError
+        If any of the probability terms is less than or equal to zero.
+    """
+
+    denominator = (
+        exposure_given_hb *
+        uncontrollable_given_exposure *
+        severity_given_uncontrollable
+    )
+
+    if denominator <= 0:
+        raise ValueError(
+            "Probability factors must be positive to derive a validation target"
+        )
+
+    return acceptance_rate / denominator

--- a/tests/test_validate_float.py
+++ b/tests/test_validate_float.py
@@ -1,0 +1,13 @@
+import unittest
+from AutoML import FaultTreeApp
+
+
+class ValidateFloatTests(unittest.TestCase):
+    def test_allows_scientific_notation(self):
+        self.assertTrue(FaultTreeApp.validate_float(None, "1e"))
+        self.assertTrue(FaultTreeApp.validate_float(None, "1e-"))
+        self.assertTrue(FaultTreeApp.validate_float(None, "1e-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validation_target.py
+++ b/tests/test_validation_target.py
@@ -1,0 +1,41 @@
+import unittest
+from analysis.utils import (
+    derive_validation_target,
+    exposure_to_probability,
+    controllability_to_probability,
+    severity_to_probability,
+)
+from analysis.risk_assessment import calculate_validation_target
+from AutoML import FaultTreeNode
+
+
+class ValidationTargetTests(unittest.TestCase):
+    def test_derive_validation_target_example(self):
+        rate = derive_validation_target(1e-8, 0.05, 0.1, 0.01)
+        self.assertAlmostEqual(rate, 2e-4)
+
+    def test_invalid_probabilities(self):
+        with self.assertRaises(ValueError):
+            derive_validation_target(1e-8, 0.0, 0.1, 0.01)
+
+    def test_wrapper(self):
+        rate = calculate_validation_target(1e-8, 0.05, 0.1, 0.01)
+        self.assertAlmostEqual(rate, 2e-4)
+
+    def test_fault_tree_node_update(self):
+        node = FaultTreeNode("SG1", "TOP EVENT")
+        node.acceptance_rate = 1e-8
+        node.exposure = 4
+        node.controllability = 3
+        node.severity = 2
+        node.update_validation_target()
+        self.assertAlmostEqual(node.validation_target, 2e-4)
+
+    def test_probability_mappings(self):
+        self.assertAlmostEqual(exposure_to_probability(4), 5e-2)
+        self.assertAlmostEqual(controllability_to_probability(3), 1e-1)
+        self.assertAlmostEqual(severity_to_probability(2), 1e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- map exposure, controllability and severity ratings to conditional probabilities
- auto-fill read-only probability and validation target fields in product goal editor
- document that probabilities are derived from risk assessment ratings
- allow scientific notation when entering acceptance rates so the field is usable for small values
- display acceptance rate in the product goal editor table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b4b1f38d883258df43a2d46e88197