### PR TITLE
Allow renaming safety governance diagrams

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -97,6 +97,37 @@ class SafetyManagementToolbox:
         repo = SysMLRepository.get_instance()
         repo.delete_diagram(diag_id)
 
+    def rename_diagram(self, old: str, new: str) -> None:
+        """Rename a managed diagram ensuring the name remains unique.
+
+        Parameters
+        ----------
+        old: str
+            Current diagram name.
+        new: str
+            Desired new name for the diagram.
+        """
+        diag_id = self.diagrams.get(old)
+        if not diag_id or not new:
+            return
+        repo = SysMLRepository.get_instance()
+        diag = repo.diagrams.get(diag_id)
+        if not diag:
+            return
+
+        # Ensure the new name is unique across all diagrams
+        existing = {d.name for d in repo.diagrams.values() if d.diag_id != diag_id}
+        base = new
+        suffix = 1
+        while new in existing:
+            new = f"{base}_{suffix}"
+            suffix += 1
+
+        diag.name = new
+        repo.touch_diagram(diag_id)
+        del self.diagrams[old]
+        self.diagrams[new] = diag_id
+
     def list_diagrams(self) -> List[str]:
         """Return the names of all managed diagrams."""
         return list(self.diagrams.keys())

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -8,10 +8,9 @@ from gui.architecture import ActivityDiagramWindow
 class SafetyManagementWindow(tk.Frame):
     """Editor and browser for Safety Management diagrams.
 
-    Users can create and delete Activity Diagrams that model the project's
-    safety governance. Only diagrams registered in the provided
-    :class:`SafetyManagementToolbox` are listed and their names remain fixed to
-    preserve the link with recorded work products.
+    Users can create, rename, and delete Activity Diagrams that model the
+    project's safety governance. Only diagrams registered in the provided
+    :class:`SafetyManagementToolbox` are listed.
     """
 
     def __init__(self, master, app, toolbox: SafetyManagementToolbox | None = None):
@@ -29,6 +28,7 @@ class SafetyManagementWindow(tk.Frame):
         self.diag_cb.bind("<<ComboboxSelected>>", self.select_diagram)
 
         ttk.Button(top, text="New", command=self.new_diagram).pack(side=tk.LEFT)
+        ttk.Button(top, text="Rename", command=self.rename_diagram).pack(side=tk.LEFT)
         ttk.Button(top, text="Delete", command=self.delete_diagram).pack(side=tk.LEFT)
 
         self.diagram_frame = ttk.Frame(self)
@@ -69,6 +69,18 @@ class SafetyManagementWindow(tk.Frame):
             return
         self.toolbox.delete_diagram(name)
         self.refresh_diagrams()
+
+    def rename_diagram(self):
+        old = self.diag_var.get()
+        if not old:
+            return
+        new = simpledialog.askstring("Rename Diagram", "Name:", initialvalue=old, parent=self)
+        if not new or new == old:
+            return
+        self.toolbox.rename_diagram(old, new)
+        self.refresh_diagrams()
+        self.diag_var.set(new)
+        self.open_diagram(new)
 
     def select_diagram(self, *_):
         name = self.diag_var.get()

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -83,7 +83,7 @@ def test_activity_boundary_label_rotated_left():
 
 
 def test_toolbox_manages_diagram_lifecycle():
-    """Toolbox creates tagged diagrams and can delete them."""
+    """Toolbox creates tagged diagrams, can rename, and delete them."""
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     toolbox = SafetyManagementToolbox()
@@ -91,9 +91,12 @@ def test_toolbox_manages_diagram_lifecycle():
     diag_id = toolbox.create_diagram("Gov1")
     assert diag_id in repo.diagrams
     assert "safety-management" in repo.diagrams[diag_id].tags
-    assert not hasattr(toolbox, "rename_diagram")
 
-    toolbox.delete_diagram("Gov1")
+    toolbox.rename_diagram("Gov1", "Gov2")
+    assert repo.diagrams[diag_id].name == "Gov2"
+    assert "Gov2" in toolbox.list_diagrams()
+
+    toolbox.delete_diagram("Gov2")
     assert diag_id not in repo.diagrams
     assert not toolbox.diagrams
 


### PR DESCRIPTION
## Summary
- Enable renaming of governance Activity Diagrams in safety management toolbox
- Add GUI controls to rename diagrams
- Expand tests to cover diagram renaming

## Testing
- `pytest tests/test_safety_management.py::test_toolbox_manages_diagram_lifecycle tests/test_safety_management.py::test_safety_diagrams_hidden_and_immutable_in_explorer -q`

------
https://chatgpt.com/codex/tasks/task_b_689b9dd442308325af2289a403e23e04