### PR TITLE
Add work product selection and cloning for GSN solutions

### DIFF
--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -33,6 +33,7 @@ class GSNNode:
     is_primary_instance: bool = True
     original: Optional["GSNNode"] = field(default=None, repr=False)
     unique_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    work_product: str = ""
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         # A freshly created node is considered its own original instance.

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -4,19 +4,27 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import ttk
 
-from gsn import GSNNode
+from gsn import GSNNode, GSNDiagram
+
+WORK_PRODUCTS = [
+    "Architectural Diagram",
+    "Hazard & Cyber Analysis",
+    "Risk Assessment",
+    "Safety Analysis",
+]
 
 
 class GSNElementConfig(tk.Toplevel):
-    """Simple dialog to edit a GSN element's name and description."""
+    """Simple dialog to edit a GSN element's properties."""
 
-    def __init__(self, master, node: GSNNode):
+    def __init__(self, master, node: GSNNode, diagram: GSNDiagram):
         super().__init__(master)
         self.node = node
+        self.diagram = diagram
         self.title("Edit GSN Element")
-        self.geometry("400x200")
+        self.geometry("400x240")
         self.columnconfigure(1, weight=1)
-        self.rowconfigure(1, weight=1)
+        self.rowconfigure(2, weight=1)
         tk.Label(self, text="Name:").grid(row=0, column=0, sticky="e", padx=4, pady=4)
         self.name_var = tk.StringVar(value=node.user_name)
         tk.Entry(self, textvariable=self.name_var, width=40).grid(
@@ -26,8 +34,21 @@ class GSNElementConfig(tk.Toplevel):
         self.desc_text = tk.Text(self, width=40, height=5)
         self.desc_text.insert("1.0", getattr(node, "description", ""))
         self.desc_text.grid(row=1, column=1, padx=4, pady=4, sticky="nsew")
+
+        self.work_var = tk.StringVar(value=getattr(node, "work_product", ""))
+        if node.node_type == "Solution":
+            tk.Label(self, text="Work Product:").grid(
+                row=2, column=0, sticky="e", padx=4, pady=4
+            )
+            ttk.Combobox(
+                self,
+                textvariable=self.work_var,
+                values=WORK_PRODUCTS,
+                state="readonly",
+            ).grid(row=2, column=1, padx=4, pady=4, sticky="ew")
+
         btns = ttk.Frame(self)
-        btns.grid(row=2, column=0, columnspan=2, pady=4)
+        btns.grid(row=3, column=0, columnspan=2, pady=4)
         ttk.Button(btns, text="OK", command=self._on_ok).pack(side=tk.LEFT, padx=4)
         ttk.Button(btns, text="Cancel", command=self.destroy).pack(side=tk.LEFT, padx=4)
         self.transient(master)
@@ -37,4 +58,23 @@ class GSNElementConfig(tk.Toplevel):
     def _on_ok(self):
         self.node.user_name = self.name_var.get()
         self.node.description = self.desc_text.get("1.0", tk.END).strip()
+        if self.node.node_type == "Solution":
+            self.node.work_product = self.work_var.get()
+            # search for existing solution with same work product
+            for n in self.diagram.nodes:
+                if (
+                    n is not self.node
+                    and n.node_type == "Solution"
+                    and getattr(n, "work_product", "") == self.node.work_product
+                ):
+                    original = n if n.is_primary_instance else n.original
+                    self.node.user_name = original.user_name
+                    self.node.description = getattr(original, "description", "")
+                    self.node.unique_id = original.unique_id
+                    self.node.original = original
+                    self.node.is_primary_instance = False
+                    break
+            else:
+                self.node.is_primary_instance = True
+                self.node.original = self.node
         self.destroy()

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -171,7 +171,7 @@ class GSNDiagramWindow(tk.Frame):
         node = self._node_at(event.x, event.y)
         if not node:
             return
-        GSNElementConfig(self, node)
+        GSNElementConfig(self, node, self.diagram)
         self.refresh()
 
     def _node_at(self, x: float, y: float) -> Optional[GSNNode]:

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -1,0 +1,44 @@
+from gsn import GSNNode, GSNDiagram
+from gui.gsn_config_window import GSNElementConfig, WORK_PRODUCTS
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class DummyText:
+    def __init__(self, text=""):
+        self.text = text
+
+    def get(self, *_args, **_kwargs):
+        return self.text
+
+
+def test_solution_clones_existing_work_product():
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    original = GSNNode("Orig", "Solution")
+    original.work_product = WORK_PRODUCTS[0]
+    diag.add_node(original)
+    node = GSNNode("New", "Solution")
+    diag.add_node(node)
+
+    cfg = GSNElementConfig.__new__(GSNElementConfig)
+    cfg.node = node
+    cfg.diagram = diag
+    cfg.name_var = DummyVar(node.user_name)
+    cfg.desc_text = DummyText(node.description)
+    cfg.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg.destroy = lambda: None
+
+    cfg._on_ok()
+
+    assert node.original is original
+    assert not node.is_primary_instance
+    assert node.user_name == original.user_name
+    assert node.unique_id == original.unique_id
+


### PR DESCRIPTION
## Summary
- allow configuring GSN solution nodes with selectable work products
- automatically clone existing solution when selecting a previously used work product
- test cloning of GSN solutions by work product

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689bd89e80f08325b099e043b9cdac67