### PR TITLE
feat: add module node support to gsn diagrams

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -252,21 +252,32 @@ class GSNDiagram:
                 font_obj=font_obj,
                 obj_id=node.unique_id,
             )
-        elif typ in {"goal", "module"}:
+        elif typ == "goal":
             ratio = 0.6
             scale = max(base_scale, width + padding, (height + padding) / ratio)
-            if typ == "goal":
-                draw_func = (
-                    self.drawing_helper.draw_goal_shape
-                    if node.is_primary_instance
-                    else self.drawing_helper.draw_away_goal_shape
-                )
-            else:  # module
-                draw_func = (
-                    self.drawing_helper.draw_goal_shape
-                    if node.is_primary_instance
-                    else self.drawing_helper.draw_away_module_shape
-                )
+            draw_func = (
+                self.drawing_helper.draw_goal_shape
+                if node.is_primary_instance
+                else self.drawing_helper.draw_away_goal_shape
+            )
+            _call(
+                draw_func,
+                canvas,
+                x,
+                y,
+                scale,
+                text=text,
+                font_obj=font_obj,
+                obj_id=node.unique_id,
+            )
+        elif typ == "module":
+            ratio = 0.6
+            scale = max(base_scale, width + padding, (height + padding) / ratio)
+            draw_func = (
+                self.drawing_helper.draw_module_shape
+                if node.is_primary_instance
+                else self.drawing_helper.draw_away_module_shape
+            )
             _call(
                 draw_func,
                 canvas,

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -938,6 +938,64 @@ class GSNDrawingHelper(FTADrawingHelper):
             tags=(obj_id,),
         )
 
