### PR TITLE
Show dotted preview when linking GSN nodes

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -132,14 +132,16 @@ class GSNDiagramWindow(tk.Frame):
                 self._connect_parent.x * self.zoom,
                 self._connect_parent.y * self.zoom,
             )
-            dash = (4, 2) if self._connect_mode == "context" else None
+            # Always show a dotted preview line similar to SysML diagrams.
+            # The final connection style (solid or dashed) is handled during
+            # diagram rendering depending on the target node type.
             self.canvas.create_line(
                 px,
                 py,
                 event.x,
                 event.y,
                 fill="dimgray",
-                dash=dash,
+                dash=(2, 2),
                 smooth=True,
                 arrow=tk.LAST,
                 tags="_temp_conn",

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -1,4 +1,5 @@
 from gui.gsn_diagram_window import GSNDiagramWindow
+from gsn import GSNNode
 
 
 def test_gsn_diagram_window_button_labels():
@@ -17,3 +18,25 @@ def test_zoom_methods_adjust_factor():
     assert win.zoom > 1.0
     GSNDiagramWindow.zoom_out(win)
     assert abs(win.zoom - 1.0) < 1e-6
+
+
+def test_temp_connection_line_is_dotted():
+    """Dragging in connect mode should draw a dotted preview line."""
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.zoom = 1.0
+    win._connect_mode = "solved"
+    win._connect_parent = GSNNode("p", "Goal", x=10, y=20)
+    win._drag_node = None
+    lines = []
+
+    class CanvasStub:
+        def create_line(self, *args, **kwargs):
+            lines.append(kwargs.get("dash"))
+
+        def delete(self, *args, **kwargs):
+            pass
+
+    win.canvas = CanvasStub()
+    event = type("Event", (), {"x": 100, "y": 100})
+    win._on_drag(event)
+    assert lines and lines[0] == (2, 2)


### PR DESCRIPTION
## Summary
- ensure GSN connector dragging shows a dotted preview line
- test dotted preview line when creating GSN connections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689bd47c0544832597029a1b1677ea68