### PR TITLE
Enable selecting and editing GSN relationships

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -68,21 +68,73 @@ class GSNDiagram:
     # ------------------------------------------------------------------
     def draw(self, canvas, zoom: float = 1.0) -> None:  # pragma: no cover - requires tkinter
         """Render the diagram on a :class:`tkinter.Canvas` instance."""
-        # draw connectors first so they appear behind nodes
+        # draw nodes first and record their bounding shapes
+        shapes: dict[str, dict] = {}
+        for node in self._traverse():
+            self._draw_node(canvas, node, zoom)
+            bbox = canvas.bbox(node.unique_id)
+            if not bbox:
+                continue
+            left, top, right, bottom = bbox
+            cx, cy = (left + right) / 2, (top + bottom) / 2
+            w, h = right - left, bottom - top
+            typ = node.node_type.lower()
+            if typ == "solution":
+                shapes[node.unique_id] = {
+                    "type": "circle",
+                    "center": (cx, cy),
+                    "radius": w / 2,
+                }
+            elif typ in {"assumption", "justification", "context"}:
+                shapes[node.unique_id] = {
+                    "type": "ellipse",
+                    "center": (cx, cy),
+                    "width": w,
+                    "height": h,
+                }
+            elif typ == "strategy":
+                offset = w * 0.2
+                points = [
+                    (cx - w / 2 + offset, cy - h / 2),
+                    (cx + w / 2, cy - h / 2),
+                    (cx + w / 2 - offset, cy + h / 2),
+                    (cx - w / 2, cy + h / 2),
+                ]
+                shapes[node.unique_id] = {
+                    "type": "polygon",
+                    "center": (cx, cy),
+                    "points": points,
+                }
+            else:
+                shapes[node.unique_id] = {
+                    "type": "rect",
+                    "center": (cx, cy),
+                    "width": w,
+                    "height": h,
+                }
+
+        # draw connectors; place lines behind nodes but arrowheads on top
         for parent in self._traverse():
             for child in parent.children:
+                rel_id = f"rel:{parent.unique_id}:{child.unique_id}"
                 p_pt = (parent.x * zoom, parent.y * zoom)
                 c_pt = (child.x * zoom, child.y * zoom)
+                p_shape = shapes.get(parent.unique_id)
+                c_shape = shapes.get(child.unique_id)
+                if p_shape:
+                    p_pt = self.drawing_helper.point_on_shape(p_shape, c_pt)
+                if c_shape:
+                    c_pt = self.drawing_helper.point_on_shape(c_shape, p_pt)
                 if child in parent.context_children:
                     self.drawing_helper.draw_in_context_connection(
-                        canvas, p_pt, c_pt
+                        canvas, p_pt, c_pt, obj_id=rel_id
                     )
                 else:
                     self.drawing_helper.draw_solved_by_connection(
-                        canvas, p_pt, c_pt
+                        canvas, p_pt, c_pt, obj_id=rel_id
                     )
-        for node in self._traverse():
-            self._draw_node(canvas, node, zoom)
+                canvas.tag_lower(rel_id)
+                canvas.tag_raise(f"{rel_id}-arrow")
 
     # ------------------------------------------------------------------
     def _draw_node(self, canvas, node: GSNNode, zoom: float) -> None:  # pragma: no cover - requires tkinter

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -231,6 +231,16 @@ class FTADrawingHelper:
                     cy -= h
                     cx += dx * (h / abs(dy)) if dy != 0 else 0
             return cx, cy
+        elif typ == "ellipse":
+            cx, cy = shape.get("center", (0, 0))
+            w = shape.get("width", 0) / 2
+            h = shape.get("height", 0) / 2
+            dx = target_pt[0] - cx
+            dy = target_pt[1] - cy
+            if w == 0 or h == 0:
+                return cx, cy
+            scale = math.hypot(dx / w, dy / h) or 1
+            return cx + dx / scale, cy + dy / scale
         elif typ == "polygon":
             cx, cy = shape.get("center", (0, 0))
             points = shape.get("points", [])
@@ -936,6 +946,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         *,
         fill="black",
         outline="black",
+        obj_id: str = "",
     ) -> None:
         """Draw a triangular arrow head from *start_pt* to *end_pt*."""
         x1, y1 = start_pt
@@ -963,7 +974,12 @@ class GSNDrawingHelper(FTADrawingHelper):
                 base_y - (arrow_width / 2) * perp_y,
             ),
         ]
-        canvas.create_polygon(points, fill=fill, outline=outline)
+        canvas.create_polygon(
+            points,
+            fill=fill,
+            outline=outline,
+            tags=(obj_id, f"{obj_id}-arrow") if obj_id else None,
+        )
 
     def draw_solved_by_connection(
         self,
@@ -972,6 +988,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         child_pt,
         outline_color="dimgray",
         line_width=1,
+        obj_id: str = "",
     ):
         """Draw a curved connector indicating a 'solved by' relationship."""
         px, py = parent_pt
@@ -990,7 +1007,9 @@ class GSNDrawingHelper(FTADrawingHelper):
                 px,
                 py,
             ]
