### PR TITLE
Ensure GSN work product dropdown lists project artifacts

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -31,15 +31,43 @@ def _collect_work_products(diagram: GSNDiagram, app=None) -> list[str]:
         for name in getattr(toolbox, "list_diagrams", lambda: [])():
             if name:
                 products.add(name)
+
         for wp in getattr(toolbox, "get_work_products", lambda: [])():
-            diagram = getattr(wp, "diagram", "")
-            analysis = getattr(wp, "analysis", "")
-            if diagram:
-                products.add(diagram)
-            if analysis:
-                products.add(analysis)
-            if diagram and analysis:
-                products.add(f"{diagram} - {analysis}")
+            if isinstance(wp, dict):
+                diag_name = wp.get("diagram", "")
+                analysis_name = wp.get("analysis", "")
+            else:
+                diag_name = getattr(wp, "diagram", "")
+                analysis_name = getattr(wp, "analysis", "")
+
+            if diag_name:
+                products.add(diag_name)
+            if analysis_name:
+                products.add(analysis_name)
+            if diag_name and analysis_name:
+                products.add(f"{diag_name} - {analysis_name}")
+
+    if app:
+        # Reuse helpers that supply items for the Analyses & Architecture
+        # combo boxes so the work product list remains consistent with those
+        # dialogs.  Fallback to common attributes when the helpers are absent.
+        for name in getattr(app, "get_architecture_box_list", lambda: [])():
+            if name:
+                products.add(name)
+        for name in getattr(app, "get_analysis_box_list", lambda: [])():
+            if name:
+                products.add(name)
+
+        if not hasattr(app, "get_architecture_box_list"):
+            for diag in getattr(app, "arch_diagrams", []):
+                name = getattr(diag, "name", "") or getattr(diag, "diag_id", "")
+                if name:
+                    products.add(name)
+        if not hasattr(app, "get_analysis_box_list"):
+            for ra in getattr(app, "reliability_analyses", []):
+                name = getattr(ra, "name", "")
+                if name:
+                    products.add(name)
 
     return sorted(products)
 


### PR DESCRIPTION
## Summary
- Reuse application helpers for architecture and analysis lists when populating GSN Solution work-product dropdown
- Fall back to project diagrams and analyses so all artifacts appear in combobox
- Test that work-product collection pulls names from app helpers and attribute lists

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_solution_work_product_clone.py::test_collect_work_products_reuses_app_lists -q`
- `PYTHONPATH=. pytest tests/test_gsn_solution_work_product_clone.py::test_collect_work_products_falls_back_to_app_objects -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c0b3e9b148325a885ac83e62fb1c9