### PR TITLE
Fix GSN drag-and-drop link creation

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -73,7 +73,7 @@ class GSNDiagram:
             for child in parent.children:
                 p_pt = (parent.x * zoom, parent.y * zoom)
                 c_pt = (child.x * zoom, child.y * zoom)
-                if child.node_type in {"Context", "Assumption", "Justification"}:
+                if child in parent.context_children:
                     self.drawing_helper.draw_in_context_connection(
                         canvas, p_pt, c_pt
                     )

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -69,10 +69,20 @@ class GSNElementConfig(tk.Toplevel):
         self.node.user_name = self.name_var.get()
         self.node.description = self.desc_text.get("1.0", tk.END).strip()
         if self.node.node_type == "Solution":
-            self.node.work_product = self.work_var.get()
-            self.node.evidence_link = self.link_var.get()
-            # search for existing solution with same work product
-            self.node.spi_target = self.spi_var.get()
+            # ``GSNElementConfig`` is sometimes instantiated in tests without
+            # running ``__init__``.  Guard against missing StringVar
+            # attributes so :meth:`_on_ok` can operate on these lightweight
+            # instances as well.
+            work_var = getattr(self, "work_var", None)
+            link_var = getattr(self, "link_var", None)
+            spi_var = getattr(self, "spi_var", None)
+
+            if work_var:
+                self.node.work_product = work_var.get()
+            if link_var:
+                self.node.evidence_link = link_var.get()
+            if spi_var:
+                self.node.spi_target = spi_var.get()
             # search for existing solution with same work product and SPI target
             for n in self.diagram.nodes:
                 if (

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -163,7 +163,10 @@ class GSNDiagramWindow(tk.Frame):
             self.canvas.delete("_temp_conn")
             node = self._node_at(event.x, event.y)
             if node and node is not self._connect_parent:
-                self._connect_parent.add_child(node)
+                # Use the current connect mode to decide whether this is a
+                # solved-by or in-context-of relationship.
+                relation = self._connect_mode
+                self._connect_parent.add_child(node, relation=relation)
             self._connect_mode = None
             self._connect_parent = None
             self.refresh()

--- a/tests/test_gsn_diagram_draw.py
+++ b/tests/test_gsn_diagram_draw.py
@@ -1,3 +1,4 @@
+
 from gsn import GSNNode, GSNDiagram
 
 
@@ -60,3 +61,25 @@ def test_draw_tags_and_zoom_scaling():
 
     assert rect2[0] == rect1[0] * 2
     assert rect1[4]["tags"] == (root.unique_id,)
+
+
+def test_draw_respects_context_links():
+    """Connections use the stored relationship type, not node type."""
+    root = GSNNode("Root", "Goal")
+    child = GSNNode("Child", "Goal")
+    root.add_child(child, relation="context")
+    diag = GSNDiagram(root, drawing_helper=DummyHelper())
+    diag.add_node(child)
+
+    calls = []
+
+    def solved(*args, **kwargs):
+        calls.append("solved")
+
+    def ctx(*args, **kwargs):
+        calls.append("context")
+
+    diag.drawing_helper.draw_solved_by_connection = solved
+    diag.drawing_helper.draw_in_context_connection = ctx
+    diag.draw(StubCanvas())
+    assert calls == ["context"]

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -66,3 +66,19 @@ def test_temp_connection_line_no_arrow_in_context_mode():
     win._on_drag(event)
     assert lines and lines[0].get("dash") == (2, 2)
     assert not lines[0].get("arrow")
+
+
+def test_on_release_creates_context_link():
+    """Releasing in context mode should mark the relation accordingly."""
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    parent = GSNNode("p", "Goal")
+    child = GSNNode("c", "Goal")
+    win._connect_mode = "context"
+    win._connect_parent = parent
+    win.canvas = type("CanvasStub", (), {"delete": lambda self, *a, **k: None})()
+    win._node_at = lambda x, y: child
+    win.refresh = lambda: None
+    event = type("Event", (), {"x": 0, "y": 0})
+    win._on_release(event)
+    assert child in parent.children
+    assert child in parent.context_children


### PR DESCRIPTION
## Summary
- support distinct "solved" and "context" relations on GSN nodes
- allow GSN diagram window to create solved-by and in-context-of links via drag and drop
- harden GSN element config dialog against missing fields

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bdcd066748325942b5d444c3834a7