### PR TITLE
Fix GSN clone handling and default work product selection

### DIFF
--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -154,6 +154,18 @@ class GSNElementConfig(tk.Toplevel):
             # ``values`` to the constructor can result in an empty list on
             # some systems.
             wp_cb.configure(values=work_products)
+            # Pre-select the first available work product only when the
+            # diagram lacks existing work products.  This keeps the field
+            # blank if other solution nodes already define entries, forcing
+            # users to consciously pick a product while still presenting a
+            # sensible default for empty diagrams populated from the toolbox.
+            existing_products = [
+                getattr(n, "work_product", "")
+                for n in getattr(diagram, "nodes", [])
+                if n.node_type == "Solution" and getattr(n, "work_product", "")
+            ]
+            if not self.work_var.get() and not existing_products and work_products:
+                self.work_var.set(work_products[0])
             row += 1
             tk.Label(self, text="Evidence Link:").grid(
                 row=row, column=0, sticky="e", padx=4, pady=4
@@ -216,7 +228,6 @@ class GSNElementConfig(tk.Toplevel):
                     original = n if n.is_primary_instance else n.original
                     self.node.user_name = original.user_name
                     self.node.description = getattr(original, "description", "")
-                    self.node.unique_id = original.unique_id
                     self.node.original = original
                     self.node.spi_target = getattr(original, "spi_target", "")
                     self.node.is_primary_instance = False

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -45,7 +45,9 @@ def test_solution_clones_existing_work_product():
     assert node.original is original
     assert not node.is_primary_instance
     assert node.user_name == original.user_name
-    assert node.unique_id == original.unique_id
+    # Clones should retain their own unique identifier so diagram
+    # connections can distinguish between primary and cloned instances.
+    assert node.unique_id != original.unique_id
 
 
 def test_solution_requires_matching_spi_for_clone():


### PR DESCRIPTION
## Summary
- Ensure cloned GSN nodes keep unique IDs while still referencing their original
- Preselect default work product only when no existing solutions define one
- Update tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c13646a3c8325ad00f72f820786da