### PR TITLE
Use combo box for HAZOP selection in new risk assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ The **HAZOP Analysis** window lets you list system functions with one or more as
 
 ## Risk Assessment
 
-The **Risk Assessment** view builds on the safety relevant malfunctions from one or more selected HAZOPs. When creating a new assessment you can pick multiple HAZOP documents; only malfunctions from those selections appear in the table. Each assessment table contains the following columns:
+The **Risk Assessment** view builds on the safety relevant malfunctions from a selected HAZOP. When creating a new assessment you pick a HAZOP document from a drop-down; only malfunctions from that selection appear in the table. Each assessment table contains the following columns:
 
-1. **Malfunction** – combo box listing malfunctions flagged as safety relevant in the chosen HAZOP documents.
+1. **Malfunction** – combo box listing malfunctions flagged as safety relevant in the chosen HAZOP document.
 2. **Hazard** – textual description of the resulting hazard.
 3. **Severity** – ISO&nbsp;26262 severity level (1–3). Values from FI2TC and
    TC2FI analyses are inherited here so the risk assessment reflects SOTIF hazards.

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -2178,12 +2178,12 @@ class RiskAssessmentWindow(tk.Frame):
             ttk.Label(master, text="Name").grid(row=0, column=0, sticky="e")
             self.name_var = tk.StringVar()
             ttk.Entry(master, textvariable=self.name_var).grid(row=0, column=1)
-            ttk.Label(master, text="HAZOPs").grid(row=1, column=0, sticky="ne")
+            ttk.Label(master, text="HAZOPs").grid(row=1, column=0, sticky="e")
             names = [d.name for d in self.app.hazop_docs]
-            self.hazop_lb = tk.Listbox(master, selectmode="extended", height=5)
-            for n in names:
-                self.hazop_lb.insert(tk.END, n)
-            self.hazop_lb.grid(row=1, column=1)
+            self.hazop_var = tk.StringVar()
+            ttk.Combobox(
+                master, textvariable=self.hazop_var, values=names, state="readonly"
+            ).grid(row=1, column=1)
             ttk.Label(master, text="STPA").grid(row=2, column=0, sticky="e")
             stpas = [d.name for d in self.app.stpa_docs]
             self.stpa_var = tk.StringVar()
@@ -2198,7 +2198,8 @@ class RiskAssessmentWindow(tk.Frame):
             ).grid(row=3, column=1)
 
         def apply(self):
-            sel = [self.hazop_lb.get(i) for i in self.hazop_lb.curselection()]
+            hazop = self.hazop_var.get()
+            sel = [hazop] if hazop else []
             self.result = (
                 self.name_var.get(),
                 sel,


### PR DESCRIPTION
## Summary
- Replace listbox with combo box for HAZOP selection when creating a new risk assessment
- Update documentation to describe single HAZOP selection from drop-down

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b570bb6748325b2335ba417e8d825