### PR TITLE
Populate solution work product combobox

### DIFF
--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -1,6 +1,7 @@
-from gsn import GSNNode, GSNDiagram
+import types
 from gsn import GSNNode, GSNDiagram
 from gui.gsn_config_window import GSNElementConfig, _collect_work_products
+from analysis import SafetyManagementToolbox
 
 
 class DummyVar:
@@ -289,4 +290,85 @@ def test_config_dialog_lists_project_spis(monkeypatch):
     _, spi_cb = combo_holder
     assert spi_cb.configured["values"] == ["SPI1"]
     assert cfg.spi_var.get() == "SPI1"
+
+
+def test_config_dialog_uses_safety_toolbox(monkeypatch):
+    """Work product combo should list toolbox diagram/analysis pairs."""
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    node = GSNNode("New", "Solution")
+    diag.add_node(node)
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Gov", "FMEA", "Reason")
+    app = types.SimpleNamespace(safety_mgmt_toolbox=toolbox)
+    diag.app = app
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            self.configured = {}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+    class DummyText(DummyWidget):
+        def get(self, *a, **k):
+            return ""
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, values=None, state=None, **k):
+            super().__init__(*a, **k)
+            self.textvariable = textvariable
+            self.state = state
+            self.init_values = values
+
+    combo_holder = []
+
+    def combo_stub(*a, **k):
+        cb = DummyCombobox(*a, **k)
+        combo_holder.append(cb)
+        return cb
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.__init__", lambda self, master=None: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.title", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.geometry", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.columnconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.rowconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.transient", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.grab_set", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.wait_window", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Text", lambda *a, **k: DummyText())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Frame", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.gsn_config_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    master = types.SimpleNamespace(app=app)
+    cfg = GSNElementConfig(master, node, diag)
+
+    wp_cb = combo_holder[0]
+    assert wp_cb.configured["values"] == ["Gov - FMEA"]
+    assert cfg.work_var.get() == "Gov - FMEA"
 


### PR DESCRIPTION
## Summary
- Include safety toolbox diagrams and analyses in solution work product options
- Wire configuration dialog to use application toolbox entries
- Add tests ensuring safety toolbox entries populate the combobox

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689be9e03190832585baf3ee3fd4193a