### PR TITLE
Refactor confusion matrix tab for manual metrics

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14137,23 +14137,17 @@ class FaultTreeApp:
                 self.tn_var = tk.DoubleVar(value=float(self.data.get("tn", 0) or 0))
                 self.fn_var = tk.DoubleVar(value=float(self.data.get("fn", 0) or 0))
 
-                inputs = ttk.Frame(cm_frame)
-                inputs.grid(row=0, column=0, pady=5)
-                ttk.Label(inputs, text="Actual P").grid(row=0, column=0)
-                ttk.Entry(inputs, textvariable=self.p_var, width=6).grid(row=0, column=1)
-                ttk.Label(inputs, text="Actual N").grid(row=0, column=2)
-                ttk.Entry(inputs, textvariable=self.n_var, width=6).grid(row=0, column=3)
-
                 matrix = ttk.Frame(cm_frame)
-                matrix.grid(row=1, column=0, pady=5)
-                ttk.Label(matrix, text="TP").grid(row=0, column=0)
-                ttk.Label(matrix, textvariable=self.tp_var, width=6).grid(row=0, column=1)
-                ttk.Label(matrix, text="FN").grid(row=0, column=2)
-                ttk.Label(matrix, textvariable=self.fn_var, width=6).grid(row=0, column=3)
-                ttk.Label(matrix, text="FP").grid(row=1, column=0)
-                ttk.Label(matrix, textvariable=self.fp_var, width=6).grid(row=1, column=1)
-                ttk.Label(matrix, text="TN").grid(row=1, column=2)
-                ttk.Label(matrix, textvariable=self.tn_var, width=6).grid(row=1, column=3)
+                matrix.grid(row=0, column=0, pady=5)
+                ttk.Label(matrix, text="").grid(row=0, column=0)
+                ttk.Label(matrix, text="Pred P").grid(row=0, column=1)
+                ttk.Label(matrix, text="Pred N").grid(row=0, column=2)
+                ttk.Label(matrix, text="Actual P").grid(row=1, column=0)
+                ttk.Entry(matrix, textvariable=self.tp_var, width=6).grid(row=1, column=1)
+                ttk.Entry(matrix, textvariable=self.fn_var, width=6).grid(row=1, column=2)
+                ttk.Label(matrix, text="Actual N").grid(row=2, column=0)
+                ttk.Entry(matrix, textvariable=self.fp_var, width=6).grid(row=2, column=1)
+                ttk.Entry(matrix, textvariable=self.tn_var, width=6).grid(row=2, column=2)
 
                 metrics_frame = ttk.Frame(cm_frame)
                 metrics_frame.grid(row=1, column=0, sticky="nsew")
@@ -14161,134 +14155,33 @@ class FaultTreeApp:
                 ttk.Label(metrics_frame, text="Precision:").grid(row=1, column=0, sticky="e")
                 ttk.Label(metrics_frame, text="Recall:").grid(row=2, column=0, sticky="e")
                 ttk.Label(metrics_frame, text="F1 Score:").grid(row=3, column=0, sticky="e")
-                ttk.Label(metrics_frame, text="TPR:").grid(row=4, column=0, sticky="e")
-                ttk.Label(metrics_frame, text="TNR:").grid(row=5, column=0, sticky="e")
-                ttk.Label(metrics_frame, text="FPR:").grid(row=6, column=0, sticky="e")
-                ttk.Label(metrics_frame, text="FNR:").grid(row=7, column=0, sticky="e")
                 self.acc_var = tk.StringVar()
                 self.prec_var = tk.StringVar()
                 self.rec_var = tk.StringVar()
                 self.f1_var = tk.StringVar()
-                self.tpr_var = tk.StringVar()
-                self.tnr_var = tk.StringVar()
-                self.fpr_var = tk.StringVar()
-                self.fnr_var = tk.StringVar()
                 ttk.Label(metrics_frame, textvariable=self.acc_var).grid(row=0, column=1, sticky="w")
                 ttk.Label(metrics_frame, textvariable=self.prec_var).grid(row=1, column=1, sticky="w")
                 ttk.Label(metrics_frame, textvariable=self.rec_var).grid(row=2, column=1, sticky="w")
                 ttk.Label(metrics_frame, textvariable=self.f1_var).grid(row=3, column=1, sticky="w")
