### PR TITLE
Improve FTA undo/redo coverage

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9722,6 +9722,7 @@ class FaultTreeApp:
         return False
 
     def add_node_of_type(self, event_type):
+        self.push_undo_state()
         # If a node is selected, ensure it is a primary instance.
         if self.selected_node:
             if not self.selected_node.is_primary_instance:
@@ -9774,6 +9775,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_basic_event_from_fmea(self):
+        self.push_undo_state()
         events = list(self.fmea_entries)
         for doc in self.fmeas:
             events.extend(doc.get("entries", []))
@@ -9816,6 +9818,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_basic_event_from_fmea(self):
+        self.push_undo_state()
         events = list(self.fmea_entries)
         for doc in self.fmeas:
             events.extend(doc.get("entries", []))
@@ -9858,6 +9861,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_basic_event_from_fmea(self):
+        self.push_undo_state()
         events = list(self.fmea_entries)
         for doc in self.fmeas:
             events.extend(doc.get("entries", []))
@@ -9901,6 +9905,7 @@ class FaultTreeApp:
 
 
     def remove_node(self):
+        self.push_undo_state()
         sel = self.analysis_tree.selection()
         target = None
         if sel:
@@ -9919,6 +9924,7 @@ class FaultTreeApp:
             messagebox.showwarning("Invalid", "Cannot remove the root node.")
 
     def remove_connection(self, node):
+        self.push_undo_state()
         if node and node != self.root_node:
             if node.parents:
                 for p in node.parents:
@@ -9936,6 +9942,7 @@ class FaultTreeApp:
             messagebox.showwarning("Remove Connection", "Cannot disconnect the root node.")
 
     def delete_node_and_subtree(self, node):
+        self.push_undo_state()
         if node:
             if node in self.top_events:
                 self.top_events.remove(node)
@@ -9954,6 +9961,7 @@ class FaultTreeApp:
     # ------------------------------------------------------------------
     def create_top_event_for_malfunction(self, name: str) -> None:
         """Create a new top level event linked to the given malfunction."""
+        self.push_undo_state()
         new_event = FaultTreeNode("", "TOP EVENT")
         new_event.x, new_event.y = 300, 200
         new_event.is_top_event = True
@@ -9964,6 +9972,7 @@ class FaultTreeApp:
 
     def delete_top_events_for_malfunction(self, name: str) -> None:
         """Remove all FTAs tied to the malfunction ``name``."""
+        self.push_undo_state()
         removed = [te for te in self.top_events if getattr(te, "malfunction", "") == name]
         if not removed:
             return
@@ -9974,6 +9983,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_gate_from_failure_mode(self):
+        self.push_undo_state()
         modes = self.get_available_failure_modes_for_gates()
         if not modes:
             messagebox.showinfo("No Failure Modes", "No failure modes available.")
@@ -10017,6 +10027,7 @@ class FaultTreeApp:
         self.update_views()
 
     def add_fault_event(self):
+        self.push_undo_state()
         dialog = self.SelectFaultDialog(self.root, sorted(self.faults), allow_new=True)
         fault = dialog.selected
         if fault == "NEW":

--- a/tests/test_fta_undo.py
+++ b/tests/test_fta_undo.py
@@ -1,0 +1,67 @@
+import unittest
+import types
+import os
+import sys
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AutoML import FaultTreeApp, FaultTreeNode
+from sysml.sysml_repository import SysMLRepository
+
+class FTAUndoRedoTests(unittest.TestCase):
+    def setUp(self):
+        # minimal app without Tk initialization
+        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app.top_events = []
+        self.app.root_node = None
+        self.app.selected_node = None
+        # stub analysis tree and view updates
+        self.app.analysis_tree = types.SimpleNamespace(selection=lambda: ())
+        self.app.update_views = lambda: None
+        self.app._undo_stack = []
+        self.app._redo_stack = []
+        # minimal persistence of state for undo/redo
+        self.app.export_model_data = lambda include_versions=False: {
+            "top_events": [n.to_dict() for n in self.app.top_events],
+            "root_node": self.app.root_node.to_dict() if self.app.root_node else None,
+        }
+        def apply_model_data(state):
+            self.app.top_events = [FaultTreeNode.from_dict(d) for d in state["top_events"]]
+            self.app.root_node = (
+                FaultTreeNode.from_dict(state["root_node"]) if state["root_node"] else None
+            )
+        self.app.apply_model_data = apply_model_data
+        SysMLRepository.reset_instance()
+
+    def test_undo_redo_top_event_creation_and_deletion(self):
+        self.app.create_top_event_for_malfunction("M1")
+        self.assertEqual(len(self.app.top_events), 1)
+        self.app.undo()
+        self.assertEqual(len(self.app.top_events), 0)
+        self.app.redo()
+        self.assertEqual(len(self.app.top_events), 1)
+        self.app.delete_top_events_for_malfunction("M1")
+        self.assertEqual(len(self.app.top_events), 0)
+        self.app.undo()
+        self.assertEqual(len(self.app.top_events), 1)
+        self.app.redo()
+        self.assertEqual(len(self.app.top_events), 0)
+
+    def test_undo_redo_add_node(self):
+        self.app.create_top_event_for_malfunction("M1")
+        self.app.selected_node = self.app.root_node
+        self.app.add_node_of_type("GATE")
+        self.assertEqual(len(self.app.root_node.children), 1)
+        self.app.undo()
+        self.assertEqual(len(self.app.root_node.children), 0)
+        self.app.redo()
+        self.assertEqual(len(self.app.root_node.children), 1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure FTA editing actions push undo states so changes can be reverted or re-applied
- add tests demonstrating undo/redo for FTA top events and node additions

## Testing
- `pytest tests/test_fta_undo.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bb20188088325a26a930ca073576d