### PR TITLE
Open work products within application tabs

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8238,6 +8238,23 @@ class FaultTreeApp:
         if action:
             action()
 
+    def open_work_product(self, name: str) -> None:
+        """Open a diagram or analysis work product within the application."""
+        action = self.tool_actions.get(name)
+        if callable(action):
+            action()
+            return
+
+        for idx, diag in enumerate(self.arch_diagrams):
+            if getattr(diag, "name", "") == name or getattr(diag, "diag_id", "") == name:
+                self.open_arch_window(idx)
+                return
+
+        for idx, diag in enumerate(self.management_diagrams):
+            if getattr(diag, "name", "") == name or getattr(diag, "diag_id", "") == name:
+                self.open_management_window(idx)
+                return
+
     def _on_tool_tab_motion(self, event):
         """Show tooltip for notebook tabs when hovering over them."""
         try:

--- a/tests/test_gsn_solution_link.py
+++ b/tests/test_gsn_solution_link.py
@@ -210,6 +210,38 @@ def test_double_click_prompts_link_choice(monkeypatch):
     assert opened == {"url": "http://example.com"}
 
 
+def test_double_click_uses_tool_action():
+    called = {}
+
+    def action():
+        called["ok"] = True
+
+    root = GSNNode("Root", "Goal")
+    diag = GSNDiagram(root)
+    node = GSNNode("Sol", "Solution")
+    node.work_product = "WP1"
+    diag.add_node(node)
+
+    wnd = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    wnd.diagram = diag
+    wnd.app = types.SimpleNamespace(tool_actions={"WP1": action})
+    wnd.refresh = lambda: None
+    wnd._node_at = lambda x, y: node
+    wnd.canvas = type(
+        "CanvasStub",
+        (),
+        {
+            "canvasx": staticmethod(lambda x: x),
+            "canvasy": staticmethod(lambda y: y),
+        },
+    )()
+
+    event = types.SimpleNamespace(x=0, y=0)
+    GSNDiagramWindow._on_double_click(wnd, event)
+
+    assert called["ok"]
+
+
 def test_double_click_falls_back_to_webbrowser(monkeypatch, tmp_path):
     opened = {}
     monkeypatch.setattr("webbrowser.open", lambda url: opened.setdefault("url", url))


### PR DESCRIPTION
## Summary
- Add `open_work_product` helper to open diagrams or analyses inside the application using existing tool actions or diagrams
- Refactor solution link handling to rely on application helpers or tool actions with a browser fallback
- Test solution double-clicks invoking tool actions and internal work product opening

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c2014b38483259aae1d39bf243984