### PR TITLE
Clarify units for acceptance rate and validation target

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -1173,7 +1173,7 @@ class EditNodeDialog(simpledialog.Dialog):
                 # the safety tab. They remain attributes of the node but are
                 # configured elsewhere.
 
-                ttk.Label(safety_frame, text="Validation Target:").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
+                ttk.Label(safety_frame, text="Validation Target (1/h):").grid(row=row_next, column=0, padx=5, pady=5, sticky="e")
                 self.val_target_var = tk.StringVar(value=str(getattr(self.node, "validation_target", 1.0)))
                 tk.Entry(
                     safety_frame,
@@ -1289,7 +1289,7 @@ class EditNodeDialog(simpledialog.Dialog):
                 width=8,
             )
             self.req_cal_combo.grid(row=4, column=1, padx=5, pady=5, sticky="w")
-            ttk.Label(master, text="Validation Target:").grid(row=5, column=0, sticky="e", padx=5, pady=5)
+            ttk.Label(master, text="Validation Target (1/h):").grid(row=5, column=0, sticky="e", padx=5, pady=5)
             self.val_var = tk.StringVar(value=str(self.initial_req.get("validation_criteria", 0.0)))
             tk.Entry(master, textvariable=self.val_var, state="readonly", width=10).grid(row=5, column=1, padx=5, pady=5, sticky="w")
 
@@ -12204,7 +12204,7 @@ class FaultTreeApp:
                     validatecommand=(master.register(self.app.validate_float), "%P"),
                 ).grid(row=4, column=1, padx=5, pady=5)
 
