### PR TITLE
feat: add evidence links for GSN solutions

### DIFF
--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -34,6 +34,7 @@ class GSNNode:
     original: Optional["GSNNode"] = field(default=None, repr=False)
     unique_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     work_product: str = ""
+    evidence_link: str = ""
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         # A freshly created node is considered its own original instance.
@@ -62,6 +63,8 @@ class GSNNode:
             y=self.y,
             is_primary_instance=False,
             original=self.original,
+            work_product=self.work_product,
+            evidence_link=self.evidence_link,
         )
         if parent is not None:
             parent.add_child(clone)
@@ -80,6 +83,8 @@ class GSNNode:
             "children": [c.unique_id for c in self.children],
             "is_primary_instance": self.is_primary_instance,
             "original": self.original.unique_id if self.original else None,
+            "work_product": self.work_product,
+            "evidence_link": self.evidence_link,
         }
 
     # ------------------------------------------------------------------
@@ -99,6 +104,8 @@ class GSNNode:
             y=data.get("y", 50),
             is_primary_instance=data.get("is_primary_instance", True),
             unique_id=data.get("unique_id", str(uuid.uuid4())),
+            work_product=data.get("work_product", ""),
+            evidence_link=data.get("evidence_link", ""),
         )
         nodes[node.unique_id] = node
         # Temporarily store child and original references for second pass

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -22,7 +22,7 @@ class GSNElementConfig(tk.Toplevel):
         self.node = node
         self.diagram = diagram
         self.title("Edit GSN Element")
-        self.geometry("400x240")
+        self.geometry("400x280")
         self.columnconfigure(1, weight=1)
         self.rowconfigure(2, weight=1)
         tk.Label(self, text="Name:").grid(row=0, column=0, sticky="e", padx=4, pady=4)
@@ -36,19 +36,28 @@ class GSNElementConfig(tk.Toplevel):
         self.desc_text.grid(row=1, column=1, padx=4, pady=4, sticky="nsew")
 
         self.work_var = tk.StringVar(value=getattr(node, "work_product", ""))
+        self.link_var = tk.StringVar(value=getattr(node, "evidence_link", ""))
+        row = 2
         if node.node_type == "Solution":
             tk.Label(self, text="Work Product:").grid(
-                row=2, column=0, sticky="e", padx=4, pady=4
+                row=row, column=0, sticky="e", padx=4, pady=4
             )
             ttk.Combobox(
                 self,
                 textvariable=self.work_var,
                 values=WORK_PRODUCTS,
                 state="readonly",
-            ).grid(row=2, column=1, padx=4, pady=4, sticky="ew")
-
+            ).grid(row=row, column=1, padx=4, pady=4, sticky="ew")
+            row += 1
+            tk.Label(self, text="Evidence Link:").grid(
+                row=row, column=0, sticky="e", padx=4, pady=4
+            )
+            tk.Entry(self, textvariable=self.link_var, width=40).grid(
+                row=row, column=1, padx=4, pady=4, sticky="ew"
+            )
+            row += 1
         btns = ttk.Frame(self)
-        btns.grid(row=3, column=0, columnspan=2, pady=4)
+        btns.grid(row=row, column=0, columnspan=2, pady=4)
         ttk.Button(btns, text="OK", command=self._on_ok).pack(side=tk.LEFT, padx=4)
         ttk.Button(btns, text="Cancel", command=self.destroy).pack(side=tk.LEFT, padx=4)
         self.transient(master)
@@ -60,6 +69,7 @@ class GSNElementConfig(tk.Toplevel):
         self.node.description = self.desc_text.get("1.0", tk.END).strip()
         if self.node.node_type == "Solution":
             self.node.work_product = self.work_var.get()
+            self.node.evidence_link = self.link_var.get()
             # search for existing solution with same work product
             for n in self.diagram.nodes:
                 if (

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk
+import webbrowser
 from typing import Optional
 
 from gsn import GSNNode, GSNDiagram
@@ -173,7 +174,15 @@ class GSNDiagramWindow(tk.Frame):
         node = self._node_at(event.x, event.y)
         if not node:
             return
-        GSNElementConfig(self, node, self.diagram)
+        if (
+            node.node_type == "Solution"
+            and getattr(node, "evidence_link", "")
+        ):
+            webbrowser.open(node.evidence_link)
+        else:
+            GSNElementConfig(self, node, self.diagram)
+            self.refresh()
+            return
         self.refresh()
 
     def _node_at(self, x: float, y: float) -> Optional[GSNNode]:

--- a/tests/test_gsn_solution_link.py
+++ b/tests/test_gsn_solution_link.py
@@ -1,0 +1,68 @@
+import types
+
+from gsn import GSNNode, GSNDiagram
+from gui.gsn_config_window import GSNElementConfig, WORK_PRODUCTS
+from gui.gsn_diagram_window import GSNDiagramWindow
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class DummyText:
+    def __init__(self, text=""):
+        self.text = text
+
+    def get(self, *_args, **_kwargs):
+        return self.text
+
+
+def test_solution_config_sets_evidence_link():
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    node = GSNNode("Sol", "Solution")
+    diag.add_node(node)
+
+    cfg = GSNElementConfig.__new__(GSNElementConfig)
+    cfg.node = node
+    cfg.diagram = diag
+    cfg.name_var = DummyVar(node.user_name)
+    cfg.desc_text = DummyText(node.description)
+    cfg.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg.link_var = DummyVar("http://example.com")
+    cfg.destroy = lambda: None
+
+    cfg._on_ok()
+
+    assert node.evidence_link == "http://example.com"
+
+
+def test_double_click_opens_evidence_link(monkeypatch):
+    opened = {}
+
+    def fake_open(url):
+        opened["url"] = url
+        return True
+
+    monkeypatch.setattr("webbrowser.open", fake_open)
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    node = GSNNode("Sol", "Solution")
+    node.evidence_link = "http://example.com"
+    diag.add_node(node)
+
+    wnd = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    wnd.diagram = diag
+    wnd.refresh = lambda: None
+    wnd._node_at = lambda x, y: node
+
+    event = types.SimpleNamespace(x=0, y=0)
+    GSNDiagramWindow._on_double_click(wnd, event)
+
+    assert opened["url"] == "http://example.com"
+

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -33,6 +33,7 @@ def test_solution_clones_existing_work_product():
     cfg.name_var = DummyVar(node.user_name)
     cfg.desc_text = DummyText(node.description)
     cfg.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg.link_var = DummyVar("")
     cfg.destroy = lambda: None
 
     cfg._on_ok()


### PR DESCRIPTION
## Summary
- allow GSN solutions to store an external evidence link
- expose evidence link in solution configuration dialog
- open evidence link on double-clicking a solution node

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689bda65c18c83259ff80ad785d5b43f