### PR TITLE
feat: show SPI in safety case table

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12723,6 +12723,9 @@ class FaultTreeApp:
                     self._solution_lookup[node.unique_id] = (node, diag)
                     prob = ""
                     v_target = ""
+                    spi_val = ""
+                    p_val = None
+                    vt_val = None
                     target = getattr(node, "spi_target", "")
                     if target:
                         for te in getattr(self, "top_events", []):
@@ -12736,9 +12739,24 @@ class FaultTreeApp:
                                 p = getattr(te, "probability", "")
                                 vt = getattr(te, "validation_target", "")
                                 if p not in ("", None):
-                                    prob = f"{p:.2e}"
+                                    try:
+                                        p_val = float(p)
+                                        prob = f"{p_val:.2e}"
+                                    except Exception:
+                                        prob = ""
+                                        p_val = None
                                 if vt not in ("", None):
-                                    v_target = f"{vt:.2e}"
+                                    try:
+                                        vt_val = float(vt)
+                                        v_target = f"{vt_val:.2e}"
+                                    except Exception:
+                                        v_target = ""
+                                        vt_val = None
+                                try:
+                                    if vt_val not in (None, 0) and p_val not in (None, 0):
+                                        spi_val = f"{math.log10(vt_val / p_val):.2f}"
+                                except Exception:
+                                    spi_val = ""
                                 break
                     tree.insert(
                         "",
@@ -12750,6 +12768,7 @@ class FaultTreeApp:
                             node.evidence_link,
                             v_target,
                             prob,
+                            spi_val,
                             CHECK_MARK if getattr(node, "evidence_sufficient", False) else "",
                             getattr(node, "manager_notes", ""),
                         ],
@@ -12772,6 +12791,7 @@ class FaultTreeApp:
             "Evidence Link",
             "Verification Target",
             "Achieved Probability",
+            "SPI",
             "Evidence OK",
             "Notes",
         ]

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -145,6 +145,8 @@ def test_edit_probability_updates_spi(monkeypatch):
     assert te.probability == 2e-4
     row = next(iter(tree.data))
     assert tree.data[row]["values"][5] == f"{2e-4:.2e}"
+    expected_spi = math.log10(1e-5 / 2e-4)
+    assert tree.data[row]["values"][6] == f"{expected_spi:.2f}"
 
     class CaptureTree(DummyTree):
         instances = []
@@ -194,8 +196,11 @@ def test_safety_case_shows_verification_target(monkeypatch):
     FaultTreeApp.show_safety_case(app)
     tree = app._safety_case_tree
     assert tree.columns[4] == "Verification Target"
+    assert tree.columns[6] == "SPI"
     iid = next(iter(tree.data))
     assert tree.data[iid]["values"][4] == f"{1e-5:.2e}"
+    expected_spi = math.log10(1e-5 / 1e-4)
+    assert tree.data[iid]["values"][6] == f"{expected_spi:.2f}"
 
 
 def test_edit_probability_in_spi_explorer(monkeypatch):
@@ -268,7 +273,7 @@ def test_edit_notes_updates_node(monkeypatch):
     tree.bindings["<Double-Button-1>"](event)
 
     assert sol.manager_notes == "new note"
-    assert tree.data[row]["values"][7] == "new note"
+    assert tree.data[row]["values"][8] == "new note"
 
 def test_safety_case_lists_and_toggles(monkeypatch):
     root = GSNNode("G", "Goal")
@@ -297,11 +302,11 @@ def test_safety_case_lists_and_toggles(monkeypatch):
     event = types.SimpleNamespace(x=0, y=0)
     tree.bindings["<Double-Button-1>"](event)
     assert sol.evidence_sufficient
-    assert tree.data[iid]["values"][6] == CHECK_MARK
+    assert tree.data[iid]["values"][7] == CHECK_MARK
 
     app.refresh_safety_case_table()
     iid = next(iter(tree.data))
-    assert tree.data[iid]["values"][6] == CHECK_MARK
+    assert tree.data[iid]["values"][7] == CHECK_MARK
 
 
 def test_safety_case_cancel_does_not_toggle(monkeypatch):
@@ -359,7 +364,7 @@ def test_safety_case_edit_updates_table(monkeypatch):
     assert called.get("ok")
     iid = next(iter(tree.data))
     assert tree.data[iid]["values"][2] == "WP"
-    assert tree.data[iid]["values"][7] == "note"
+    assert tree.data[iid]["values"][8] == "note"
 
 
 def test_safety_case_undo_redo_toggle(monkeypatch):


### PR DESCRIPTION
## Summary
- display SPI values for each solution in the Safety Case table
- extend GUI and logic to compute and show SPI
- update tests for new SPI column

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c10c50d308325b5ea903c03e2481e