### PR TITLE
Align solution node font and show validation targets

### DIFF
--- a/tests/test_gsn_diagram_draw.py
+++ b/tests/test_gsn_diagram_draw.py
@@ -1,5 +1,6 @@
 
 from gsn import GSNNode, GSNDiagram
+import gsn.diagram as gsn_diagram
 
 
 class StubCanvas:
@@ -44,6 +45,9 @@ class DummyHelper:
     draw_justification_shape = draw_goal_shape
     draw_context_shape = draw_goal_shape
     draw_away_module_shape = draw_goal_shape
+
+    def get_text_size(self, text, font_obj):
+        return len(text), 10
 
     def draw_solved_by_connection(self, *args, **kwargs):
         pass
@@ -100,14 +104,15 @@ def test_draw_respects_context_links():
     assert calls == ["context"]
 
 
-def test_solution_draws_on_small_circle():
-    """Solution nodes should render on a fixed smaller circle."""
+def test_solution_scales_with_text(monkeypatch):
+    """Solution nodes grow to fit their text."""
+    monkeypatch.setattr(gsn_diagram.tkFont, "Font", lambda *a, **k: _StubFont())
     node = GSNNode("Sol", "Solution", x=10, y=10, description="long text " * 10)
     diag = GSNDiagram(node, drawing_helper=DummyHelper())
     canvas = StubCanvas()
     diag.draw(canvas)
     rect = _rect_for(node.unique_id, canvas)
-    assert rect[2] - rect[0] == 40
+    assert rect[2] - rect[0] > 40
 
 
 class _StubFont:

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -86,7 +86,7 @@ def test_solution_requires_matching_spi_for_clone():
     assert node2.original is original
 
 
-def test_format_text_shows_spi_probability():
+def test_format_text_shows_validation_target():
     root = GSNNode("Root", "Goal")
     sol = GSNNode("Sol", "Solution")
     sol.spi_target = "Brake Time"
@@ -96,7 +96,7 @@ def test_format_text_shows_spi_probability():
     class TopEvent:
         def __init__(self):
             self.validation_desc = "Brake Time"
-            self.probability = 1e-5
+            self.validation_target = 1e-5
 
     diag.app = types.SimpleNamespace(top_events=[TopEvent()])
     text = diag._format_text(sol)


### PR DESCRIPTION
## Summary
- Allow solution nodes to grow so their text uses the same font as other GSN elements
- Show validation target from the selected product goal in each solution's SPI label

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bf1157b2083259699e4acbee345ac