### PR TITLE
Display existing work products for GSN solutions

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -6,12 +6,21 @@ from tkinter import ttk
 
 from gsn import GSNNode, GSNDiagram
 
-WORK_PRODUCTS = [
-    "Architectural Diagram",
-    "Hazard & Cyber Analysis",
-    "Risk Assessment",
-    "Safety Analysis",
-]
+
+def _collect_work_products(diagram: GSNDiagram) -> list[str]:
+    """Return sorted unique work product names from *diagram*.
+
+    Only non-empty ``work_product`` attributes of nodes are considered to
+    provide meaningful options in the configuration dialog.
+    """
+
+    return sorted(
+        {
+            getattr(n, "work_product", "")
+            for n in getattr(diagram, "nodes", [])
+            if getattr(n, "work_product", "")
+        }
+    )
 
 
 class GSNElementConfig(tk.Toplevel):
@@ -43,10 +52,13 @@ class GSNElementConfig(tk.Toplevel):
             tk.Label(self, text="Work Product:").grid(
                 row=row, column=0, sticky="e", padx=4, pady=4
             )
+            work_products = _collect_work_products(diagram)
+            if self.work_var.get() and self.work_var.get() not in work_products:
+                work_products.append(self.work_var.get())
             ttk.Combobox(
                 self,
                 textvariable=self.work_var,
-                values=WORK_PRODUCTS,
+                values=work_products,
                 state="readonly",
             ).grid(row=row, column=1, padx=4, pady=4, sticky="ew")
             row += 1

--- a/tests/test_gsn_solution_link.py
+++ b/tests/test_gsn_solution_link.py
@@ -1,7 +1,7 @@
 import types
 
 from gsn import GSNNode, GSNDiagram
-from gui.gsn_config_window import GSNElementConfig, WORK_PRODUCTS
+from gui.gsn_config_window import GSNElementConfig
 from gui.gsn_diagram_window import GSNDiagramWindow
 
 
@@ -32,8 +32,9 @@ def test_solution_config_sets_evidence_link():
     cfg.diagram = diag
     cfg.name_var = DummyVar(node.user_name)
     cfg.desc_text = DummyText(node.description)
-    cfg.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg.work_var = DummyVar("WP1")
     cfg.link_var = DummyVar("http://example.com")
+    cfg.spi_var = DummyVar("")
     cfg.destroy = lambda: None
 
     cfg._on_ok()

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -1,5 +1,5 @@
 from gsn import GSNNode, GSNDiagram
-from gui.gsn_config_window import GSNElementConfig, WORK_PRODUCTS
+from gui.gsn_config_window import GSNElementConfig, _collect_work_products
 
 
 class DummyVar:
@@ -22,7 +22,7 @@ def test_solution_clones_existing_work_product():
     root = GSNNode("Root", "Goal")
     diag = GSNDiagram(root)
     original = GSNNode("Orig", "Solution")
-    original.work_product = WORK_PRODUCTS[0]
+    original.work_product = "WP1"
     diag.add_node(original)
     node = GSNNode("New", "Solution")
     diag.add_node(node)
@@ -32,7 +32,7 @@ def test_solution_clones_existing_work_product():
     cfg.diagram = diag
     cfg.name_var = DummyVar(node.user_name)
     cfg.desc_text = DummyText(node.description)
-    cfg.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg.work_var = DummyVar("WP1")
     cfg.link_var = DummyVar("")
     cfg.spi_var = DummyVar("")
     cfg.destroy = lambda: None
@@ -49,7 +49,7 @@ def test_solution_requires_matching_spi_for_clone():
     root = GSNNode("Root", "Goal")
     diag = GSNDiagram(root)
     original = GSNNode("Orig", "Solution")
-    original.work_product = WORK_PRODUCTS[0]
+    original.work_product = "WP1"
     original.spi_target = "Brake Time"
     diag.add_node(original)
 
@@ -60,7 +60,8 @@ def test_solution_requires_matching_spi_for_clone():
     cfg.diagram = diag
     cfg.name_var = DummyVar(node.user_name)
     cfg.desc_text = DummyText(node.description)
-    cfg.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg.work_var = DummyVar("WP1")
+    cfg.link_var = DummyVar("")
     cfg.spi_var = DummyVar("Other SPI")
     cfg.destroy = lambda: None
     cfg._on_ok()
@@ -74,7 +75,8 @@ def test_solution_requires_matching_spi_for_clone():
     cfg2.diagram = diag
     cfg2.name_var = DummyVar(node2.user_name)
     cfg2.desc_text = DummyText(node2.description)
-    cfg2.work_var = DummyVar(WORK_PRODUCTS[0])
+    cfg2.work_var = DummyVar("WP1")
+    cfg2.link_var = DummyVar("")
     cfg2.spi_var = DummyVar("Brake Time")
     cfg2.destroy = lambda: None
     cfg2._on_ok()
@@ -90,4 +92,20 @@ def test_format_text_shows_spi_target():
     diag.add_node(sol)
     text = diag._format_text(sol)
     assert "SPI: Brake Time" in text
+
+
+def test_collect_work_products_returns_unique_sorted():
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    n1 = GSNNode("S1", "Solution")
+    n1.work_product = "B"
+    diag.add_node(n1)
+    n2 = GSNNode("S2", "Solution")
+    n2.work_product = "A"
+    diag.add_node(n2)
+    n3 = GSNNode("S3", "Solution")
+    n3.work_product = "A"  # duplicate
+    diag.add_node(n3)
+
+    assert _collect_work_products(diag) == ["A", "B"]
 


### PR DESCRIPTION
## Summary
- Build work product list dynamically from diagram nodes
- Ensure solution editor shows available work products rather than static titles
- Cover work product collection with new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689bdc8e7a648325932f26af85d9d100