### PR TITLE
Include connection and flow assets in threat dialog

### DIFF
--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -277,10 +277,17 @@ class ThreatDialog(simpledialog.Dialog):
 
             for conn in getattr(diag, "connections", []):
                 name = conn.get("name")
+                if not name:
+                    elem_id = conn.get("element_id")
+                    if elem_id and elem_id in repo.elements:
+                        name = repo.elements[elem_id].name
                 if name:
                     names.add(name)
-                # Connections might also carry a "flow" property
-                flow = conn.get("properties", {}).get("flow")
+
+                # Connections might define a flow either directly or within
+                # their properties. Include those so that data flows and
+                # unnamed connectors appear in the asset combobox.
+                flow = conn.get("flow") or conn.get("properties", {}).get("flow")
                 if flow:
                     names.add(flow)
         return sorted(names)

--- a/tests/test_threat_assets.py
+++ b/tests/test_threat_assets.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from gui.threat_dialog import ThreatDialog
+from sysml.sysml_repository import SysMLRepository
+
+
+class ThreatAssetTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def test_connections_and_flows_included(self):
+        repo = self.repo
+        # Create element to serve as connection's element with name
+        elem = repo.create_element("Block", name="ConnElem")
+        # Create diagram and attach a connection with element_id and flow
+        diag = repo.create_diagram("Block Definition", name="BD")
+        diag.connections = [
+            {
+                "src": 1,
+                "dst": 2,
+                "conn_type": "Connector",
+                "element_id": elem.elem_id,
+                "flow": "DataFlow",
+            }
+        ]
+        # Call _get_assets without constructing full dialog
+        dlg = ThreatDialog.__new__(ThreatDialog)
+        assets = dlg._get_assets(diag.diag_id)
+        self.assertIn("ConnElem", assets)
+        self.assertIn("DataFlow", assets)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- populate threat asset combobox with connection names and flow labels
- test that threat analysis assets include connections and flows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bb34fab908325b12c6b1f071c8e08