### PR TITLE
Add confusion matrix rate calculations

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14123,28 +14123,37 @@ class FaultTreeApp:
                 nb.add(self.attr_frame, text="Attributes")
                 self.attr_rows = []
                 for k, v in self.data.items():
-                    if k not in {"name", "tp", "fp", "tn", "fn"}:
+                    if k not in {"name", "p", "n", "tp", "fp", "tn", "fn"}:
                         self.add_attr_row(k, v)
                 ttk.Button(self.attr_frame, text="Add Attribute", command=self.add_attr_row).grid(row=99, column=0, columnspan=2, pady=5)
 
                 # Confusion matrix tab
                 cm_frame = ttk.Frame(nb)
                 nb.add(cm_frame, text="Confusion Matrix")
+                self.p_var = tk.DoubleVar(value=float(self.data.get("p", 0) or 0))
+                self.n_var = tk.DoubleVar(value=float(self.data.get("n", 0) or 0))
                 self.tp_var = tk.DoubleVar(value=float(self.data.get("tp", 0) or 0))
                 self.fp_var = tk.DoubleVar(value=float(self.data.get("fp", 0) or 0))
                 self.tn_var = tk.DoubleVar(value=float(self.data.get("tn", 0) or 0))
                 self.fn_var = tk.DoubleVar(value=float(self.data.get("fn", 0) or 0))
 
+                inputs = ttk.Frame(cm_frame)
+                inputs.grid(row=0, column=0, pady=5)
+                ttk.Label(inputs, text="Actual P").grid(row=0, column=0)
+                ttk.Entry(inputs, textvariable=self.p_var, width=6).grid(row=0, column=1)
+                ttk.Label(inputs, text="Actual N").grid(row=0, column=2)
+                ttk.Entry(inputs, textvariable=self.n_var, width=6).grid(row=0, column=3)
+
                 matrix = ttk.Frame(cm_frame)
-                matrix.grid(row=0, column=0, pady=5)
+                matrix.grid(row=1, column=0, pady=5)
                 ttk.Label(matrix, text="TP").grid(row=0, column=0)
-                ttk.Entry(matrix, textvariable=self.tp_var, width=6).grid(row=0, column=1)
+                ttk.Label(matrix, textvariable=self.tp_var, width=6).grid(row=0, column=1)
                 ttk.Label(matrix, text="FN").grid(row=0, column=2)
-                ttk.Entry(matrix, textvariable=self.fn_var, width=6).grid(row=0, column=3)
+                ttk.Label(matrix, textvariable=self.fn_var, width=6).grid(row=0, column=3)
                 ttk.Label(matrix, text="FP").grid(row=1, column=0)
-                ttk.Entry(matrix, textvariable=self.fp_var, width=6).grid(row=1, column=1)
+                ttk.Label(matrix, textvariable=self.fp_var, width=6).grid(row=1, column=1)
                 ttk.Label(matrix, text="TN").grid(row=1, column=2)
-                ttk.Entry(matrix, textvariable=self.tn_var, width=6).grid(row=1, column=3)
+                ttk.Label(matrix, textvariable=self.tn_var, width=6).grid(row=1, column=3)
 
                 metrics_frame = ttk.Frame(cm_frame)
                 metrics_frame.grid(row=1, column=0, sticky="nsew")
@@ -14152,29 +14161,73 @@ class FaultTreeApp:
                 ttk.Label(metrics_frame, text="Precision:").grid(row=1, column=0, sticky="e")
                 ttk.Label(metrics_frame, text="Recall:").grid(row=2, column=0, sticky="e")
                 ttk.Label(metrics_frame, text="F1 Score:").grid(row=3, column=0, sticky="e")
