### PR TITLE
Show calculated SPI for GSN solutions

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Iterable, List
 import uuid
+import math
 
 import tkinter.font as tkFont
 
@@ -327,12 +328,23 @@ class GSNDiagram:
             if getattr(node, "spi_target", ""):
                 prob = self._lookup_spi_probability(node.spi_target)
                 v_target = self._lookup_validation_target(node.spi_target)
-                if prob is not None:
-                    label = f"SPI: {prob:.2e}/h"
-                elif v_target:
-                    label = f"SPI: {v_target}/h"
-                else:
-                    label = f"SPI: {node.spi_target}"
+                label = None
+                try:
+                    if v_target not in (None, "") and prob not in (None, ""):
+                        v_val = float(v_target)
+                        p_val = float(prob)
+                        if v_val > 0 and p_val > 0:
+                            spi = math.log10(v_val / p_val)
+                            label = f"SPI: {spi:.2f}"
+                except Exception:
+                    label = None
+                if not label:
+                    if v_target not in (None, ""):
+                        label = f"SPI: {v_target}/h"
+                    elif prob not in (None, ""):
+                        label = f"SPI: {prob:.2e}/h"
+                    else:
+                        label = f"SPI: {node.spi_target}"
                 lines.append(label)
             if getattr(node, "description", ""):
                 lines.append(node.description)

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -177,12 +177,7 @@ class GSNExplorer(tk.Frame):
             return
         typ, obj = self.item_map.get(sel[0], (None, None))
         if typ == "module":
-            new = simpledialog.askstring("Rename Module", "Name:", initialvalue=obj.name, parent=self)
-            if new:
-                undo = getattr(self.app, "push_undo_state", None)
-                if undo:
-                    undo()
-                obj.name = new
+            return
         elif typ == "diagram":
             new = simpledialog.askstring("Rename Diagram", "Name:", initialvalue=obj.root.user_name, parent=self)
             if new:

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -1,4 +1,5 @@
 import types
+import math
 from gsn import GSNNode, GSNDiagram
 from gui.gsn_config_window import GSNElementConfig, _collect_work_products
 from analysis import SafetyManagementToolbox
@@ -86,7 +87,7 @@ def test_solution_requires_matching_spi_for_clone():
     assert node2.original is original
 
 
-def test_format_text_shows_spi_probability():
+def test_format_text_shows_calculated_spi():
     root = GSNNode("Root", "Goal")
     sol = GSNNode("Sol", "Solution")
     sol.spi_target = "Brake Time"
@@ -96,11 +97,13 @@ def test_format_text_shows_spi_probability():
     class TopEvent:
         def __init__(self):
             self.validation_desc = "Brake Time"
+            self.validation_target = 1e-4
             self.probability = 1e-5
 
     diag.app = types.SimpleNamespace(top_events=[TopEvent()])
     text = diag._format_text(sol)
-    assert f"SPI: {1e-5:.2e}/h" in text
+    expected_spi = math.log10(1e-4 / 1e-5)
+    assert f"SPI: {expected_spi:.2f}" in text
 
 
 def test_format_text_shows_validation_target_when_no_probability():


### PR DESCRIPTION
## Summary
- Compute and display Safety Performance Index for GSN solution nodes using validation targets and achieved probabilities
- Prevent GSN modules from being renamed via the explorer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c088c95ac8325aa1d16f1416f480a