### PR TITLE
Enable dragging from GSN text areas

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -340,13 +340,15 @@ class FTADrawingHelper:
             fill="",
             outline=outline_color,
             width=line_width,
+            tags=(obj_id,),
         )
         canvas.create_text(top_box_x + top_box_width / 2,
                            top_y + top_box_height / 2,
                            text=top_text,
                            font=font_obj,
                            anchor="center",
-                           width=top_box_width)
+                           width=top_box_width,
+                           tags=(obj_id,))
 
         # Draw the bottom label box
         b_width, b_height = self.get_text_size(bottom_text, font_obj)
@@ -371,13 +373,15 @@ class FTADrawingHelper:
             fill="",
             outline=outline_color,
             width=line_width,
+            tags=(obj_id,),
         )
         canvas.create_text(bottom_box_x + bottom_box_width / 2,
                            bottom_y + bottom_box_height / 2,
                            text=bottom_text,
                            font=font_obj,
                            anchor="center",
-                           width=bottom_box_width)
+                           width=bottom_box_width,
+                           tags=(obj_id,))
 
     def draw_rotated_or_gate_shape(
         self,
@@ -447,11 +451,13 @@ class FTADrawingHelper:
             fill="",
             outline=outline_color,
             width=line_width,
+            tags=(obj_id,),
         )
         canvas.create_text(top_box_x + top_box_width / 2,
                            top_y + top_box_height / 2,
                            text=top_text, font=font_obj, anchor="center",
-                           width=top_box_width)
+                           width=top_box_width,
+                           tags=(obj_id,))
 
         # Draw the bottom label box
         b_width, b_height = self.get_text_size(bottom_text, font_obj)
@@ -476,11 +482,13 @@ class FTADrawingHelper:
             fill="",
             outline=outline_color,
             width=line_width,
+            tags=(obj_id,),
         )
         canvas.create_text(bottom_box_x + bottom_box_width / 2,
                            bottom_y + bottom_box_height / 2,
                            text=bottom_text, font=font_obj,
-                           anchor="center", width=bottom_box_width)
+                           anchor="center", width=bottom_box_width,
+                           tags=(obj_id,))
 
     def draw_rotated_and_gate_clone_shape(
         self,
@@ -635,11 +643,13 @@ class FTADrawingHelper:
             fill="",
             outline=outline_color,
             width=line_width,
+            tags=(obj_id,),
         )
         canvas.create_text(top_box_x + top_box_width / 2,
                            top_box_y + top_box_height / 2,
                            text=top_text,
-                           font=font_obj, anchor="center", width=top_box_width)
+                           font=font_obj, anchor="center", width=top_box_width,
+                           tags=(obj_id,))
         
         b_width, b_height = self.get_text_size(bottom_text, font_obj)
         bottom_box_width = b_width + 2 * padding
@@ -662,11 +672,13 @@ class FTADrawingHelper:
             fill="",
             outline=outline_color,
             width=line_width,
+            tags=(obj_id,),
         )
         canvas.create_text(bottom_box_x + bottom_box_width / 2,
                            bottom_box_y + bottom_box_height / 2,
                            text=bottom_text,
-                           font=font_obj, anchor="center", width=bottom_box_width)
+                           font=font_obj, anchor="center", width=bottom_box_width,
+                           tags=(obj_id,))
                            
     def draw_circle_event_shape(
         self,
@@ -699,6 +711,7 @@ class FTADrawingHelper:
             fill="",
             outline=outline_color,
             width=line_width,
+            tags=(obj_id,),
         )
         t_width, t_height = self.get_text_size(top_text, font_obj)
         padding = 6
@@ -722,12 +735,14 @@ class FTADrawingHelper:
             fill="",
             outline=outline_color,
             width=line_width,
+            tags=(obj_id,),
         )
         canvas.create_text(top_box_x + top_box_width / 2,
                            top_box_y + top_box_height / 2,
                            text=top_text,
                            font=font_obj, anchor="center",
-                           width=top_box_width)
+                           width=top_box_width,
+                           tags=(obj_id,))
         b_width, b_height = self.get_text_size(bottom_text, font_obj)
         bottom_box_width = b_width + 2 * padding
         bottom_box_height = b_height + 2 * padding