+                ttk.Label(metrics_frame, text="TPR:").grid(row=4, column=0, sticky="e")
+                ttk.Label(metrics_frame, text="TNR:").grid(row=5, column=0, sticky="e")
+                ttk.Label(metrics_frame, text="FPR:").grid(row=6, column=0, sticky="e")
+                ttk.Label(metrics_frame, text="FNR:").grid(row=7, column=0, sticky="e")
                 self.acc_var = tk.StringVar()
                 self.prec_var = tk.StringVar()
                 self.rec_var = tk.StringVar()
                 self.f1_var = tk.StringVar()
+                self.tpr_var = tk.StringVar()
+                self.tnr_var = tk.StringVar()
+                self.fpr_var = tk.StringVar()
+                self.fnr_var = tk.StringVar()
                 ttk.Label(metrics_frame, textvariable=self.acc_var).grid(row=0, column=1, sticky="w")
                 ttk.Label(metrics_frame, textvariable=self.prec_var).grid(row=1, column=1, sticky="w")
                 ttk.Label(metrics_frame, textvariable=self.rec_var).grid(row=2, column=1, sticky="w")
                 ttk.Label(metrics_frame, textvariable=self.f1_var).grid(row=3, column=1, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.tpr_var).grid(row=4, column=1, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.tnr_var).grid(row=5, column=1, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.fpr_var).grid(row=6, column=1, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.fnr_var).grid(row=7, column=1, sticky="w")
+                ttk.Label(metrics_frame, text="TP/hr:").grid(row=0, column=2, sticky="e")
+                ttk.Label(metrics_frame, text="TN/hr:").grid(row=1, column=2, sticky="e")
+                ttk.Label(metrics_frame, text="FP/hr:").grid(row=2, column=2, sticky="e")
+                ttk.Label(metrics_frame, text="FN/hr:").grid(row=3, column=2, sticky="e")
+                self.tp_rate_var = tk.StringVar()
+                self.tn_rate_var = tk.StringVar()
+                self.fp_rate_var = tk.StringVar()
+                self.fn_rate_var = tk.StringVar()
+                ttk.Label(metrics_frame, textvariable=self.tp_rate_var).grid(row=0, column=3, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.tn_rate_var).grid(row=1, column=3, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.fp_rate_var).grid(row=2, column=3, sticky="w")
+                ttk.Label(metrics_frame, textvariable=self.fn_rate_var).grid(row=3, column=3, sticky="w")
 
                 def update_metrics(*_):
-                    from analysis.confusion_matrix import compute_metrics
+                    from analysis.confusion_matrix import compute_metrics, compute_rates
 
-                    tp = self.tp_var.get()
-                    fp = self.fp_var.get()
-                    tn = self.tn_var.get()
-                    fn = self.fn_var.get()
-                    metrics = compute_metrics(tp, fp, tn, fn)
+                    p = self.p_var.get()
+                    n = self.n_var.get()
+                    tau_on = getattr(self, "current_tau_on", 0.0)
+                    val_target = None
+                    if getattr(self, "selected_goal", None) is not None:
+                        val_target = getattr(self.selected_goal, "validation_target", None)
+                    rates = compute_rates(
+                        hours=tau_on or 0.0,
+                        validation_target=val_target,
+                        p=p,
+                        n=n,
+                    )
+                    self.tp_var.set(rates["tp"])
+                    self.fp_var.set(rates["fp"])
+                    self.tn_var.set(rates["tn"])
+                    self.fn_var.set(rates["fn"])
+                    metrics = compute_metrics(rates["tp"], rates["fp"], rates["tn"], rates["fn"])
                     self.acc_var.set(f"{metrics['accuracy']:.3f}")
                     self.prec_var.set(f"{metrics['precision']:.3f}")
                     self.rec_var.set(f"{metrics['recall']:.3f}")
                     self.f1_var.set(f"{metrics['f1']:.3f}")
