### PR TITLE
Fix GSN connection arrow orientation

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -1011,17 +1011,32 @@ class GSNDrawingHelper(FTADrawingHelper):
                 *path, fill=outline_color, width=line_width, tags=(obj_id,)
             )
         else:
-            offset = (cy - py) / 2
-            path = [
-                px,
-                py,
-                px,
-                py + offset,
-                cx,
-                cy - offset,
-                cx,
-                cy,
-            ]
+            dx = cx - px
+            dy = cy - py
+            if abs(dx) > abs(dy):
+                offset = dx / 2
+                path = [
+                    px,
+                    py,
+                    px + offset,
+                    py,
+                    cx - offset,
+                    cy,
+                    cx,
+                    cy,
+                ]
+            else:
+                offset = dy / 2
+                path = [
+                    px,
+                    py,
+                    px,
+                    py + offset,
+                    cx,
+                    cy - offset,
+                    cx,
+                    cy,
+                ]
             canvas.create_line(
                 *path,
                 smooth=True,
@@ -1029,10 +1044,14 @@ class GSNDrawingHelper(FTADrawingHelper):
                 width=line_width,
                 tags=(obj_id,),
             )
+        start = (path[-4], path[-3])
+        end = (path[-2], path[-1])
+        if start == end:
+            start = parent_pt
         self._draw_arrow(
             canvas,
-            (path[-4], path[-3]),
-            (path[-2], path[-1]),
+            start,
+            end,
             fill="black",
             outline="black",
             obj_id=obj_id,
@@ -1050,7 +1069,6 @@ class GSNDrawingHelper(FTADrawingHelper):
         """Draw a dashed curved connector for an 'in context of' relationship."""
         px, py = parent_pt
         cx, cy = child_pt
-        offset = (cy - py) / 2
         dash = (4, 2)
         if parent_pt == child_pt:
             size = 20
@@ -1074,16 +1092,32 @@ class GSNDrawingHelper(FTADrawingHelper):
                 tags=(obj_id,),
             )
         else:
-            path = [
-                px,
-                py,
-                px,
-                py + offset,
-                cx,
-                cy - offset,
-                cx,
-                cy,
-            ]
+            dx = cx - px
+            dy = cy - py
+            if abs(dx) > abs(dy):
+                offset = dx / 2
+                path = [
+                    px,
+                    py,
+                    px + offset,
+                    py,
+                    cx - offset,
+                    cy,
+                    cx,
+                    cy,
+                ]
+            else:
+                offset = dy / 2
+                path = [
+                    px,
+                    py,
+                    px,
+                    py + offset,
+                    cx,
+                    cy - offset,
+                    cx,
+                    cy,
+                ]
             canvas.create_line(
                 *path,
                 smooth=True,
@@ -1092,10 +1126,14 @@ class GSNDrawingHelper(FTADrawingHelper):
                 dash=dash,
                 tags=(obj_id,),
             )
+        start = (path[-4], path[-3])
+        end = (path[-2], path[-1])
+        if start == end:
+            start = parent_pt
         self._draw_arrow(
             canvas,
-            (path[-4], path[-3]),
-            (path[-2], path[-1]),
+            start,
+            end,
             fill="white",
             outline=outline_color,
             obj_id=obj_id,

--- a/tests/test_gsn_horizontal_connection.py
+++ b/tests/test_gsn_horizontal_connection.py
@@ -1,0 +1,86 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from gsn import GSNNode, GSNDiagram
+from gui.drawing_helper import GSNDrawingHelper
+
+
+class ArrowCanvas:
+    """Minimal canvas tracking rectangles for bbox() calls."""
+
+    def __init__(self):
+        self.rects = {}
+
+    def create_rectangle(self, left, top, right, bottom, tags=()):
+        if tags:
+            self.rects[tags[0]] = (left, top, right, bottom)
+
+    def create_line(self, *args, **kwargs):
+        pass
+
+    def create_text(self, *args, **kwargs):
+        pass
+
+    def create_polygon(self, *args, **kwargs):
+        pass
+
+    def bbox(self, tag):
+        return self.rects.get(tag)
+
+    def tag_lower(self, *args, **kwargs):
+        pass
+
+    def tag_raise(self, *args, **kwargs):
+        pass
+
+
+class ArrowHelper(GSNDrawingHelper):
+    """Helper that records arrow orientation and connection points."""
+
+    def __init__(self):
+        super().__init__()
+        self.arrow = None
+        self.connection = None
+
+    def draw_goal_shape(self, canvas, x, y, scale, text="", font_obj=None, obj_id=""):
+        half = scale / 2
+        canvas.create_rectangle(x - half, y - half, x + half, y + half, tags=(obj_id,))
+
+    # Reuse the rectangle for other node types used in the test.
+    draw_strategy_shape = draw_solution_shape = draw_goal_shape
+    draw_assumption_shape = draw_goal_shape
+    draw_justification_shape = draw_goal_shape
+    draw_context_shape = draw_goal_shape
+    draw_away_solution_shape = draw_goal_shape
+    draw_away_goal_shape = draw_goal_shape
+    draw_away_module_shape = draw_goal_shape
+
+    def _draw_arrow(self, canvas, start_pt, end_pt, fill="black", outline="black", obj_id=""):
+        self.arrow = (start_pt, end_pt)
+
+    def draw_solved_by_connection(self, canvas, parent_pt, child_pt, obj_id=""):
+        super().draw_solved_by_connection(canvas, parent_pt, child_pt, obj_id=obj_id)
+        self.connection = (parent_pt, child_pt)
+
+
+def test_horizontal_connection_uses_side_and_arrow_points_right():
+    parent = GSNNode("p", "Goal", x=0, y=0)
+    child = GSNNode("c", "Assumption", x=100, y=0)
+    parent.add_child(child)
+
+    helper = ArrowHelper()
+    diag = GSNDiagram(parent, drawing_helper=helper)
+    diag.add_node(child)
+
+    canvas = ArrowCanvas()
+    diag.draw(canvas)
+
+    # Connections should start/end on the sides of both shapes.
+    assert helper.connection == ((30.0, 0.0), (70.0, 0.0))
+
+    # Arrow orientation should be horizontal, pointing from parent to child.
+    assert helper.arrow[0][1] == helper.arrow[1][1]
+    assert helper.arrow[0][0] < helper.arrow[1][0]
+


### PR DESCRIPTION
## Summary
- Correct GSN connection path calculation to orient arrows along relationship direction
- Ensure connectors touch the surfaces of adjacent nodes across shapes
- Add regression test for horizontal GSN connections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bf1ac10748325823a0bbbd376be58