### PR TITLE
Add comments column to safety case table

### DIFF
--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -42,6 +42,7 @@ class GSNNode:
     evidence_link: str = ""
     spi_target: str = ""
     evidence_sufficient: bool = False
+    manager_notes: str = ""
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         # A freshly created node is considered its own original instance.
@@ -86,9 +87,11 @@ class GSNNode:
             work_product=self.work_product,
             evidence_link=self.evidence_link,
             evidence_sufficient=self.evidence_sufficient,
+            manager_notes=self.manager_notes,
         )
         clone.work_product = self.work_product
         clone.spi_target = self.spi_target
+        clone.manager_notes = self.manager_notes
         if parent is not None:
             parent.add_child(clone)
         return clone
@@ -111,6 +114,7 @@ class GSNNode:
             "evidence_link": self.evidence_link,
             "spi_target": self.spi_target,
             "evidence_sufficient": self.evidence_sufficient,
+            "manager_notes": self.manager_notes,
         }
 
     # ------------------------------------------------------------------
@@ -134,6 +138,7 @@ class GSNNode:
             evidence_link=data.get("evidence_link", ""),
             spi_target=data.get("spi_target", ""),
             evidence_sufficient=data.get("evidence_sufficient", False),
+            manager_notes=data.get("manager_notes", ""),
         )
         nodes[node.unique_id] = node
         # Temporarily store child and original references for second pass.

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -22,6 +22,7 @@ class DummyTree:
         self.data = {}
         self.counter = 0
         self.bindings = {}
+        self.next_column = "Evidence OK"
 
     def heading(self, column, text=""):
         pass
@@ -51,7 +52,8 @@ class DummyTree:
         return next(iter(self.data.keys()), "")
 
     def identify_column(self, x):
-        return f"#{len(self.columns)}"
+        idx = self.columns.index(self.next_column) + 1
+        return f"#{idx}"
 
     def item(self, iid, option):
         if option == "tags":
@@ -134,3 +136,28 @@ def test_safety_case_refresh_on_tab_focus(monkeypatch):
     app._on_tab_change(event)
 
     assert called["count"] == 1
+
+
+def test_safety_case_add_notes(monkeypatch):
+    root = GSNNode("G", "Goal")
+    sol = GSNNode("E", "Solution")
+    root.add_child(sol)
+    diag = GSNDiagram(root)
+    diag.add_node(sol)
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
+    app._new_tab = lambda title: DummyTab()
+    app.all_gsn_diagrams = [diag]
+
+    monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)
+    monkeypatch.setattr("AutoML.simpledialog.askstring", lambda title, prompt, initialvalue=None: "note")
+
+    FaultTreeApp.show_safety_case(app)
+    tree = app._safety_case_tree
+    tree.next_column = "Notes"
+    event = types.SimpleNamespace(x=0, y=0)
+    tree.bindings["<Double-1>"](event)
+    iid = next(iter(tree.data))
+    assert sol.manager_notes == "note"
+    assert tree.data[iid]["values"][6] == "note"


### PR DESCRIPTION
## Summary
- allow safety managers to record notes in Safety Case table
- persist notes on solution nodes
- test notes editing and Evidence OK toggle

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bf859917483259ee25fd824181b60