### PR TITLE
Refine GSN solution node rendering

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -87,40 +87,29 @@ class GSNDiagram:
                 method(*args, **kwargs)
 
         if typ == "solution":
-            top_w, top_h = self.drawing_helper.get_text_size(node.user_name, font_obj)
-            bottom_w, bottom_h = self.drawing_helper.get_text_size(
-                getattr(node, "description", ""), font_obj
-            )
+            text = self._format_text(node)
+            t_width, t_height = self.drawing_helper.get_text_size(text, font_obj)
             radius = max(
                 base_scale / 2,
-                bottom_w / 2 + padding,
-                bottom_h + padding,
+                t_width / 2 + padding,
+                t_height / 2 + padding,
             )
             scale = radius * 2
-            if node.is_primary_instance:
-                _call(
-                    self.drawing_helper.draw_solution_shape,
-                    canvas,
-                    x,
-                    y,
-                    scale,
-                    top_text=node.user_name,
-                    bottom_text=node.description,
-                    font_obj=font_obj,
-                    obj_id=node.unique_id,
-                )
-            else:
-                _call(
-                    self.drawing_helper.draw_away_solution_shape,
-                    canvas,
-                    x,
-                    y,
-                    scale,
-                    top_text=node.user_name,
-                    bottom_text=node.description,
-                    font_obj=font_obj,
-                    obj_id=node.unique_id,
-                )
+            draw_func = (
+                self.drawing_helper.draw_solution_shape
+                if node.is_primary_instance
+                else self.drawing_helper.draw_away_solution_shape
+            )
+            _call(
+                draw_func,
+                canvas,
+                x,
+                y,
+                scale,
+                text=text,
+                font_obj=font_obj,
+                obj_id=node.unique_id,
+            )
         elif typ in {"goal", "module"}:
             ratio = 0.6
             scale = max(base_scale, width + padding, (height + padding) / ratio)

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -989,8 +989,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         x,
         y,
         scale=40.0,
-        top_text="Solution",
-        bottom_text="",
+        text="Solution",
         fill="lightyellow",
         outline_color="dimgray",
         line_width=1,
@@ -998,19 +997,30 @@ class GSNDrawingHelper(FTADrawingHelper):
         obj_id: str = "",
     ):
         radius = scale / 2
-        self.draw_circle_event_shape(
-            canvas,
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        left = x - radius
+        top = y - radius
+        right = x + radius
+        bottom = y + radius
+        self._fill_gradient_circle(canvas, x, y, radius, fill)
+        canvas.create_oval(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
             x,
             y,
-            radius,
-            top_text=top_text,
-            bottom_text=bottom_text,
-            fill=fill,
-            outline_color=outline_color,
-            line_width=line_width,
-            font_obj=font_obj,
-            base_event=True,
-            obj_id=obj_id,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=scale - 8,
         )
 
     def draw_assumption_shape(


### PR DESCRIPTION
## Summary
- Draw GSN solutions with a dedicated circular style instead of reusing FTA base event graphics
- Simplify GSN diagram logic to render solution text directly inside the node

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bd7a50adc83259836709b9cbde077