### PR TITLE
Add SPI target selection to GSN solution configuration

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -192,6 +192,13 @@ class GSNDiagram:
 
     def _format_text(self, node: GSNNode) -> str:
         """Return node label including description if present."""
+        if node.node_type == "Solution":
+            lines = [node.user_name]
+            if getattr(node, "spi_target", ""):
+                lines.append(f"SPI: {node.spi_target}")
+            if getattr(node, "description", ""):
+                lines.append(node.description)
+            return "\n".join(lines)
         if getattr(node, "description", ""):
             return f"{node.user_name}\n{node.description}"
         return node.user_name

--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -34,6 +34,7 @@ class GSNNode:
     original: Optional["GSNNode"] = field(default=None, repr=False)
     unique_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     work_product: str = ""
+    spi_target: str = ""
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         # A freshly created node is considered its own original instance.
@@ -63,6 +64,8 @@ class GSNNode:
             is_primary_instance=False,
             original=self.original,
         )
+        clone.work_product = self.work_product
+        clone.spi_target = self.spi_target
         if parent is not None:
             parent.add_child(clone)
         return clone
@@ -80,6 +83,8 @@ class GSNNode:
             "children": [c.unique_id for c in self.children],
             "is_primary_instance": self.is_primary_instance,
             "original": self.original.unique_id if self.original else None,
+            "work_product": self.work_product,
+            "spi_target": self.spi_target,
         }
 
     # ------------------------------------------------------------------
@@ -99,6 +104,8 @@ class GSNNode:
             y=data.get("y", 50),
             is_primary_instance=data.get("is_primary_instance", True),
             unique_id=data.get("unique_id", str(uuid.uuid4())),
+            work_product=data.get("work_product", ""),
+            spi_target=data.get("spi_target", ""),
         )
         nodes[node.unique_id] = node
         # Temporarily store child and original references for second pass

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -36,6 +36,7 @@ class GSNElementConfig(tk.Toplevel):
         self.desc_text.grid(row=1, column=1, padx=4, pady=4, sticky="nsew")
 
         self.work_var = tk.StringVar(value=getattr(node, "work_product", ""))
+        self.spi_var = tk.StringVar(value=getattr(node, "spi_target", ""))
         if node.node_type == "Solution":
             tk.Label(self, text="Work Product:").grid(
                 row=2, column=0, sticky="e", padx=4, pady=4
@@ -47,8 +48,26 @@ class GSNElementConfig(tk.Toplevel):
                 state="readonly",
             ).grid(row=2, column=1, padx=4, pady=4, sticky="ew")
 
+            spi_names = [
+                te.user_name or f"SG {te.unique_id}"
+                for te in getattr(master.app, "top_events", [])
+            ]
+            tk.Label(self, text="SPI Target:").grid(
+                row=3, column=0, sticky="e", padx=4, pady=4
+            )
+            ttk.Combobox(
+                self,
+                textvariable=self.spi_var,
+                values=spi_names,
+                state="readonly",
+            ).grid(row=3, column=1, padx=4, pady=4, sticky="ew")
+
+            btn_row = 4
+        else:
+            btn_row = 3
+
         btns = ttk.Frame(self)
-        btns.grid(row=3, column=0, columnspan=2, pady=4)
+        btns.grid(row=btn_row, column=0, columnspan=2, pady=4)
         ttk.Button(btns, text="OK", command=self._on_ok).pack(side=tk.LEFT, padx=4)
         ttk.Button(btns, text="Cancel", command=self.destroy).pack(side=tk.LEFT, padx=4)
         self.transient(master)
@@ -60,18 +79,21 @@ class GSNElementConfig(tk.Toplevel):
         self.node.description = self.desc_text.get("1.0", tk.END).strip()
         if self.node.node_type == "Solution":
             self.node.work_product = self.work_var.get()
-            # search for existing solution with same work product
+            self.node.spi_target = self.spi_var.get()
+            # search for existing solution with same work product and SPI target
             for n in self.diagram.nodes:
                 if (
                     n is not self.node
                     and n.node_type == "Solution"
                     and getattr(n, "work_product", "") == self.node.work_product
+                    and getattr(n, "spi_target", "") == self.node.spi_target
                 ):
                     original = n if n.is_primary_instance else n.original
                     self.node.user_name = original.user_name
                     self.node.description = getattr(original, "description", "")
                     self.node.unique_id = original.unique_id
                     self.node.original = original
+                    self.node.spi_target = getattr(original, "spi_target", "")
                     self.node.is_primary_instance = False
                     break
             else:

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -33,6 +33,7 @@ def test_solution_clones_existing_work_product():
     cfg.name_var = DummyVar(node.user_name)
     cfg.desc_text = DummyText(node.description)
     cfg.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg.spi_var = DummyVar("")
     cfg.destroy = lambda: None
 
     cfg._on_ok()
@@ -41,4 +42,51 @@ def test_solution_clones_existing_work_product():
     assert not node.is_primary_instance
     assert node.user_name == original.user_name
     assert node.unique_id == original.unique_id
+
+
+def test_solution_requires_matching_spi_for_clone():
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    original = GSNNode("Orig", "Solution")
+    original.work_product = WORK_PRODUCTS[0]
+    original.spi_target = "Brake Time"
+    diag.add_node(original)
+
+    node = GSNNode("New", "Solution")
+    diag.add_node(node)
+    cfg = GSNElementConfig.__new__(GSNElementConfig)
+    cfg.node = node
+    cfg.diagram = diag
+    cfg.name_var = DummyVar(node.user_name)
+    cfg.desc_text = DummyText(node.description)
+    cfg.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg.spi_var = DummyVar("Other SPI")
+    cfg.destroy = lambda: None
+    cfg._on_ok()
+
+    assert node.original is node
+
+    node2 = GSNNode("New2", "Solution")
+    diag.add_node(node2)
+    cfg2 = GSNElementConfig.__new__(GSNElementConfig)
+    cfg2.node = node2
+    cfg2.diagram = diag
+    cfg2.name_var = DummyVar(node2.user_name)
+    cfg2.desc_text = DummyText(node2.description)
+    cfg2.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg2.spi_var = DummyVar("Brake Time")
+    cfg2.destroy = lambda: None
+    cfg2._on_ok()
+
+    assert node2.original is original
+
+
+def test_format_text_shows_spi_target():
+    root = GSNNode("Root", "Goal")
+    sol = GSNNode("Sol", "Solution")
+    sol.spi_target = "Brake Time"
+    diag = GSNDiagram(root)
+    diag.add_node(sol)
+    text = diag._format_text(sol)
+    assert "SPI: Brake Time" in text
 


### PR DESCRIPTION
## Summary
- allow selecting Safety Performance Indicator targets for solution nodes
- show chosen SPI on diagram nodes
- ensure solution clones require matching work product and SPI target

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bd9f53f208325bf1de94f8b8ea306