### PR TITLE
Fix copy/paste selection handling

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -15435,22 +15435,43 @@ class FaultTreeApp:
         self.refresh_all()
         
     def copy_node(self):
-        if self.selected_node and self.selected_node != self.root_node:
-            self.clipboard_node = self.selected_node
+        node = self.selected_node
+        if (node is None or node == self.root_node) and hasattr(self, "analysis_tree"):
+            sel = self.analysis_tree.selection()
+            if sel:
+                tags = self.analysis_tree.item(sel[0], "tags")
+                if tags:
+                    node = self.find_node_by_id(self.root_node, int(tags[0]))
+        if node and node != self.root_node:
+            self.clipboard_node = node
+            self.selected_node = node
             self.cut_mode = False
         else:
             messagebox.showwarning("Copy", "Select a non-root node to copy.")
 
     def cut_node(self):
         """Store the currently selected node for a cut & paste operation."""
-        if self.selected_node and self.selected_node != self.root_node:
-            self.clipboard_node = self.selected_node
+        node = self.selected_node
+        if (node is None or node == self.root_node) and hasattr(self, "analysis_tree"):
+            sel = self.analysis_tree.selection()
+            if sel:
+                tags = self.analysis_tree.item(sel[0], "tags")
+                if tags:
+                    node = self.find_node_by_id(self.root_node, int(tags[0]))
+        if node and node != self.root_node:
+            self.clipboard_node = node
+            self.selected_node = node
             self.cut_mode = True
         else:
             messagebox.showwarning("Cut", "Select a non-root node to cut.")
 
     def paste_node(self):
-        # 1) Determine target from selection or current selected node.
+        # 1) Ensure clipboard is not empty.
+        if not self.clipboard_node:
+            messagebox.showwarning("Paste", "Clipboard is empty.")
+            return
+
+        # 2) Determine target from selection or current selected node.
         target = None
         sel = self.analysis_tree.selection()
         if sel:
@@ -15463,19 +15484,14 @@ class FaultTreeApp:
             messagebox.showwarning("Paste", "Select a target node to paste into.")
             return
 
-        # 2) Do not allow pasting into base events.
+        # 3) Do not allow pasting into base events.
         if target.node_type.upper() in ["CONFIDENCE LEVEL", "ROBUSTNESS SCORE"]:
             messagebox.showwarning("Paste", "Cannot paste into a base event.")
             return
 
-        # 3) Always use the primary instance of target.
+        # 4) Always use the primary instance of target.
         if not target.is_primary_instance:
             target = target.original
-
-        # 4) Ensure clipboard is not empty.
-        if not self.clipboard_node:
-            messagebox.showwarning("Paste", "Clipboard is empty.")
-            return
 
         # 5) Prevent self-pasting.
         if target.unique_id == self.clipboard_node.unique_id:

--- a/tests/test_copy_paste_selection.py
+++ b/tests/test_copy_paste_selection.py
@@ -1,0 +1,76 @@
+import unittest
+import types
+import os
+import sys
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AutoML import FaultTreeApp, FaultTreeNode
+from gui import messagebox
+
+
+class DummyTree:
+    def __init__(self, node):
+        self._sel = ("item1",)
+        self._meta = {"item1": {"tags": (str(node.unique_id),)}}
+    def selection(self):
+        return self._sel
+    def item(self, iid, attr):
+        return self._meta[iid][attr]
+
+
+class CopyPasteSelectionTests(unittest.TestCase):
+    def setUp(self):
+        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app.root_node = FaultTreeNode("root", "TOP EVENT")
+        child = FaultTreeNode("child", "GATE", parent=self.app.root_node)
+        self.app.root_node.children.append(child)
+        self.child = child
+        self.app.selected_node = None
+        self.app.clipboard_node = None
+        self.app.analysis_tree = DummyTree(child)
+        self.app.find_node_by_id = FaultTreeApp.find_node_by_id.__get__(self.app)
+        self.app.top_events = []
+        self.app.update_views = lambda: None
+        self.app.cut_mode = False
+
+    def test_copy_uses_tree_selection_when_no_selected_node(self):
+        self.app.copy_node()
+        self.assertIs(self.app.clipboard_node, self.child)
+
+    def test_cut_uses_tree_selection_when_no_selected_node(self):
+        self.app.cut_node()
+        self.assertIs(self.app.clipboard_node, self.child)
+        self.assertTrue(self.app.cut_mode)
+
+    def test_copy_prefers_tree_selection_over_root(self):
+        self.app.selected_node = self.app.root_node
+        self.app.copy_node()
+        self.assertIs(self.app.clipboard_node, self.child)
+
+    def test_cut_prefers_tree_selection_over_root(self):
+        self.app.selected_node = self.app.root_node
+        self.app.cut_node()
+        self.assertIs(self.app.clipboard_node, self.child)
+        self.assertTrue(self.app.cut_mode)
+
+    def test_paste_warns_when_clipboard_empty_first(self):
+        warnings = []
+        orig = messagebox.showwarning
+        messagebox.showwarning = lambda title, msg: warnings.append((title, msg))
+        try:
+            self.app.paste_node()
+        finally:
+            messagebox.showwarning = orig
+        self.assertEqual(warnings[0][1], "Clipboard is empty.")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Allow copy and cut actions to fall back to tree selection when the current selection is the root
- Extend regression tests to cover root selection behavior for copy and cut

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c16d1aa18832590e51a706866f067