### PR TITLE
Add verification reviews listing in safety management explorer

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8134,6 +8134,12 @@ class FaultTreeApp:
         elif kind == "gsn":
             if 0 <= idx < len(getattr(self, "all_gsn_diagrams", [])):
                 self.open_gsn_diagram(self.all_gsn_diagrams[idx])
+        elif kind == "jrev":
+            if 0 <= idx < len(getattr(self, "joint_reviews", [])):
+                review = self.joint_reviews[idx]
+                self.review_data = review
+                self.open_review_document(review)
+                self.open_review_toolbox()
         elif kind == "gov":
             self.open_management_window(idx)
         elif kind == "arch":
@@ -8174,6 +8180,8 @@ class FaultTreeApp:
             current = self.management_diagrams[idx].name
         elif kind == "gsn":
             current = self.all_gsn_diagrams[idx].root.user_name
+        elif kind == "jrev":
+            current = self.joint_reviews[idx].name
         elif kind == "fta":
             node = next((t for t in self.top_events if t.unique_id == idx), None)
             current = node.user_name if node else ""
@@ -8200,6 +8208,11 @@ class FaultTreeApp:
             self.management_diagrams[idx].name = new
         elif kind == "gsn":
             self.all_gsn_diagrams[idx].root.user_name = new
+        elif kind == "jrev":
+            if any(r.name == new for r in self.reviews if r is not self.joint_reviews[idx]):
+                messagebox.showerror("Review", "Name already exists")
+                return
+            self.joint_reviews[idx].name = new
         elif kind == "fta" and node:
             node.user_name = new
         self.update_views()
@@ -9117,6 +9130,17 @@ class FaultTreeApp:
                     "end",
                     text=diag.root.user_name or f"Diagram {idx + 1}",
                     tags=("gsn", str(idx)),
+                )
+
+            # --- Verification Reviews Section ---
+            self.joint_reviews = [r for r in getattr(self, "reviews", []) if getattr(r, "mode", "") == "joint"]
+            rev_root = tree.insert(mgmt_root, "end", text="Verification Reviews", open=True)
+            for idx, review in enumerate(self.joint_reviews):
+                tree.insert(
+                    rev_root,
+                    "end",
+                    text=review.name,
+                    tags=("jrev", str(idx)),
                 )
 
             # --- System Design (Item Definition) Section ---

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -21,6 +21,7 @@ from AutoML import FaultTreeApp
 import AutoML
 from analysis import SafetyManagementToolbox
 from gui.architecture import BPMNDiagramWindow, SysMLObject, ArchitectureManagerDialog
+from gui.review_toolbox import ReviewData
 from sysml.sysml_repository import SysMLRepository
 
 
@@ -294,6 +295,56 @@ def test_gsn_diagrams_visible_in_analysis_tree():
     texts = [meta["text"] for meta in app.analysis_tree.items.values()]
     assert "GSN Diagrams" in texts
     assert "Goal1" in texts
+
+
+def test_joint_reviews_visible_in_analysis_tree():
+    SysMLRepository._instance = None
+    SysMLRepository.get_instance()
+
+    class DummyTree:
+        def __init__(self):
+            self.items = {}
+            self.counter = 0
+
+        def delete(self, *items):
+            pass
+
+        def get_children(self, item=""):
+            return [iid for iid, meta in self.items.items() if meta["parent"] == item]
+
+        def insert(self, parent, index, iid=None, text="", **kwargs):
+            if iid is None:
+                iid = f"i{self.counter}"
+                self.counter += 1
+            self.items[iid] = {"parent": parent, "text": text}
+            return iid
+
+    joint = ReviewData(name="JR1", mode="joint")
+    peer = ReviewData(name="PR1", mode="peer")
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.refresh_model = lambda: None
+    app.compute_occurrence_counts = lambda: {}
+    app.diagram_icons = {}
+    app.hazop_docs = []
+    app.stpa_docs = []
+    app.threat_docs = []
+    app.fi2tc_docs = []
+    app.tc2fi_docs = []
+    app.hara_docs = []
+    app.top_events = []
+    app.fmeas = []
+    app.fmedas = []
+    app.gsn_diagrams = []
+    app.gsn_modules = []
+    app.reviews = [joint, peer]
+    app.analysis_tree = DummyTree()
+
+    app.update_views()
+    texts = [meta["text"] for meta in app.analysis_tree.items.values()]
+    assert "Verification Reviews" in texts
+    assert "JR1" in texts
+    assert "PR1" not in texts
 
 
 def test_external_safety_diagrams_load_in_toolbox_list():


### PR DESCRIPTION
## Summary
- Show joint verification reviews under Safety Management in the Analyses & Architecture tree
- Support opening and renaming joint reviews from the explorer
- Test that verification reviews appear and only include joint reviews

## Testing
- `pytest tests/test_safety_management.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689be85d17a08325bedeaf48944e093b