### PR TITLE
Allow editing notes in safety case

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12828,6 +12828,15 @@ class FaultTreeApp:
                         te.probability = float(new_val)
                         self.refresh_safety_case_table()
                         self.update_views()
+            elif col_name == "Notes":
+                current = tree.set(row, "Notes")
+                new_val = simpledialog.askstring(
+                    "Notes", "Enter notes:", initialvalue=current
+                )
+                if new_val is not None:
+                    self.push_undo_state()
+                    tree.set(row, "Notes", new_val)
+                    node.manager_notes = new_val
 
         for seq in ("<Double-Button-1>", "<Double-1>"):
             tree.bind(seq, on_double_click)

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -79,8 +79,10 @@ class GSNElementConfig(tk.Toplevel):
         self.node = node
         self.diagram = diagram
         self.title("Edit GSN Element")
-        self.geometry("400x280")
+        self.geometry("400x360")
         self.columnconfigure(1, weight=1)
+        # Allow both text fields to expand when the dialog is resized
+        self.rowconfigure(1, weight=1)
         self.rowconfigure(2, weight=1)
         tk.Label(self, text="Name:").grid(row=0, column=0, sticky="e", padx=4, pady=4)
         self.name_var = tk.StringVar(value=node.user_name)
@@ -92,9 +94,14 @@ class GSNElementConfig(tk.Toplevel):
         self.desc_text.insert("1.0", getattr(node, "description", ""))
         self.desc_text.grid(row=1, column=1, padx=4, pady=4, sticky="nsew")
 
+        tk.Label(self, text="Notes:").grid(row=2, column=0, sticky="ne", padx=4, pady=4)
+        self.notes_text = tk.Text(self, width=40, height=5)
+        self.notes_text.insert("1.0", getattr(node, "manager_notes", ""))
+        self.notes_text.grid(row=2, column=1, padx=4, pady=4, sticky="nsew")
+
         self.work_var = tk.StringVar(value=getattr(node, "work_product", ""))
         self.link_var = tk.StringVar(value=getattr(node, "evidence_link", ""))
-        row = 2
+        row = 3
         self.spi_var = tk.StringVar(value=getattr(node, "spi_target", ""))
         if node.node_type == "Solution":
             tk.Label(self, text="Work Product:").grid(
@@ -151,6 +158,9 @@ class GSNElementConfig(tk.Toplevel):
     def _on_ok(self):
         self.node.user_name = self.name_var.get()
         self.node.description = self.desc_text.get("1.0", tk.END).strip()
+        notes_text = getattr(self, "notes_text", None)
+        if notes_text:
+            self.node.manager_notes = notes_text.get("1.0", tk.END).strip()
         if self.node.node_type == "Solution":
             # ``GSNElementConfig`` is sometimes instantiated in tests without
             # running ``__init__``.  Guard against missing StringVar

--- a/tests/test_gsn_solution_link.py
+++ b/tests/test_gsn_solution_link.py
@@ -42,6 +42,28 @@ def test_solution_config_sets_evidence_link():
     assert node.evidence_link == "http://example.com"
 
 
+def test_solution_config_sets_manager_notes():
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    node = GSNNode("Sol", "Solution")
+    diag.add_node(node)
+
+    cfg = GSNElementConfig.__new__(GSNElementConfig)
+    cfg.node = node
+    cfg.diagram = diag
+    cfg.name_var = DummyVar(node.user_name)
+    cfg.desc_text = DummyText(node.description)
+    cfg.notes_text = DummyText("Review this later")
+    cfg.work_var = DummyVar("")
+    cfg.link_var = DummyVar("")
+    cfg.spi_var = DummyVar("")
+    cfg.destroy = lambda: None
+
+    cfg._on_ok()
+
+    assert node.manager_notes == "Review this later"
+
+
 def test_double_click_opens_evidence_link(monkeypatch):
     opened = {}
 


### PR DESCRIPTION
## Summary
- enable editing of manager notes in GSN element configuration dialog
- allow editing of notes directly from the Safety Case table
- test coverage for notes handling

## Testing
- `pytest tests/test_gsn_solution_link.py tests/test_gsn_solution_work_product_clone.py tests/test_safety_case.py::test_safety_case_edit_updates_table tests/test_safety_case.py::test_edit_notes_updates_node -q`

------
https://chatgpt.com/codex/tasks/task_b_689c097548d08325b5c13f8c476af73c