### PR TITLE
Fix cyber risk assessment persistence

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -305,6 +305,7 @@ from analysis.models import (
     REQUIREMENT_TYPE_OPTIONS,
     CAL_LEVEL_OPTIONS,
     CybersecurityGoal,
+    CyberRiskEntry,
 )
 from gui.architecture import (
     UseCaseDiagramWindow,
@@ -15661,22 +15662,44 @@ class FaultTreeApp:
 
         self.hara_docs = []
         for d in data.get("haras", []):
-            entries = [
-                HaraEntry(
-                    e.get("malfunction", ""),
-                    e.get("hazard", ""),
-                    e.get("scenario", ""),
-                    e.get("severity", 1),
-                    e.get("sev_rationale", ""),
-                    e.get("controllability", 1),
-                    e.get("cont_rationale", ""),
-                    e.get("exposure", 1),
-                    e.get("exp_rationale", ""),
-                    e.get("asil", "QM"),
-                    e.get("safety_goal", ""),
+            entries = []
+            for e in d.get("entries", []):
+                cyber = None
+                cdata = e.get("cyber")
+                if isinstance(cdata, dict):
+                    allowed = {
+                        "damage_scenario",
+                        "threat_scenario",
+                        "attack_vector",
+                        "feasibility",
+                        "financial_impact",
+                        "safety_impact",
+                        "operational_impact",
+                        "privacy_impact",
+                        "cybersecurity_goal",
+                        "attack_paths",
+                    }
+                    clean = {k: cdata.get(k) for k in allowed if k in cdata}
+                    try:
+                        cyber = CyberRiskEntry(**clean)
+                    except TypeError:
+                        cyber = None
+                entries.append(
+                    HaraEntry(
+                        e.get("malfunction", ""),
+                        e.get("hazard", ""),
+                        e.get("scenario", ""),
+                        e.get("severity", 1),
+                        e.get("sev_rationale", ""),
+                        e.get("controllability", 1),
+                        e.get("cont_rationale", ""),
+                        e.get("exposure", 1),
+                        e.get("exp_rationale", ""),
+                        e.get("asil", "QM"),
+                        e.get("safety_goal", ""),
+                        cyber,
+                    )
                 )
-                for e in d.get("entries", [])
-            ]
             hazops = d.get("hazops")
             if not hazops:
                 hazop = d.get("hazop")
@@ -15694,26 +15717,49 @@ class FaultTreeApp:
             )
         if not self.hara_docs and "hara_entries" in data:
             hazop_name = self.hazop_docs[0].name if self.hazop_docs else ""
+            entries = []
+            for e in data.get("hara_entries", []):
+                cyber = None
+                cdata = e.get("cyber")
+                if isinstance(cdata, dict):
+                    allowed = {
+                        "damage_scenario",
+                        "threat_scenario",
+                        "attack_vector",
+                        "feasibility",
+                        "financial_impact",
+                        "safety_impact",
+                        "operational_impact",
+                        "privacy_impact",
+                        "cybersecurity_goal",
+                        "attack_paths",
+                    }
+                    clean = {k: cdata.get(k) for k in allowed if k in cdata}
+                    try:
+                        cyber = CyberRiskEntry(**clean)
+                    except TypeError:
+                        cyber = None
+                entries.append(
+                    HaraEntry(
+                        e.get("malfunction", ""),
+                        e.get("hazard", ""),
+                        e.get("scenario", ""),
+                        e.get("severity", 1),
+                        e.get("sev_rationale", ""),
+                        e.get("controllability", 1),
+                        e.get("cont_rationale", ""),
+                        e.get("exposure", 1),
+                        e.get("exp_rationale", ""),
+                        e.get("asil", "QM"),
+                        e.get("safety_goal", ""),
+                        cyber,
+                    )
+                )
             self.hara_docs.append(
                 HaraDoc(
                     "Default",
                     [hazop_name] if hazop_name else [],
-                    [
-                        HaraEntry(
-                            e.get("malfunction", ""),
-                            e.get("hazard", ""),
-                            e.get("scenario", ""),
-                            e.get("severity", 1),
-                            e.get("sev_rationale", ""),
-                            e.get("controllability", 1),
-                            e.get("cont_rationale", ""),
-                            e.get("exposure", 1),
-                            e.get("exp_rationale", ""),
-                            e.get("asil", "QM"),
-                            e.get("safety_goal", ""),
-                        )
-                        for e in data.get("hara_entries", [])
-                    ],
+                    entries,
                     False,
                     "draft",
                     stpa="",

--- a/tests/test_cyber_risk_assessment.py
+++ b/tests/test_cyber_risk_assessment.py
@@ -1,4 +1,5 @@
 import unittest
+from dataclasses import asdict
 
 from analysis.models import (
     CyberRiskEntry,
@@ -79,6 +80,51 @@ class CyberRiskEntryTests(unittest.TestCase):
         doc = HaraDoc("RA", [], [entry1, entry2])
         app.hara_docs = [doc]
         self.assertEqual(app.get_cyber_goal_cal("CG"), cyber1.cal)
+
+    def test_cyber_risk_persistence(self):
+        cyber = CyberRiskEntry(
+            damage_scenario="D",
+            threat_scenario="T",
+            attack_vector="Network",
+            feasibility="Medium",
+            financial_impact="Moderate",
+            safety_impact="Minor",
+            operational_impact="Negligible",
+            privacy_impact="Negligible",
+            cybersecurity_goal="CG1",
+        )
+        cyber.attack_paths = [{"path": "p", "vector": "Network", "feasibility": "Medium"}]
+        entry = HaraEntry("M", "H", "S", 1, "", 1, "", 1, "", "QM", "", cyber)
+        data = {
+            "haras": [
+                {
+                    "name": "RA",
+                    "hazops": [],
+                    "entries": [asdict(entry)],
+                    "approved": False,
+                    "status": "draft",
+                    "stpa": "",
+                    "threat": "",
+                }
+            ]
+        }
+        app = FaultTreeApp.__new__(FaultTreeApp)
+        app.update_failure_list = lambda: None
+        app.get_all_fmea_entries = lambda: []
+        app.get_all_basic_events = lambda: []
+        app.update_global_requirements_from_nodes = lambda *a, **k: None
+        app.sync_hara_to_safety_goals = lambda: None
+        app.update_hara_statuses = lambda: None
+        app.update_fta_statuses = lambda: None
+        app.update_views = lambda: None
+        app.project_properties = {}
+        app.hazard_severity = {}
+        FaultTreeApp.apply_model_data(app, data, ensure_root=False)
+        loaded = app.hara_docs[0].entries[0].cyber
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.threat_scenario, cyber.threat_scenario)
+        self.assertEqual(loaded.attack_paths, cyber.attack_paths)
+        self.assertEqual(loaded.cal, cyber.cal)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reconstruct CyberRiskEntry objects when loading risk assessment documents
- add regression test for cyber risk assessment persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bac119ac8832593048657d8de02a6