### PR TITLE
Improve SPI and work product combos

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -26,6 +26,13 @@ def _collect_work_products(diagram: GSNDiagram, app=None) -> list[str]:
         app = getattr(diagram, "app", None)
     toolbox = getattr(app, "safety_mgmt_toolbox", None)
     if toolbox:
+        # Include any diagrams managed by the safety management toolbox so they
+        # appear in the work product dropdown even if they have not yet been
+        # paired with an analysis.
+        for name in getattr(toolbox, "list_diagrams", lambda: [])():
+            if name:
+                products.add(name)
+
         for wp in getattr(toolbox, "get_work_products", lambda: [])():
             parts = [getattr(wp, "diagram", ""), getattr(wp, "analysis", "")]
             parts = [p for p in parts if p]
@@ -137,8 +144,9 @@ class GSNElementConfig(tk.Toplevel):
             )
             spi_cb.grid(row=row, column=1, padx=4, pady=4, sticky="ew")
             spi_cb.configure(values=spi_targets)
-            if not self.spi_var.get() and spi_targets:
-                self.spi_var.set(spi_targets[0])
+            # Leave the SPI target blank by default so users explicitly choose
+            # a target.  If the node already has a value it will be displayed
+            # via ``self.spi_var`` which was initialized above.
             row += 1
         btns = ttk.Frame(self)
         btns.grid(row=row, column=0, columnspan=2, pady=4)

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -141,6 +141,7 @@ def test_collect_work_products_includes_toolbox_entries():
     diag = GSNDiagram(root)
     toolbox = SafetyManagementToolbox()
     toolbox.add_work_product("Architecture Diagram", "Safety Analysis", "rationale")
+    toolbox.list_diagrams = lambda: []
 
     class App:
         def __init__(self):
@@ -153,6 +154,29 @@ def test_collect_work_products_includes_toolbox_entries():
         "Architecture Diagram - Safety Analysis",
         "Safety Analysis",
     ]
+
+
+def test_collect_work_products_includes_toolbox_diagrams():
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+
+    class Toolbox:
+        def __init__(self):
+            self.diagrams = {"D1": "id1", "D2": "id2"}
+
+        def list_diagrams(self):
+            return list(self.diagrams.keys())
+
+        def get_work_products(self):
+            return []
+
+    class App:
+        def __init__(self):
+            self.safety_mgmt_toolbox = Toolbox()
+
+    diag.app = App()
+
+    assert _collect_work_products(diag) == ["D1", "D2"]
 
 
 def test_config_dialog_populates_comboboxes(monkeypatch):
@@ -239,9 +263,9 @@ def test_config_dialog_populates_comboboxes(monkeypatch):
     assert spi_cb.init_values is None
     assert wp_cb.configured["values"] == ["WP1"]
     assert spi_cb.configured["values"] == ["SPI1"]
-    # first existing entries should be preselected when the node has none
+    # work product should be preselected while SPI remains blank
     assert cfg.work_var.get() == "WP1"
-    assert cfg.spi_var.get() == "SPI1"
+    assert cfg.spi_var.get() == ""
 
 
 def test_config_dialog_lists_project_spis(monkeypatch):
@@ -336,7 +360,8 @@ def test_config_dialog_lists_project_spis(monkeypatch):
     # work product combobox is first, spi combobox second
     _, spi_cb = combo_holder
     assert spi_cb.configured["values"] == ["SPI1"]
-    assert cfg.spi_var.get() == "SPI1"
+    # SPI selection should remain empty by default
+    assert cfg.spi_var.get() == ""
 
 
 def test_config_dialog_lists_toolbox_work_products(monkeypatch):
@@ -349,6 +374,7 @@ def test_config_dialog_lists_toolbox_work_products(monkeypatch):
 
     toolbox = SafetyManagementToolbox()
     toolbox.add_work_product("Architecture Diagram", "Safety Analysis", "")
+    toolbox.list_diagrams = lambda: []
 
     class App:
         def __init__(self):


### PR DESCRIPTION
## Summary
- Leave SPI target combobox blank by default so users explicitly choose a target
- Populate work product combobox with diagrams managed by the safety toolbox in addition to registered analyses
- Update and extend tests for new combobox behavior

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_solution_work_product_clone.py -q`
- `PYTHONPATH=. pytest tests/test_gsn_solution_link.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689c0917eb2c83259904ddbd27adce82