### PR TITLE
Add governance diagram hierarchy helper

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -141,6 +141,57 @@ class SafetyManagementToolbox:
         return list(self.diagrams.keys())
 
     # ------------------------------------------------------------------
+    def diagram_hierarchy(self) -> List[List[str]]:
+        """Return governance diagrams arranged into hierarchy levels.
+
+        Diagrams appear in successive levels when a task in one diagram links
+        to another diagram. Any diagrams not referenced by others start at the
+        top level. Each level lists diagram names sorted alphabetically.
+        """
+        self._sync_diagrams()
+        repo = SysMLRepository.get_instance()
+
+        edges: dict[str, set[str]] = {d: set() for d in self.diagrams.values()}
+        reverse: dict[str, set[str]] = {d: set() for d in self.diagrams.values()}
+
+        for diag_id in edges:
+            diag = repo.diagrams.get(diag_id)
+            if not diag:
+                continue
+            for obj in getattr(diag, "objects", []):
+                elem_id = obj.get("element_id")
+                if not elem_id:
+                    continue
+                target = repo.get_linked_diagram(elem_id)
+                if target in edges:
+                    edges[diag_id].add(target)
+                    reverse[target].add(diag_id)
+
+        roots = sorted(
+            (d for d in edges if not reverse[d]),
+            key=lambda d: repo.diagrams[d].name,
+        )
+        levels: List[List[str]] = []
+        visited: set[str] = set()
+        current = roots
+        while current:
+            levels.append([repo.diagrams[d].name for d in current])
+            visited.update(current)
+            next_level: set[str] = set()
+            for d in current:
+                next_level.update(child for child in edges[d] if child not in visited)
+            current = sorted(next_level, key=lambda d: repo.diagrams[d].name)
+
+        remaining = sorted(
+            [d for d in edges if d not in visited],
+            key=lambda d: repo.diagrams[d].name,
+        )
+        for d in remaining:
+            levels.append([repo.diagrams[d].name])
+
+        return levels
+
+    # ------------------------------------------------------------------
     def _sync_diagrams(self) -> None:
         """Synchronize ``self.diagrams`` with repository contents.
 

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -404,3 +404,34 @@ def test_governance_diagram_opens_with_bpmn_toolbox(monkeypatch):
     assert calls["bpmn"]
     assert not calls["activity"]
 
+
+def test_diagram_hierarchy_orders_levels():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    a = repo.create_diagram("BPMN Diagram", name="A")
+    b = repo.create_diagram("BPMN Diagram", name="B")
+    c = repo.create_diagram("BPMN Diagram", name="C")
+    for diag in (a, b, c):
+        diag.tags.append("safety-management")
+
+    toolbox.list_diagrams()
+
+    act_ab = repo.create_element("Action", name="AB", owner=a.package)
+    repo.add_element_to_diagram(a.diag_id, act_ab.elem_id)
+    repo.link_diagram(act_ab.elem_id, b.diag_id)
+    a.objects.append(
+        SysMLObject(1, "Action", 0.0, 0.0, element_id=act_ab.elem_id, properties={}).__dict__
+    )
+
+    act_bc = repo.create_element("Action", name="BC", owner=b.package)
+    repo.add_element_to_diagram(b.diag_id, act_bc.elem_id)
+    repo.link_diagram(act_bc.elem_id, c.diag_id)
+    b.objects.append(
+        SysMLObject(2, "Action", 0.0, 0.0, element_id=act_bc.elem_id, properties={}).__dict__
+    )
+
+    hierarchy = toolbox.diagram_hierarchy()
+    assert hierarchy == [["A"], ["B"], ["C"]]
+


### PR DESCRIPTION
## Summary
- Add `diagram_hierarchy` to organise governance BPMN diagrams into levels based on diagram calls
- Test hierarchical ordering of governance diagrams

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c2e50ed0c8325b58ac6864b6e3f91