### PR TITLE
Add Safety Performance Indicators tool to Safety Management

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2353,6 +2353,7 @@ class FaultTreeApp:
             "FTA Cut Sets": self.show_cut_sets,
             "FTA-FMEA Traceability": self.show_traceability_matrix,
             "Safety Management": self.open_safety_management_toolbox,
+            "Safety Performance Indicators": self.show_safety_performance_indicators,
         }
 
         self.tool_categories = {
@@ -2407,6 +2408,7 @@ class FaultTreeApp:
             ],
             "Safety Management": [
                 "Safety Management",
+                "Safety Performance Indicators",
             ],
         }
 

--- a/README.md
+++ b/README.md
@@ -1124,7 +1124,7 @@ Use **Export Product Goal Requirements** in the Requirements menu to generate a 
 
 ### Safety Performance Indicators
 
-The **Safety Performance Indicators** tab in the Requirements menu lists each product goal's validation target and acceptance criteria with their descriptions for quick reference.
+The **Safety Performance Indicators** tool in the Safety Management tab lists each product goal's validation target and acceptance criteria with their descriptions for quick reference.
 
 ### Safety Management Toolbox
 


### PR DESCRIPTION
## Summary
- expose Safety Performance Indicators in Safety Management tools
- document Safety Performance Indicators access in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b9cbba2e88325bf6542a38c1bb6da