### PR TITLE
feat: add BPMN governance diagrams

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -71,7 +71,7 @@ class SafetyManagementToolbox:
     # Diagram management helpers
     # ------------------------------------------------------------------
     def create_diagram(self, name: str) -> str:
-        """Create a new Activity Diagram tracked by this toolbox.
+        """Create a new BPMN Diagram tracked by this toolbox.
 
         Parameters
         ----------
@@ -84,7 +84,7 @@ class SafetyManagementToolbox:
             The repository identifier of the created diagram.
         """
         repo = SysMLRepository.get_instance()
-        diag = repo.create_diagram("Activity Diagram", name=name)
+        diag = repo.create_diagram("BPMN Diagram", name=name)
         diag.tags.append("safety-management")
         self.diagrams[name] = diag.diag_id
         return diag.diag_id
@@ -131,7 +131,7 @@ class SafetyManagementToolbox:
     def list_diagrams(self) -> List[str]:
         """Return the names of all managed diagrams.
 
-        Any Activity Diagram in the repository tagged with
+        Any BPMN Diagram in the repository tagged with
         ``"safety-management"`` should appear in the toolbox even if it
         was created outside of :meth:`create_diagram`. To ensure the list is
         complete we rescan the repository on each call and synchronize the

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -2,13 +2,13 @@ import tkinter as tk
 from tkinter import ttk, simpledialog
 
 from analysis import SafetyManagementToolbox
-from gui.architecture import ActivityDiagramWindow
+from gui.architecture import BPMNDiagramWindow
 
 
 class SafetyManagementWindow(tk.Frame):
     """Editor and browser for Safety Management diagrams.
 
-    Users can create, rename, and delete Activity Diagrams that model the
+    Users can create, rename, and delete BPMN Diagrams that model the
     project's safety governance. Only diagrams registered in the provided
     :class:`SafetyManagementToolbox` are listed.
     """
@@ -95,5 +95,5 @@ class SafetyManagementWindow(tk.Frame):
         diag_id = self.toolbox.diagrams.get(name)
         if diag_id is None:
             return
-        self.current_window = ActivityDiagramWindow(self.diagram_frame, self.app, diagram_id=diag_id)
+        self.current_window = BPMNDiagramWindow(self.diagram_frame, self.app, diagram_id=diag_id)
         self.current_window.pack(fill=tk.BOTH, expand=True)

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -19,17 +19,17 @@ sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 
 from AutoML import FaultTreeApp
 from analysis import SafetyManagementToolbox
-from gui.architecture import ActivityDiagramWindow, SysMLObject, ArchitectureManagerDialog
+from gui.architecture import BPMNDiagramWindow, SysMLObject, ArchitectureManagerDialog
 from sysml.sysml_repository import SysMLRepository
 
 
 def test_work_product_registration():
     toolbox = SafetyManagementToolbox()
-    toolbox.add_work_product("Activity Diagram", "HAZOP", "Link action to hazard")
+    toolbox.add_work_product("BPMN Diagram", "HAZOP", "Link action to hazard")
 
     products = toolbox.get_work_products()
     assert len(products) == 1
-    assert products[0].diagram == "Activity Diagram"
+    assert products[0].diagram == "BPMN Diagram"
     assert products[0].analysis == "HAZOP"
     assert products[0].rationale == "Link action to hazard"
 
@@ -64,8 +64,8 @@ class DummyCanvas:
 def test_activity_boundary_label_rotated_left():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("Activity Diagram")
-    win = ActivityDiagramWindow.__new__(ActivityDiagramWindow)
+    diag = repo.create_diagram("BPMN Diagram")
+    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.zoom = 1.0
@@ -249,7 +249,7 @@ def test_external_safety_diagrams_load_in_toolbox_list():
     """Diagrams tagged for governance appear even if created elsewhere."""
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("Activity Diagram", name="GovX")
+    diag = repo.create_diagram("BPMN Diagram", name="GovX")
     diag.tags.append("safety-management")
     toolbox = SafetyManagementToolbox()
     names = toolbox.list_diagrams()


### PR DESCRIPTION
## Summary
- introduce BPMNDiagramWindow with custom Task tool and no fork/join/action
- switch SafetyManagement toolbox to use BPMN diagrams
- update safety management tests for BPMN terminology

## Testing
- `pytest tests/test_safety_management.py`

------
https://chatgpt.com/codex/tasks/task_b_689be1ad78f083259f8175f560682336