### PR TITLE
Add configuration dialog for GSN elements

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -60,46 +60,124 @@ class GSNDiagram:
         x, y = node.x * zoom, node.y * zoom
         scale = 40 * zoom
         typ = node.node_type.lower()
+        text = self._format_text(node)
+        
+        def _call(method, *args, **kwargs):
+            try:
+                method(*args, **kwargs)
+            except TypeError:  # pragma: no cover - fallback for simplified helpers
+                kwargs.pop("text", None)
+                kwargs.pop("top_text", None)
+                kwargs.pop("bottom_text", None)
+                method(*args, **kwargs)
         if typ == "solution":
             if node.is_primary_instance:
-                self.drawing_helper.draw_solution_shape(
-                    canvas, x, y, scale, obj_id=node.unique_id
+                _call(
+                    self.drawing_helper.draw_solution_shape,
+                    canvas,
+                    x,
+                    y,
+                    scale,
+                    top_text=node.user_name,
+                    bottom_text=node.description,
+                    obj_id=node.unique_id,
                 )
             else:
-                self.drawing_helper.draw_away_solution_shape(
-                    canvas, x, y, scale, obj_id=node.unique_id
+                _call(
+                    self.drawing_helper.draw_away_solution_shape,
+                    canvas,
+                    x,
+                    y,
+                    scale,
+                    top_text=node.user_name,
+                    bottom_text=node.description,
+                    obj_id=node.unique_id,
                 )
         elif typ == "goal":
             if node.is_primary_instance:
-                self.drawing_helper.draw_goal_shape(
-                    canvas, x, y, scale, obj_id=node.unique_id
+                _call(
+                    self.drawing_helper.draw_goal_shape,
+                    canvas,
+                    x,
+                    y,
+                    scale,
+                    text=text,
+                    obj_id=node.unique_id,
                 )
             else:
-                self.drawing_helper.draw_away_goal_shape(
-                    canvas, x, y, scale, obj_id=node.unique_id
+                _call(
+                    self.drawing_helper.draw_away_goal_shape,
+                    canvas,
+                    x,
+                    y,
+                    scale,
+                    text=text,
+                    obj_id=node.unique_id,
                 )
         elif typ == "strategy":
-            self.drawing_helper.draw_strategy_shape(
-                canvas, x, y, scale, obj_id=node.unique_id
+            _call(
+                self.drawing_helper.draw_strategy_shape,
+                canvas,
+                x,
+                y,
+                scale,
+                text=text,
+                obj_id=node.unique_id,
             )
         elif typ == "assumption":
-            self.drawing_helper.draw_assumption_shape(
-                canvas, x, y, scale, obj_id=node.unique_id
+            _call(
+                self.drawing_helper.draw_assumption_shape,
+                canvas,
+                x,
+                y,
+                scale,
+                text=text,
+                obj_id=node.unique_id,
             )
         elif typ == "justification":
-            self.drawing_helper.draw_justification_shape(
-                canvas, x, y, scale, obj_id=node.unique_id
+            _call(
+                self.drawing_helper.draw_justification_shape,
+                canvas,
+                x,
+                y,
+                scale,
+                text=text,
+                obj_id=node.unique_id,
             )
         elif typ == "context":
-            self.drawing_helper.draw_context_shape(
-                canvas, x, y, scale, obj_id=node.unique_id
+            _call(
+                self.drawing_helper.draw_context_shape,
+                canvas,
+                x,
+                y,
+                scale,
+                text=text,
+                obj_id=node.unique_id,
             )
         elif typ == "module":
             if node.is_primary_instance:
-                self.drawing_helper.draw_goal_shape(
-                    canvas, x, y, scale, obj_id=node.unique_id
+                _call(
+                    self.drawing_helper.draw_goal_shape,
+                    canvas,
+                    x,
+                    y,
+                    scale,
+                    text=text,
+                    obj_id=node.unique_id,
                 )
             else:
-                self.drawing_helper.draw_away_module_shape(
-                    canvas, x, y, scale, obj_id=node.unique_id
+                _call(
+                    self.drawing_helper.draw_away_module_shape,
+                    canvas,
+                    x,
+                    y,
+                    scale,
+                    text=text,
+                    obj_id=node.unique_id,
                 )
+
+    def _format_text(self, node: GSNNode) -> str:
+        """Return node label including description if present."""
+        if getattr(node, "description", ""):
+            return f"{node.user_name}\n{node.description}"
+        return node.user_name

--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -13,7 +13,9 @@ class GSNNode:
     Parameters
     ----------
     user_name:
-        Human readable label for the node.
+        Human readable label for the node (name).
+    description:
+        Optional description shown beneath the name when rendering.
     node_type:
         One of ``Goal``, ``Strategy``, ``Solution``, ``Assumption``,
         ``Justification`` or ``Context``.
@@ -23,6 +25,7 @@ class GSNNode:
 
     user_name: str
     node_type: str
+    description: str = ""
     x: float = 50
     y: float = 50
     children: List["GSNNode"] = field(default_factory=list)
@@ -53,6 +56,7 @@ class GSNNode:
         clone = GSNNode(
             self.user_name,
             self.node_type,
+            description=self.description,
             x=self.x,
             y=self.y,
             is_primary_instance=False,

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -1,0 +1,34 @@
+"""Configuration dialog for editing GSN node properties."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+from gsn import GSNNode
+
+
+class GSNElementConfig(tk.Toplevel):
+    """Simple dialog to edit a GSN element's name and description."""
+
+    def __init__(self, master, node: GSNNode):
+        super().__init__(master)
+        self.node = node
+        self.title("Edit GSN Element")
+        tk.Label(self, text="Name:").grid(row=0, column=0, sticky="e", padx=4, pady=4)
+        self.name_var = tk.StringVar(value=node.user_name)
+        tk.Entry(self, textvariable=self.name_var).grid(row=0, column=1, padx=4, pady=4)
+        tk.Label(self, text="Description:").grid(row=1, column=0, sticky="e", padx=4, pady=4)
+        self.desc_var = tk.StringVar(value=getattr(node, "description", ""))
+        tk.Entry(self, textvariable=self.desc_var).grid(row=1, column=1, padx=4, pady=4)
+        btns = ttk.Frame(self)
+        btns.grid(row=2, column=0, columnspan=2, pady=4)
+        ttk.Button(btns, text="OK", command=self._on_ok).pack(side=tk.LEFT, padx=4)
+        ttk.Button(btns, text="Cancel", command=self.destroy).pack(side=tk.LEFT, padx=4)
+        self.transient(master)
+        self.grab_set()
+        self.wait_window(self)
+
+    def _on_ok(self):
+        self.node.user_name = self.name_var.get()
+        self.node.description = self.desc_var.get()
+        self.destroy()

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -6,6 +6,7 @@ from tkinter import ttk
 from typing import Optional
 
 from gsn import GSNNode, GSNDiagram
+from .gsn_config_window import GSNElementConfig
 
 
 class GSNDiagramWindow(tk.Frame):
@@ -62,6 +63,7 @@ class GSNDiagramWindow(tk.Frame):
         self.canvas.bind("<Button-1>", self._on_click)
         self.canvas.bind("<B1-Motion>", self._on_drag)
         self.canvas.bind("<ButtonRelease-1>", self._on_release)
+        self.canvas.bind("<Double-1>", self._on_double_click)
         self.refresh()
 
     # ------------------------------------------------------------------
@@ -139,6 +141,13 @@ class GSNDiagramWindow(tk.Frame):
 
     def _on_release(self, _event):  # pragma: no cover - requires tkinter
         self._drag_node = None
+
+    def _on_double_click(self, event):  # pragma: no cover - requires tkinter
+        node = self._node_at(event.x, event.y)
+        if not node:
+            return
+        GSNElementConfig(self, node)
+        self.refresh()
 
     def _node_at(self, x: float, y: float) -> Optional[GSNNode]:
         items = self.canvas.find_overlapping(x, y, x, y)


### PR DESCRIPTION
## Summary
- allow GSN nodes to store and clone a description
- render node name and description in diagrams
- add GUI dialog to edit a node's name and description

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_diagram_draw.py tests/test_gsn_diagram_window.py tests/test_gsn_explorer.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689bca49e7f88325aba06e172e9015aa