### PR TITLE
Improve assumption and justification label rendering

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -1142,13 +1142,16 @@ class GSNDrawingHelper(FTADrawingHelper):
             width=w - 2 * padding,
             tags=(obj_id,),
         )
-        label_font = self._scaled_font(scale * 0.3)
+        label_font = tkFont.Font(
+            family="Arial", size=max(int(scale / 5), 1), weight="bold"
+        )
+        offset = padding + scale * 0.1
         canvas.create_text(
-            right - padding,
-            bottom - padding,
+            right + offset,
+            bottom + offset,
             text="A",
             font=label_font,
-            anchor="se",
+            anchor="nw",
             tags=(obj_id,),
         )
 
@@ -1194,13 +1197,16 @@ class GSNDrawingHelper(FTADrawingHelper):
             width=w - 2 * padding,
             tags=(obj_id,),
         )
-        label_font = self._scaled_font(scale * 0.3)
+        label_font = tkFont.Font(
+            family="Arial", size=max(int(scale / 5), 1), weight="bold"
+        )
+        offset = padding + scale * 0.1
         canvas.create_text(
-            right - padding,
-            bottom - padding,
+            right + offset,
+            bottom + offset,
             text="J",
             font=label_font,
-            anchor="se",
+            anchor="nw",
             tags=(obj_id,),
         )
 


### PR DESCRIPTION
## Summary
- Increase size and bold weight of J/A labels on assumption and justification shapes
- Position labels further from shapes to avoid overlap

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689be511e03c8325ac7d96f5e9b20734