### PR TITLE
Track achieved probability and compute SPI

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12626,7 +12626,14 @@ class FaultTreeApp:
         self._spi_tab = self._new_tab("Safety Performance Indicators")
         win = self._spi_tab
 
-        columns = ["Product Goal", "Validation Target", "Target Description", "Acceptance Criteria"]
+        columns = [
+            "Product Goal",
+            "Validation Target",
+            "Achieved Probability",
+            "SPI",
+            "Target Description",
+            "Acceptance Criteria",
+        ]
         tree = ttk.Treeview(win, columns=columns, show="headings", selectmode="browse")
         for c in columns:
             tree.heading(c, text=c)
@@ -12635,14 +12642,27 @@ class FaultTreeApp:
                 width = 300
             tree.column(c, width=width, anchor="center")
         tree.pack(fill=tk.BOTH, expand=True)
+        self._spi_tree = tree
 
-        for sg in self.top_events:
+        for sg in getattr(self, "top_events", []):
+            v_target = getattr(sg, "validation_target", "")
+            prob = getattr(sg, "probability", "")
+            v_str = f"{v_target:.2e}" if v_target not in ("", None) else ""
+            p_str = f"{prob:.2e}" if prob not in ("", None) else ""
+            spi_val = ""
+            try:
+                if v_target not in ("", None) and prob not in ("", None) and prob != 0:
+                    spi_val = f"{float(v_target) / float(prob):.2f}"
+            except Exception:
+                spi_val = ""
             tree.insert(
                 "",
                 "end",
                 values=[
                     sg.user_name or f"SG {sg.unique_id}",
-                    getattr(sg, "validation_target", ""),
+                    v_str,
+                    p_str,
+                    spi_val,
                     self._spi_label(sg),
                     getattr(sg, "acceptance_criteria", ""),
                 ],
@@ -12660,6 +12680,21 @@ class FaultTreeApp:
             for node in getattr(diag, "nodes", []):
                 if getattr(node, "node_type", "").lower() == "solution":
                     self._solution_lookup[node.unique_id] = (node, diag)
+                    prob = ""
+                    target = getattr(node, "spi_target", "")
+                    if target:
+                        for te in getattr(self, "top_events", []):
+                            label = (
+                                getattr(te, "validation_desc", "")
+                                or getattr(te, "safety_goal_description", "")
+                                or getattr(te, "user_name", "")
+                                or f"SG {getattr(te, 'unique_id', '')}"
+                            )
+                            if label == target:
+                                p = getattr(te, "probability", "")
+                                if p not in ("", None):
+                                    prob = f"{p:.2e}"
+                                break
                     tree.insert(
                         "",
                         "end",
@@ -12669,6 +12704,7 @@ class FaultTreeApp:
                             node.work_product,
                             node.evidence_link,
                             node.spi_target,
+                            prob,
                             CHECK_MARK if getattr(node, "evidence_sufficient", False) else "",
                             getattr(node, "manager_notes", ""),
                         ],
@@ -12690,6 +12726,7 @@ class FaultTreeApp:
             "Work Product",
             "Evidence Link",
             "SPI Target",
+            "Achieved Probability",
             "Evidence OK",
             "Notes",
         ]
@@ -12719,12 +12756,37 @@ class FaultTreeApp:
             if not node_diag:
                 return
             node = node_diag[0]
-            current = tree.set(row, "Evidence OK")
-            new_val = "" if current == CHECK_MARK else CHECK_MARK
-            if messagebox.askokcancel("Evidence", "Are you sure?"):
-                self.push_undo_state()
-                tree.set(row, "Evidence OK", new_val)
-                node.evidence_sufficient = new_val == CHECK_MARK
+            if col_name == "Evidence OK":
+                current = tree.set(row, "Evidence OK")
+                new_val = "" if current == CHECK_MARK else CHECK_MARK
+                if messagebox.askokcancel("Evidence", "Are you sure?"):
+                    self.push_undo_state()
+                    tree.set(row, "Evidence OK", new_val)
+                    node.evidence_sufficient = new_val == CHECK_MARK
+            elif col_name == "Achieved Probability":
+                target = getattr(node, "spi_target", "")
+                te = None
+                for sg in getattr(self, "top_events", []):
+                    label = (
+                        getattr(sg, "validation_desc", "")
+                        or getattr(sg, "safety_goal_description", "")
+                        or getattr(sg, "user_name", "")
+                        or f"SG {getattr(sg, 'unique_id', '')}"
+                    )
+                    if label == target:
+                        te = sg
+                        break
+                if te:
+                    new_val = simpledialog.askfloat(
+                        "Achieved Probability",
+                        "Enter achieved probability:",
+                        initialvalue=getattr(te, "probability", 0.0),
+                    )
+                    if new_val is not None:
+                        self.push_undo_state()
+                        te.probability = float(new_val)
+                        self.refresh_safety_case_table()
+                        self.update_views()
 
         for seq in ("<Double-Button-1>", "<Double-1>"):
             tree.bind(seq, on_double_click)

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -103,6 +103,63 @@ class DummyMenu:
     def post(self, *a, **k):
         pass
 
