### PR TITLE
feat: add safety management toolbox

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14328,6 +14328,27 @@ class FaultTreeApp:
         from gui.fault_prioritization import FaultPrioritizationWindow
         self._fault_prio_window = FaultPrioritizationWindow(self._fault_prio_tab, self)
 
+    def open_safety_management_toolbox(self):
+        """Open a placeholder tab for the Safety Management toolbox."""
+        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
+            self.doc_nb.select(self._safety_mgmt_tab)
+            return
+
+        self._safety_mgmt_tab = self._new_tab("Safety Management")
+
+        from analysis.safety_management import SafetyManagementToolbox
+
+        # Reuse existing toolbox instance if present; otherwise create one
+        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
+
+        msg = (
+            "Safety Management toolbox initialized.\n"
+            "Future versions will provide a full graphical interface."
+        )
+        ttk.Label(self._safety_mgmt_tab, text=msg, justify=tk.CENTER).pack(
+            fill=tk.BOTH, expand=True, padx=10, pady=10
+        )
+
     def open_style_editor(self):
         """Open the diagram style editor window."""
         StyleEditor(self.root)

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -2,10 +2,20 @@
 
 from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
 from .confusion_matrix import compute_metrics
+from .safety_management import (
+    SafetyManagementToolbox,
+    SafetyWorkProduct,
+    LifecycleStage,
+    SafetyWorkflow,
+)
 
 __all__ = [
     "acceptance_rate",
     "hazardous_behavior_rate",
     "validation_time",
     "compute_metrics",
+    "SafetyManagementToolbox",
+    "SafetyWorkProduct",
+    "LifecycleStage",
+    "SafetyWorkflow",
 ]

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -1,0 +1,77 @@
+"""Data structures for safety governance artifacts."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class SafetyWorkProduct:
+    """Describe a work product generated from a diagram or analysis."""
+
+    diagram: str
+    analysis: str
+    rationale: str
+
+
+@dataclass
+class LifecycleStage:
+    """Represent a single stage in the project lifecycle."""
+
+    name: str
+
+
+@dataclass
+class SafetyWorkflow:
+    """A named workflow with its ordered list of steps."""
+
+    name: str
+    steps: List[str]
+
+
+@dataclass
+class SafetyManagementToolbox:
+    """Collect work products and governance artifacts for safety management.
+
+    The toolbox lets users register work products from various diagrams and
+    analyses with an associated rationale. It also stores lifecycle stages and
+    named workflows so projects can describe their safety governance.
+    """
+
+    work_products: List[SafetyWorkProduct] = field(default_factory=list)
+    lifecycle: List[LifecycleStage] = field(default_factory=list)
+    workflows: Dict[str, SafetyWorkflow] = field(default_factory=dict)
+
+    def add_work_product(self, diagram: str, analysis: str, rationale: str) -> None:
+        """Add a work product linking a diagram to an analysis with rationale."""
+
+        self.work_products.append(SafetyWorkProduct(diagram, analysis, rationale))
+
+    def build_lifecycle(self, stages: List[str]) -> None:
+        """Define the project lifecycle stages."""
+
+        self.lifecycle = [LifecycleStage(name) for name in stages]
+
+    def define_workflow(self, name: str, steps: List[str]) -> None:
+        """Record an ordered list of steps for a workflow."""
+
+        self.workflows[name] = SafetyWorkflow(name, steps)
+
+    def get_work_products(self) -> List[SafetyWorkProduct]:
+        """Return all registered work products."""
+
+        return list(self.work_products)
+
+    def get_workflow(self, name: str) -> List[str]:
+        """Return the steps for the requested workflow."""
+
+        workflow = self.workflows.get(name)
+        return workflow.steps if workflow else []
+
+
+__all__ = [
+    "SafetyWorkProduct",
+    "LifecycleStage",
+    "SafetyWorkflow",
+    "SafetyManagementToolbox",
+]
+

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -1,0 +1,30 @@
+"""Placeholder GUI for the Safety Management toolbox."""
+
+from tkinter import Frame, Label
+
+from analysis.safety_management import (
+    SafetyManagementToolbox as CoreSafetyManagementToolbox,
+    SafetyWorkProduct,
+    LifecycleStage,
+    SafetyWorkflow,
+)
+
+
+class SafetyManagementToolbox(Frame):
+    """Minimal graphical wrapper around :class:`CoreSafetyManagementToolbox`."""
+
+    def __init__(self, master):
+        super().__init__(master)
+        self.toolbox = CoreSafetyManagementToolbox()
+        Label(self, text="Safety Management toolbox is under construction").pack(
+            padx=10, pady=10
+        )
+
+
+__all__ = [
+    "SafetyManagementToolbox",
+    "SafetyWorkProduct",
+    "LifecycleStage",
+    "SafetyWorkflow",
+]
+

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from analysis import SafetyManagementToolbox
+
+
+def test_work_product_registration():
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Activity Diagram", "HAZOP", "Link action to hazard")
+
+    products = toolbox.get_work_products()
+    assert len(products) == 1
+    assert products[0].diagram == "Activity Diagram"
+    assert products[0].analysis == "HAZOP"
+    assert products[0].rationale == "Link action to hazard"
+
+
+def test_lifecycle_and_workflow_storage():
+    toolbox = SafetyManagementToolbox()
+    toolbox.build_lifecycle(["concept", "development", "operation"])
+    toolbox.define_workflow("risk", ["identify", "assess", "mitigate"])
+
+    assert [stage.name for stage in toolbox.lifecycle] == [
+        "concept",
+        "development",
+        "operation",
+    ]
+    assert toolbox.get_workflow("risk") == ["identify", "assess", "mitigate"]
+    assert toolbox.get_workflow("missing") == []


### PR DESCRIPTION
## Summary
- add dataclasses for safety work products, lifecycle stages, and workflows
- expose dataclasses via the analysis package and provide a placeholder GUI wrapper
- update safety management tests for lifecycle stage handling

## Testing
- `pytest tests/test_safety_management.py`
- `python - <<'PY'
import gui.safety_management_toolbox as smt
print('imported', smt.SafetyManagementToolbox.__name__)
PY`


------
https://chatgpt.com/codex/tasks/task_b_689b709da7988325a81ed35edca26ef1