+                    self.tpr_var.set(f"{rates['tpr']:.3f}")
+                    self.tnr_var.set(f"{rates['tnr']:.3f}")
+                    self.fpr_var.set(f"{rates['fpr']:.3f}")
+                    self.fnr_var.set(f"{rates['fnr']:.3f}")
+                    self.tp_rate_var.set(f"{rates['tp_rate']:.3f}")
+                    self.tn_rate_var.set(f"{rates['tn_rate']:.3f}")
+                    self.fp_rate_var.set(f"{rates['fp_rate']:.3f}")
+                    self.fn_rate_var.set(f"{rates['fn_rate']:.3f}")
 
-                for var in (self.tp_var, self.fp_var, self.tn_var, self.fn_var):
+                for var in (self.p_var, self.n_var):
                     var.trace_add("write", update_metrics)
                 update_metrics()
 
@@ -14194,12 +14247,36 @@ class FaultTreeApp:
                     width = 120 if c in ("Product Goal", "Validation Target") else 200
                     self.vt_tree.column(c, width=width, anchor="center")
                 self.vt_tree.pack(fill=tk.BOTH, expand=True)
+                self.vt_item_to_goal = {}
+                self.selected_goal = None
+                self.current_tau_on = 0.0
+
+                def on_vt_select(event=None):
+                    sel = self.vt_tree.selection()
+                    if not sel:
+                        self.selected_goal = None
+                        self.current_tau_on = 0.0
+                    else:
+                        sg = self.vt_item_to_goal.get(sel[0])
+                        self.selected_goal = sg
+                        tau_on = 0.0
+                        mp_name = getattr(sg, "mission_profile", "")
+                        if mp_name:
+                            for mp in self.app.mission_profiles:
+                                if mp.name == mp_name:
+                                    tau_on = mp.tau_on
+                                    break
+                        self.current_tau_on = tau_on
+                    update_metrics()
+
+                self.vt_tree.bind("<<TreeviewSelect>>", on_vt_select)
 
                 def refresh_vt(*_):
                     self.vt_tree.delete(*self.vt_tree.get_children())
+                    self.vt_item_to_goal.clear()
                     name = self.name_var.get().strip()
                     for sg in self.app.get_validation_targets_for_odd(name):
