### PR TITLE
Fix GSN configuration combobox listing

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -67,12 +67,19 @@ class GSNElementConfig(tk.Toplevel):
             work_products = _collect_work_products(diagram)
             if self.work_var.get() and self.work_var.get() not in work_products:
                 work_products.append(self.work_var.get())
-            ttk.Combobox(
+            wp_cb = ttk.Combobox(
                 self,
                 textvariable=self.work_var,
-                values=work_products,
                 state="readonly",
-            ).grid(row=row, column=1, padx=4, pady=4, sticky="ew")
+            )
+            wp_cb.grid(row=row, column=1, padx=4, pady=4, sticky="ew")
+            # Explicitly configure the combobox values after creation so Tk
+            # updates the drop-down list reliably across platforms.  Passing
+            # ``values`` to the constructor can result in an empty list on
+            # some systems.
+            wp_cb.configure(values=work_products)
+            if not self.work_var.get() and work_products:
+                self.work_var.set(work_products[0])
             row += 1
             tk.Label(self, text="Evidence Link:").grid(
                 row=row, column=0, sticky="e", padx=4, pady=4
@@ -87,12 +94,15 @@ class GSNElementConfig(tk.Toplevel):
             spi_targets = _collect_spi_targets(diagram)
             if self.spi_var.get() and self.spi_var.get() not in spi_targets:
                 spi_targets.append(self.spi_var.get())
-            ttk.Combobox(
+            spi_cb = ttk.Combobox(
                 self,
                 textvariable=self.spi_var,
-                values=spi_targets,
                 state="readonly",
-            ).grid(row=row, column=1, padx=4, pady=4, sticky="ew")
+            )
+            spi_cb.grid(row=row, column=1, padx=4, pady=4, sticky="ew")
+            spi_cb.configure(values=spi_targets)
+            if not self.spi_var.get() and spi_targets:
+                self.spi_var.set(spi_targets[0])
             row += 1
         btns = ttk.Frame(self)
         btns.grid(row=row, column=0, columnspan=2, pady=4)

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -1,4 +1,5 @@
 from gsn import GSNNode, GSNDiagram
+from gsn import GSNNode, GSNDiagram
 from gui.gsn_config_window import GSNElementConfig, _collect_work_products
 
 
@@ -108,4 +109,93 @@ def test_collect_work_products_returns_unique_sorted():
     diag.add_node(n3)
 
     assert _collect_work_products(diag) == ["A", "B"]
+
+
+def test_config_dialog_populates_comboboxes(monkeypatch):
+    """Work product and SPI combos should list existing entries."""
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    existing = GSNNode("Orig", "Solution")
+    existing.work_product = "WP1"
+    existing.spi_target = "SPI1"
+    diag.add_node(existing)
+
+    node = GSNNode("New", "Solution")
+    diag.add_node(node)
+
+    # ------------------------------------------------------------------
+    # Stub tkinter widgets so the dialog can be created headlessly
+    # ------------------------------------------------------------------
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            self.configured = {}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+    class DummyText(DummyWidget):
+        def get(self, *a, **k):
+            return ""
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, values=None, state=None, **k):
+            super().__init__(*a, **k)
+            self.textvariable = textvariable
+            self.state = state
+            self.init_values = values
+
+    combo_holder = []
+
+    def combo_stub(*a, **k):
+        cb = DummyCombobox(*a, **k)
+        combo_holder.append(cb)
+        return cb
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+    # Patch tkinter components used by the dialog
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.__init__", lambda self, master=None: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.title", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.geometry", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.columnconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.rowconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.transient", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.grab_set", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.wait_window", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Text", lambda *a, **k: DummyText())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Frame", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.gsn_config_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    cfg = GSNElementConfig(None, node, diag)
+
+    wp_cb, spi_cb = combo_holder
+    assert wp_cb.init_values is None
+    assert spi_cb.init_values is None
+    assert wp_cb.configured["values"] == ["WP1"]
+    assert spi_cb.configured["values"] == ["SPI1"]
+    # first existing entries should be preselected when the node has none
+    assert cfg.work_var.get() == "WP1"
+    assert cfg.spi_var.get() == "SPI1"
 


### PR DESCRIPTION
## Summary
- Ensure work product and SPI combo boxes populate reliably by configuring values after creation and selecting defaults
- Add regression test to validate combo box population for work products and SPI targets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689be4668ce08325a8a505f17f4d05a8