### PR TITLE
Enable GSN model serialization and persistence

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -244,6 +244,7 @@ from gui.review_toolbox import (
 from gui.safety_management_toolbox import SafetyManagementToolbox
 from gui.gsn_explorer import GSNExplorer
 from gui.gsn_diagram_window import GSNDiagramWindow
+from gsn import GSNDiagram, GSNModule
 from gui.closable_notebook import ClosableNotebook
 from dataclasses import asdict
 from analysis.mechanisms import (
@@ -15526,6 +15527,8 @@ class FaultTreeApp:
             "reviews": reviews,
             "current_review": current_name,
             "sysml_repository": repo.to_dict(),
+            "gsn_modules": [m.to_dict() for m in getattr(self, "gsn_modules", [])],
+            "gsn_diagrams": [d.to_dict() for d in getattr(self, "gsn_diagrams", [])],
         }
         if include_versions:
             data["versions"] = self.versions
@@ -15551,6 +15554,13 @@ class FaultTreeApp:
             new_root.x, new_root.y = 300, 200
             self.top_events.append(new_root)
         self.root_node = self.top_events[0] if self.top_events else None
+
+        self.gsn_modules = [
+            GSNModule.from_dict(m) for m in data.get("gsn_modules", [])
+        ]
+        self.gsn_diagrams = [
+            GSNDiagram.from_dict(d) for d in data.get("gsn_diagrams", [])
+        ]
 
         self.fmeas = []
         for fmea_data in data.get("fmeas", []):

--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -36,6 +36,29 @@ class GSNDiagram:
             self.nodes.append(node)
 
     # ------------------------------------------------------------------
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable representation of this diagram."""
+        return {
+            "diag_id": self.diag_id,
+            "root": self.root.unique_id,
+            "nodes": [n.to_dict() for n in self.nodes],
+        }
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_dict(cls, data: dict) -> "GSNDiagram":
+        """Reconstruct a :class:`GSNDiagram` from *data*."""
+        node_map: dict[str, GSNNode] = {}
+        for nd in data.get("nodes", []):
+            GSNNode.from_dict(nd, nodes=node_map)
+        GSNNode.resolve_references(node_map)
+        root_id = data.get("root")
+        root = node_map.get(root_id)
+        diag = cls(root, diag_id=data.get("diag_id", str(uuid.uuid4())))
+        diag.nodes = list(node_map.values())
+        return diag
+
+    # ------------------------------------------------------------------
     def _traverse(self) -> Iterable[GSNNode]:
         # ``nodes`` already contains all diagram nodes, including ones that
         # are not connected yet.  Simply iterate over the list to avoid

--- a/gsn/module.py
+++ b/gsn/module.py
@@ -15,3 +15,21 @@ class GSNModule:
     name: str
     modules: List["GSNModule"] = field(default_factory=list)
     diagrams: List["GSNDiagram"] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> dict:
+        """Return a serialisable representation of this module."""
+        return {
+            "name": self.name,
+            "modules": [m.to_dict() for m in self.modules],
+            "diagrams": [d.to_dict() for d in self.diagrams],
+        }
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_dict(cls, data: dict) -> "GSNModule":
+        mod = cls(data.get("name", ""))
+        mod.modules = [cls.from_dict(m) for m in data.get("modules", [])]
+        from .diagram import GSNDiagram  # local import to avoid cycle
+        mod.diagrams = [GSNDiagram.from_dict(d) for d in data.get("diagrams", [])]
+        return mod

--- a/tests/test_gsn_persistence.py
+++ b/tests/test_gsn_persistence.py
@@ -1,0 +1,91 @@
+import types
+import sys
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+import os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import FaultTreeApp
+from gsn import GSNNode, GSNDiagram, GSNModule
+
+
+def _minimal_app():
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.top_events = []
+    app.root_node = None
+    app.fmea_entries = []
+    app.fmeas = []
+    app.fmedas = []
+    app.mechanism_libraries = []
+    app.selected_mechanism_libraries = []
+    app.mission_profiles = []
+    app.reliability_analyses = []
+    app.hazop_docs = []
+    app.hara_docs = []
+    app.stpa_docs = []
+    app.threat_docs = []
+    app.fi2tc_docs = []
+    app.tc2fi_docs = []
+    app.hazop_entries = []
+    app.fi2tc_entries = []
+    app.tc2fi_entries = []
+    app.scenario_libraries = []
+    app.odd_libraries = []
+    app.faults = []
+    app.malfunctions = []
+    app.hazards = []
+    app.failures = []
+    app.project_properties = {}
+    app.reviews = []
+    app.review_data = types.SimpleNamespace(name=None)
+    app.update_odd_elements = lambda: None
+    app.update_failure_list = lambda: None
+    app.load_default_mechanisms = lambda: None
+    app.update_hazard_list = lambda: None
+    app.update_hara_statuses = lambda: None
+    app.update_fta_statuses = lambda: None
+    app.get_all_basic_events = lambda: []
+    app.get_all_nodes = lambda te: []
+    app.get_all_fmea_entries = lambda: []
+    app.update_global_requirements_from_nodes = lambda *args, **kwargs: None
+    app.sync_hara_to_safety_goals = lambda: None
+    app.close_page_diagram = lambda: None
+    app.update_views = lambda: None
+    return app
+
+
+def test_gsn_roundtrip_serialisation():
+    # build a simple module/diagram structure
+    root1 = GSNNode("G1", "Goal")
+    strat = GSNNode("S1", "Strategy")
+    root1.add_child(strat)
+    diag1 = GSNDiagram(root1)
+    diag1.add_node(strat)
+    mod = GSNModule("Pkg", diagrams=[diag1])
+
+    root2 = GSNNode("G2", "Goal")
+    diag2 = GSNDiagram(root2)
+
+    app = _minimal_app()
+    app.gsn_modules = [mod]
+    app.gsn_diagrams = [diag2]
+
+    data = app.export_model_data(include_versions=False)
+
+    new_app = _minimal_app()
+    new_app.apply_model_data(data, ensure_root=False)
+
+    assert len(new_app.gsn_modules) == 1
+    loaded_mod = new_app.gsn_modules[0]
+    assert loaded_mod.name == "Pkg"
+    assert len(loaded_mod.diagrams) == 1
+    assert loaded_mod.diagrams[0].root.user_name == "G1"
+    assert loaded_mod.diagrams[0].root.children[0].node_type == "Strategy"
+    assert len(new_app.gsn_diagrams) == 1
+    assert new_app.gsn_diagrams[0].root.user_name == "G2"


### PR DESCRIPTION
## Summary
- add `to_dict`/`from_dict` helpers for GSN nodes, diagrams, and modules
- include GSN modules/diagrams in model export and loading
- test round-trip persistence of GSN models

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bd7be5bb883258a280f476fef676e