### PR TITLE
refactor: reuse activity diagrams for safety

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14328,6 +14328,18 @@ class FaultTreeApp:
         from gui.fault_prioritization import FaultPrioritizationWindow
         self._fault_prio_window = FaultPrioritizationWindow(self._fault_prio_tab, self)
 
+    def open_safety_management_toolbox(self):
+        """Open a Safety Management tab with an Activity Diagram."""
+        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
+            self.doc_nb.select(self._safety_mgmt_tab)
+            return
+
+        self._safety_mgmt_tab = self._new_tab("Safety Management")
+
+        from gui.architecture import ActivityDiagramWindow
+
+        ActivityDiagramWindow(self._safety_mgmt_tab, self)
+
     def open_style_editor(self):
         """Open the diagram style editor window."""
         StyleEditor(self.root)

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -2,10 +2,12 @@
 
 from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
 from .confusion_matrix import compute_metrics
+from .safety_management import SafetyManagementToolbox
 
 __all__ = [
     "acceptance_rate",
     "hazardous_behavior_rate",
     "validation_time",
     "compute_metrics",
+    "SafetyManagementToolbox",
 ]

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -1,0 +1,67 @@
+"""Safety management data structures.
+
+This module defines simple data classes used by the GUI and other modules to
+collect work products, lifecycle information and workflows related to safety
+governance."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class SafetyWorkProduct:
+    """Describe a work product generated from a diagram or analysis."""
+
+    diagram: str
+    analysis: str
+    rationale: str
+
+
+@dataclass
+class LifecycleStage:
+    """Represent a single stage in a safety lifecycle."""
+
+    name: str
+
+
+@dataclass
+class Workflow:
+    """Ordered list of steps for a named workflow."""
+
+    name: str
+    steps: List[str]
+
+
+@dataclass
+class SafetyManagementToolbox:
+    """Collect work products and governance artifacts for safety management.
+
+    The toolbox lets users register work products from various diagrams and
+    analyses with an associated rationale. It also stores lifecycle stages and
+    named workflows so projects can describe their safety governance.
+    """
+
+    work_products: List[SafetyWorkProduct] = field(default_factory=list)
+    lifecycle: List[str] = field(default_factory=list)
+    workflows: Dict[str, List[str]] = field(default_factory=dict)
+
+    def add_work_product(self, diagram: str, analysis: str, rationale: str) -> None:
+        """Add a work product linking a diagram to an analysis with rationale."""
+        self.work_products.append(SafetyWorkProduct(diagram, analysis, rationale))
+
+    def build_lifecycle(self, stages: List[str]) -> None:
+        """Define the project lifecycle stages."""
+        self.lifecycle = stages
+
+    def define_workflow(self, name: str, steps: List[str]) -> None:
+        """Record an ordered list of steps for a workflow."""
+        self.workflows[name] = steps
+
+    def get_work_products(self) -> List[SafetyWorkProduct]:
+        """Return all registered work products."""
+        return list(self.work_products)
+
+    def get_workflow(self, name: str) -> List[str]:
+        """Return the steps for the requested workflow."""
+        return self.workflows.get(name, [])
+

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5334,15 +5334,28 @@ class SysMLDiagramWindow(tk.Frame):
             )
             label = obj.properties.get("name", "")
             if label:
-                lx = x
-                ly = y - h - 4 * self.zoom
-                self.canvas.create_text(
-                    lx,
-                    ly,
-                    text=label,
-                    anchor="s",
-                    font=self.font,
-                )
+                diag = self.repo.diagrams.get(self.diagram_id)
+                if diag and diag.diag_type == "Activity Diagram":
+                    lx = x - w - 4 * self.zoom
+                    ly = y
+                    self.canvas.create_text(
+                        lx,
+                        ly,
+                        text=label,
+                        angle=90,
+                        anchor="e",
+                        font=self.font,
+                    )
+                else:
+                    lx = x
+                    ly = y - h - 4 * self.zoom
+                    self.canvas.create_text(
+                        lx,
+                        ly,
+                        text=label,
+                        anchor="s",
+                        font=self.font,
+                    )
         elif obj.obj_type == "Block Boundary":
             self._create_round_rect(
                 x - w,
@@ -7768,6 +7781,7 @@ class ActivityDiagramWindow(SysMLDiagramWindow):
             "Fork",
             "Join",
             "Flow",
+            "System Boundary",
         ]
         super().__init__(master, "Activity Diagram", tools, diagram_id, app=app, history=history)
         ttk.Button(

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from analysis import SafetyManagementToolbox
+from gui.architecture import ActivityDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_work_product_registration():
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Activity Diagram", "HAZOP", "Link action to hazard")
+
+    products = toolbox.get_work_products()
+    assert len(products) == 1
+    assert products[0].diagram == "Activity Diagram"
+    assert products[0].analysis == "HAZOP"
+    assert products[0].rationale == "Link action to hazard"
+
+
+def test_lifecycle_and_workflow_storage():
+    toolbox = SafetyManagementToolbox()
+    toolbox.build_lifecycle(["concept", "development", "operation"])
+    toolbox.define_workflow("risk", ["identify", "assess", "mitigate"])
+
+    assert toolbox.lifecycle == ["concept", "development", "operation"]
+    assert toolbox.get_workflow("risk") == ["identify", "assess", "mitigate"]
+    assert toolbox.get_workflow("missing") == []
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.text_calls = []
+
+    def create_text(self, x, y, **kw):
+        self.text_calls.append((x, y, kw))
+
+    def create_rectangle(self, *args, **kwargs):
+        pass
+
+    def create_line(self, *args, **kwargs):
+        pass
+
+    def create_polygon(self, *args, **kwargs):
+        pass
+
+
+def test_activity_boundary_label_rotated_left():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Activity Diagram")
+    win = ActivityDiagramWindow.__new__(ActivityDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.zoom = 1.0
+    win.canvas = DummyCanvas()
+    win.font = None
+    win._draw_gradient_rect = lambda *args, **kwargs: None
+    win.selected_objs = []
+    obj = SysMLObject(1, "System Boundary", 0.0, 0.0, width=100.0, height=80.0, properties={"name": "Lane"})
+    win.draw_object(obj)
+
+    assert win.canvas.text_calls, "label not drawn"
+    x, _, kwargs = win.canvas.text_calls[0]
+    assert kwargs.get("angle") == 90
+    assert x < obj.x - obj.width / 2


### PR DESCRIPTION
## Summary
- drop custom BPMN editor and open an Activity Diagram for Safety Management
- add a System Boundary tool and rotate boundary titles 90° on the left
- streamline safety management data classes to work products and workflows

## Testing
- `pytest tests/test_safety_management.py -q`
- `pytest tests/test_add_boundary_port.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689b709da7988325a81ed35edca26ef1