-                ttk.Label(metrics_frame, textvariable=self.tpr_var).grid(row=4, column=1, sticky="w")
-                ttk.Label(metrics_frame, textvariable=self.tnr_var).grid(row=5, column=1, sticky="w")
-                ttk.Label(metrics_frame, textvariable=self.fpr_var).grid(row=6, column=1, sticky="w")
-                ttk.Label(metrics_frame, textvariable=self.fnr_var).grid(row=7, column=1, sticky="w")
-                ttk.Label(metrics_frame, text="TP/hr:").grid(row=0, column=2, sticky="e")
-                ttk.Label(metrics_frame, text="TN/hr:").grid(row=1, column=2, sticky="e")
-                ttk.Label(metrics_frame, text="FP/hr:").grid(row=2, column=2, sticky="e")
-                ttk.Label(metrics_frame, text="FN/hr:").grid(row=3, column=2, sticky="e")
-                self.tp_rate_var = tk.StringVar()
-                self.tn_rate_var = tk.StringVar()
-                self.fp_rate_var = tk.StringVar()
-                self.fn_rate_var = tk.StringVar()
-                ttk.Label(metrics_frame, textvariable=self.tp_rate_var).grid(row=0, column=3, sticky="w")
-                ttk.Label(metrics_frame, textvariable=self.tn_rate_var).grid(row=1, column=3, sticky="w")
-                ttk.Label(metrics_frame, textvariable=self.fp_rate_var).grid(row=2, column=3, sticky="w")
-                ttk.Label(metrics_frame, textvariable=self.fn_rate_var).grid(row=3, column=3, sticky="w")
 
                 def update_metrics(*_):
-                    from analysis.confusion_matrix import compute_metrics_from_target
+                    from analysis.confusion_matrix import compute_metrics
 
-                    p = self.p_var.get()
-                    n = self.n_var.get()
-                    tau_on = getattr(self, "current_tau_on", 0.0)
-                    val_target = None
-                    if getattr(self, "selected_goal", None) is not None:
-                        val_target = getattr(self.selected_goal, "validation_target", None)
-                    data = compute_metrics_from_target(
-                        hours=tau_on or 0.0,
-                        validation_target=val_target,
-                        p=p,
-                        n=n,
-                    )
-                    self.acc_var.set(f"{data['accuracy']:.3f}")
-                    self.prec_var.set(f"{data['precision']:.3f}")
-                    self.rec_var.set(f"{data['recall']:.3f}")
-                    self.f1_var.set(f"{data['f1']:.3f}")
-                    tp = data["tp"]
-                    fp = data["fp"]
-                    tn = data["tn"]
-                    fn = data["fn"]
-                    self.tp_var.set(tp)
-                    self.fp_var.set(fp)
-                    self.tn_var.set(tn)
-                    self.fn_var.set(fn)
+                    tp = self.tp_var.get()
+                    fp = self.fp_var.get()
+                    tn = self.tn_var.get()
+                    fn = self.fn_var.get()
+                    metrics = compute_metrics(tp, fp, tn, fn)
+                    self.acc_var.set(f"{metrics['accuracy']:.3f}")
+                    self.prec_var.set(f"{metrics['precision']:.3f}")
+                    self.rec_var.set(f"{metrics['recall']:.3f}")
+                    self.f1_var.set(f"{metrics['f1']:.3f}")
+                    self.p_var.set(tp + fn)
+                    self.n_var.set(tn + fp)
 
-                for var in (self.p_var, self.n_var):
+                for var in (self.tp_var, self.fp_var, self.tn_var, self.fn_var):
                     var.trace_add("write", update_metrics)
                 update_metrics()
