### PR TITLE
Align assumption and justification labels with shapes

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -1227,10 +1227,10 @@ class GSNDrawingHelper(FTADrawingHelper):
         offset = padding
         canvas.create_text(
             right + offset,
-            bottom + offset,
+            bottom - offset,
             text="A",
             font=label_font,
-            anchor="nw",
+            anchor="sw",
             tags=(obj_id,),
         )
 
@@ -1281,10 +1281,10 @@ class GSNDrawingHelper(FTADrawingHelper):
         offset = padding
         canvas.create_text(
             right + offset,
-            bottom + offset,
+            bottom - offset,
             text="J",
             font=label_font,
-            anchor="nw",
+            anchor="sw",
             tags=(obj_id,),
         )
 

--- a/tests/test_gsn_connection_tags.py
+++ b/tests/test_gsn_connection_tags.py
@@ -18,6 +18,15 @@ class StubCanvas:
     def create_rectangle(self, *args, **kwargs):
         pass
 
+    def bbox(self, tag):
+        return None
+
+    def tag_lower(self, *args, **kwargs):
+        pass
+
+    def tag_raise(self, *args, **kwargs):
+        pass
+
 
 class DummyHelper:
     def draw_solved_by_connection(self, canvas, parent_pt, child_pt, obj_id=""):
@@ -37,6 +46,6 @@ def test_connection_tags_present():
     diag._draw_node = lambda *a, **k: None  # avoid tkinter font
     canvas = StubCanvas()
     diag.draw(canvas)
-    tag = f"{parent.unique_id}->{child.unique_id}"
+    tag = f"rel:{parent.unique_id}:{child.unique_id}"
     assert canvas.lines[0] == (tag,)
     assert canvas.polys[0] == (tag,)


### PR DESCRIPTION
## Summary
- adjust Assumption and Justification labels to sit next to their shapes
- extend GSN connection tag test stub and expectation for new tag format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689bedb8910c8325895b136e74e307c0