### PR TITLE
Compute metrics from validation target before confusion counts

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14195,7 +14195,7 @@ class FaultTreeApp:
                 ttk.Label(metrics_frame, textvariable=self.fn_rate_var).grid(row=3, column=3, sticky="w")
 
                 def update_metrics(*_):
-                    from analysis.confusion_matrix import compute_metrics, compute_rates
+                    from analysis.confusion_matrix import compute_metrics_from_target
 
                     p = self.p_var.get()
                     n = self.n_var.get()
@@ -14203,21 +14203,24 @@ class FaultTreeApp:
                     val_target = None
                     if getattr(self, "selected_goal", None) is not None:
                         val_target = getattr(self.selected_goal, "validation_target", None)
-                    rates = compute_rates(
+                    data = compute_metrics_from_target(
                         hours=tau_on or 0.0,
                         validation_target=val_target,
                         p=p,
                         n=n,
                     )
-                    self.tp_var.set(rates["tp"])
-                    self.fp_var.set(rates["fp"])
-                    self.tn_var.set(rates["tn"])
-                    self.fn_var.set(rates["fn"])
-                    metrics = compute_metrics(rates["tp"], rates["fp"], rates["tn"], rates["fn"])
-                    self.acc_var.set(f"{metrics['accuracy']:.3f}")
-                    self.prec_var.set(f"{metrics['precision']:.3f}")
-                    self.rec_var.set(f"{metrics['recall']:.3f}")
-                    self.f1_var.set(f"{metrics['f1']:.3f}")
+                    self.acc_var.set(f"{data['accuracy']:.3f}")
+                    self.prec_var.set(f"{data['precision']:.3f}")
+                    self.rec_var.set(f"{data['recall']:.3f}")
+                    self.f1_var.set(f"{data['f1']:.3f}")
+                    tp = data["tp"]
+                    fp = data["fp"]
+                    tn = data["tn"]
+                    fn = data["fn"]
+                    self.tp_var.set(tp)
+                    self.fp_var.set(fp)
+                    self.tn_var.set(tn)
+                    self.fn_var.set(fn)
 
                 for var in (self.p_var, self.n_var):
                     var.trace_add("write", update_metrics)
@@ -14295,29 +14298,19 @@ class FaultTreeApp:
                         new_data[key] = v_var.get()
                 p = float(self.p_var.get())
                 n = float(self.n_var.get())
-                from analysis.confusion_matrix import compute_metrics, compute_rates
+                from analysis.confusion_matrix import compute_metrics_from_target
 
                 tau_on = getattr(self, "current_tau_on", 0.0)
                 val_target = None
                 if getattr(self, "selected_goal", None) is not None:
                     val_target = getattr(self.selected_goal, "validation_target", None)
-                rates = compute_rates(
+                data = compute_metrics_from_target(
                     hours=tau_on or 0.0,
                     validation_target=val_target,
                     p=p,
                     n=n,
                 )
-                metrics = compute_metrics(rates["tp"], rates["fp"], rates["tn"], rates["fn"])
-                new_data.update({
-                    "p": p,
-                    "n": n,
-                    "tp": rates["tp"],
-                    "fp": rates["fp"],
-                    "tn": rates["tn"],
-                    "fn": rates["fn"],
-                })
-                new_data.update(metrics)
-                new_data.update(rates)
+                new_data.update(data)
                 self.data = new_data
 
         def add_lib():

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,7 +1,7 @@
 """Analysis utilities for AutoML."""
 
 from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
-from .confusion_matrix import compute_metrics
+from .confusion_matrix import compute_metrics, compute_metrics_from_target
 from .safety_management import SafetyManagementToolbox
 
 __all__ = [
@@ -9,5 +9,6 @@ __all__ = [
     "hazardous_behavior_rate",
     "validation_time",
     "compute_metrics",
+    "compute_metrics_from_target",
     "SafetyManagementToolbox",
 ]

--- a/tests/test_confusion_matrix.py
+++ b/tests/test_confusion_matrix.py
@@ -3,7 +3,11 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from analysis.confusion_matrix import compute_metrics, compute_rates
+from analysis.confusion_matrix import (
+    compute_metrics,
+    compute_metrics_from_target,
+    compute_rates,
+)
 
 
 def test_compute_metrics_basic():
@@ -51,3 +55,15 @@ def test_compute_rates_zero_hours():
     assert counts["tn"] == 0.0
     assert counts["fp"] == 0.0
     assert counts["fn"] == 0.0
+
+
+def test_compute_metrics_from_target():
+    data = compute_metrics_from_target(hours=100, validation_target=0.01, p=60, n=40)
+    assert math.isclose(data["accuracy"], 0.98)
+    assert math.isclose(data["precision"], 0.9833333333333333)
+    assert math.isclose(data["recall"], 0.9833333333333333)
+    assert math.isclose(data["f1"], 0.9833333333333333)
+    assert math.isclose(data["tp"], 59.0)
+    assert math.isclose(data["fp"], 1.0)
+    assert math.isclose(data["tn"], 39.0)
+    assert math.isclose(data["fn"], 1.0)


### PR DESCRIPTION
## Summary
- add `compute_metrics_from_target` utility to derive metrics from mission profile duration and validation target
- update ODD elements confusion matrix window to compute metrics first, then confusion matrix counts
- cover new helper with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b8be1123883259c32a6ba0fe4eeda