### PR TITLE
Add modern PAS 8800 diagnostic mechanisms

### DIFF
--- a/analysis/mechanisms.py
+++ b/analysis/mechanisms.py
@@ -512,4 +512,32 @@ PAS_8800_MECHANISMS = [
         "",
         "G.4.9.2",
     ),
+    DiagnosticMechanism(
+        "Bayesian inference",
+        1.0,
+        "Uses probabilistic models to quantify prediction uncertainty and improve reliability.",
+        "",
+        "",
+    ),
+    DiagnosticMechanism(
+        "Monte Carlo dropout",
+        1.0,
+        "Applies dropout during inference to approximate Bayesian uncertainty for robust decisions.",
+        "",
+        "",
+    ),
+    DiagnosticMechanism(
+        "Data distillation",
+        1.0,
+        "Compresses datasets into representative samples to enhance training efficiency while retaining performance.",
+        "",
+        "",
+    ),
+    DiagnosticMechanism(
+        "Auto data labeling and annotation",
+        1.0,
+        "Automates labeling processes to accelerate dataset creation and improve consistency.",
+        "",
+        "",
+    ),
 ]

--- a/tests/test_pas8800_mechanisms.py
+++ b/tests/test_pas8800_mechanisms.py
@@ -32,6 +32,18 @@ def test_pas8800_contains_fault_aware_training():
     assert "Fault-aware training" in names
 
 
+def test_pas8800_contains_new_diagnostics():
+    names = [m.name for m in PAS_8800_MECHANISMS]
+    expected = [
+        "Bayesian inference",
+        "Monte Carlo dropout",
+        "Data distillation",
+        "Auto data labeling and annotation",
+    ]
+    for mech in expected:
+        assert mech in names
+
+
 def test_pas8800_library_non_empty():
     lib = MechanismLibrary("PAS 8800", PAS_8800_MECHANISMS.copy())
     assert len(lib.mechanisms) >= 30


### PR DESCRIPTION
## Summary
- Extend PAS 8800 diagnostic library with Bayesian inference, Monte Carlo dropout, data distillation, and automated data labeling/annotation
- Verify new mechanisms are present via additional tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b9b42000c8325b0b18fde756d61d3