### PR TITLE
Enable double-click editing across more tables

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12291,6 +12291,8 @@ class FaultTreeApp:
                 refresh_tree()
                 self.update_views()
 
+        tree.bind("<Double-1>", lambda e: edit_sg())
+
         btn = ttk.Frame(win)
         btn.pack(fill=tk.X)
         ttk.Button(btn, text="Add", command=add_sg).pack(side=tk.LEFT)

--- a/gui/faults_gui.py
+++ b/gui/faults_gui.py
@@ -878,6 +878,28 @@ class FaultsWindow(QMainWindow):
         self.model.set_dataframe(self.df)
         self.status.showMessage(f"Deleted {len(rows)} row(s).", 4000)
 
+    def on_table_double_clicked(self, index: QModelIndex):
+        """Open an editor for the clicked cell or show requirement selection."""
+        if not index.isValid():
+            return
+        col_name = self.df.columns[index.column()]
+        req_map = {
+            "Operational Requirement": "operational",
+            "Technical Safety Requirement": "technical safety",
+            "Functional Modification": "functional modification",
+        }
+        if col_name in req_map:
+            options = requirement_ids(req_map[col_name])
+            current = [
+                v for v in str(self.df.iat[index.row(), index.column()]).split(";") if v
+            ]
+            dlg = MultiSelectDialog(options, current, title=col_name, parent=self)
+            if dlg.exec():
+                new_val = ";".join(dlg.selected_items())
+                self.model.setData(index, new_val, Qt.ItemDataRole.EditRole)
+            return
+        self.table.edit(index)
+
     def on_thresholds_changed(self, _value: float):
         for i in range(len(self.df)):
             self.recompute_row(i)

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -2092,6 +2092,7 @@ class RiskAssessmentWindow(tk.Frame):
             width = 200 if c == "hazard" else 120
             self.tree.column(c, width=width)
         self.tree.grid(row=0, column=0, sticky="nsew")
+        self.tree.bind("<Double-1>", lambda e: self.edit_row())
         vsb.grid(row=0, column=1, sticky="ns")
         hsb.grid(row=1, column=0, sticky="ew")
         table_frame.columnconfigure(0, weight=1)

--- a/tests/test_gui_classes.py
+++ b/tests/test_gui_classes.py
@@ -1,12 +1,34 @@
 import unittest
 import os
 import sys
+import inspect
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from gui.toolboxes import TC2FIWindow
+from gui.toolboxes import TC2FIWindow, RiskAssessmentWindow
+from AutoML import FaultTreeApp
+try:
+    from gui.faults_gui import FaultsWindow
+except Exception:  # pragma: no cover - optional dependency
+    FaultsWindow = None
 
 class RowDialogMethodTests(unittest.TestCase):
     def test_rowdialog_has_add_func_existing(self):
         self.assertTrue(hasattr(TC2FIWindow.RowDialog, 'add_func_existing'))
+
+
+class FaultsGuiTests(unittest.TestCase):
+    @unittest.skipIf(FaultsWindow is None, "faults_gui dependencies not available")
+    def test_faults_window_has_double_click_handler(self):
+        self.assertTrue(hasattr(FaultsWindow, 'on_table_double_clicked'))
+
+
+class DoubleClickBindingTests(unittest.TestCase):
+    def test_risk_assessment_double_click_binding(self):
+        src = inspect.getsource(RiskAssessmentWindow.__init__)
+        self.assertIn('bind("<Double-1>"', src)
+
+    def test_product_goals_editor_double_click_binding(self):
+        src = inspect.getsource(FaultTreeApp.show_product_goals_editor)
+        self.assertIn('bind("<Double-1>"', src)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Bind double-click to open risk assessment row editor
- Trigger product goal dialog on tree double-click
- Cover double-click bindings in unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b53065e948325a5e114f11c2cf6e3