-            canvas.create_line(*path, fill=outline_color, width=line_width)
+            canvas.create_line(
+                *path, fill=outline_color, width=line_width, tags=(obj_id,)
+            )
         else:
             offset = (cy - py) / 2
             path = [
@@ -1008,6 +1027,7 @@ class GSNDrawingHelper(FTADrawingHelper):
                 smooth=True,
                 fill=outline_color,
                 width=line_width,
+                tags=(obj_id,),
             )
         self._draw_arrow(
             canvas,
@@ -1015,6 +1035,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             (path[-2], path[-1]),
             fill="black",
             outline="black",
+            obj_id=obj_id,
         )
 
     def draw_in_context_connection(
@@ -1024,6 +1045,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         child_pt,
         outline_color="dimgray",
         line_width=1,
+        obj_id: str = "",
     ):
         """Draw a dashed curved connector for an 'in context of' relationship."""
         px, py = parent_pt
@@ -1049,6 +1071,7 @@ class GSNDrawingHelper(FTADrawingHelper):
                 fill=outline_color,
                 width=line_width,
                 dash=dash,
+                tags=(obj_id,),
             )
         else:
             path = [
@@ -1067,6 +1090,7 @@ class GSNDrawingHelper(FTADrawingHelper):
                 fill=outline_color,
                 width=line_width,
                 dash=dash,
+                tags=(obj_id,),
             )
         self._draw_arrow(
             canvas,
@@ -1074,6 +1098,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             (path[-2], path[-1]),
             fill="white",
             outline=outline_color,
+            obj_id=obj_id,
         )
 
     def draw_strategy_shape(

--- a/tests/test_gsn_connection_edit.py
+++ b/tests/test_gsn_connection_edit.py
@@ -1,0 +1,97 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from gsn import GSNNode, GSNDiagram
+from gui.drawing_helper import GSNDrawingHelper
+from gui.gsn_diagram_window import GSNDiagramWindow
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.lines = []
+        self.polys = []
+        self.items = 0
+
+    def create_line(self, *pts, **kw):
+        self.items += 1
+        self.lines.append((pts, kw))
+        return self.items
+
+    def create_polygon(self, *pts, **kw):
+        self.items += 1
+        self.polys.append((pts, kw))
+        return self.items
+
+    def create_rectangle(self, *a, **k):
+        pass
+
+    def create_text(self, *a, **k):
+        pass
+
+    def bbox(self, *a, **k):
+        return (0, 0, 0, 0)
+
+    def find_withtag(self, tag):
+        return []
+
+    def itemconfigure(self, *a, **k):
+        pass
+
+    def find_overlapping(self, *a, **k):
+        return []
+
+    def gettags(self, item):
+        return ()
+
+    def tag_lower(self, *a, **k):
+        pass
+
+    def tag_raise(self, *a, **k):
+        pass
+
+
+def test_connection_tags_and_arrow_fill():
+    helper = GSNDrawingHelper()
+    canvas = DummyCanvas()
+    helper.draw_solved_by_connection(canvas, (0, 0), (10, 10), obj_id="r1")
+    helper.draw_in_context_connection(canvas, (0, 0), (20, 20), obj_id="r2")
+    assert canvas.lines[0][1]["tags"] == ("r1",)
+    assert canvas.lines[1][1]["tags"] == ("r2",)
+    assert canvas.polys[0][1]["fill"] == "black"
+    assert canvas.polys[0][1]["tags"] == ("r1", "r1-arrow")
+    assert canvas.polys[1][1]["fill"] == "white"
+    assert canvas.polys[1][1]["tags"] == ("r2", "r2-arrow")
+
+
+def test_move_connection_updates_links():
+    p = GSNNode("p", "Goal")
+    c1 = GSNNode("c1", "Goal")
+    c2 = GSNNode("c2", "Goal")
+    p.add_child(c1)
+    diag = GSNDiagram(p)
+    diag.add_node(c1)
+    diag.add_node(c2)
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.diagram = diag
+    win.refresh = lambda: None
+    win._move_connection(p, c1, c2)
+    assert c1 not in p.children
+    assert c2 in p.children
+    assert p not in c1.parents
+    assert p in c2.parents
+
+
+def test_delete_connection_removes_links():
+    p = GSNNode("p", "Goal")
+    c = GSNNode("c", "Goal")
+    p.add_child(c, relation="context")
+    diag = GSNDiagram(p)
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.diagram = diag
+    win.refresh = lambda: None
+    win._selected_connection = (p, c)
+    win._on_delete(None)
+    assert c not in p.children
+    assert c not in p.context_children
+    assert p not in c.parents

--- a/tests/test_gsn_diagram_draw.py
+++ b/tests/test_gsn_diagram_draw.py
@@ -15,6 +15,18 @@ class StubCanvas:
     def create_text(self, *args, **kwargs):
         pass
 
+    def bbox(self, tag):
+        for left, top, right, bottom, kw in self.items:
+            if kw.get("tags") == (tag,):
+                return left, top, right, bottom
+        return None
+
+    def tag_lower(self, *args, **kwargs):
+        pass
+
+    def tag_raise(self, *args, **kwargs):
+        pass
+
 
 class DummyHelper:
     def draw_goal_shape(self, canvas, x, y, scale, obj_id=""):
@@ -38,6 +50,9 @@ class DummyHelper:
 
     def draw_in_context_connection(self, *args, **kwargs):
         pass
+
+    def point_on_shape(self, shape, target_pt):
+        return target_pt
 
 
 def _rect_for(node_id, canvas):


### PR DESCRIPTION
## Summary
- compute node shapes to trim connections so arrows only touch element surfaces
- draw connectors behind nodes and raise arrowheads above shapes with unique tags
- cover new arrow tags and helper behavior in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689be96bb2608325a139034938916955