### PR TITLE
Add visual enhancements and SPI selection for GSN diagrams

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -1002,6 +1002,7 @@ class GSNDrawingHelper(FTADrawingHelper):
                 fill=outline_color,
                 width=line_width,
                 dash=dash,
+                arrow=tk.LAST,
             )
             return
         canvas.create_line(
@@ -1017,6 +1018,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             fill=outline_color,
             width=line_width,
             dash=dash,
+            arrow=tk.LAST,
         )
 
     def draw_strategy_shape(
@@ -1121,15 +1123,13 @@ class GSNDrawingHelper(FTADrawingHelper):
         top = y - h / 2
         right = x + w / 2
         bottom = y + h / 2
-        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
-        canvas.create_rectangle(
+        canvas.create_oval(
             left,
             top,
             right,
             bottom,
-            fill="",
+            fill=fill,
             outline=outline_color,
-            dash=(4, 2),
             width=line_width,
             tags=(obj_id,),
         )
@@ -1140,6 +1140,15 @@ class GSNDrawingHelper(FTADrawingHelper):
             font=font_obj,
             anchor="center",
             width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        label_font = self._scaled_font(scale * 0.3)
+        canvas.create_text(
+            right - padding,
+            bottom - padding,
+            text="A",
+            font=label_font,
+            anchor="se",
             tags=(obj_id,),
         )
 
@@ -1166,25 +1175,15 @@ class GSNDrawingHelper(FTADrawingHelper):
         top = y - h / 2
         right = x + w / 2
         bottom = y + h / 2
-        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
-        canvas.create_rectangle(
+        canvas.create_oval(
             left,
             top,
             right,
             bottom,
-            fill="",
+            fill=fill,
             outline=outline_color,
             width=line_width,
             tags=(obj_id,),
-        )
-        inset = 4
-        canvas.create_rectangle(
-            left + inset,
-            top + inset,
-            right - inset,
-            bottom - inset,
-            outline=outline_color,
-            width=line_width,
         )
         canvas.create_text(
             x,
@@ -1193,6 +1192,15 @@ class GSNDrawingHelper(FTADrawingHelper):
             font=font_obj,
             anchor="center",
             width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        label_font = self._scaled_font(scale * 0.3)
+        canvas.create_text(
+            right - padding,
+            bottom - padding,
+            text="J",
+            font=label_font,
+            anchor="se",
             tags=(obj_id,),
         )
 
@@ -1219,16 +1227,71 @@ class GSNDrawingHelper(FTADrawingHelper):
         top = y - h / 2
         right = x + w / 2
         bottom = y + h / 2
-        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        radius = h / 2
         canvas.create_rectangle(
+            left + radius,
+            top,
+            right - radius,
+            bottom,
+            fill=fill,
+            outline="",
+            width=0,
+        )
+        canvas.create_oval(
             left,
+            top,
+            left + h,
+            bottom,
+            fill=fill,
+            outline="",
+            width=0,
+        )
+        canvas.create_oval(
+            right - h,
             top,
             right,
             bottom,
-            fill="",
+            fill=fill,
+            outline="",
+            width=0,
+        )
+        canvas.create_line(
+            left + radius,
+            top,
+            right - radius,
+            top,
+            fill=outline_color,
+            width=line_width,
+        )
+        canvas.create_line(
+            left + radius,
+            bottom,
+            right - radius,
+            bottom,
+            fill=outline_color,
+            width=line_width,
+        )
+        canvas.create_arc(
+            left,
+            top,
+            left + h,
+            bottom,
+            start=90,
+            extent=180,
+            style=tk.ARC,
             outline=outline_color,
             width=line_width,
-            tags=(obj_id,),
+        )
+        canvas.create_arc(
+            right - h,
+            top,
+            right,
+            bottom,
+            start=270,
+            extent=180,
+            style=tk.ARC,
+            outline=outline_color,
+            width=line_width,
         )
         canvas.create_text(
             x,

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -23,6 +23,18 @@ def _collect_work_products(diagram: GSNDiagram) -> list[str]:
     )
 
 
+def _collect_spi_targets(diagram: GSNDiagram) -> list[str]:
+    """Return sorted list of SPI targets referenced in *diagram*."""
+
+    return sorted(
+        {
+            getattr(n, "spi_target", "")
+            for n in getattr(diagram, "nodes", [])
+            if getattr(n, "spi_target", "")
+        }
+    )
+
+
 class GSNElementConfig(tk.Toplevel):
     """Simple dialog to edit a GSN element's properties."""
 
@@ -68,6 +80,19 @@ class GSNElementConfig(tk.Toplevel):
             tk.Entry(self, textvariable=self.link_var, width=40).grid(
                 row=row, column=1, padx=4, pady=4, sticky="ew"
             )
+            row += 1
+            tk.Label(self, text="SPI Target:").grid(
+                row=row, column=0, sticky="e", padx=4, pady=4
+            )
+            spi_targets = _collect_spi_targets(diagram)
+            if self.spi_var.get() and self.spi_var.get() not in spi_targets:
+                spi_targets.append(self.spi_var.get())
+            ttk.Combobox(
+                self,
+                textvariable=self.spi_var,
+                values=spi_targets,
+                state="readonly",
+            ).grid(row=row, column=1, padx=4, pady=4, sticky="ew")
             row += 1
         btns = ttk.Frame(self)
         btns.grid(row=row, column=0, columnspan=2, pady=4)

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -2,6 +2,7 @@ import tkinter as tk
 
 from gui.gsn_diagram_window import GSNDiagramWindow
 from gsn import GSNNode
+import tkinter as tk
 
 
 def test_gsn_diagram_window_button_labels():
@@ -45,8 +46,8 @@ def test_temp_connection_line_is_dotted():
     assert lines[0].get("arrow") == tk.LAST
 
 
-def test_temp_connection_line_no_arrow_in_context_mode():
-    """Context connections preview without an arrow."""
+def test_temp_connection_line_has_arrow_in_context_mode():
+    """Context connections preview with an arrow."""
     win = GSNDiagramWindow.__new__(GSNDiagramWindow)
     win.zoom = 1.0
     win._connect_mode = "context"
@@ -65,7 +66,7 @@ def test_temp_connection_line_no_arrow_in_context_mode():
     event = type("Event", (), {"x": 50, "y": 50})
     win._on_drag(event)
     assert lines and lines[0].get("dash") == (2, 2)
-    assert not lines[0].get("arrow")
+    assert lines[0].get("arrow") == tk.LAST
 
 
 def test_on_release_creates_context_link():


### PR DESCRIPTION
## Summary
- Show arrowheads on both solved-by and in-context-of links
- Animate dotted connection preview during drag operations
- Redesign assumption/justification nodes as labeled ovals and context nodes as capsules
- Allow selecting existing SPI targets from a new combo box in solution configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689be03c6718832599b8713e27f00c46