-
-                vt_frame = ttk.Frame(cm_frame)
-                vt_frame.grid(row=2, column=0, sticky="nsew", pady=5)
-                columns = [
-                    "Product Goal",
-                    "Validation Target",
-                    "Target Description",
-                    "Acceptance Criteria",
-                ]
-                self.vt_tree = ttk.Treeview(
-                    vt_frame, columns=columns, show="headings", height=4
-                )
-                for c in columns:
-                    self.vt_tree.heading(c, text=c)
-                    width = 120 if c in ("Product Goal", "Validation Target") else 200
-                    self.vt_tree.column(c, width=width, anchor="center")
-                self.vt_tree.pack(fill=tk.BOTH, expand=True)
-                self.vt_item_to_goal = {}
-                self.selected_goal = None
-                self.current_tau_on = 0.0
-
-                def on_vt_select(event=None):
-                    sel = self.vt_tree.selection()
-                    if not sel:
-                        self.selected_goal = None
-                        self.current_tau_on = 0.0
-                    else:
-                        sg = self.vt_item_to_goal.get(sel[0])
-                        self.selected_goal = sg
-                        tau_on = 0.0
-                        mp_name = getattr(sg, "mission_profile", "")
-                        if mp_name:
-                            for mp in self.app.mission_profiles:
-                                if mp.name == mp_name:
-                                    tau_on = mp.tau_on
-                                    break
-                        self.current_tau_on = tau_on
-                    update_metrics()
-
-                self.vt_tree.bind("<<TreeviewSelect>>", on_vt_select)
-
-                def refresh_vt(*_):
-                    self.vt_tree.delete(*self.vt_tree.get_children())
-                    self.vt_item_to_goal.clear()
-                    name = self.name_var.get().strip()
-                    for sg in self.app.get_validation_targets_for_odd(name):
-                        iid = self.vt_tree.insert(
-                            "",
-                            "end",
-                            values=[
-                                sg.user_name or f"SG {sg.unique_id}",
-                                getattr(sg, "validation_target", ""),
-                                getattr(sg, "validation_desc", ""),
-                                getattr(sg, "acceptance_criteria", ""),
-                            ],
-                        )
-                        self.vt_item_to_goal[iid] = sg
-                    items = self.vt_tree.get_children()
-                    if items:
-                        self.vt_tree.selection_set(items[0])
-                        on_vt_select()
-
-                refresh_vt()
-                self.name_var.trace_add("write", refresh_vt)
 
             def apply(self):
                 new_data = {"name": self.name_var.get()}
@@ -14296,21 +14189,24 @@ class FaultTreeApp:
                     key = k_var.get().strip()
                     if key:
                         new_data[key] = v_var.get()
-                p = float(self.p_var.get())
-                n = float(self.n_var.get())
-                from analysis.confusion_matrix import compute_metrics_from_target
+                tp = float(self.tp_var.get())
+                fp = float(self.fp_var.get())
+                tn = float(self.tn_var.get())
+                fn = float(self.fn_var.get())
+                from analysis.confusion_matrix import compute_metrics
 
-                tau_on = getattr(self, "current_tau_on", 0.0)
-                val_target = None
-                if getattr(self, "selected_goal", None) is not None:
-                    val_target = getattr(self.selected_goal, "validation_target", None)
-                data = compute_metrics_from_target(
-                    hours=tau_on or 0.0,
-                    validation_target=val_target,
-                    p=p,
-                    n=n,
-                )
-                new_data.update(data)
+                metrics = compute_metrics(tp, fp, tn, fn)
+                p = tp + fn
+                n = tn + fp
+                new_data.update({
+                    "tp": tp,
+                    "fp": fp,
+                    "tn": tn,
+                    "fn": fn,
+                    "p": p,
+                    "n": n,
+                })
+                new_data.update(metrics)
                 self.data = new_data
 
         def add_lib():


### PR DESCRIPTION
## Summary
- Simplify the confusion matrix tab to accept TP/FP/TN/FN inputs
- Compute accuracy, precision, recall and F1 directly from user-provided counts
- Remove validation target dependencies and unused rate displays

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b912147d483259414161ef748f371