### PR TITLE
Open governance diagrams as BPMN

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -317,6 +317,7 @@ from gui.architecture import (
     BlockDiagramWindow,
     InternalBlockDiagramWindow,
     ControlFlowDiagramWindow,
+    BPMNDiagramWindow,
     ArchitectureManagerDialog,
     parse_behaviors,
 )
@@ -1955,6 +1956,7 @@ class FaultTreeApp:
         self.diagram_icons = {
             "Use Case Diagram": self._create_icon("circle", "blue"),
             "Activity Diagram": self._create_icon("arrow", "green"),
+            "BPMN Diagram": self._create_icon("arrow", "green"),
             "Block Diagram": self._create_icon("rect", "orange"),
             "Internal Block Diagram": self._create_icon("nested", "purple"),
             "Control Flow Diagram": self._create_icon("arrow", "red"),
@@ -15004,6 +15006,8 @@ class FaultTreeApp:
             UseCaseDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Activity Diagram":
             ActivityDiagramWindow(tab, self, diagram_id=diag.diag_id)
+        elif diag.diag_type == "BPMN Diagram":
+            BPMNDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Block Diagram":
             BlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Internal Block Diagram":
@@ -15031,6 +15035,8 @@ class FaultTreeApp:
             UseCaseDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Activity Diagram":
             ActivityDiagramWindow(tab, self, diagram_id=diag.diag_id)
+        elif diag.diag_type == "BPMN Diagram":
+            BPMNDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Block Diagram":
             BlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Internal Block Diagram":


### PR DESCRIPTION
## Summary
- import and handle BPMNDiagramWindow for governance diagrams
- ensure architecture and management windows open BPMN diagrams
- test that governance diagrams open with BPMN toolbox

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689be5dedf8883259ac8a2bb6578e455