### PR TITLE
Add Safety Case tool with evidence tracking

### DIFF
--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -41,6 +41,7 @@ class GSNNode:
     work_product: str = ""
     evidence_link: str = ""
     spi_target: str = ""
+    evidence_sufficient: bool = False
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         # A freshly created node is considered its own original instance.
@@ -87,6 +88,7 @@ class GSNNode:
         )
         clone.work_product = self.work_product
         clone.spi_target = self.spi_target
+        clone.evidence_sufficient = self.evidence_sufficient
         if parent is not None:
             parent.add_child(clone)
         return clone
@@ -108,6 +110,7 @@ class GSNNode:
             "work_product": self.work_product,
             "evidence_link": self.evidence_link,
             "spi_target": self.spi_target,
+            "evidence_sufficient": self.evidence_sufficient,
         }
 
     # ------------------------------------------------------------------
@@ -130,6 +133,7 @@ class GSNNode:
             work_product=data.get("work_product", ""),
             evidence_link=data.get("evidence_link", ""),
             spi_target=data.get("spi_target", ""),
+            evidence_sufficient=data.get("evidence_sufficient", False),
         )
         nodes[node.unique_id] = node
         # Temporarily store child and original references for second pass.

--- a/tests/test_gsn_evidence_flag.py
+++ b/tests/test_gsn_evidence_flag.py
@@ -1,0 +1,28 @@
+import sys
+import types
+import os
+
+# Provide stubs for Pillow dependencies used by AutoML/gsn modules
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from gsn import GSNNode, GSNDiagram
+
+
+def test_solution_evidence_flag_roundtrip():
+    root = GSNNode("G", "Goal")
+    sol = GSNNode("S", "Solution")
+    root.add_child(sol)
+    sol.evidence_sufficient = True
+    diag = GSNDiagram(root)
+    diag.add_node(sol)
+
+    data = diag.to_dict()
+    loaded = GSNDiagram.from_dict(data)
+    loaded_sol = next(n for n in loaded.nodes if n.node_type == "Solution")
+    assert loaded_sol.evidence_sufficient

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -245,6 +245,7 @@ def test_safety_diagrams_visible_in_analysis_tree():
     assert "Safety & Security Governance Diagrams" in texts
     assert "Gov" in texts
     assert "Arch" in texts
+    assert "Safety Case" in texts
 
 
 def test_gsn_diagrams_visible_in_analysis_tree():


### PR DESCRIPTION
## Summary
- Add evidence_sufficient flag to GSN nodes with serialization support
- Introduce Safety Case tool listing GSN solutions and allowing evidence checkmarks
- Expose Safety Case under Safety Management tools and explorer tree

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bf46e8adc8325a6182118c4ec6f32