### PR TITLE
Add GSN diagram section to Safety Management tree

### DIFF
--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -245,6 +245,56 @@ def test_safety_diagrams_visible_in_analysis_tree():
     assert "Arch" in texts
 
 
+def test_gsn_diagrams_visible_in_analysis_tree():
+    SysMLRepository._instance = None
+    SysMLRepository.get_instance()
+
+    class DummyTree:
+        def __init__(self):
+            self.items = {}
+            self.counter = 0
+
+        def delete(self, *items):
+            pass
+
+        def get_children(self, item=""):
+            return [iid for iid, meta in self.items.items() if meta["parent"] == item]
+
+        def insert(self, parent, index, iid=None, text="", **kwargs):
+            if iid is None:
+                iid = f"i{self.counter}"
+                self.counter += 1
+            self.items[iid] = {"parent": parent, "text": text}
+            return iid
+
+    from gsn import GSNNode, GSNDiagram
+
+    root = GSNNode("Goal1", "Goal")
+    diag = GSNDiagram(root)
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.refresh_model = lambda: None
+    app.compute_occurrence_counts = lambda: {}
+    app.diagram_icons = {}
+    app.hazop_docs = []
+    app.stpa_docs = []
+    app.threat_docs = []
+    app.fi2tc_docs = []
+    app.tc2fi_docs = []
+    app.hara_docs = []
+    app.top_events = []
+    app.fmeas = []
+    app.fmedas = []
+    app.gsn_diagrams = [diag]
+    app.gsn_modules = []
+    app.analysis_tree = DummyTree()
+
+    app.update_views()
+    texts = [meta["text"] for meta in app.analysis_tree.items.values()]
+    assert "GSN Diagrams" in texts
+    assert "Goal1" in texts
+
+
 def test_external_safety_diagrams_load_in_toolbox_list():
     """Diagrams tagged for governance appear even if created elsewhere."""
     SysMLRepository._instance = None


### PR DESCRIPTION
## Summary
- List GSN diagrams under Safety Management in the analyses explorer
- Open and rename GSN diagrams from the explorer tree
- Test that GSN diagrams appear in analysis tree

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689be4dd72d08325ae81d59f2e18478b