### PR TITLE
Include flow connections in threat asset list

### DIFF
--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -268,6 +268,10 @@ class ThreatDialog(simpledialog.Dialog):
                         names.add(name)
             for conn in getattr(diag, "connections", []):
                 name = conn.get("name")
+                if not name:
+                    elem_id = conn.get("element_id")
+                    if elem_id and elem_id in repo.elements:
+                        name = repo.elements[elem_id].name
                 if name:
                     names.add(name)
         return sorted(names)

--- a/tests/test_threat_asset_flows.py
+++ b/tests/test_threat_asset_flows.py
@@ -1,0 +1,14 @@
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+from gui.threat_dialog import ThreatDialog
+
+
+def test_get_assets_includes_flows():
+    repo = SysMLRepository.reset_instance()
+    flow_elem = repo.create_element("Flow", name="F1")
+    diag = SysMLDiagram(diag_id="d1", diag_type="Internal Block Diagram")
+    diag.connections.append({"element_id": flow_elem.elem_id})
+    repo.diagrams[diag.diag_id] = diag
+
+    dlg = ThreatDialog.__new__(ThreatDialog)
+    assets = dlg._get_assets(diag.diag_id)
+    assert "F1" in assets


### PR DESCRIPTION
## Summary
- display connections such as flows in the Threat Analysis asset picker
- test that flow connection names appear in asset list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ba19258308325b1345286755bb178