### PR TITLE
Use actions instead of CallBehaviorAction in BPMN diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2906,24 +2906,24 @@ class SysMLDiagramWindow(tk.Frame):
         elif diag_type == "BPMN Diagram":
             allowed = {
                 "Initial": {
-                    "CallBehaviorAction",
+                    "Action",
                     "Decision",
                     "Merge",
                 },
-                "CallBehaviorAction": {
-                    "CallBehaviorAction",
+                "Action": {
+                    "Action",
                     "Decision",
                     "Merge",
                     "Final",
                 },
                 "Decision": {
-                    "CallBehaviorAction",
+                    "Action",
                     "Decision",
                     "Merge",
                     "Final",
                 },
                 "Merge": {
-                    "CallBehaviorAction",
+                    "Action",
                     "Decision",
                     "Merge",
                 },
@@ -4009,7 +4009,7 @@ class SysMLDiagramWindow(tk.Frame):
                 diag_id = self.repo.get_linked_diagram(def_id)
         view_id = obj.properties.get("view")
         if (
-            obj.obj_type == "CallBehaviorAction"
+            obj.obj_type in ("CallBehaviorAction", "Action")
             and diag_id
             and view_id
             and view_id in self.repo.diagrams
@@ -6954,6 +6954,7 @@ class SysMLObjectDialog(simpledialog.Dialog):
                     rel_row += 1
 
         repo = SysMLRepository.get_instance()
+        current_diagram = repo.diagrams.get(getattr(self.master, "diagram_id", ""))
         link_row = 0
         if self.obj.obj_type == "Block":
             diags = [d for d in repo.diagrams.values() if d.diag_type == "Internal Block Diagram"]
@@ -6987,11 +6988,20 @@ class SysMLObjectDialog(simpledialog.Dialog):
             ).grid(row=link_row, column=1, padx=4, pady=2)
             link_row += 1
         elif self.obj.obj_type in ("Action Usage", "Action"):
-            diagrams = [
-                d
-                for d in repo.diagrams.values()
-                if d.diag_type in ("Activity Diagram", "BPMN Diagram")
-            ]
+            if (
+                self.obj.obj_type == "Action"
+                and current_diagram
+                and current_diagram.diag_type == "BPMN Diagram"
+            ):
+                diagrams = [
+                    d for d in repo.diagrams.values() if d.diag_type == "BPMN Diagram"
+                ]
+            else:
+                diagrams = [
+                    d
+                    for d in repo.diagrams.values()
+                    if d.diag_type in ("Activity Diagram", "BPMN Diagram")
+                ]
             self.behavior_map = {d.name or d.diag_id: d.diag_id for d in diagrams}
             ttk.Label(link_frame, text="Behavior Diagram:").grid(
                 row=link_row, column=0, sticky="e", padx=4, pady=2
@@ -7958,7 +7968,7 @@ class ActivityDiagramWindow(SysMLDiagramWindow):
 class BPMNDiagramWindow(SysMLDiagramWindow):
     def __init__(self, master, app, diagram_id: str | None = None, history=None):
         tools = [
-            "CallBehaviorAction",
+            "Action",
             "Initial",
             "Final",
             "Decision",
@@ -7968,7 +7978,7 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
         ]
         super().__init__(master, "BPMN Diagram", tools, diagram_id, app=app, history=history)
         for child in self.toolbox.winfo_children():
-            if isinstance(child, ttk.Button) and child.cget("text") == "CallBehaviorAction":
+            if isinstance(child, ttk.Button) and child.cget("text") == "Action":
                 child.configure(text="Task")
 
 
@@ -9027,7 +9037,7 @@ class ArchitectureManagerDialog(tk.Frame):
         if elem_id.startswith("obj_"):
             messagebox.showerror("Drop Error", "Objects cannot be dropped on a diagram.")
             return
-        # Dropping a diagram onto an Activity or BPMN Diagram creates a CallBehaviorAction
+        # Dropping a diagram onto an Activity or BPMN Diagram creates a behavior reference
         if elem_id.startswith("diag_"):
             src_diag = repo.diagrams.get(elem_id[5:])
             if (
@@ -9035,8 +9045,9 @@ class ArchitectureManagerDialog(tk.Frame):
                 and diagram.diag_type in ("Activity Diagram", "BPMN Diagram")
                 and src_diag.diag_type in ("Activity Diagram", "Internal Block Diagram", "BPMN Diagram")
             ):
+                elem_type = "Action" if diagram.diag_type == "BPMN Diagram" else "CallBehaviorAction"
                 act = repo.create_element(
-                    "CallBehaviorAction", name=src_diag.name, owner=diagram.package
+                    elem_type, name=src_diag.name, owner=diagram.package
                 )
                 repo.add_element_to_diagram(diagram.diag_id, act.elem_id)
                 props = {"name": src_diag.name}
@@ -9047,7 +9058,7 @@ class ArchitectureManagerDialog(tk.Frame):
                     repo.link_diagram(act.elem_id, src_diag.diag_id)
                 obj = SysMLObject(
                     _get_next_id(),
-                    "CallBehaviorAction",
+                    elem_type,
                     50.0,
                     50.0,
                     element_id=act.elem_id,

--- a/tests/test_bpmn_actions.py
+++ b/tests/test_bpmn_actions.py
@@ -1,0 +1,61 @@
+import types
+import unittest
+from unittest import mock
+
+from sysml.sysml_repository import SysMLRepository
+from gui.architecture import ArchitectureManagerDialog, BPMNDiagramWindow
+
+
+class BPMNActionsTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+        self.repo = SysMLRepository.get_instance()
+
+    def test_drop_creates_action(self):
+        src = self.repo.create_diagram("BPMN Diagram", name="Src")
+        target = self.repo.create_diagram("BPMN Diagram", name="Tgt")
+        explorer = ArchitectureManagerDialog.__new__(ArchitectureManagerDialog)
+        explorer.repo = self.repo
+        with mock.patch("gui.messagebox.showerror"):
+            explorer._drop_on_diagram(f"diag_{src.diag_id}", target)
+        obj = target.objects[0]
+        elem = self.repo.elements[obj["element_id"]]
+        self.assertEqual(obj["obj_type"], "Action")
+        self.assertEqual(elem.elem_type, "Action")
+        self.assertEqual(self.repo.get_linked_diagram(elem.elem_id), src.diag_id)
+
+    def test_toolbox_creates_action(self):
+        diag = self.repo.create_diagram("BPMN Diagram")
+        win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+        win.repo = self.repo
+        win.diagram_id = diag.diag_id
+        win.zoom = 1.0
+        win.current_tool = "Action"
+        win.objects = []
+        win.connections = []
+        win.selected_obj = None
+        win.selected_objs = []
+        win.selected_conn = None
+        win.dragging_point_index = None
+        win.dragging_endpoint = None
+        win.start = None
+        win.temp_line_end = None
+        win.find_object = lambda *args, **kwargs: None
+        win.ensure_text_fits = lambda obj: None
+        win.sort_objects = lambda: None
+        win._sync_to_repository = lambda: None
+        win.redraw = lambda: None
+        win.update_property_view = lambda: None
+        win.canvas = types.SimpleNamespace(
+            canvasx=lambda v: v, canvasy=lambda v: v, configure=lambda **kw: None
+        )
+        event = types.SimpleNamespace(x=10, y=10)
+        BPMNDiagramWindow.on_left_press(win, event)
+        obj = win.objects[0]
+        elem = self.repo.elements[obj.element_id]
+        self.assertEqual(obj.obj_type, "Action")
+        self.assertEqual(elem.elem_type, "Action")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Ensure BPMN "Task" toolbox items create `Action` elements
- Validate BPMN flows against `Action` nodes and support opening linked diagrams for Actions
- Cover BPMN task creation via toolbox with a new unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c2391d3b48325abb82d1cf735ab95