+    def draw_module_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Module",
+        fill="lightyellow",
+        outline_color="dimgray",
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        padding = 4
+        t_width, t_height = self.get_text_size(text, font_obj)
+        w = max(scale, t_width + 2 * padding)
+        base_h = max(scale * 0.6, t_height + 2 * padding)
+        tab_h = base_h * 0.25
+        left = x - w / 2
+        base_top = y - base_h / 2
+        right = x + w / 2
+        bottom = y + base_h / 2
+        tab_top = base_top - tab_h
+        tab_w = w * 0.4
+        self._fill_gradient_rect(canvas, left, base_top, right, bottom, fill)
+        self._fill_gradient_rect(canvas, left, tab_top, left + tab_w, base_top, fill)
+        canvas.create_polygon(
+            left,
+            base_top,
+            left,
+            bottom,
+            right,
+            bottom,
+            right,
+            tab_top,
+            left + tab_w,
+            tab_top,
+            left + tab_w,
+            base_top,
+            left,
+            base_top,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
+            x,
+            (base_top + bottom) / 2,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+
     def _draw_arrow(
         self,
         canvas,
@@ -1435,7 +1493,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
 
     def draw_away_module_shape(self, canvas, x, y, scale=60.0, **kwargs):
-        self.draw_goal_shape(canvas, x, y, scale=scale, **kwargs)
+        self.draw_module_shape(canvas, x, y, scale=scale, **kwargs)
         self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
 
 

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import tkinter as tk
-from tkinter import ttk
+from tkinter import ttk, simpledialog
 import webbrowser
 from typing import Optional
 
@@ -21,6 +21,7 @@ class GSNDiagramWindow(tk.Frame):
         "Assumption",
         "Justification",
         "Context",
+        "Module",
         "Solved By",
         "In Context Of",
         "Zoom In",
@@ -42,6 +43,7 @@ class GSNDiagramWindow(tk.Frame):
             ("Assumption", self.add_assumption),
             ("Justification", self.add_justification),
             ("Context", self.add_context),
+            ("Module", self.add_module),
             ("Solved By", self.connect_solved_by),
             ("In Context Of", self.connect_in_context),
             ("Zoom In", self.zoom_in),
@@ -139,6 +141,23 @@ class GSNDiagramWindow(tk.Frame):
 
     def add_context(self):  # pragma: no cover - requires tkinter
         self._add_node("Context")
+
+    def add_module(self):  # pragma: no cover - requires tkinter
+        if not self.app:
+            return
+        modules = getattr(self.app, "gsn_modules", [])
+        if not modules:
+            return
+        names = [m.name for m in modules]
+        name = simpledialog.askstring(
+            "Add Existing Module", "Module:", initialvalue=names[0], parent=self
+        )
+        if not name or name not in names:
+            return
+        node = GSNNode(name, "Module", x=50, y=50)
+        self.diagram.add_node(node)
+        self.selected_node = node
+        self.refresh()
 
     def connect_solved_by(self):  # pragma: no cover - GUI interaction stub
         self._connect_mode = "solved"

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -44,6 +44,7 @@ class GSNExplorer(tk.Frame):
             "Assumption": self._create_icon("rect", "#b22222"),
             "Justification": self._create_icon("rect", "#ff8c00"),
             "Context": self._create_icon("rect", "#696969"),
+            "Module": self.module_icon,
         }
         self.default_node_icon = self._create_icon("rect")
         self.item_map: dict[str, tuple[str, object]] = {}

--- a/tests/test_gsn_connection_surface.py
+++ b/tests/test_gsn_connection_surface.py
@@ -58,6 +58,7 @@ class TrackingHelper(GSNDrawingHelper):
     draw_assumption_shape = draw_goal_shape
     draw_justification_shape = draw_goal_shape
     draw_context_shape = draw_goal_shape
+    draw_module_shape = draw_goal_shape
     draw_away_module_shape = draw_goal_shape
 
     def point_on_shape(self, shape, target_pt):

--- a/tests/test_gsn_diagram_draw.py
+++ b/tests/test_gsn_diagram_draw.py
@@ -43,6 +43,7 @@ class DummyHelper:
     draw_assumption_shape = draw_goal_shape
     draw_justification_shape = draw_goal_shape
     draw_context_shape = draw_goal_shape
+    draw_module_shape = draw_goal_shape
     draw_away_module_shape = draw_goal_shape
 
     def draw_solved_by_connection(self, *args, **kwargs):

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -1,8 +1,10 @@
 import tkinter as tk
 import types
 
+import types
+import gui.gsn_diagram_window as gdw
 from gui.gsn_diagram_window import GSNDiagramWindow
-from gsn import GSNNode, GSNDiagram
+from gsn import GSNNode, GSNDiagram, GSNModule
 
 
 def test_gsn_diagram_window_button_labels():
@@ -11,6 +13,7 @@ def test_gsn_diagram_window_button_labels():
     assert "Solved By" in labels
     assert "In Context Of" in labels
     assert "Zoom In" in labels
+    assert "Module" in labels
 
 
 def test_zoom_methods_adjust_factor():
@@ -196,6 +199,20 @@ def test_click_and_drag_uses_canvas_coordinates():
     drag = type("Evt", (), {"x": 60, "y": 60})
     win._on_drag(drag)
     assert node.x == 160 and node.y == 260
+
+
+def test_add_module_uses_existing_modules(monkeypatch):
+    app = types.SimpleNamespace(gsn_modules=[GSNModule("Pkg1"), GSNModule("Pkg2")])
+    diagram = GSNDiagram(GSNNode("r", "Goal"))
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.app = app
+    win.diagram = diagram
+    win.selected_node = None
+    win.refresh = lambda: None
+    monkeypatch.setattr(gdw.simpledialog, "askstring", lambda *a, **k: "Pkg2")
+    GSNDiagramWindow.add_module(win)
+    names = [n.user_name for n in diagram.nodes if n.node_type == "Module"]
+    assert names == ["Pkg2"]
 
 
 def test_right_click_node_shows_menu(monkeypatch):

--- a/tests/test_gsn_horizontal_connection.py
+++ b/tests/test_gsn_horizontal_connection.py
@@ -55,6 +55,7 @@ class ArrowHelper(GSNDrawingHelper):
     draw_context_shape = draw_goal_shape
     draw_away_solution_shape = draw_goal_shape
     draw_away_goal_shape = draw_goal_shape
+    draw_module_shape = draw_goal_shape
     draw_away_module_shape = draw_goal_shape
 
     def _draw_arrow(self, canvas, start_pt, end_pt, fill="black", outline="black", obj_id=""):


### PR DESCRIPTION
## Summary
- allow existing modules to be inserted into GSN diagrams
- render modules with a folder-like shape
- show module icons in the explorer and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bf52b416c832589057bd8f4c0f14f