### PR TITLE
Derive confusion counts from validation targets

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,11 +1,12 @@
 """Analysis utilities for AutoML."""
 
 from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
-from .confusion_matrix import compute_metrics
+from .confusion_matrix import compute_metrics, compute_counts
 
 __all__ = [
     "acceptance_rate",
     "hazardous_behavior_rate",
     "validation_time",
     "compute_metrics",
+    "compute_counts",
 ]

--- a/tests/test_confusion_matrix.py
+++ b/tests/test_confusion_matrix.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from analysis.confusion_matrix import compute_metrics
+from analysis.confusion_matrix import compute_metrics, compute_counts
 
 
 def test_compute_metrics_basic():
@@ -23,3 +23,55 @@ def test_compute_metrics_zero_division():
     assert metrics["precision"] == 0.0
     assert metrics["recall"] == 0.0
     assert metrics["f1"] == 0.0
+
+
+def test_compute_counts_basic():
+    counts = compute_counts(50, 10, 30, 10)
+    assert math.isclose(counts["tp"], 50)
+    assert math.isclose(counts["fp"], 10)
+    assert math.isclose(counts["tn"], 30)
+    assert math.isclose(counts["fn"], 10)
+    assert math.isclose(counts["p"], 60)
+    assert math.isclose(counts["n"], 40)
+
+
+def test_compute_counts_auto_fp():
+    counts = compute_counts(hours=100, validation_target=0.01, p=60, n=40, target_type="fp")
+    assert math.isclose(counts["fp"], 0.01 * 100)
+    assert math.isclose(counts["tn"], 40 - 0.01 * 100)
+    assert math.isclose(counts["tp"], 60)
+    assert math.isclose(counts["fn"], 0.0)
+    assert math.isclose(counts["p"], 60)
+    assert math.isclose(counts["n"], 40)
+
+
+def test_compute_counts_auto_fn():
+    counts = compute_counts(hours=100, validation_target=0.02, p=60, n=40, target_type="fn")
+    assert math.isclose(counts["fn"], 0.02 * 100)
+    assert math.isclose(counts["tp"], 60 - 0.02 * 100)
+    assert math.isclose(counts["tn"], 40)
+    assert math.isclose(counts["fp"], 0.0)
+
+
+def test_compute_counts_auto_tp():
+    counts = compute_counts(hours=100, validation_target=0.5, p=60, n=40, target_type="tp")
+    assert math.isclose(counts["tp"], 0.5 * 100)
+    assert math.isclose(counts["fn"], 60 - 0.5 * 100)
+    assert math.isclose(counts["tn"], 40)
+    assert math.isclose(counts["fp"], 0.0)
+
+
+def test_compute_counts_auto_tn():
+    counts = compute_counts(hours=100, validation_target=0.2, p=60, n=40, target_type="tn")
+    assert math.isclose(counts["tn"], 0.2 * 100)
+    assert math.isclose(counts["fp"], 40 - 0.2 * 100)
+    assert math.isclose(counts["tp"], 60)
+    assert math.isclose(counts["fn"], 0.0)
+
+
+def test_compute_counts_zero_hours():
+    counts = compute_counts(hours=0, validation_target=0.1, p=10, n=10, target_type="fp")
+    assert counts["tp"] == 10
+    assert counts["tn"] == 10
+    assert counts["fp"] == 0.0
+    assert counts["fn"] == 0.0


### PR DESCRIPTION
## Summary
- allow selecting TP/FP/TN/FN type for each validation target in the ODD element editor
- derive confusion-matrix counts from validation-target events/hour and mission profile TAU ON
- show only accuracy, precision, recall, and F1 from the auto-computed counts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b763b62f48325ac89872846937c62