### PR TITLE
feat: add safety diagram browser

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14328,6 +14328,24 @@ class FaultTreeApp:
         from gui.fault_prioritization import FaultPrioritizationWindow
         self._fault_prio_window = FaultPrioritizationWindow(self._fault_prio_tab, self)
 
+    def open_safety_management_toolbox(self):
+        """Open the Safety Management editor and browser."""
+        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
+            self.doc_nb.select(self._safety_mgmt_tab)
+            return
+
+        self._safety_mgmt_tab = self._new_tab("Safety Management")
+
+        from gui.safety_management_toolbox import SafetyManagementWindow
+        from analysis import SafetyManagementToolbox
+
+        if not hasattr(self, "safety_mgmt_toolbox"):
+            self.safety_mgmt_toolbox = SafetyManagementToolbox()
+
+        SafetyManagementWindow(
+            self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
+        )
+
     def open_style_editor(self):
         """Open the diagram style editor window."""
         StyleEditor(self.root)

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -8,4 +8,13 @@ __all__ = [
     "hazardous_behavior_rate",
     "validation_time",
     "compute_metrics",
+    "SafetyManagementToolbox",
 ]
+
+
+def __getattr__(name):
+    if name == "SafetyManagementToolbox":
+        from .safety_management import SafetyManagementToolbox as _SMT
+
+        return _SMT
+    raise AttributeError(name)

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -1,0 +1,113 @@
+"""Safety management data structures.
+
+This module defines simple data classes used by the GUI and other modules to
+collect work products, lifecycle information and workflows related to safety
+governance."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from sysml.sysml_repository import SysMLRepository
+
+
+@dataclass
+class SafetyWorkProduct:
+    """Describe a work product generated from a diagram or analysis."""
+
+    diagram: str
+    analysis: str
+    rationale: str
+
+
+@dataclass
+class LifecycleStage:
+    """Represent a single stage in a safety lifecycle."""
+
+    name: str
+
+
+@dataclass
+class Workflow:
+    """Ordered list of steps for a named workflow."""
+
+    name: str
+    steps: List[str]
+
+
+@dataclass
+class SafetyManagementToolbox:
+    """Collect work products and governance artifacts for safety management.
+
+    The toolbox lets users register work products from various diagrams and
+    analyses with an associated rationale. It also stores lifecycle stages and
+    named workflows so projects can describe their safety governance.
+    """
+
+    work_products: List[SafetyWorkProduct] = field(default_factory=list)
+    lifecycle: List[str] = field(default_factory=list)
+    workflows: Dict[str, List[str]] = field(default_factory=dict)
+    diagrams: Dict[str, str] = field(default_factory=dict)
+
+    def add_work_product(self, diagram: str, analysis: str, rationale: str) -> None:
+        """Add a work product linking a diagram to an analysis with rationale."""
+        self.work_products.append(SafetyWorkProduct(diagram, analysis, rationale))
+
+    def build_lifecycle(self, stages: List[str]) -> None:
+        """Define the project lifecycle stages."""
+        self.lifecycle = stages
+
+    def define_workflow(self, name: str, steps: List[str]) -> None:
+        """Record an ordered list of steps for a workflow."""
+        self.workflows[name] = steps
+
+    def get_work_products(self) -> List[SafetyWorkProduct]:
+        """Return all registered work products."""
+        return list(self.work_products)
+
+    def get_workflow(self, name: str) -> List[str]:
+        """Return the steps for the requested workflow."""
+        return self.workflows.get(name, [])
+
+    # ------------------------------------------------------------------
+    # Diagram management helpers
+    # ------------------------------------------------------------------
+    def create_diagram(self, name: str) -> str:
+        """Create a new Activity Diagram tracked by this toolbox.
+
+        Parameters
+        ----------
+        name: str
+            Human readable name of the diagram.
+
+        Returns
+        -------
+        str
+            The repository identifier of the created diagram.
+        """
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Activity Diagram", name=name)
+        self.diagrams[name] = diag.diag_id
+        return diag.diag_id
+
+    def rename_diagram(self, old_name: str, new_name: str) -> None:
+        """Rename an existing tracked diagram."""
+        if old_name not in self.diagrams:
+            return
+        diag_id = self.diagrams.pop(old_name)
+        self.diagrams[new_name] = diag_id
+        repo = SysMLRepository.get_instance()
+        if diag_id in repo.diagrams:
+            repo.diagrams[diag_id].name = new_name
+
+    def delete_diagram(self, name: str) -> None:
+        """Remove a diagram from the toolbox and repository."""
+        diag_id = self.diagrams.pop(name, None)
+        if not diag_id:
+            return
+        repo = SysMLRepository.get_instance()
+        repo.delete_diagram(diag_id)
+
+    def list_diagrams(self) -> List[str]:
+        """Return the names of all managed diagrams."""
+        return list(self.diagrams.keys())
+

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5334,15 +5334,28 @@ class SysMLDiagramWindow(tk.Frame):
             )
             label = obj.properties.get("name", "")
             if label:
-                lx = x
-                ly = y - h - 4 * self.zoom
-                self.canvas.create_text(
-                    lx,
-                    ly,
-                    text=label,
-                    anchor="s",
-                    font=self.font,
-                )
+                diag = self.repo.diagrams.get(self.diagram_id)
+                if diag and diag.diag_type == "Activity Diagram":
+                    lx = x - w - 4 * self.zoom
+                    ly = y
+                    self.canvas.create_text(
+                        lx,
+                        ly,
+                        text=label,
+                        angle=90,
+                        anchor="e",
+                        font=self.font,
+                    )
+                else:
+                    lx = x
+                    ly = y - h - 4 * self.zoom
+                    self.canvas.create_text(
+                        lx,
+                        ly,
+                        text=label,
+                        anchor="s",
+                        font=self.font,
+                    )
         elif obj.obj_type == "Block Boundary":
             self._create_round_rect(
                 x - w,
@@ -7768,6 +7781,7 @@ class ActivityDiagramWindow(SysMLDiagramWindow):
             "Fork",
             "Join",
             "Flow",
+            "System Boundary",
         ]
         super().__init__(master, "Activity Diagram", tools, diagram_id, app=app, history=history)
         ttk.Button(

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -1,0 +1,99 @@
+import tkinter as tk
+from tkinter import ttk, simpledialog
+
+from analysis import SafetyManagementToolbox
+from gui.architecture import ActivityDiagramWindow
+
+
+class SafetyManagementWindow(tk.Frame):
+    """Editor and browser for Safety Management diagrams.
+
+    Users can create, rename and delete Activity Diagrams that model the
+    project's safety governance. Only diagrams registered in the provided
+    :class:`SafetyManagementToolbox` are listed.
+    """
+
+    def __init__(self, master, app, toolbox: SafetyManagementToolbox | None = None):
+        super().__init__(master)
+        self.app = app
+        self.toolbox = toolbox or SafetyManagementToolbox()
+
+        top = ttk.Frame(self)
+        top.pack(fill=tk.X)
+
+        ttk.Label(top, text="Diagram:").pack(side=tk.LEFT)
+        self.diag_var = tk.StringVar()
+        self.diag_cb = ttk.Combobox(top, textvariable=self.diag_var, state="readonly")
+        self.diag_cb.pack(side=tk.LEFT, padx=2)
+        self.diag_cb.bind("<<ComboboxSelected>>", self.select_diagram)
+
+        ttk.Button(top, text="New", command=self.new_diagram).pack(side=tk.LEFT)
+        ttk.Button(top, text="Rename", command=self.rename_diagram).pack(side=tk.LEFT)
+        ttk.Button(top, text="Delete", command=self.delete_diagram).pack(side=tk.LEFT)
+
+        self.diagram_frame = ttk.Frame(self)
+        self.diagram_frame.pack(fill=tk.BOTH, expand=True)
+        self.current_window = None
+
+        self.refresh_diagrams()
+        if not isinstance(master, tk.Toplevel):
+            self.pack(fill=tk.BOTH, expand=True)
+
+    # ------------------------------------------------------------------
+    # Diagram operations
+    # ------------------------------------------------------------------
+    def refresh_diagrams(self):
+        names = self.toolbox.list_diagrams()
+        self.diag_cb.configure(values=names)
+        if names:
+            current = self.diag_var.get()
+            if current not in names:
+                self.diag_var.set(names[0])
+            self.open_diagram(self.diag_var.get())
+        else:
+            self.diag_var.set("")
+            self.open_diagram(None)
+
+    def new_diagram(self):
+        name = simpledialog.askstring("New Diagram", "Name:", parent=self)
+        if not name:
+            return
+        self.toolbox.create_diagram(name)
+        self.refresh_diagrams()
+        self.diag_var.set(name)
+        self.open_diagram(name)
+
+    def rename_diagram(self):
+        name = self.diag_var.get()
+        if not name:
+            return
+        new_name = simpledialog.askstring("Rename Diagram", "Name:", initialvalue=name, parent=self)
+        if not new_name:
+            return
+        self.toolbox.rename_diagram(name, new_name)
+        self.refresh_diagrams()
+        self.diag_var.set(new_name)
+        self.open_diagram(new_name)
+
+    def delete_diagram(self):
+        name = self.diag_var.get()
+        if not name:
+            return
+        self.toolbox.delete_diagram(name)
+        self.refresh_diagrams()
+
+    def select_diagram(self, *_):
+        name = self.diag_var.get()
+        self.open_diagram(name)
+
+    def open_diagram(self, name: str | None):
+        for child in self.diagram_frame.winfo_children():
+            child.destroy()
+        self.current_window = None
+        if not name:
+            return
+        diag_id = self.toolbox.diagrams.get(name)
+        if diag_id is None:
+            return
+        self.current_window = ActivityDiagramWindow(self.diagram_frame, self.app, diagram_id=diag_id)
+        self.current_window.pack(fill=tk.BOTH, expand=True)

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1,0 +1,142 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import types
+import sys
+
+# Stub out Pillow dependencies so importing the main app doesn't require Pillow
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace()
+PIL_stub.ImageTk = types.SimpleNamespace()
+PIL_stub.ImageDraw = types.SimpleNamespace()
+PIL_stub.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+sys.modules.setdefault("PIL.Image", PIL_stub.Image)
+sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
+sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
+sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
+
+from AutoML import FaultTreeApp
+from analysis import SafetyManagementToolbox
+from gui.architecture import ActivityDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_work_product_registration():
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Activity Diagram", "HAZOP", "Link action to hazard")
+
+    products = toolbox.get_work_products()
+    assert len(products) == 1
+    assert products[0].diagram == "Activity Diagram"
+    assert products[0].analysis == "HAZOP"
+    assert products[0].rationale == "Link action to hazard"
+
+
+def test_lifecycle_and_workflow_storage():
+    toolbox = SafetyManagementToolbox()
+    toolbox.build_lifecycle(["concept", "development", "operation"])
+    toolbox.define_workflow("risk", ["identify", "assess", "mitigate"])
+
+    assert toolbox.lifecycle == ["concept", "development", "operation"]
+    assert toolbox.get_workflow("risk") == ["identify", "assess", "mitigate"]
+    assert toolbox.get_workflow("missing") == []
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.text_calls = []
+
+    def create_text(self, x, y, **kw):
+        self.text_calls.append((x, y, kw))
+
+    def create_rectangle(self, *args, **kwargs):
+        pass
+
+    def create_line(self, *args, **kwargs):
+        pass
+
+    def create_polygon(self, *args, **kwargs):
+        pass
+
+
+def test_activity_boundary_label_rotated_left():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Activity Diagram")
+    win = ActivityDiagramWindow.__new__(ActivityDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.zoom = 1.0
+    win.canvas = DummyCanvas()
+    win.font = None
+    win._draw_gradient_rect = lambda *args, **kwargs: None
+    win.selected_objs = []
+    obj = SysMLObject(1, "System Boundary", 0.0, 0.0, width=100.0, height=80.0, properties={"name": "Lane"})
+    win.draw_object(obj)
+
+    assert win.canvas.text_calls, "label not drawn"
+    x, _, kwargs = win.canvas.text_calls[0]
+    assert kwargs.get("angle") == 90
+    assert x < obj.x - obj.width / 2
+
+
+def test_toolbox_manages_diagram_lifecycle():
+    """Toolbox can create, rename and delete diagrams in the repository."""
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    diag_id = toolbox.create_diagram("Gov1")
+    assert diag_id in repo.diagrams
+
+    toolbox.rename_diagram("Gov1", "GovMain")
+    assert "GovMain" in toolbox.diagrams
+    assert repo.diagrams[diag_id].name == "GovMain"
+
+    toolbox.delete_diagram("GovMain")
+    assert diag_id not in repo.diagrams
+    assert not toolbox.diagrams
+
+
+def test_open_safety_management_toolbox_uses_browser():
+    """FaultTreeApp opens the Safety Management window and toolbox."""
+    SysMLRepository._instance = None
+
+    class DummyTab:
+        def __init__(self):
+            self._exists = True
+
+        def winfo_exists(self):
+            return self._exists
+
+    class DummyNotebook:
+        def add(self, tab, text):
+            pass
+
+        def select(self, tab):
+            pass
+
+    class DummySMW:
+        def __init__(self, master, app, toolbox):
+            DummySMW.created = True
+            assert toolbox is app.safety_mgmt_toolbox
+
+    import gui.safety_management_toolbox as smt
+    smt.SafetyManagementWindow = DummySMW
+
+    class DummyApp:
+        open_safety_management_toolbox = FaultTreeApp.open_safety_management_toolbox
+
+        def __init__(self):
+            self.doc_nb = DummyNotebook()
+
+        def _new_tab(self, title):
+            return DummyTab()
+
+    DummySMW.created = False
+    app = DummyApp()
+    app.open_safety_management_toolbox()
+    assert DummySMW.created
+    assert hasattr(app, "safety_mgmt_toolbox")


### PR DESCRIPTION
## Summary
- track governance diagrams in SafetyManagementToolbox with create/rename/delete helpers
- introduce SafetyManagementWindow to browse safety diagrams and edit them via Activity Diagram windows
- wire FaultTreeApp to open the safety management browser and reuse a shared toolbox

## Testing
- `pytest tests/test_safety_management.py -q`
- `pytest tests/test_add_boundary_port.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689b709da7988325a81ed35edca26ef1