### PR TITLE
Ensure GSN work product dropdown lists project artifacts

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -31,15 +31,21 @@ def _collect_work_products(diagram: GSNDiagram, app=None) -> list[str]:
         for name in getattr(toolbox, "list_diagrams", lambda: [])():
             if name:
                 products.add(name)
+
         for wp in getattr(toolbox, "get_work_products", lambda: [])():
-            diagram = getattr(wp, "diagram", "")
-            analysis = getattr(wp, "analysis", "")
-            if diagram:
-                products.add(diagram)
-            if analysis:
-                products.add(analysis)
-            if diagram and analysis:
-                products.add(f"{diagram} - {analysis}")
+            if isinstance(wp, dict):
+                diag_name = wp.get("diagram", "")
+                analysis_name = wp.get("analysis", "")
+            else:
+                diag_name = getattr(wp, "diagram", "")
+                analysis_name = getattr(wp, "analysis", "")
+
+            if diag_name:
+                products.add(diag_name)
+            if analysis_name:
+                products.add(analysis_name)
+            if diag_name and analysis_name:
+                products.add(f"{diag_name} - {analysis_name}")
 
     return sorted(products)
 

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -453,3 +453,94 @@ def test_config_dialog_lists_toolbox_work_products(monkeypatch):
         "Architecture Diagram - Safety Analysis",
         "Safety Analysis",
     ]
+
+
+def test_config_dialog_lists_toolbox_diagrams(monkeypatch):
+    """Work product combo should list diagrams tracked in the toolbox."""
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    node = GSNNode("New", "Solution")
+    diag.add_node(node)
+
+    class Toolbox:
+        def list_diagrams(self):
+            return ["DiagB", "DiagA"]
+
+        def get_work_products(self):
+            return []
+
+    class App:
+        def __init__(self):
+            self.safety_mgmt_toolbox = Toolbox()
+
+    class Master:
+        def __init__(self):
+            self.app = App()
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            self.configured = {}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+    class DummyText(DummyWidget):
+        def get(self, *a, **k):
+            return ""
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, values=None, state=None, **k):
+            super().__init__(*a, **k)
+            self.textvariable = textvariable
+            self.state = state
+            self.init_values = values
+
+    combo_holder = []
+
+    def combo_stub(*a, **k):
+        cb = DummyCombobox(*a, **k)
+        combo_holder.append(cb)
+        return cb
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.__init__", lambda self, master=None: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.title", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.geometry", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.columnconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.rowconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.transient", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.grab_set", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.wait_window", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Text", lambda *a, **k: DummyText())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Frame", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.gsn_config_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    cfg = GSNElementConfig(Master(), node, diag)
+
+    wp_cb = combo_holder[0]
+    assert wp_cb.configured["values"] == ["DiagA", "DiagB"]
+    assert cfg.work_var.get() == "DiagA"
+


### PR DESCRIPTION
## Summary
- Broaden work product collection to include diagrams and analyses from the safety management toolbox, handling dict and dataclass entries
- Add regression test verifying toolbox diagrams appear in work product combo box

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c0b3e9b148325a885ac83e62fb1c9