### PR TITLE
Add safety case overview tool

### DIFF
--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -41,6 +41,7 @@ class GSNNode:
     work_product: str = ""
     evidence_link: str = ""
     spi_target: str = ""
+    evidence_sufficient: bool = False
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         # A freshly created node is considered its own original instance.
@@ -84,6 +85,7 @@ class GSNNode:
             original=self.original,
             work_product=self.work_product,
             evidence_link=self.evidence_link,
+            evidence_sufficient=self.evidence_sufficient,
         )
         clone.work_product = self.work_product
         clone.spi_target = self.spi_target
@@ -108,6 +110,7 @@ class GSNNode:
             "work_product": self.work_product,
             "evidence_link": self.evidence_link,
             "spi_target": self.spi_target,
+            "evidence_sufficient": self.evidence_sufficient,
         }
 
     # ------------------------------------------------------------------
@@ -130,6 +133,7 @@ class GSNNode:
             work_product=data.get("work_product", ""),
             evidence_link=data.get("evidence_link", ""),
             spi_target=data.get("spi_target", ""),
+            evidence_sufficient=data.get("evidence_sufficient", False),
         )
         nodes[node.unique_id] = node
         # Temporarily store child and original references for second pass.

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Stub out Pillow modules so AutoML can be imported without the dependency
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+
+from gsn import GSNNode, GSNDiagram
+from AutoML import FaultTreeApp
+from analysis.constants import CHECK_MARK
+
+
+class DummyTree:
+    def __init__(self, master=None, *, columns=None, show=None, selectmode=None):
+        self.columns = list(columns or [])
+        self.data = {}
+        self.counter = 0
+        self.bindings = {}
+
+    def heading(self, column, text=""):
+        pass
+
+    def column(self, column, width=None, anchor=None):
+        pass
+
+    def pack(self, **kwargs):
+        pass
+
+    def insert(self, parent, index, values=None, tags=()):
+        iid = f"i{self.counter}"
+        self.counter += 1
+        self.data[iid] = {"values": list(values or []), "tags": tags}
+        return iid
+
+    def get_children(self, item=""):
+        return list(self.data.keys())
+
+    def delete(self, iid):
+        self.data.pop(iid, None)
+
+    def bind(self, event, callback):
+        self.bindings[event] = callback
+
+    def identify_row(self, y):
+        return next(iter(self.data.keys()), "")
+
+    def identify_column(self, x):
+        return f"#{len(self.columns)}"
+
+    def item(self, iid, option):
+        if option == "tags":
+            return self.data.get(iid, {}).get("tags", ())
+        return None
+
+    def set(self, iid, column, value=None):
+        idx = self.columns.index(column)
+        if value is None:
+            return self.data[iid]["values"][idx]
+        self.data[iid]["values"][idx] = value
+
+    def winfo_exists(self):
+        return True
+
+
+def test_safety_case_lists_and_toggles(monkeypatch):
+    root = GSNNode("G", "Goal")
+    sol = GSNNode("E", "Solution")
+    root.add_child(sol)
+    diag = GSNDiagram(root)
+    diag.add_node(sol)
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
+    app._new_tab = lambda title: types.SimpleNamespace(winfo_exists=lambda: True)
+    app.all_gsn_diagrams = [diag]
+
+    monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)
+
+    FaultTreeApp.show_safety_case(app)
+    tree = app._safety_case_tree
+    assert len(tree.data) == 1
+    iid = next(iter(tree.data))
+    assert tree.data[iid]["values"][0] == "E"
+
+    event = types.SimpleNamespace(x=0, y=0)
+    tree.bindings["<Double-1>"](event)
+    assert sol.evidence_sufficient
+    assert tree.data[iid]["values"][5] == CHECK_MARK
+
+    app.refresh_safety_case_table()
+    iid = next(iter(tree.data))
+    assert tree.data[iid]["values"][5] == CHECK_MARK


### PR DESCRIPTION
## Summary
- add Safety Case option in Safety Management tools and explorer
- display and persist solution evidence status across GSN diagrams
- cover Safety Case table interactions with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bf46e8adc8325a6182118c4ec6f32