### PR TITLE
Add CSV export for safety case table

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12910,6 +12910,22 @@ class FaultTreeApp:
         btn = ttk.Button(win, text="Edit", command=edit_selected)
         btn.pack(pady=4)
 
+        def export_csv():
+            path = filedialog.asksaveasfilename(
+                defaultextension=".csv", filetypes=[("CSV", "*.csv")]
+            )
+            if not path:
+                return
+            with open(path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(columns)
+                for iid in tree.get_children():
+                    writer.writerow(tree.item(iid, "values"))
+            messagebox.showinfo("Export", "Safety case exported")
+
+        self.export_safety_case_csv = export_csv
+        ttk.Button(win, text="Export CSV", command=export_csv).pack(pady=4)
+
         menu = tk.Menu(win, tearoff=0)
         menu.add_command(label="Edit", command=edit_selected)
 


### PR DESCRIPTION
## Summary
- add CSV export support to Safety Case view
- validate Safety Case export by saving table contents to CSV

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c1d3e8d788325914809e713696279