### PR TITLE
style(gsn): add white-yellow gradient

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -15,6 +15,7 @@ _NAMED_COLORS = {
     "lightgrey": "#d3d3d3",
     "lightblue": "#add8e6",
     "lightyellow": "#ffffe0",
+    "yellow": "#ffff00",
 }
 
 # Basic mapping of a few common color names to their hex equivalents. The
@@ -27,6 +28,7 @@ _NAMED_COLORS = {
     "lightgrey": "#d3d3d3",
     "lightblue": "#add8e6",
     "lightyellow": "#ffffe0",
+    "yellow": "#ffff00",
 }
 
 class FTADrawingHelper:
@@ -850,7 +852,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         y,
         scale=60.0,
         text="Goal",
-        fill="lightyellow",
+        fill="yellow",
         outline_color="dimgray",
         line_width=1,
         font_obj=None,
@@ -939,7 +941,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         y,
         scale=60.0,
         text="Strategy",
-        fill="lightyellow",
+        fill="yellow",
         outline_color="dimgray",
         line_width=1,
         font_obj=None,
@@ -968,7 +970,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=40.0,
         top_text="Solution",
         bottom_text="",
-        fill="lightyellow",
+        fill="yellow",
         outline_color="dimgray",
         line_width=1,
         font_obj=None,
@@ -997,7 +999,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         y,
         scale=60.0,
         text="Assumption",
-        fill="lightyellow",
+        fill="yellow",
         outline_color="dimgray",
         line_width=1,
         font_obj=None,
@@ -1032,7 +1034,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         y,
         scale=60.0,
         text="Justification",
-        fill="lightyellow",
+        fill="yellow",
         outline_color="dimgray",
         line_width=1,
         font_obj=None,
@@ -1075,7 +1077,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         y,
         scale=60.0,
         text="Context",
-        fill="lightyellow",
+        fill="yellow",
         outline_color="dimgray",
         line_width=1,
         font_obj=None,

--- a/tests/test_drawing_helper_colors.py
+++ b/tests/test_drawing_helper_colors.py
@@ -1,3 +1,4 @@
+import pytest
 from gui.drawing_helper import GSNDrawingHelper
 
 
@@ -11,11 +12,12 @@ class DummyCanvas:
         self.lines.append(fill)
 
 
-def test_fill_gradient_rect_accepts_named_color():
+@pytest.mark.parametrize("color", ["lightyellow", "yellow"])
+def test_fill_gradient_rect_accepts_named_color(color):
     helper = GSNDrawingHelper()
     canvas = DummyCanvas()
     # Using a Tk-style color name previously triggered a ValueError
-    helper._fill_gradient_rect(canvas, 0, 0, 4, 4, "lightyellow")
+    helper._fill_gradient_rect(canvas, 0, 0, 4, 4, color)
     assert canvas.lines  # some lines were drawn
     assert all(line.startswith("#") for line in canvas.lines)
 


### PR DESCRIPTION
## Summary
- give GSN diagram elements a white-to-yellow gradient
- map the named color `yellow` for gradient fills
- expand drawing helper color tests to cover yellow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bd57645448325b3666d56c3623da3