### PR TITLE
Include toolbox work products in GSN config

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -27,11 +27,14 @@ def _collect_work_products(diagram: GSNDiagram, app=None) -> list[str]:
     toolbox = getattr(app, "safety_mgmt_toolbox", None)
     if toolbox:
         for wp in getattr(toolbox, "get_work_products", lambda: [])():
-            name = " - ".join(
-                filter(None, [getattr(wp, "diagram", ""), getattr(wp, "analysis", "")])
-            )
-            if name:
-                products.add(name)
+            parts = [getattr(wp, "diagram", ""), getattr(wp, "analysis", "")]
+            parts = [p for p in parts if p]
+            if parts:
+                # Include the individual components (diagram or analysis)
+                products.update(parts)
+                # and the combined "diagram - analysis" name for clarity
+                if len(parts) > 1:
+                    products.add(" - ".join(parts))
 
     return sorted(products)
 

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -136,6 +136,25 @@ def test_collect_work_products_returns_unique_sorted():
     assert _collect_work_products(diag) == ["A", "B"]
 
 
+def test_collect_work_products_includes_toolbox_entries():
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Architecture Diagram", "Safety Analysis", "rationale")
+
+    class App:
+        def __init__(self):
+            self.safety_mgmt_toolbox = toolbox
+
+    diag.app = App()
+
+    assert _collect_work_products(diag) == [
+        "Architecture Diagram",
+        "Architecture Diagram - Safety Analysis",
+        "Safety Analysis",
+    ]
+
+
 def test_config_dialog_populates_comboboxes(monkeypatch):
     """Work product and SPI combos should list existing entries."""
 
@@ -318,3 +337,92 @@ def test_config_dialog_lists_project_spis(monkeypatch):
     _, spi_cb = combo_holder
     assert spi_cb.configured["values"] == ["SPI1"]
     assert cfg.spi_var.get() == "SPI1"
+
+
+def test_config_dialog_lists_toolbox_work_products(monkeypatch):
+    """Work product combo should list toolbox entries."""
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    node = GSNNode("New", "Solution")
+    diag.add_node(node)
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Architecture Diagram", "Safety Analysis", "")
+
+    class App:
+        def __init__(self):
+            self.safety_mgmt_toolbox = toolbox
+
+    class Master:
+        def __init__(self):
+            self.app = App()
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            self.configured = {}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+    class DummyText(DummyWidget):
+        def get(self, *a, **k):
+            return ""
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, values=None, state=None, **k):
+            super().__init__(*a, **k)
+            self.textvariable = textvariable
+            self.state = state
+            self.init_values = values
+
+    combo_holder = []
+
+    def combo_stub(*a, **k):
+        cb = DummyCombobox(*a, **k)
+        combo_holder.append(cb)
+        return cb
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.__init__", lambda self, master=None: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.title", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.geometry", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.columnconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.rowconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.transient", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.grab_set", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.wait_window", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Text", lambda *a, **k: DummyText())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Frame", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.gsn_config_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    GSNElementConfig(Master(), node, diag)
+
+    wp_cb = combo_holder[0]
+    assert wp_cb.configured["values"] == [
+        "Architecture Diagram",
+        "Architecture Diagram - Safety Analysis",
+        "Safety Analysis",
+    ]

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -117,7 +117,9 @@ def test_safety_case_cancel_does_not_toggle(monkeypatch):
 
     app = FaultTreeApp.__new__(FaultTreeApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
-    app._new_tab = lambda title: types.SimpleNamespace(winfo_exists=lambda: True)
+    app._new_tab = lambda title: types.SimpleNamespace(
+        winfo_exists=lambda: True, winfo_children=lambda: []
+    )
     app.all_gsn_diagrams = [diag]
 
     monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)


### PR DESCRIPTION
## Summary
- ensure GSN solution work product combobox lists entries from the Safety Management Toolbox, including individual diagrams and analyses
- add tests covering toolbox work products and UI combobox population
- fix safety case test stubs to include required widget methods

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689bf9b971888325be7f49fcb3a6f37c