### PR TITLE
Color solution nodes based on SPI sign

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -200,6 +200,33 @@ class GSNDiagram:
         return None
 
     # ------------------------------------------------------------------
+    def _get_spi_label_and_value(self, node: GSNNode) -> tuple[str, float | None]:
+        """Return formatted SPI label and numeric value for ``node``."""
+
+        prob = self._lookup_spi_probability(node.spi_target)
+        v_target = self._lookup_validation_target(node.spi_target)
+
+        spi = None
+        label = None
+        try:
+            if v_target not in (None, "") and prob not in (None, ""):
+                v_val = float(v_target)
+                p_val = float(prob)
+                if v_val > 0 and p_val > 0:
+                    spi = math.log10(v_val / p_val)
+                    label = f"SPI: {spi:.2f}"
+        except Exception:
+            label = None
+        if not label:
+            if v_target not in (None, ""):
+                label = f"SPI: {v_target}/h"
+            elif prob not in (None, ""):
+                label = f"SPI: {prob:.2e}/h"
+            else:
+                label = f"SPI: {node.spi_target}"
+        return label, spi
+
+    # ------------------------------------------------------------------
     def _draw_node(self, canvas, node: GSNNode, zoom: float) -> None:  # pragma: no cover - requires tkinter
         x, y = node.x * zoom, node.y * zoom
         typ = node.node_type.lower()
@@ -222,6 +249,7 @@ class GSNDiagram:
                 kwargs.pop("top_text", None)
                 kwargs.pop("bottom_text", None)
                 kwargs.pop("font_obj", None)
+                kwargs.pop("fill", None)
                 method(*args, **kwargs)
 
         if typ == "solution":
@@ -243,6 +271,15 @@ class GSNDiagram:
                 if node.is_primary_instance
                 else self.drawing_helper.draw_away_solution_shape
             )
+            fill_color = "lightyellow"
+            if getattr(node, "spi_target", ""):
+                _, spi_val = self._get_spi_label_and_value(node)
+                if spi_val is not None:
+                    if spi_val < 0:
+                        fill_color = "orange"
+                    elif spi_val > 0:
+                        fill_color = "#ADD8E6"
+
             _call(
                 draw_func,
                 canvas,
@@ -252,6 +289,7 @@ class GSNDiagram:
                 text=text,
                 font_obj=font_obj,
                 obj_id=node.unique_id,
+                fill=fill_color,
             )
         elif typ == "goal":
             ratio = 0.6
@@ -326,25 +364,7 @@ class GSNDiagram:
         if node.node_type == "Solution":
             lines = [node.user_name]
             if getattr(node, "spi_target", ""):
-                prob = self._lookup_spi_probability(node.spi_target)
-                v_target = self._lookup_validation_target(node.spi_target)
-                label = None
-                try:
-                    if v_target not in (None, "") and prob not in (None, ""):
-                        v_val = float(v_target)
-                        p_val = float(prob)
-                        if v_val > 0 and p_val > 0:
-                            spi = math.log10(v_val / p_val)
-                            label = f"SPI: {spi:.2f}"
-                except Exception:
-                    label = None
-                if not label:
-                    if v_target not in (None, ""):
-                        label = f"SPI: {v_target}/h"
-                    elif prob not in (None, ""):
-                        label = f"SPI: {prob:.2e}/h"
-                    else:
-                        label = f"SPI: {node.spi_target}"
+                label, _ = self._get_spi_label_and_value(node)
                 lines.append(label)
             if getattr(node, "description", ""):
                 lines.append(node.description)

--- a/tests/test_solution_spi_color.py
+++ b/tests/test_solution_spi_color.py
@@ -1,0 +1,101 @@
+import types
+
+from gsn import GSNNode, GSNDiagram
+
+
+class StubCanvas:
+    def __init__(self):
+        self.items = []
+
+    def create_rectangle(self, left, top, right, bottom, **kw):  # pragma: no cover - simple storage
+        self.items.append((left, top, right, bottom, kw))
+
+    def create_line(self, *args, **kwargs):  # pragma: no cover - placeholder
+        pass
+
+    def create_text(self, *args, **kwargs):  # pragma: no cover - placeholder
+        pass
+
+    def tag_lower(self, *args, **kwargs):  # pragma: no cover - placeholder
+        pass
+
+    def tag_raise(self, *args, **kwargs):  # pragma: no cover - placeholder
+        pass
+
+
+class ColorHelper:
+    def draw_goal_shape(self, canvas, x, y, scale, obj_id="", **kw):  # pragma: no cover - basic rectangle
+        left = x - scale / 2
+        top = y - scale / 2
+        right = x + scale / 2
+        bottom = y + scale / 2
+        canvas.create_rectangle(left, top, right, bottom, tags=(obj_id,), **kw)
+
+    draw_strategy_shape = draw_goal_shape
+    draw_solution_shape = draw_goal_shape
+    draw_away_solution_shape = draw_goal_shape
+    draw_away_goal_shape = draw_goal_shape
+    draw_assumption_shape = draw_goal_shape
+    draw_justification_shape = draw_goal_shape
+    draw_context_shape = draw_goal_shape
+    draw_module_shape = draw_goal_shape
+    draw_away_module_shape = draw_goal_shape
+
+    def draw_solved_by_connection(self, *args, **kwargs):  # pragma: no cover - placeholder
+        pass
+
+    def draw_in_context_connection(self, *args, **kwargs):  # pragma: no cover - placeholder
+        pass
+
+    def point_on_shape(self, shape, target_pt):  # pragma: no cover - straight through
+        return target_pt
+
+    def get_text_size(self, text, font_obj):  # pragma: no cover - simple approximation
+        lines = text.split("\n")
+        width = max(len(l) for l in lines) * 5
+        height = 10 * len(lines)
+        return width, height
+
+
+def _kw_for(node_id, canvas):
+    for _, _, _, _, kw in canvas.items:
+        if kw.get("tags") == (node_id,):
+            return kw
+    raise KeyError(node_id)
+
+
+def test_solution_spi_colors():
+    root = GSNNode("Root", "Goal", x=0, y=0)
+    pos = GSNNode("P", "Solution", x=10, y=10)
+    neg = GSNNode("N", "Solution", x=30, y=10)
+    pos.spi_target = "Pos"
+    neg.spi_target = "Neg"
+    root.add_child(pos)
+    root.add_child(neg)
+    helper = ColorHelper()
+    diag = GSNDiagram(root, drawing_helper=helper)
+    diag.add_node(pos)
+    diag.add_node(neg)
+
+    class TopEvent:
+        def __init__(self, name, validation_target, probability):
+            self.validation_desc = name
+            self.validation_target = validation_target
+            self.probability = probability
+
+    app = types.SimpleNamespace(
+        top_events=[
+            TopEvent("Pos", "1e-5", "1e-6"),
+            TopEvent("Neg", "1e-5", "1e-4"),
+        ]
+    )
+    diag.app = app
+
+    canvas = StubCanvas()
+    diag.draw(canvas, zoom=1.0)
+
+    pos_kw = _kw_for(pos.unique_id, canvas)
+    neg_kw = _kw_for(neg.unique_id, canvas)
+    assert pos_kw["fill"] == "#ADD8E6"
+    assert neg_kw["fill"] == "orange"
+


### PR DESCRIPTION
## Summary
- color solution nodes orange for negative SPIs and light blue for positive SPIs
- add helper to compute SPI value and rework text formatting
- test SPI-based solution coloring

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c0be87f1c8325bc68652f4b0a5afe