### PR TITLE
fix: avoid grid/pack conflict in threat dialog

### DIFF
--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -535,7 +535,7 @@ class ThreatDialog(simpledialog.Dialog):
     def buttonbox(self):
         """Add explicit OK/Cancel buttons and set dialog size."""
         box = ttk.Frame(self)
-        box.grid(row=1, column=0, sticky="ew", padx=5, pady=5)
+        box.pack(fill="x", padx=5, pady=5)
 
         ok_btn = ttk.Button(
             box, text="OK", width=10, command=self.ok, default=tk.ACTIVE


### PR DESCRIPTION
## Summary
- fix ThreatDialog button box to use `pack` instead of `grid`
- prevents TclError from mixing geometry managers in dialog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b6093cb788325904c4a1f6ef286e2