### PR TITLE
Fix cyber risk assessment persistence

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -305,6 +305,7 @@ from analysis.models import (
     REQUIREMENT_TYPE_OPTIONS,
     CAL_LEVEL_OPTIONS,
     CybersecurityGoal,
+    CyberRiskEntry,
 )
 from gui.architecture import (
     UseCaseDiagramWindow,
@@ -15661,22 +15662,39 @@ class FaultTreeApp:
 
         self.hara_docs = []
         for d in data.get("haras", []):
-            entries = [
-                HaraEntry(
-                    e.get("malfunction", ""),
-                    e.get("hazard", ""),
-                    e.get("scenario", ""),
-                    e.get("severity", 1),
-                    e.get("sev_rationale", ""),
-                    e.get("controllability", 1),
-                    e.get("cont_rationale", ""),
-                    e.get("exposure", 1),
-                    e.get("exp_rationale", ""),
-                    e.get("asil", "QM"),
-                    e.get("safety_goal", ""),
+            entries = []
+            for e in d.get("entries", []):
+                cyber = None
+                cdata = e.get("cyber")
+                if cdata:
+                    cyber = CyberRiskEntry(
+                        damage_scenario=cdata.get("damage_scenario", ""),
+                        threat_scenario=cdata.get("threat_scenario", ""),
+                        attack_vector=cdata.get("attack_vector", ""),
+                        feasibility=cdata.get("feasibility", ""),
+                        financial_impact=cdata.get("financial_impact", ""),
+                        safety_impact=cdata.get("safety_impact", ""),
+                        operational_impact=cdata.get("operational_impact", ""),
+                        privacy_impact=cdata.get("privacy_impact", ""),
+                        cybersecurity_goal=cdata.get("cybersecurity_goal", ""),
+                    )
+                    cyber.attack_paths = cdata.get("attack_paths", [])
+                entries.append(
+                    HaraEntry(
+                        e.get("malfunction", ""),
+                        e.get("hazard", ""),
+                        e.get("scenario", ""),
+                        e.get("severity", 1),
+                        e.get("sev_rationale", ""),
+                        e.get("controllability", 1),
+                        e.get("cont_rationale", ""),
+                        e.get("exposure", 1),
+                        e.get("exp_rationale", ""),
+                        e.get("asil", "QM"),
+                        e.get("safety_goal", ""),
+                        cyber,
+                    )
                 )
-                for e in d.get("entries", [])
-            ]
             hazops = d.get("hazops")
             if not hazops:
                 hazop = d.get("hazop")
@@ -15694,26 +15712,44 @@ class FaultTreeApp:
             )
         if not self.hara_docs and "hara_entries" in data:
             hazop_name = self.hazop_docs[0].name if self.hazop_docs else ""
+            entries = []
+            for e in data.get("hara_entries", []):
+                cyber = None
+                cdata = e.get("cyber")
+                if cdata:
+                    cyber = CyberRiskEntry(
+                        damage_scenario=cdata.get("damage_scenario", ""),
+                        threat_scenario=cdata.get("threat_scenario", ""),
+                        attack_vector=cdata.get("attack_vector", ""),
+                        feasibility=cdata.get("feasibility", ""),
+                        financial_impact=cdata.get("financial_impact", ""),
+                        safety_impact=cdata.get("safety_impact", ""),
+                        operational_impact=cdata.get("operational_impact", ""),
+                        privacy_impact=cdata.get("privacy_impact", ""),
+                        cybersecurity_goal=cdata.get("cybersecurity_goal", ""),
+                    )
+                    cyber.attack_paths = cdata.get("attack_paths", [])
+                entries.append(
+                    HaraEntry(
+                        e.get("malfunction", ""),
+                        e.get("hazard", ""),
+                        e.get("scenario", ""),
+                        e.get("severity", 1),
+                        e.get("sev_rationale", ""),
+                        e.get("controllability", 1),
+                        e.get("cont_rationale", ""),
+                        e.get("exposure", 1),
+                        e.get("exp_rationale", ""),
+                        e.get("asil", "QM"),
+                        e.get("safety_goal", ""),
+                        cyber,
+                    )
+                )
             self.hara_docs.append(
                 HaraDoc(
                     "Default",
                     [hazop_name] if hazop_name else [],
-                    [
-                        HaraEntry(
-                            e.get("malfunction", ""),
-                            e.get("hazard", ""),
-                            e.get("scenario", ""),
-                            e.get("severity", 1),
-                            e.get("sev_rationale", ""),
-                            e.get("controllability", 1),
-                            e.get("cont_rationale", ""),
-                            e.get("exposure", 1),
-                            e.get("exp_rationale", ""),
-                            e.get("asil", "QM"),
-                            e.get("safety_goal", ""),
-                        )
-                        for e in data.get("hara_entries", [])
-                    ],
+                    entries,
                     False,
                     "draft",
                     stpa="",
@@ -16138,22 +16174,39 @@ class FaultTreeApp:
 
         self.hara_docs = []
         for d in data.get("haras", []):
-            entries = [
-                HaraEntry(
-                    e.get("malfunction", ""),
-                    e.get("hazard", ""),
-                    e.get("scenario", ""),
-                    e.get("severity", 1),
-                    e.get("sev_rationale", ""),
-                    e.get("controllability", 1),
-                    e.get("cont_rationale", ""),
-                    e.get("exposure", 1),
-                    e.get("exp_rationale", ""),
-                    e.get("asil", "QM"),
-                    e.get("safety_goal", ""),
+            entries = []
+            for e in d.get("entries", []):
+                cyber = None
+                cdata = e.get("cyber")
+                if cdata:
+                    cyber = CyberRiskEntry(
+                        damage_scenario=cdata.get("damage_scenario", ""),
+                        threat_scenario=cdata.get("threat_scenario", ""),
+                        attack_vector=cdata.get("attack_vector", ""),
+                        feasibility=cdata.get("feasibility", ""),
+                        financial_impact=cdata.get("financial_impact", ""),
+                        safety_impact=cdata.get("safety_impact", ""),
+                        operational_impact=cdata.get("operational_impact", ""),
+                        privacy_impact=cdata.get("privacy_impact", ""),
+                        cybersecurity_goal=cdata.get("cybersecurity_goal", ""),
+                    )
+                    cyber.attack_paths = cdata.get("attack_paths", [])
+                entries.append(
+                    HaraEntry(
+                        e.get("malfunction", ""),
+                        e.get("hazard", ""),
+                        e.get("scenario", ""),
+                        e.get("severity", 1),
+                        e.get("sev_rationale", ""),
+                        e.get("controllability", 1),
+                        e.get("cont_rationale", ""),
+                        e.get("exposure", 1),
+                        e.get("exp_rationale", ""),
+                        e.get("asil", "QM"),
+                        e.get("safety_goal", ""),
+                        cyber,
+                    )
                 )
-                for e in d.get("entries", [])
-            ]
             hazops = d.get("hazops")
             if not hazops:
                 hazop = d.get("hazop")
@@ -16171,26 +16224,44 @@ class FaultTreeApp:
             )
         if not self.hara_docs and "hara_entries" in data:
             hazop_name = self.hazop_docs[0].name if self.hazop_docs else ""
+            entries = []
+            for e in data.get("hara_entries", []):
+                cyber = None
+                cdata = e.get("cyber")
+                if cdata:
+                    cyber = CyberRiskEntry(
+                        damage_scenario=cdata.get("damage_scenario", ""),
+                        threat_scenario=cdata.get("threat_scenario", ""),
+                        attack_vector=cdata.get("attack_vector", ""),
+                        feasibility=cdata.get("feasibility", ""),
+                        financial_impact=cdata.get("financial_impact", ""),
+                        safety_impact=cdata.get("safety_impact", ""),
+                        operational_impact=cdata.get("operational_impact", ""),
+                        privacy_impact=cdata.get("privacy_impact", ""),
+                        cybersecurity_goal=cdata.get("cybersecurity_goal", ""),
+                    )
+                    cyber.attack_paths = cdata.get("attack_paths", [])
+                entries.append(
+                    HaraEntry(
+                        e.get("malfunction", ""),
+                        e.get("hazard", ""),
+                        e.get("scenario", ""),
+                        e.get("severity", 1),
+                        e.get("sev_rationale", ""),
+                        e.get("controllability", 1),
+                        e.get("cont_rationale", ""),
+                        e.get("exposure", 1),
+                        e.get("exp_rationale", ""),
+                        e.get("asil", "QM"),
+                        e.get("safety_goal", ""),
+                        cyber,
+                    )
+                )
             self.hara_docs.append(
                 HaraDoc(
                     "Default",
                     [hazop_name] if hazop_name else [],
-                    [
-                        HaraEntry(
-                            e.get("malfunction", ""),
-                            e.get("hazard", ""),
-                            e.get("scenario", ""),
-                            e.get("severity", 1),
-                            e.get("sev_rationale", ""),
-                            e.get("controllability", 1),
-                            e.get("cont_rationale", ""),
-                            e.get("exposure", 1),
-                            e.get("exp_rationale", ""),
-                            e.get("asil", "QM"),
-                            e.get("safety_goal", ""),
-                        )
-                        for e in data.get("hara_entries", [])
-                    ],
+                    entries,
                     False,
                     "draft",
                     stpa="",

--- a/tests/test_cyber_risk_persistence.py
+++ b/tests/test_cyber_risk_persistence.py
@@ -1,0 +1,61 @@
+from dataclasses import asdict
+from AutoML import FaultTreeApp
+from analysis.models import HaraEntry, CyberRiskEntry
+
+def test_cyber_risk_entry_persistence():
+    cyber = CyberRiskEntry(
+        damage_scenario="D",
+        threat_scenario="T",
+        attack_vector="Network",
+        feasibility="High",
+        financial_impact="Major",
+        safety_impact="Moderate",
+        operational_impact="Negligible",
+        privacy_impact="Moderate",
+        cybersecurity_goal="CG1",
+    )
+    cyber.attack_paths = [{"path": "p1", "vector": "Network", "feasibility": "High"}]
+    entry = HaraEntry("M", "H", "S", 1, "", 1, "", 1, "", "QM", "SG", cyber)
+    data = {
+        "haras": [
+            {
+                "name": "RA",
+                "hazops": [],
+                "entries": [asdict(entry)],
+                "approved": False,
+                "status": "draft",
+                "stpa": "",
+                "threat": "",
+            }
+        ]
+    }
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.top_events = []
+    app.fmea_entries = []
+    app.fmeas = []
+    app.fmedas = []
+    app.mechanism_libraries = []
+    app.selected_mechanism_libraries = []
+    app.mission_profiles = []
+    app.reliability_analyses = []
+    app.faults = []
+    app.malfunctions = []
+    app.hazards = []
+    app.hazard_severity = {}
+    app.failures = []
+    app.triggering_conditions = []
+    app.functional_insufficiencies = []
+    app.hazop_docs = []
+    app.hara_docs = []
+    app.stpa_docs = []
+    app.threat_docs = []
+    app.fi2tc_docs = []
+    app.tc2fi_docs = []
+    app.cybersecurity_goals = []
+    app.reviews = []
+    app.project_properties = {}
+    app.apply_model_data(data)
+    loaded = app.hara_docs[0].entries[0].cyber
+    assert loaded.damage_scenario == "D"
+    assert loaded.attack_paths == [{"path": "p1", "vector": "Network", "feasibility": "High"}]
+    assert loaded.cybersecurity_goal == "CG1"


### PR DESCRIPTION
## Summary
- ensure CyberRiskEntry imports and serialization are preserved
- load cyber risk assessment data from saved models including attack paths and linked goals
- add regression test for CyberRiskEntry persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bac119ac8832593048657d8de02a6