### PR TITLE
Use actions for BPMN diagram behavior links

### DIFF
--- a/tests/test_bpmn_action_drop.py
+++ b/tests/test_bpmn_action_drop.py
@@ -1,0 +1,42 @@
+from gui import messagebox
+from gui.architecture import ArchitectureManagerDialog
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_drop_bpmn_diagram_creates_action(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    src = repo.create_diagram("BPMN Diagram", name="Src")
+    target = repo.create_diagram("BPMN Diagram", name="Target")
+
+    mgr = ArchitectureManagerDialog.__new__(ArchitectureManagerDialog)
+    mgr.repo = repo
+
+    errors = []
+    monkeypatch.setattr(messagebox, "showerror", lambda *args: errors.append(args[1]))
+
+    mgr._drop_on_diagram(f"diag_{src.diag_id}", target)
+
+    assert not errors
+    assert any(obj["obj_type"] == "Action" for obj in target.objects)
+    elem_id = next(obj["element_id"] for obj in target.objects if obj["obj_type"] == "Action")
+    assert repo.elements[elem_id].elem_type == "Action"
+    assert repo.get_linked_diagram(elem_id) == src.diag_id
+
+
+def test_drop_non_bpmn_diagram_on_bpmn_fails(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    src = repo.create_diagram("Activity Diagram", name="Act")
+    target = repo.create_diagram("BPMN Diagram", name="Target")
+
+    mgr = ArchitectureManagerDialog.__new__(ArchitectureManagerDialog)
+    mgr.repo = repo
+
+    errors = []
+    monkeypatch.setattr(messagebox, "showerror", lambda *args: errors.append(args[1]))
+
+    mgr._drop_on_diagram(f"diag_{src.diag_id}", target)
+
+    assert errors
+    assert target.objects == []


### PR DESCRIPTION
## Summary
- Drop a BPMN diagram onto another BPMN diagram to create an Action linked to the source
- Restrict behavior diagram choices to BPMN diagrams for Use Cases and BPMN Actions
- Add tests ensuring BPMN drops create Actions and non-BPMN drops are rejected

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c2391d3b48325abb82d1cf735ab95