### PR TITLE
Use system handler for solution work products

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -5,6 +5,9 @@ import csv
 import tkinter as tk
 from tkinter import ttk, simpledialog, filedialog
 import webbrowser
+import os
+import sys
+import subprocess
 from pathlib import Path
 from typing import Optional
 
@@ -389,8 +392,18 @@ class GSNDiagramWindow(tk.Frame):
 
         if name:
             path = Path(name)
-            url = path.resolve().as_uri() if path.exists() else name
-            webbrowser.open(url)
+            if path.exists():
+                try:
+                    if os.name == "nt":
+                        os.startfile(path)  # type: ignore[attr-defined]
+                    elif sys.platform == "darwin":
+                        subprocess.run(["open", str(path)], check=False)
+                    else:
+                        subprocess.run(["xdg-open", str(path)], check=False)
+                except Exception:
+                    webbrowser.open(path.resolve().as_uri())
+            else:
+                webbrowser.open(name)
 
     def _on_double_click(self, event):  # pragma: no cover - requires tkinter
         cx = self.canvas.canvasx(event.x)


### PR DESCRIPTION
## Summary
- open local work product files via system default app rather than web browser fallback
- adjust solution link tests for system opening

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c2014b38483259aae1d39bf243984