### PR TITLE
Ensure GSN work product dropdown lists project artifacts

### DIFF
--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -181,6 +181,41 @@ def test_collect_work_products_includes_toolbox_diagrams():
     assert _collect_work_products(diag) == ["DiagA", "DiagB"]
 
 
+def test_collect_work_products_reuses_app_lists():
+    """Names from app combo-box helpers should be included."""
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+
+    class App:
+        def get_architecture_box_list(self):
+            return ["Arch1"]
+
+        def get_analysis_box_list(self):
+            return ["RA1"]
+
+    assert _collect_work_products(diag, App()) == ["Arch1", "RA1"]
+
+
+def test_collect_work_products_falls_back_to_app_objects():
+    """Fallback to app attributes when helper functions are absent."""
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+
+    class Diagram:
+        name = "Diag1"
+
+    class Analysis:
+        name = "Analysis1"
+
+    class App:
+        arch_diagrams = [Diagram()]
+        reliability_analyses = [Analysis()]
+
+    assert _collect_work_products(diag, App()) == ["Analysis1", "Diag1"]
+
+
 def test_config_dialog_populates_comboboxes(monkeypatch):
     """Work product and SPI combos should list existing entries."""
 
@@ -265,9 +300,8 @@ def test_config_dialog_populates_comboboxes(monkeypatch):
     assert spi_cb.init_values is None
     assert wp_cb.configured["values"] == ["WP1"]
     assert spi_cb.configured["values"] == ["SPI1"]
-    # work product should default to the first existing entry when the node has
-    # none, while the SPI target remains blank until explicitly selected.
-    assert cfg.work_var.get() == "WP1"
+    # Both comboboxes should remain blank until the user picks an option.
+    assert cfg.work_var.get() == ""
     assert cfg.spi_var.get() == ""
 
 
@@ -453,3 +487,94 @@ def test_config_dialog_lists_toolbox_work_products(monkeypatch):
         "Architecture Diagram - Safety Analysis",
         "Safety Analysis",
     ]
+
+
+def test_config_dialog_lists_toolbox_diagrams(monkeypatch):
+    """Work product combo should list diagrams tracked in the toolbox."""
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    node = GSNNode("New", "Solution")
+    diag.add_node(node)
+
+    class Toolbox:
+        def list_diagrams(self):
+            return ["DiagB", "DiagA"]
+
+        def get_work_products(self):
+            return []
+
+    class App:
+        def __init__(self):
+            self.safety_mgmt_toolbox = Toolbox()
+
+    class Master:
+        def __init__(self):
+            self.app = App()
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            self.configured = {}
+
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+    class DummyText(DummyWidget):
+        def get(self, *a, **k):
+            return ""
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, values=None, state=None, **k):
+            super().__init__(*a, **k)
+            self.textvariable = textvariable
+            self.state = state
+            self.init_values = values
+
+    combo_holder = []
+
+    def combo_stub(*a, **k):
+        cb = DummyCombobox(*a, **k)
+        combo_holder.append(cb)
+        return cb
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._value = value
+
+        def get(self):
+            return self._value
+
+        def set(self, v):
+            self._value = v
+
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.__init__", lambda self, master=None: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.title", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.geometry", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.columnconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.rowconfigure", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.transient", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.grab_set", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Toplevel.wait_window", lambda self, *a, **k: None)
+    monkeypatch.setattr("gui.gsn_config_window.tk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.tk.Text", lambda *a, **k: DummyText())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Button", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Frame", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.gsn_config_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.gsn_config_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    cfg = GSNElementConfig(Master(), node, diag)
+
+    wp_cb = combo_holder[0]
+    assert wp_cb.configured["values"] == ["DiagA", "DiagB"]
+    assert cfg.work_var.get() == ""
+


### PR DESCRIPTION
## Summary
- Reuse application helpers for architecture and analysis lists when populating GSN Solution work-product dropdown
- Fall back to project diagrams and analyses so all artifacts appear in combobox
- Leave work product combo box unselected so users must explicitly choose an entry
- Test work-product discovery and blank default behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c0b3e9b148325a885ac83e62fb1c9