### PR TITLE
Render square loops for self connections

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -261,6 +261,25 @@ class FTADrawingHelper:
         if child_shape:
             child_pt = self.point_on_shape(child_shape, parent_pt)
 
+        if parent_pt == child_pt:
+            size = fixed_length
+            x, y = parent_pt
+            canvas.create_line(
+                x,
+                y,
+                x,
+                y - size,
+                x + size,
+                y - size,
+                x + size,
+                y,
+                x,
+                y,
+                fill=outline_color,
+                width=line_width,
+            )
+            return
+
         fixed_y = parent_pt[1] + fixed_length
         canvas.create_line(parent_pt[0], parent_pt[1], parent_pt[0], fixed_y,
                            fill=outline_color, width=line_width)
@@ -902,6 +921,24 @@ class GSNDrawingHelper(FTADrawingHelper):
         """Draw a curved connector indicating a 'solved by' relationship."""
         px, py = parent_pt
         cx, cy = child_pt
+        if parent_pt == child_pt:
+            size = 20
+            canvas.create_line(
+                px,
+                py,
+                px,
+                py - size,
+                px + size,
+                py - size,
+                px + size,
+                py,
+                px,
+                py,
+                fill=outline_color,
+                width=line_width,
+                arrow=tk.LAST,
+            )
+            return
         offset = (cy - py) / 2
         canvas.create_line(
             px,
@@ -931,6 +968,24 @@ class GSNDrawingHelper(FTADrawingHelper):
         cx, cy = child_pt
         offset = (cy - py) / 2
         dash = (4, 2)
+        if parent_pt == child_pt:
+            size = 20
+            canvas.create_line(
+                px,
+                py,
+                px,
+                py - size,
+                px + size,
+                py - size,
+                px + size,
+                py,
+                px,
+                py,
+                fill=outline_color,
+                width=line_width,
+                dash=dash,
+            )
+            return
         canvas.create_line(
             px,
             py,

--- a/tests/test_self_connection_square.py
+++ b/tests/test_self_connection_square.py
@@ -1,0 +1,63 @@
+import tkinter as tk
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from gui.drawing_helper import GSNDrawingHelper
+from gui.architecture import SysMLDiagramWindow, SysMLObject, DiagramConnection
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.lines = []
+
+    def create_line(self, *args, **kwargs):
+        self.lines.append(args)
+        return len(self.lines)
+
+    def create_polygon(self, *args, **kwargs):
+        return 0
+
+    def create_text(self, *args, **kwargs):
+        return 0
+
+    def create_rectangle(self, *args, **kwargs):
+        return 0
+
+
+def test_gsn_self_connection_square():
+    helper = GSNDrawingHelper()
+    canvas = DummyCanvas()
+    pt = (50, 50)
+    helper.draw_solved_by_connection(canvas, pt, pt)
+    assert canvas.lines[0] == (50, 50, 50, 30, 70, 30, 70, 50, 50, 50)
+
+
+def test_relationship_self_connection_square():
+    repo = SysMLRepository.reset_instance()
+    diag = SysMLDiagram(diag_id="d", diag_type="Block Definition Diagram")
+    repo.diagrams["d"] = diag
+    window = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    window.canvas = DummyCanvas()
+    window.zoom = 1.0
+    window.repo = repo
+    window.diagram_id = "d"
+    window.font = None
+    obj = SysMLObject(1, "Block", 0, 0)
+    conn = DiagramConnection(1, 1, "Association")
+    window.draw_connection(obj, obj, conn)
+    assert window.canvas.lines[0] == (
+        40.0,
+        0.0,
+        80.0,
+        0.0,
+        80.0,
+        -40.0,
+        40.0,
+        -40.0,
+        40.0,
+        0.0,
+    )


### PR DESCRIPTION
## Summary
- Draw self-referential connectors and relationships as square loops
- Support selecting square self-connections in diagrams
- Add tests for square rendering of self connections

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bdb01a44883259ceb2f33013486aa