### PR TITLE
feat: show SPI values derived from achieved probability

### DIFF
--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -177,12 +177,7 @@ class GSNExplorer(tk.Frame):
             return
         typ, obj = self.item_map.get(sel[0], (None, None))
         if typ == "module":
-            new = simpledialog.askstring("Rename Module", "Name:", initialvalue=obj.name, parent=self)
-            if new:
-                undo = getattr(self.app, "push_undo_state", None)
-                if undo:
-                    undo()
-                obj.name = new
+            return
         elif typ == "diagram":
             new = simpledialog.askstring("Rename Diagram", "Name:", initialvalue=obj.root.user_name, parent=self)
             if new:


### PR DESCRIPTION
## Summary
- allow entering achieved probability in Safety Case and compute SPI
- display Achieved Probability and SPI in Safety Performance Indicators explorer
- disallow GSN module renaming in explorer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c0367d1588325ada696ac5e138788