### PR TITLE
Fix hidden acceptance rate field in Product Goals editor

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12211,7 +12211,7 @@ class FaultTreeApp:
                     textvariable=self.accept_rate_var,
                     validate="key",
                     validatecommand=(master.register(self.app.validate_float), "%P"),
-                ).grid(row=9, column=1, padx=5, pady=5)
+                ).grid(row=5, column=1, padx=5, pady=5)
 
                 exp = exposure_to_probability(getattr(self.initial, "exposure", 1))
                 ctrl = controllability_to_probability(getattr(self.initial, "controllability", 1))


### PR DESCRIPTION
## Summary
- ensure acceptance rate input is placed in the correct row so users can enter acceptance rates
## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b56718b9c8325a9620e5b01000335