### PR TITLE
Add item definition editor and persistence

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8121,6 +8121,8 @@ class FaultTreeApp:
                 doc = self.tc2fi_docs[idx]
                 self._tc2fi_window.doc_var.set(doc.name)
                 self._tc2fi_window.select_doc()
+        elif kind == "itemdef":
+            self.show_item_definition_editor()
         elif kind == "reqs":
             self.show_requirements_editor()
         elif kind == "sg":
@@ -9125,6 +9127,7 @@ class FaultTreeApp:
                 "end",
                 text="System Design (Item Definition)",
                 open=True,
+                tags=("itemdef", "0"),
             )
             self.arch_diagrams = sorted(
                 [
@@ -10266,6 +10269,46 @@ class FaultTreeApp:
             text.insert(tk.END, "\n\n")
 
         tk.Button(win, text="Open Requirements Editor", command=self.show_requirements_editor).pack(pady=5)
+
+    def show_item_definition_editor(self):
+        """Open a tab to edit item description and assumptions."""
+        repo = SysMLRepository.get_instance()
+        if hasattr(self, "_itemdef_tab") and self._itemdef_tab.winfo_exists():
+            self.doc_nb.select(self._itemdef_tab)
+            return
+        self._itemdef_tab = self._new_tab("Item Definition")
+        win = self._itemdef_tab
+
+        frame = ttk.Frame(win)
+        frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+        frame.columnconfigure(0, weight=1)
+        ttk.Label(frame, text="Item Description:").grid(row=0, column=0, sticky="w")
+        desc_txt = tk.Text(frame, height=6, wrap="word")
+        desc_txt.grid(row=1, column=0, sticky="nsew", pady=(0, 5))
+        ttk.Label(frame, text="Assumptions:").grid(row=2, column=0, sticky="w")
+        assum_txt = tk.Text(frame, height=6, wrap="word")
+        assum_txt.grid(row=3, column=0, sticky="nsew")
+        frame.rowconfigure(1, weight=1)
+        frame.rowconfigure(3, weight=1)
+
+        desc_txt.insert("1.0", getattr(repo, "item_description", ""))
+        assum_txt.insert("1.0", getattr(repo, "assumptions", ""))
+
+        btn_frame = ttk.Frame(win)
+        btn_frame.pack(fill=tk.X)
+
+        def save():
+            repo.item_description = desc_txt.get("1.0", tk.END).rstrip()
+            repo.assumptions = assum_txt.get("1.0", tk.END).rstrip()
+
+        def reload():
+            desc_txt.delete("1.0", tk.END)
+            desc_txt.insert("1.0", getattr(repo, "item_description", ""))
+            assum_txt.delete("1.0", tk.END)
+            assum_txt.insert("1.0", getattr(repo, "assumptions", ""))
+
+        ttk.Button(btn_frame, text="Save", command=save).pack(side=tk.LEFT, padx=5, pady=5)
+        ttk.Button(btn_frame, text="Reload", command=reload).pack(side=tk.LEFT, padx=5, pady=5)
 
     def show_requirements_editor(self):
         """Open an editor to manage global requirements and traceability."""

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -72,6 +72,8 @@ class SysMLRepository:
         # maintain undo and redo history of repository snapshots
         self._undo_stack: list[dict] = []
         self._redo_stack: list[dict] = []
+        self.item_description: str = ""
+        self.assumptions: str = ""
         self.root_package = self.create_element("Package", name="Root")
 
     def touch_element(self, elem_id: str) -> None:
@@ -344,6 +346,8 @@ class SysMLRepository:
             diag = SysMLDiagram(**d)
             self.diagrams[diag.diag_id] = diag
         self.element_diagrams = data.get("element_diagrams", {})
+        self.item_description = data.get("item_description", "")
+        self.assumptions = data.get("assumptions", "")
         self.root_package = None
         for elem in self.elements.values():
             if elem.elem_type == "Package" and elem.owner is None:
@@ -392,6 +396,8 @@ class SysMLRepository:
             "relationships": [asdict(rel) for rel in self.relationships],
             "diagrams": [asdict(diag) for diag in self.diagrams.values()],
             "element_diagrams": self.element_diagrams,
+            "item_description": self.item_description,
+            "assumptions": self.assumptions,
         }
         return json.dumps(data, indent=2)
 
@@ -414,6 +420,8 @@ class SysMLRepository:
             diag = SysMLDiagram(**d)
             self.diagrams[diag.diag_id] = diag
         self.element_diagrams = data.get("element_diagrams", {})
+        self.item_description = data.get("item_description", "")
+        self.assumptions = data.get("assumptions", "")
         self.root_package = None
         for elem in self.elements.values():
             if elem.elem_type == "Package" and elem.owner is None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -246,5 +246,17 @@ class RepositoryTests(unittest.TestCase):
 
         self.assertEqual(original, loaded)
 
+    def test_item_definition_persistence(self):
+        self.repo.item_description = "Some description"
+        self.repo.assumptions = "Assumptions here"
+        path = "repo_itemdef.json"
+        self.repo.save(path)
+        SysMLRepository._instance = None
+        new_repo = SysMLRepository.get_instance()
+        new_repo.load(path)
+        os.remove(path)
+        self.assertEqual(new_repo.item_description, "Some description")
+        self.assertEqual(new_repo.assumptions, "Assumptions here")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- open Item Definition tab with description and assumptions when System Design is double-clicked
- persist item description and assumptions in SysML repository
- test repository read/write of item definition fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689be8d3eeb48325af4ec13ab7bba458