### PR TITLE
Display SPI probability for GSN solutions

### DIFF
--- a/tests/test_gsn_connection_tags.py
+++ b/tests/test_gsn_connection_tags.py
@@ -46,6 +46,6 @@ def test_connection_tags_present():
     diag._draw_node = lambda *a, **k: None  # avoid tkinter font
     canvas = StubCanvas()
     diag.draw(canvas)
-    tag = f"rel:{parent.unique_id}:{child.unique_id}"
+    tag = f"{parent.unique_id}->{child.unique_id}"
     assert canvas.lines[0] == (tag,)
     assert canvas.polys[0] == (tag,)

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -86,14 +86,21 @@ def test_solution_requires_matching_spi_for_clone():
     assert node2.original is original
 
 
-def test_format_text_shows_spi_target():
+def test_format_text_shows_spi_probability():
     root = GSNNode("Root", "Goal")
     sol = GSNNode("Sol", "Solution")
     sol.spi_target = "Brake Time"
     diag = GSNDiagram(root)
     diag.add_node(sol)
+
+    class TopEvent:
+        def __init__(self):
+            self.validation_desc = "Brake Time"
+            self.probability = 1e-5
+
+    diag.app = types.SimpleNamespace(top_events=[TopEvent()])
     text = diag._format_text(sol)
-    assert "SPI: Brake Time" in text
+    assert f"SPI: {1e-5:.2e}" in text
 
 
 def test_collect_work_products_returns_unique_sorted():


### PR DESCRIPTION
## Summary
- Show SPI probability for Solution nodes instead of SPI name
- Map SPI label to top event probability via new helper in diagram
- Update tests to expect probabilities and current connection tag format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689befc1dcb88325b8d34084808f0e82