### PR TITLE
Recalculate safety case values on tab focus

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -15007,6 +15007,8 @@ class FaultTreeApp:
         """Refresh diagrams when their tab becomes active."""
         tab_id = event.widget.select()
         tab = event.widget.nametowidget(tab_id)
+        if tab is getattr(self, "_safety_case_tab", None):
+            self.refresh_safety_case_table()
         for child in tab.winfo_children():
             if hasattr(child, "refresh_from_repository"):
                 child.refresh_from_repository()

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -68,6 +68,13 @@ class DummyTree:
         return True
 
 
+class DummyTab:
+    def winfo_exists(self):
+        return True
+
+    def winfo_children(self):
+        return []
+
 def test_safety_case_lists_and_toggles(monkeypatch):
     root = GSNNode("G", "Goal")
     sol = GSNNode("E", "Solution")
@@ -77,7 +84,7 @@ def test_safety_case_lists_and_toggles(monkeypatch):
 
     app = FaultTreeApp.__new__(FaultTreeApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
-    app._new_tab = lambda title: types.SimpleNamespace(winfo_exists=lambda: True)
+    app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
 
     monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)
@@ -96,3 +103,34 @@ def test_safety_case_lists_and_toggles(monkeypatch):
     app.refresh_safety_case_table()
     iid = next(iter(tree.data))
     assert tree.data[iid]["values"][5] == CHECK_MARK
+
+
+def test_safety_case_refresh_on_tab_focus(monkeypatch):
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
+    app._new_tab = lambda title: DummyTab()
+    app.all_gsn_diagrams = []
+
+    monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)
+
+    FaultTreeApp.show_safety_case(app)
+
+    called = {"count": 0}
+
+    def fake_refresh():
+        called["count"] += 1
+
+    app.refresh_safety_case_table = fake_refresh
+
+    class Notebook:
+        def select(self):
+            return "tab1"
+
+        def nametowidget(self, tab_id):
+            assert tab_id == "tab1"
+            return app._safety_case_tab
+
+    event = types.SimpleNamespace(widget=Notebook())
+    app._on_tab_change(event)
+
+    assert called["count"] == 1


### PR DESCRIPTION
## Summary
- Recalculate safety case table whenever its tab gains focus
- Add regression test verifying safety case refresh on tab change

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bf71f0b5483258a027a82a23e6219