+
+def test_edit_probability_updates_spi(monkeypatch):
+    root = GSNNode("G", "Goal")
+    sol = GSNNode("E", "Solution")
+    sol.spi_target = "SG1"
+    root.add_child(sol)
+    diag = GSNDiagram(root)
+    diag.add_node(sol)
+
+    te = types.SimpleNamespace(
+        user_name="SG1",
+        validation_target=1e-5,
+        probability=1e-4,
+        validation_desc="",
+        safety_goal_description="",
+        acceptance_criteria="AC",
+        unique_id=1,
+    )
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
+    app._new_tab = lambda title: DummyTab()
+    app.all_gsn_diagrams = [diag]
+    app.push_undo_state = lambda: None
+    app.top_events = [te]
+    app.update_views = lambda: None
+
+    monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)
+    monkeypatch.setattr("AutoML.ttk.Button", DummyButton)
+    monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
+    monkeypatch.setattr("AutoML.simpledialog.askfloat", lambda *a, **k: 2e-4)
+
+    FaultTreeApp.show_safety_case(app)
+    tree = app._safety_case_tree
+    row = next(iter(tree.data))
+    tree.next_column = "Achieved Probability"
+    event = types.SimpleNamespace(x=0, y=0)
+    tree.bindings["<Double-Button-1>"](event)
+    assert te.probability == 2e-4
+    row = next(iter(tree.data))
+    assert tree.data[row]["values"][5] == f"{2e-4:.2e}"
+
+    class CaptureTree(DummyTree):
+        instances = []
+
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            CaptureTree.instances.append(self)
+
+    monkeypatch.setattr("AutoML.ttk.Treeview", CaptureTree)
+    FaultTreeApp.show_safety_performance_indicators(app)
+    spi_tree = CaptureTree.instances[-1]
+    iid = next(iter(spi_tree.data))
+    assert spi_tree.data[iid]["values"][2] == f"{2e-4:.2e}"
+    expected_spi = 1e-5 / 2e-4
+    assert spi_tree.data[iid]["values"][3] == f"{expected_spi:.2f}"
+
 def test_safety_case_lists_and_toggles(monkeypatch):
     root = GSNNode("G", "Goal")
     sol = GSNNode("E", "Solution")
@@ -130,11 +187,11 @@ def test_safety_case_lists_and_toggles(monkeypatch):
     event = types.SimpleNamespace(x=0, y=0)
     tree.bindings["<Double-Button-1>"](event)
     assert sol.evidence_sufficient
-    assert tree.data[iid]["values"][5] == CHECK_MARK
+    assert tree.data[iid]["values"][6] == CHECK_MARK
 
     app.refresh_safety_case_table()
     iid = next(iter(tree.data))
-    assert tree.data[iid]["values"][5] == CHECK_MARK
+    assert tree.data[iid]["values"][6] == CHECK_MARK
 
 
 def test_safety_case_cancel_does_not_toggle(monkeypatch):


### PR DESCRIPTION
## Summary
- Add Achieved Probability column in Safety Case table with editable values
- Display computed SPI (Validation Target / Achieved Probability) in Safety Performance Indicators explorer
- Test probability editing and SPI display

## Testing
- `pytest` *(fails: tests/test_gsn_explorer.py::test_rename_module_disallowed)*


------
https://chatgpt.com/codex/tasks/task_b_689c0367d1588325ada696ac5e138788