@@ -749,12 +764,14 @@ class FTADrawingHelper:
             fill="",
             outline=outline_color,
             width=line_width,
+            tags=(obj_id,),
         )
         canvas.create_text(bottom_box_x + bottom_box_width / 2,
                            bottom_box_y + bottom_box_height / 2,
                            text=bottom_text,
                            font=font_obj, anchor="center",
-                           width=bottom_box_width)
+                           width=bottom_box_width,
+                           tags=(obj_id,))
                            
     def draw_triangle_clone_shape(
         self,
@@ -889,6 +906,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             font=font_obj,
             anchor="center",
             width=w - 2 * padding,
+            tags=(obj_id,),
         )
 
     def draw_solved_by_connection(
@@ -981,6 +999,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             font=font_obj,
             anchor="center",
             width=w - 2 * padding,
+            tags=(obj_id,),
         )
 
     def draw_solution_shape(
@@ -1021,6 +1040,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             font=font_obj,
             anchor="center",
             width=scale - 8,
+            tags=(obj_id,),
         )
 
     def draw_assumption_shape(
@@ -1065,6 +1085,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             font=font_obj,
             anchor="center",
             width=w - 2 * padding,
+            tags=(obj_id,),
         )
 
     def draw_justification_shape(
@@ -1117,6 +1138,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             font=font_obj,
             anchor="center",
             width=w - 2 * padding,
+            tags=(obj_id,),
         )
 
     def draw_context_shape(
@@ -1160,6 +1182,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             font=font_obj,
             anchor="center",
             width=w - 2 * padding,
+            tags=(obj_id,),
         )
 
     def draw_away_solution_shape(self, canvas, x, y, scale=40.0, **kwargs):

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -70,9 +70,8 @@ class GSNElementConfig(tk.Toplevel):
         self.node.description = self.desc_text.get("1.0", tk.END).strip()
         if self.node.node_type == "Solution":
             self.node.work_product = self.work_var.get()
-            self.node.evidence_link = self.link_var.get()
-            # search for existing solution with same work product
-            self.node.spi_target = self.spi_var.get()
+            self.node.evidence_link = self.link_var.get() if hasattr(self, "link_var") else ""
+            self.node.spi_target = self.spi_var.get() if hasattr(self, "spi_var") else ""
             # search for existing solution with same work product and SPI target
             for n in self.diagram.nodes:
                 if (

--- a/tests/test_gsn_text_dragging.py
+++ b/tests/test_gsn_text_dragging.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from gui.drawing_helper import GSNDrawingHelper
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.text_calls = []
+
+    def create_rectangle(self, *a, **k):
+        pass
+
+    def create_polygon(self, *a, **k):
+        pass
+
+    def create_oval(self, *a, **k):
+        pass
+
+    def create_line(self, *a, **k):
+        pass
+
+    def create_text(self, *a, **k):
+        self.text_calls.append(k)
+
+
+def test_goal_text_has_obj_id_tag(monkeypatch):
+    canvas = DummyCanvas()
+    helper = GSNDrawingHelper()
+
+    class DummyFont:
+        def measure(self, _):
+            return 10
+
+        def metrics(self, _):
+            return 10
+
+    monkeypatch.setattr("gui.drawing_helper.tkFont.Font", lambda *a, **k: DummyFont())
+
+    helper.draw_goal_shape(canvas, 0, 0, text="Goal", obj_id="nid")
+    assert any(call.get("tags") == ("nid",) for call in canvas.text_calls)


### PR DESCRIPTION
## Summary
- Tag all GSN diagram text elements with their node ID so dragging from labels works
- Ensure `GSNElementConfig` tolerates missing SPI and evidence fields during save
- Add regression test verifying text carries node ID tag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bdcab57d483259008a23a032f6941