### PR TITLE
Show project SPIs in solution config combo box

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -23,16 +23,29 @@ def _collect_work_products(diagram: GSNDiagram) -> list[str]:
     )
 
 
-def _collect_spi_targets(diagram: GSNDiagram) -> list[str]:
-    """Return sorted list of SPI targets referenced in *diagram*."""
+def _collect_spi_targets(diagram: GSNDiagram, app=None) -> list[str]:
+    """Return sorted list of SPI targets available for *diagram*.
 
-    return sorted(
-        {
-            getattr(n, "spi_target", "")
-            for n in getattr(diagram, "nodes", [])
-            if getattr(n, "spi_target", "")
-        }
+    Besides existing solution nodes in the diagram, this also includes
+    validation targets defined on the application's top level product goals
+    when an ``app`` instance is provided.  Duplicates and empty entries are
+    removed.
+    """
+
+    targets = {
+        getattr(n, "spi_target", "")
+        for n in getattr(diagram, "nodes", [])
+        if getattr(n, "spi_target", "")
+    }
+    if app is None:
+        app = getattr(diagram, "app", None)
+    top_events = getattr(app, "top_events", []) if app else []
+    targets.update(
+        getattr(te, "validation_desc", "")
+        for te in top_events
+        if getattr(te, "validation_desc", "")
     )
+    return sorted(targets)
 
 
 class GSNElementConfig(tk.Toplevel):
@@ -91,7 +104,7 @@ class GSNElementConfig(tk.Toplevel):
             tk.Label(self, text="SPI Target:").grid(
                 row=row, column=0, sticky="e", padx=4, pady=4
             )
-            spi_targets = _collect_spi_targets(diagram)
+            spi_targets = _collect_spi_targets(diagram, getattr(master, "app", None))
             if self.spi_var.get() and self.spi_var.get() not in spi_targets:
                 spi_targets.append(self.spi_var.get())
             spi_cb = ttk.Combobox(

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -199,3 +199,94 @@ def test_config_dialog_populates_comboboxes(monkeypatch):
     assert cfg.work_var.get() == "WP1"
     assert cfg.spi_var.get() == "SPI1"
 
+
+def test_config_dialog_lists_project_spis(monkeypatch):
+    """SPI combo should list project validation targets."""
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    node = GSNNode("New", "Solution")
+    diag.add_node(node)
+
+    class TopEvent:
+        def __init__(self, desc):
+            self.validation_desc = desc
+
+    class App:
+        def __init__(self):
+            self.top_events = [TopEvent("SPI1")]
+
+    class Master:
+        def __init__(self):
+            self.app = App()
+
+    # ------------------------------------------------------------------
+    # Stub tkinter widgets similar to the previous test
+    # ------------------------------------------------------------------
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            self.configured = {}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+    class DummyText(DummyWidget):
+        def get(self, *a, **k):
+            return ""
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, values=None, state=None, **k):
+            super().__init__(*a, **k)
+            self.textvariable = textvariable
+            self.state = state
+            self.init_values = values
+
+    combo_holder = []
+
+    def combo_stub(*a, **k):
+        cb = DummyCombobox(*a, **k)
+        combo_holder.append(cb)
+        return cb
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.__init__", lambda self, master=None: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.title", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.geometry", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.columnconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.rowconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.transient", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.grab_set", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.wait_window", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Text", lambda *a, **k: DummyText())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Frame", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.gsn_config_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    cfg = GSNElementConfig(Master(), node, diag)
+
+    # work product combobox is first, spi combobox second
+    _, spi_cb = combo_holder
+    assert spi_cb.configured["values"] == ["SPI1"]
+    assert cfg.spi_var.get() == "SPI1"
+


### PR DESCRIPTION
## Summary
- include project-level validation targets when populating SPI combo box
- add regression test ensuring project SPIs appear even if not used in diagram

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689be7f7fa0c832587162570cefe3474