-                        self.vt_tree.insert(
+                        iid = self.vt_tree.insert(
                             "",
                             "end",
                             values=[
@@ -14209,6 +14286,11 @@ class FaultTreeApp:
                                 getattr(sg, "acceptance_criteria", ""),
                             ],
                         )
+                        self.vt_item_to_goal[iid] = sg
+                    items = self.vt_tree.get_children()
+                    if items:
+                        self.vt_tree.selection_set(items[0])
+                        on_vt_select()
 
                 refresh_vt()
                 self.name_var.trace_add("write", refresh_vt)
@@ -14219,14 +14301,31 @@ class FaultTreeApp:
                     key = k_var.get().strip()
                     if key:
                         new_data[key] = v_var.get()
-                tp = float(self.tp_var.get())
-                fp = float(self.fp_var.get())
-                tn = float(self.tn_var.get())
-                fn = float(self.fn_var.get())
-                from analysis.confusion_matrix import compute_metrics
+                p = float(self.p_var.get())
+                n = float(self.n_var.get())
+                from analysis.confusion_matrix import compute_metrics, compute_rates
 
-                new_data.update({"tp": tp, "fp": fp, "tn": tn, "fn": fn})
-                new_data.update(compute_metrics(tp, fp, tn, fn))
+                tau_on = getattr(self, "current_tau_on", 0.0)
+                val_target = None
+                if getattr(self, "selected_goal", None) is not None:
+                    val_target = getattr(self.selected_goal, "validation_target", None)
+                rates = compute_rates(
+                    hours=tau_on or 0.0,
+                    validation_target=val_target,
+                    p=p,
+                    n=n,
+                )
+                metrics = compute_metrics(rates["tp"], rates["fp"], rates["tn"], rates["fn"])
+                new_data.update({
+                    "p": p,
+                    "n": n,
+                    "tp": rates["tp"],
+                    "fp": rates["fp"],
+                    "tn": rates["tn"],
+                    "fn": rates["fn"],
+                })
+                new_data.update(metrics)
+                new_data.update(rates)
                 self.data = new_data
 
         def add_lib():

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,11 +1,12 @@
 """Analysis utilities for AutoML."""
 
 from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
-from .confusion_matrix import compute_metrics
+from .confusion_matrix import compute_metrics, compute_rates
 
 __all__ = [
     "acceptance_rate",
     "hazardous_behavior_rate",
     "validation_time",
     "compute_metrics",
+    "compute_rates",
 ]

--- a/analysis/confusion_matrix.py
+++ b/analysis/confusion_matrix.py
@@ -32,3 +32,116 @@ def compute_metrics(tp: float, fp: float, tn: float, fn: float) -> Dict[str, flo
         "recall": recall,
         "f1": f1,
     }
+
+
+def compute_rates(
+    tp: float | None = None,
+    fp: float | None = None,
+    tn: float | None = None,
+    fn: float | None = None,
+    hours: float = 0.0,
+    validation_target: float | None = None,
+    p: float | None = None,
+    n: float | None = None,
+) -> Dict[str, float]:
+    """Calculate confusion matrix rates and per-hour event rates.
+
+    This helper can either operate on explicit confusion matrix counts
+    (``tp``, ``fp``, ``tn``, ``fn``) or derive them from dataset sizes
+    ``p`` (actual positives) and ``n`` (actual negatives) together with an
+    allowed hazardous event rate ``validation_target`` expressed in
+    events/hour.
+
+    Parameters
+    ----------
+    tp, fp, tn, fn:
+        Confusion matrix counts. If any are ``None`` then ``p`` and ``n``
+        must be supplied and counts are derived assuming the per-hour
+        limit ``validation_target`` applies equally to false positives and
+        false negatives.
+    hours:
+        Total test duration in hours (mission profile ``TAU ON``).
+    validation_target:
+        Optional allowed hazardous events per hour for the selected
+        validation target. When provided, additional maximum/minimum rates
+        are computed using the formulas in the project documentation.
+    p, n:
+        Dataset sizes for actual positives and negatives. Required when
+        explicit confusion matrix counts are not supplied.
+
+    Returns
+    -------
+    dict
+        Dictionary containing the confusion matrix counts (``tp``, ``fp``,
+        ``tn``, ``fn``), derived totals ``p`` and ``n``, the dimensionless
+        rates ``tpr``, ``tnr``, ``fpr`` and ``fnr`` as well as the per-hour
+        event rates ``tp_rate``, ``tn_rate``, ``fp_rate`` and
+        ``fn_rate``. When ``validation_target`` is supplied, the dictionary
+        also contains ``fpr_max``, ``fnr_max``, ``tpr_min`` and
+        ``tnr_min``.
+    """
+
+    hours = float(hours)
+    if tp is None or fp is None or tn is None or fn is None:
+        if p is None or n is None:
+            raise ValueError(
+                "Either confusion matrix counts or dataset sizes P and N must be provided"
+            )
+        p = float(p)
+        n = float(n)
+        rate = float(validation_target or 0.0)
+        fp = rate * hours
+        fn = rate * hours
+        tp = max(p - fn, 0.0)
+        tn = max(n - fp, 0.0)
+    else:
+        tp = float(tp)
+        fp = float(fp)
+        tn = float(tn)
+        fn = float(fn)
+        p = tp + fn
+        n = tn + fp
+
+    validation_target = float(validation_target) if validation_target is not None else None
+
+    tpr = tp / p if p else 0.0
+    tnr = tn / n if n else 0.0
+    fpr = fp / n if n else 0.0
+    fnr = fn / p if p else 0.0
+
+    tp_rate = tp / hours if hours else 0.0
+    tn_rate = tn / hours if hours else 0.0
+    fp_rate = fp / hours if hours else 0.0
+    fn_rate = fn / hours if hours else 0.0
+
+    results = {
+        "tp": tp,
+        "fp": fp,
+        "tn": tn,
+        "fn": fn,
+        "p": p,
+        "n": n,
+        "tpr": tpr,
+        "tnr": tnr,
+        "fpr": fpr,
+        "fnr": fnr,
+        "tp_rate": tp_rate,
+        "tn_rate": tn_rate,
+        "fp_rate": fp_rate,
+        "fn_rate": fn_rate,
+    }
+
+    if validation_target is not None and hours > 0.0:
+        max_events = validation_target * hours
+        fpr_max = max_events / n if n else 0.0
+        fnr_max = max_events / p if p else 0.0
+        results.update(
+            {
+                "fpr_max": fpr_max,
+                "fnr_max": fnr_max,
+                "tpr_min": 1.0 - fnr_max,
+                "tnr_min": 1.0 - fpr_max,
+            }
+        )
+
+    return results

--- a/tests/test_confusion_matrix.py
+++ b/tests/test_confusion_matrix.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from analysis.confusion_matrix import compute_metrics
+from analysis.confusion_matrix import compute_metrics, compute_rates
 
 
 def test_compute_metrics_basic():
@@ -23,3 +23,45 @@ def test_compute_metrics_zero_division():
     assert metrics["precision"] == 0.0
     assert metrics["recall"] == 0.0
     assert metrics["f1"] == 0.0
+
+
+def test_compute_rates_basic():
+    rates = compute_rates(50, 10, 30, 10, 100, 0.01)
+    assert math.isclose(rates["tp"], 50)
+    assert math.isclose(rates["fp"], 10)
+    assert math.isclose(rates["tn"], 30)
+    assert math.isclose(rates["fn"], 10)
+    assert math.isclose(rates["tpr"], 50 / 60)
+    assert math.isclose(rates["tnr"], 30 / 40)
+    assert math.isclose(rates["fpr"], 10 / 40)
+    assert math.isclose(rates["fnr"], 10 / 60)
+    assert math.isclose(rates["tp_rate"], 50 / 100)
+    assert math.isclose(rates["tn_rate"], 30 / 100)
+    assert math.isclose(rates["fp_rate"], 10 / 100)
+    assert math.isclose(rates["fn_rate"], 10 / 100)
+    assert math.isclose(rates["fpr_max"], (0.01 * 100) / 40)
+    assert math.isclose(rates["fnr_max"], (0.01 * 100) / 60)
+    assert math.isclose(rates["tpr_min"], 1 - (0.01 * 100) / 60)
+    assert math.isclose(rates["tnr_min"], 1 - (0.01 * 100) / 40)
+
+
+def test_compute_rates_auto_counts():
+    rates = compute_rates(hours=100, validation_target=0.01, p=60, n=40)
+    assert math.isclose(rates["fp"], 0.01 * 100)
+    assert math.isclose(rates["fn"], 0.01 * 100)
+    assert math.isclose(rates["tp"], 60 - 0.01 * 100)
+    assert math.isclose(rates["tn"], 40 - 0.01 * 100)
+    assert math.isclose(rates["tpr"], rates["tp"] / 60)
+    assert math.isclose(rates["tnr"], rates["tn"] / 40)
+
+
+def test_compute_rates_zero_hours():
+    rates = compute_rates(0, 0, 0, 0, 0, None)
+    assert rates["tp_rate"] == 0.0
+    assert rates["tn_rate"] == 0.0
+    assert rates["fp_rate"] == 0.0
+    assert rates["fn_rate"] == 0.0
+    assert rates["tpr"] == 0.0
+    assert rates["tnr"] == 0.0
+    assert rates["fpr"] == 0.0
+    assert rates["fnr"] == 0.0


### PR DESCRIPTION
## Summary
- auto-derive TP/FP/TN/FN counts from dataset size and per-hour validation targets
- let ODD element confusion matrix compute and display counts using mission profile TAU ON
- expand tests for automatic confusion matrix count derivation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b763b62f48325ac89872846937c62