### PR TITLE
Add safety management toolbox and governance model

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -241,6 +241,7 @@ from gui.review_toolbox import (
     ReviewDocumentDialog,
     VersionCompareDialog,
 )
+from gui.safety_management_toolbox import SafetyManagementToolbox
 from dataclasses import asdict
 from analysis.mechanisms import (
     DiagnosticMechanism,
@@ -2351,6 +2352,7 @@ class FaultTreeApp:
             "Product Goals Export": self.export_product_goal_requirements,
             "FTA Cut Sets": self.show_cut_sets,
             "FTA-FMEA Traceability": self.show_traceability_matrix,
+            "Safety Management": self.open_safety_management_toolbox,
         }
 
         self.tool_categories = {
@@ -2402,6 +2404,9 @@ class FaultTreeApp:
                 "Faults Editor",
                 "Cause & Effect Chain",
                 "Fault Prioritization",
+            ],
+            "Safety Management": [
+                "Safety Management",
             ],
         }
 
@@ -16418,7 +16423,14 @@ class FaultTreeApp:
             self._review_tab = self._new_tab("Review")
             self.review_window = ReviewToolbox(self._review_tab, self)
             self.review_window.pack(fill=tk.BOTH, expand=True)
-        self.set_current_user()
+
+    def open_safety_management_toolbox(self):
+        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
+            self.doc_nb.select(self._safety_mgmt_tab)
+        else:
+            self._safety_mgmt_tab = self._new_tab("Safety Management")
+            self.safety_mgmt_window = SafetyManagementToolbox(self._safety_mgmt_tab, self)
+            self.safety_mgmt_window.pack(fill=tk.BOTH, expand=True)
 
     def send_review_email(self, review):
         """Send the review summary to all reviewers via configured SMTP."""

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ AutoML is an automotive modeling language. It lets you model items, operating sc
   - [Risk & Assurance Gate Calculator](#risk--assurance-gate-calculator)
   - [Product Goals Export](#product-goals-export)
   - [Safety Performance Indicators](#safety-performance-indicators)
+  - [Safety Management Toolbox](#safety-management-toolbox)
 - [Email Setup](#email-setup)
 - [Dependencies](#dependencies)
 - [Diagram Styles](#diagram-styles)
@@ -1124,6 +1125,10 @@ Use **Export Product Goal Requirements** in the Requirements menu to generate a 
 ### Safety Performance Indicators
 
 The **Safety Performance Indicators** tab in the Requirements menu lists each product goal's validation target and acceptance criteria with their descriptions for quick reference.
+
+### Safety Management Toolbox
+
+The **Safety Management Toolbox** lets you organize safety work products across the entire lifecycle. You can define phases, attach tailored work products from any diagram or analysis with a supporting rationale, and capture workflows that govern how these items interact. The resulting lifecycle and workflow definition can be exported as a JSON business diagram to document your safety governance process.
 
 ### Acceptance Criteria and Validation Targets
 

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class SafetyWorkProduct:
+    """Represents a deliverable created during a safety activity."""
+    name: str
+    source: str
+    rationale: str = ""
+
+@dataclass
+class LifecyclePhase:
+    """Phase in the safety lifecycle grouping related work products."""
+    name: str
+    work_products: List[SafetyWorkProduct] = field(default_factory=list)
+
+@dataclass
+class Workflow:
+    """Named workflow consisting of sequential steps."""
+    name: str
+    steps: List[str] = field(default_factory=list)
+
+@dataclass
+class SafetyGovernance:
+    """High level safety management model combining lifecycle and workflows."""
+    phases: List[LifecyclePhase] = field(default_factory=list)
+    workflows: List[Workflow] = field(default_factory=list)

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -1,0 +1,121 @@
+import json
+import tkinter as tk
+from tkinter import ttk, filedialog
+from dataclasses import asdict
+from analysis.safety_management import (
+    SafetyWorkProduct,
+    LifecyclePhase,
+    Workflow,
+    SafetyGovernance,
+)
+
+
+class SafetyManagementToolbox(tk.Frame):
+    """UI to tailor safety work products and workflows."""
+
+    def __init__(self, master, app):
+        super().__init__(master)
+        self.app = app
+        self.governance = SafetyGovernance()
+
+        # --- Work Product Section ---
+        wp_frame = ttk.LabelFrame(self, text="Work Products")
+        wp_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        ttk.Label(wp_frame, text="Phase:").grid(row=0, column=0, sticky="e")
+        ttk.Label(wp_frame, text="Name:").grid(row=1, column=0, sticky="e")
+        ttk.Label(wp_frame, text="Source:").grid(row=2, column=0, sticky="e")
+        ttk.Label(wp_frame, text="Rationale:").grid(row=3, column=0, sticky="ne")
+
+        self.phase_var = tk.StringVar()
+        self.name_var = tk.StringVar()
+        self.source_var = tk.StringVar()
+        self.rationale_txt = tk.Text(wp_frame, width=30, height=3)
+
+        ttk.Entry(wp_frame, textvariable=self.phase_var).grid(row=0, column=1, padx=5, pady=2)
+        ttk.Entry(wp_frame, textvariable=self.name_var).grid(row=1, column=1, padx=5, pady=2)
+        ttk.Entry(wp_frame, textvariable=self.source_var).grid(row=2, column=1, padx=5, pady=2)
+        self.rationale_txt.grid(row=3, column=1, padx=5, pady=2)
+
+        ttk.Button(wp_frame, text="Add", command=self.add_work_product).grid(row=4, column=1, pady=5, sticky="e")
+
+        columns = ("Phase", "Name", "Source", "Rationale")
+        self.wp_tree = ttk.Treeview(wp_frame, columns=columns, show="headings", height=5)
+        for c in columns:
+            self.wp_tree.heading(c, text=c)
+            self.wp_tree.column(c, width=120)
+        self.wp_tree.grid(row=5, column=0, columnspan=2, sticky="nsew", pady=5)
+        wp_frame.grid_rowconfigure(5, weight=1)
+        wp_frame.grid_columnconfigure(1, weight=1)
+
+        # --- Workflow Section ---
+        wf_frame = ttk.LabelFrame(self, text="Workflows")
+        wf_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        ttk.Label(wf_frame, text="Workflow Name:").grid(row=0, column=0, sticky="e")
+        ttk.Label(wf_frame, text="Steps (comma separated):").grid(row=1, column=0, sticky="e")
+
+        self.workflow_name_var = tk.StringVar()
+        self.workflow_steps_var = tk.StringVar()
+        ttk.Entry(wf_frame, textvariable=self.workflow_name_var).grid(row=0, column=1, padx=5, pady=2)
+        ttk.Entry(wf_frame, textvariable=self.workflow_steps_var).grid(row=1, column=1, padx=5, pady=2)
+
+        ttk.Button(wf_frame, text="Add Workflow", command=self.add_workflow).grid(row=2, column=1, pady=5, sticky="e")
+
+        wf_columns = ("Workflow", "Steps")
+        self.wf_tree = ttk.Treeview(wf_frame, columns=wf_columns, show="headings", height=5)
+        for c in wf_columns:
+            self.wf_tree.heading(c, text=c)
+            self.wf_tree.column(c, width=150)
+        self.wf_tree.grid(row=3, column=0, columnspan=2, sticky="nsew", pady=5)
+        wf_frame.grid_rowconfigure(3, weight=1)
+        wf_frame.grid_columnconfigure(1, weight=1)
+
+        ttk.Button(self, text="Export Governance", command=self.export_json).pack(pady=5, anchor="e")
+
+    # ------------------------------------------------------------------
+    def add_work_product(self):
+        phase = self.phase_var.get().strip()
+        name = self.name_var.get().strip()
+        source = self.source_var.get().strip()
+        rationale = self.rationale_txt.get("1.0", "end-1c").strip()
+        if not (phase and name):
+            return
+        lp = next((p for p in self.governance.phases if p.name == phase), None)
+        if lp is None:
+            lp = LifecyclePhase(name=phase)
+            self.governance.phases.append(lp)
+        lp.work_products.append(SafetyWorkProduct(name=name, source=source, rationale=rationale))
+        self.phase_var.set("")
+        self.name_var.set("")
+        self.source_var.set("")
+        self.rationale_txt.delete("1.0", "end")
+        self.refresh_work_products()
+
+    def refresh_work_products(self):
+        self.wp_tree.delete(*self.wp_tree.get_children())
+        for phase in self.governance.phases:
+            for wp in phase.work_products:
+                self.wp_tree.insert("", "end", values=(phase.name, wp.name, wp.source, wp.rationale))
+
+    def add_workflow(self):
+        name = self.workflow_name_var.get().strip()
+        steps = [s.strip() for s in self.workflow_steps_var.get().split(",") if s.strip()]
+        if not name:
+            return
+        self.governance.workflows.append(Workflow(name=name, steps=steps))
+        self.workflow_name_var.set("")
+        self.workflow_steps_var.set("")
+        self.refresh_workflows()
+
+    def refresh_workflows(self):
+        self.wf_tree.delete(*self.wf_tree.get_children())
+        for wf in self.governance.workflows:
+            self.wf_tree.insert("", "end", values=(wf.name, ", ".join(wf.steps)))
+
+    def export_json(self):
+        path = filedialog.asksaveasfilename(defaultextension=".json", filetypes=[("JSON", "*.json")])
+        if not path:
+            return
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(asdict(self.governance), fh, indent=2)

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1,0 +1,20 @@
+import unittest
+from analysis.safety_management import SafetyWorkProduct, LifecyclePhase, SafetyGovernance, Workflow
+
+
+class SafetyManagementTests(unittest.TestCase):
+    def test_work_product_added_to_phase(self):
+        phase = LifecyclePhase(name="Concept")
+        wp = SafetyWorkProduct(name="HAZOP", source="Hazop Analysis", rationale="Identify hazards")
+        phase.work_products.append(wp)
+        self.assertEqual(len(phase.work_products), 1)
+        self.assertEqual(phase.work_products[0].rationale, "Identify hazards")
+
+    def test_workflow_steps(self):
+        gov = SafetyGovernance()
+        wf = Workflow(name="Review", steps=["plan", "execute"])
+        gov.workflows.append(wf)
+        self.assertEqual(gov.workflows[0].steps, ["plan", "execute"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add dataclasses to model safety management lifecycle, work products, and workflows
- introduce a GUI toolbox to tailor safety work products and export governance
- integrate toolbox into AutoML tools list and document usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b709da7988325a81ed35edca26ef1