### PR TITLE
feat(gsn): preview arrows match connection type

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -133,8 +133,10 @@ class GSNDiagramWindow(tk.Frame):
                 self._connect_parent.y * self.zoom,
             )
             # Always show a dotted preview line similar to SysML diagrams.
-            # The final connection style (solid or dashed) is handled during
-            # diagram rendering depending on the target node type.
+            # For solved-by connectors the preview line carries an arrow just
+            # like the final connection, while context relationships omit the
+            # arrow entirely.
+            arrow = tk.LAST if self._connect_mode == "solved" else None
             self.canvas.create_line(
                 px,
                 py,
@@ -143,7 +145,7 @@ class GSNDiagramWindow(tk.Frame):
                 fill="dimgray",
                 dash=(2, 2),
                 smooth=True,
-                arrow=tk.LAST,
+                arrow=arrow,
                 tags="_temp_conn",
             )
             return

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -1,3 +1,5 @@
+import tkinter as tk
+
 from gui.gsn_diagram_window import GSNDiagramWindow
 from gsn import GSNNode
 
@@ -31,7 +33,7 @@ def test_temp_connection_line_is_dotted():
 
     class CanvasStub:
         def create_line(self, *args, **kwargs):
-            lines.append(kwargs.get("dash"))
+            lines.append(kwargs)
 
         def delete(self, *args, **kwargs):
             pass
@@ -39,4 +41,28 @@ def test_temp_connection_line_is_dotted():
     win.canvas = CanvasStub()
     event = type("Event", (), {"x": 100, "y": 100})
     win._on_drag(event)
-    assert lines and lines[0] == (2, 2)
+    assert lines and lines[0].get("dash") == (2, 2)
+    assert lines[0].get("arrow") == tk.LAST
+
+
+def test_temp_connection_line_no_arrow_in_context_mode():
+    """Context connections preview without an arrow."""
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.zoom = 1.0
+    win._connect_mode = "context"
+    win._connect_parent = GSNNode("p", "Goal", x=10, y=20)
+    win._drag_node = None
+    lines = []
+
+    class CanvasStub:
+        def create_line(self, *args, **kwargs):
+            lines.append(kwargs)
+
+        def delete(self, *args, **kwargs):
+            pass
+
+    win.canvas = CanvasStub()
+    event = type("Event", (), {"x": 50, "y": 50})
+    win._on_drag(event)
+    assert lines and lines[0].get("dash") == (2, 2)
+    assert not lines[0].get("arrow")


### PR DESCRIPTION
## Summary
- show dashed preview line while connecting GSN nodes
- preview arrow mirrors final connection type
- test connector preview arrow behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bd789b8148325b570c74ad6475e49