### PR TITLE
Include cybersecurity attack paths in cause-effect chain

### DIFF
--- a/tests/test_render_cause_effect_diagram.py
+++ b/tests/test_render_cause_effect_diagram.py
@@ -25,12 +25,29 @@ class CauseEffectPDFTests(unittest.TestCase):
             "faults": set(),
             "fis": set(),
             "tcs": set(),
+            "threats": {},
         }
         img = self.app.render_cause_effect_diagram(row)
         self.assertIsNotNone(img)
         w, h = img.size
         self.assertGreaterEqual(w, 120)
         self.assertGreaterEqual(h, 60)
+
+    def test_graph_includes_threats_and_attack_paths(self):
+        row = {
+            "hazard": "H",
+            "malfunction": "M",
+            "failure_modes": {},
+            "faults": set(),
+            "fis": set(),
+            "tcs": set(),
+            "threats": {"TS": {"AP"}},
+        }
+        nodes, edges, _ = self.app._build_cause_effect_graph(row)
+        self.assertIn("threat:TS", nodes)
+        self.assertIn("ap:AP", nodes)
+        self.assertIn(("threat:TS", "ap:AP"), edges)
+        self.assertIn(("ap:AP", "mal:M"), edges)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Capture threat scenarios and attack paths when building cause-effect data
- Visualize threats and attack paths in diagrams and table view
- Test graph generation with threats and attack paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ba9ad5b688325add79aa73fcb5fa8