### PR TITLE
Ensure GSN work product dropdown has no default selection

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -126,8 +126,6 @@ class GSNElementConfig(tk.Toplevel):
             # ``values`` to the constructor can result in an empty list on
             # some systems.
             wp_cb.configure(values=work_products)
-            if not self.work_var.get() and work_products:
-                self.work_var.set(work_products[0])
             row += 1
             tk.Label(self, text="Evidence Link:").grid(
                 row=row, column=0, sticky="e", padx=4, pady=4

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -265,9 +265,8 @@ def test_config_dialog_populates_comboboxes(monkeypatch):
     assert spi_cb.init_values is None
     assert wp_cb.configured["values"] == ["WP1"]
     assert spi_cb.configured["values"] == ["SPI1"]
-    # work product should default to the first existing entry when the node has
-    # none, while the SPI target remains blank until explicitly selected.
-    assert cfg.work_var.get() == "WP1"
+    # Both comboboxes should remain blank until the user picks an option.
+    assert cfg.work_var.get() == ""
     assert cfg.spi_var.get() == ""
 
 


### PR DESCRIPTION
## Summary
- Collect work products from existing solutions and toolbox entries
- Leave the work-product combobox blank until the user chooses an item
- Update regression test to expect an empty initial selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c0b3e9b148325a885ac83e62fb1c9