### PR TITLE
Add OK/Cancel buttons to threat entry dialog

### DIFF
--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -24,8 +24,11 @@ class ThreatDialog(simpledialog.Dialog):
 
     # ------------------------------------------------------------------
     def body(self, master):
+        master.columnconfigure(0, weight=1)
+        master.rowconfigure(0, weight=1)
+
         nb = ttk.Notebook(master)
-        nb.pack(fill=tk.BOTH, expand=True)
+        nb.grid(row=0, column=0, sticky="nsew")
 
         # Asset Identification tab --------------------------------------
         asset_tab = ttk.Frame(nb)
@@ -568,19 +571,18 @@ class ThreatDialog(simpledialog.Dialog):
 
     # ------------------------------------------------------------------
     def buttonbox(self):
-        """Add explicit Accept/Cancel buttons and set dialog size."""
+        """Add explicit OK/Cancel buttons and set dialog size."""
         box = ttk.Frame(self)
+        box.grid(row=1, column=0, sticky="ew", padx=5, pady=5)
 
-        accept_btn = ttk.Button(
-            box, text="Accept", width=10, command=self.ok, default=tk.ACTIVE
+        ok_btn = ttk.Button(
+            box, text="OK", width=10, command=self.ok, default=tk.ACTIVE
         )
-        accept_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        ok_btn.pack(side=tk.RIGHT, padx=5)
         cancel_btn = ttk.Button(box, text="Cancel", width=10, command=self.cancel)
-        cancel_btn.pack(side=tk.LEFT, padx=5, pady=5)
+        cancel_btn.pack(side=tk.RIGHT, padx=5)
 
-        box.pack(side=tk.BOTTOM, fill=tk.X)
-
-        accept_btn.focus_set()
+        ok_btn.focus_set()
         self.bind("<Return>", self.ok)
         self.bind("<Escape>", self.cancel)
 


### PR DESCRIPTION
## Summary
- Switch threat dialog to use explicit OK and Cancel buttons
- Place buttons in a dedicated section below the main controls and set initial focus

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b57da9f10832582b186512af5f8df