### PR TITLE
Annotate SPI and analysis data with units

### DIFF
--- a/analysis/confusion_matrix.py
+++ b/analysis/confusion_matrix.py
@@ -16,6 +16,7 @@ def compute_metrics(tp: float, fp: float, tn: float, fn: float) -> Dict[str, flo
     -------
     dict
         Dictionary with keys ``accuracy``, ``precision``, ``recall`` and ``f1``.
+        A nested ``units`` mapping records the dimension of each metric.
     """
     tp = float(tp)
     fp = float(fp)
@@ -31,6 +32,12 @@ def compute_metrics(tp: float, fp: float, tn: float, fn: float) -> Dict[str, flo
         "precision": precision,
         "recall": recall,
         "f1": f1,
+        "units": {
+            "accuracy": "ratio",
+            "precision": "ratio",
+            "recall": "ratio",
+            "f1": "ratio",
+        },
     }
 
 
@@ -73,6 +80,8 @@ def compute_rates(
     dict
         Dictionary containing the confusion matrix counts (``tp``, ``fp``,
         ``tn``, ``fn``) and totals ``p`` and ``n``.
+        A nested ``units`` mapping documents the measurement unit for
+        each value.
     """
 
     hours = float(hours)
@@ -96,7 +105,24 @@ def compute_rates(
         p = tp + fn
         n = tn + fp
 
-    return {"tp": tp, "fp": fp, "tn": tn, "fn": fn, "p": p, "n": n}
+    return {
+        "tp": tp,
+        "fp": fp,
+        "tn": tn,
+        "fn": fn,
+        "p": p,
+        "n": n,
+        "units": {
+            "tp": "count",
+            "fp": "count",
+            "tn": "count",
+            "fn": "count",
+            "p": "count",
+            "n": "count",
+            "hours": "h",
+            "validation_target": "events/h",
+        },
+    }
 
 
 def compute_metrics_from_target(
@@ -125,7 +151,8 @@ def compute_metrics_from_target(
         Dictionary containing classification metrics (``accuracy``,
         ``precision``, ``recall`` and ``f1``) together with the confusion
         matrix counts and totals (``tp``, ``fp``, ``tn``, ``fn``, ``p``,
-        ``n``).
+        ``n``). A nested ``units`` mapping annotates every entry with its
+        corresponding unit.
     """
 
     hours = float(hours)
@@ -156,4 +183,18 @@ def compute_metrics_from_target(
         "fn": fn,
         "p": p,
         "n": n,
+        "units": {
+            "accuracy": "ratio",
+            "precision": "ratio",
+            "recall": "ratio",
+            "f1": "ratio",
+            "tp": "count",
+            "fp": "count",
+            "tn": "count",
+            "fn": "count",
+            "p": "count",
+            "n": "count",
+            "hours": "h",
+            "validation_target": "events/h",
+        },
     }

--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -328,9 +328,9 @@ class GSNDiagram:
                 prob = self._lookup_spi_probability(node.spi_target)
                 v_target = self._lookup_validation_target(node.spi_target)
                 if prob is not None:
-                    label = f"SPI: {prob:.2e}"
+                    label = f"SPI: {prob:.2e}/h"
                 elif v_target:
-                    label = f"SPI: {v_target}"
+                    label = f"SPI: {v_target}/h"
                 else:
                     label = f"SPI: {node.spi_target}"
                 lines.append(label)

--- a/tests/test_confusion_matrix.py
+++ b/tests/test_confusion_matrix.py
@@ -19,6 +19,7 @@ def test_compute_metrics_basic():
     rec = 50 / (50 + 10)
     expected_f1 = 2 * prec * rec / (prec + rec)
     assert math.isclose(metrics["f1"], expected_f1)
+    assert metrics["units"]["accuracy"] == "ratio"
 
 
 def test_compute_metrics_zero_division():
@@ -37,6 +38,8 @@ def test_compute_rates_basic():
     assert math.isclose(counts["fn"], 10)
     assert math.isclose(counts["p"], 60)
     assert math.isclose(counts["n"], 40)
+    assert counts["units"]["tp"] == "count"
+    assert counts["units"]["validation_target"] == "events/h"
 
 
 def test_compute_rates_auto_counts():
@@ -67,3 +70,4 @@ def test_compute_metrics_from_target():
     assert math.isclose(data["fp"], 1.0)
     assert math.isclose(data["tn"], 39.0)
     assert math.isclose(data["fn"], 1.0)
+    assert data["units"]["validation_target"] == "events/h"

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -342,4 +342,4 @@ def test_refresh_sets_app_for_spi_lookup():
 
     GSNDiagramWindow.refresh(win)
     assert diag.app is app
-    assert "SPI: 1e-5" in captured.get("text", "")
+    assert "SPI: 1e-5/h" in captured.get("text", "")

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -100,7 +100,7 @@ def test_format_text_shows_spi_probability():
 
     diag.app = types.SimpleNamespace(top_events=[TopEvent()])
     text = diag._format_text(sol)
-    assert f"SPI: {1e-5:.2e}" in text
+    assert f"SPI: {1e-5:.2e}/h" in text
 
 
 def test_format_text_shows_validation_target_when_no_probability():
@@ -117,7 +117,7 @@ def test_format_text_shows_validation_target_when_no_probability():
 
     diag.app = types.SimpleNamespace(top_events=[TopEvent()])
     text = diag._format_text(sol)
-    assert "SPI: 1e-5" in text
+    assert "SPI: 1e-5/h" in text
 
 
 def test_collect_work_products_returns_unique_sorted():


### PR DESCRIPTION
## Summary
- append per-hour units to SPI labels in GSN diagrams
- add `units` metadata to confusion matrix utilities so each metric and count specifies its measurement unit
- adjust tests to verify unit annotations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689bfcacd16883259c665fa8f09dd6b5