### PR TITLE
Fix GSN relationship buttons to allow drag-and-drop connections

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -105,16 +105,29 @@ class GSNDiagramWindow(tk.Frame):
 
     def connect_solved_by(self):  # pragma: no cover - GUI interaction stub
         self._connect_mode = "solved"
-        self._connect_parent = None
+        # start connection from the currently selected node if available so
+        # the user can immediately drag from it
+        self._connect_parent = self.selected_node
 
     def connect_in_context(self):  # pragma: no cover - GUI interaction stub
         self._connect_mode = "context"
-        self._connect_parent = None
+        # start connection from the currently selected node if available so
+        # the user can immediately drag from it
+        self._connect_parent = self.selected_node
 
     def _on_click(self, event):  # pragma: no cover - requires tkinter
         node = self._node_at(event.x, event.y)
         if self._connect_mode:
-            self._connect_parent = node
+            # first click selects the parent node; a subsequent click on a
+            # different node finalises the connection.  This allows both
+            # click-to-click and drag-and-drop workflows.
+            if self._connect_parent is None and node:
+                self._connect_parent = node
+            elif self._connect_parent and node and node is not self._connect_parent:
+                self._connect_parent.add_child(node)
+                self._connect_mode = None
+                self._connect_parent = None
+                self.refresh()
             return
         if not node:
             self.selected_node = None


### PR DESCRIPTION
## Summary
- Allow "Solved By" and "In Context Of" tools to start from the selected node so connectors can be drawn via drag-and-drop
- Support click-to-click connection creation for convenience
- Test that dragging creates both solved-by and context connections

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_diagram_window.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689bdcd066748325942b5d444c3834a7