-                ttk.Label(master, text="Acceptance Rate:").grid(row=5, column=0, sticky="e")
+                ttk.Label(master, text="Acceptance Rate (1/h):").grid(row=5, column=0, sticky="e")
                 self.accept_rate_var = tk.StringVar(value=str(getattr(self.initial, "acceptance_rate", 0.0)))
                 tk.Entry(
                     master,
@@ -12229,7 +12229,7 @@ class FaultTreeApp:
                 self.psc_var = tk.StringVar(value=str(sev))
                 tk.Entry(master, textvariable=self.psc_var, state="readonly").grid(row=8, column=1, padx=5, pady=5)
 
-                ttk.Label(master, text="Validation Target:").grid(row=9, column=0, sticky="e")
+                ttk.Label(master, text="Validation Target (1/h):").grid(row=9, column=0, sticky="e")
                 try:
                     val = derive_validation_target(float(self.accept_rate_var.get() or 0.0), exp, ctrl, sev)
                 except Exception:

--- a/README.md
+++ b/README.md
@@ -1129,8 +1129,10 @@ The **Safety Performance Indicators** tab in the Requirements menu lists each pr
 
 ISO 21448 provides a method to derive a validation target from an acceptance
 criterion by analysing the rate of the hazardous behaviour :math:`R_{HB}`.
-Given an acceptance criterion for a harm :math:`A_H` and conditional
-probabilities for exposure :math:`P_{E|HB}`, uncontrollability
+The **acceptance rate** :math:`A_H` represents the tolerated rate of harm
+in events per hour. The derived validation target is the corresponding rate
+of hazardous behaviour :math:`R_{HB}` that should not be exceeded. Given
+conditional probabilities for exposure :math:`P_{E|HB}`, uncontrollability
 :math:`P_{C|E}` and severity :math:`P_{S|C}`, the acceptable rate of the
 hazardous behaviour is computed as:
 
@@ -1140,7 +1142,10 @@ R_HB = A_H / (P_{E|HB} * P_{C|E} * P_{S|C})
 
 This value can serve as a validation target when planning tests. For example,
 an acceptance criterion of ``1e-8/h`` with ``P_{E|HB}=0.05``,
-``P_{C|E}=0.1`` and ``P_{S|C}=0.01`` yields ``R_HB = 2e-4/h``.
+``P_{C|E}=0.1`` and ``P_{S|C}=0.01`` yields ``R_HB = 2e-4/h``. Because the
+conditional probabilities are often very small, even moderate acceptance
+rates can produce seemingly large validation targets.
+
 The product goal editor derives exposure, controllability and severity
 probabilities from their risk assessment ratings and shows them as read-only
 fields. Only the acceptance rate is editable; the validation target is then

--- a/analysis/sotif_validation.py
+++ b/analysis/sotif_validation.py
@@ -19,10 +19,15 @@ def hazardous_behavior_rate(
 ) -> float:
     """Derive the rate of hazardous behaviour.
 
+    All rates are expressed in **events per hour**. The function implements
+    ISO 21448 Formula (C.2)::
+
+        RHB = AH / (P_E|HB * P_C|E * P_S|C)
+
     Parameters
     ----------
     acceptance_rate:
-        The acceptance criterion :math:`A_H` (e.g. ``1e-8`` per hour).
+        The acceptance criterion :math:`A_H` (e.g. ``1e-8`` events per hour).
     p_exposure_given_hb:
         Probability :math:`P_{E|HB}` that the hazardous behaviour occurs in a
         scenario leading to harm.
@@ -36,10 +41,12 @@ def hazardous_behavior_rate(
     Returns
     -------
     float
-        Rate of hazardous behaviour :math:`R_{HB}` derived using ISO 21448
-        Formula (C.2):
+        Rate of hazardous behaviour :math:`R_{HB}` in events per hour.
 
-        ``RHB = AH / (P_E|HB * P_C|E * P_S|C)``
+    Examples
+    --------
+    >>> hazardous_behavior_rate(1e-8, 0.05, 0.1, 0.01)
+    0.0002
     """
 
     denominator = (
@@ -58,9 +65,25 @@ def acceptance_rate(
 ) -> float:
     """Compute the acceptance rate from the hazardous behaviour rate.
 
-    Implements ISO 21448 Formula (C.1):
+    All rates are expressed in **events per hour**. Implements ISO 21448
+    Formula (C.1)::
 
-    ``AH = RHB * P_E|HB * P_C|E * P_S|C``
+        AH = RHB * P_E|HB * P_C|E * P_S|C
+
+    Parameters
+    ----------
+    hazardous_behavior_rate:
+        Rate of hazardous behaviour :math:`R_{HB}` in events per hour.
+
+    Returns
+    -------
+    float
+        Acceptance criterion :math:`A_H` in events per hour.
+
+    Examples
+    --------
+    >>> acceptance_rate(0.0002, 0.05, 0.1, 0.01)
+    1e-08
     """
 
     return (

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -50,7 +50,7 @@ def derive_validation_target(acceptance_rate: float,
     """Derive a validation target from an acceptance criterion.
 
     This implements the ISO 21448 relationship for the rate of hazardous
-    behaviour :math:`R_{HB}`.
+    behaviour :math:`R_{HB}`. All rates are expressed in **events per hour**.
 
     The acceptance criterion :math:`A_H` is decomposed into conditional
     probabilities for exposure (``exposure_given_hb``), lack of
@@ -60,10 +60,13 @@ def derive_validation_target(acceptance_rate: float,
 
     ``R_HB = A_H / (P_E|HB * P_C|E * P_S|C)``
 
+    For example, ``A_H = 1e-8/h`` with ``P_E|HB = 0.05``, ``P_C|E = 0.1``
+    and ``P_S|C = 0.01`` yields ``R_HB = 2e-4/h``.
+
     Parameters
     ----------
     acceptance_rate:
-        Acceptance criterion for the harm :math:`A_H`.
+        Acceptance criterion for the harm :math:`A_H` in events per hour.
     exposure_given_hb:
         Conditional probability of being exposed to the scenario given the
         hazardous behaviour, :math:`P_{E|HB}`.
@@ -77,8 +80,8 @@ def derive_validation_target(acceptance_rate: float,
     Returns
     -------
     float
-        The acceptable rate of the hazardous behaviour ``R_HB`` that can be
-        used as a validation target.
+        The acceptable rate of the hazardous behaviour ``R_HB`` (events per
+        hour) that can be used as a validation target.
 
     Raises
     ------


### PR DESCRIPTION
## Summary
- Show units for Acceptance Rate and Validation Target fields in the GUI
- Document per-hour units and examples for validation helpers
- Clarify that acceptance rate is a tolerated harm rate in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b58e1ad908325aaaf954f01a4a122