### PR TITLE
Sync edits between clones and originals

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16008,9 +16008,55 @@ class FaultTreeApp:
         return _search_modules(getattr(self, "gsn_modules", []))
 
     def sync_nodes_by_id(self, updated_node):
-        # Always work with the primary instance.
+        """Synchronize all nodes (original and clones) sharing an ID.
+
+        If *updated_node* is a clone, its values are first copied back to the
+        original before propagating to all other clones.  If *updated_node* is
+        the original, the values are simply pushed to all clones.
+        """
+
+        # If a clone was edited, copy its changes to the original before
+        # propagating.
         if not updated_node.is_primary_instance and updated_node.original:
-            updated_node = updated_node.original
+            clone = updated_node
+            updated_node = clone.original
+
+            attrs = [
+                "node_type",
+                "user_name",
+                "description",
+                "rationale",
+                "quant_value",
+                "gate_type",
+                "severity",
+                "input_subtype",
+                "equation",
+                "detailed_equation",
+                "is_page",
+                "failure_prob",
+                "prob_formula",
+                "failure_mode_ref",
+                "fmea_effect",
+                "fmea_cause",
+                "fmea_severity",
+                "fmea_occurrence",
+                "fmea_detection",
+                "fmea_component",
+                "fmeda_malfunction",
+                "fmeda_safety_goal",
+                "fmeda_diag_cov",
+                "fmeda_fit",
+                "fmeda_spfm",
+                "fmeda_lpfm",
+                "fmeda_fault_type",
+                "fmeda_fault_fraction",
+            ]
+            for attr in attrs:
+                setattr(updated_node, attr, getattr(clone, attr))
+
+            # Remove the clone marker before storing the label on the original.
+            updated_node.display_label = clone.display_label.replace(" (clone)", "")
+
         updated_primary_id = updated_node.unique_id
 
         nodes_to_check = self.get_all_nodes(self.root_node)
@@ -16091,6 +16137,8 @@ class FaultTreeApp:
             new_name = simpledialog.askstring("Edit User Name", "Enter new user name:", initialvalue=self.selected_node.user_name)
             if new_name is not None:
                 self.selected_node.user_name = new_name.strip()
+                # Ensure all clones and the original stay in sync.
+                self.sync_nodes_by_id(self.selected_node)
                 self.update_views()
         else:
             messagebox.showwarning("Edit User Name", "Select a node first.")
@@ -16100,6 +16148,8 @@ class FaultTreeApp:
             new_desc = simpledialog.askstring("Edit Description", "Enter new description:", initialvalue=self.selected_node.description)
             if new_desc is not None:
                 self.selected_node.description = new_desc
+                # Propagate the updated description across clones/original.
+                self.sync_nodes_by_id(self.selected_node)
                 self.update_views()
         else:
             messagebox.showwarning("Edit Description", "Select a node first.")
@@ -16109,6 +16159,8 @@ class FaultTreeApp:
             new_rat = simpledialog.askstring("Edit Rationale", "Enter new rationale:", initialvalue=self.selected_node.rationale)
             if new_rat is not None:
                 self.selected_node.rationale = new_rat
+                # Synchronize rationale changes with related clones.
+                self.sync_nodes_by_id(self.selected_node)
                 self.update_views()
         else:
             messagebox.showwarning("Edit Rationale", "Select a node first.")
@@ -16119,6 +16171,8 @@ class FaultTreeApp:
                 new_val = simpledialog.askfloat("Edit Value", "Enter new value (1-5):", initialvalue=self.selected_node.quant_value)
                 if new_val is not None and 1 <= new_val <= 5:
                     self.selected_node.quant_value = new_val
+                    # Keep all nodes sharing this ID up to date.
+                    self.sync_nodes_by_id(self.selected_node)
                     self.update_views()
                 else:
                     messagebox.showerror("Error", "Value must be between 1 and 5.")
@@ -16132,6 +16186,8 @@ class FaultTreeApp:
             new_gt = simpledialog.askstring("Edit Gate Type", "Enter new gate type (AND/OR):", initialvalue=self.selected_node.gate_type)
             if new_gt is not None and new_gt.upper() in ["AND", "OR"]:
                 self.selected_node.gate_type = new_gt.upper()
+                # Reflect gate type changes everywhere.
+                self.sync_nodes_by_id(self.selected_node)
                 self.update_views()
             else:
                 messagebox.showerror("Error", "Gate type must be AND or OR.")

--- a/tests/test_sync_nodes_by_id.py
+++ b/tests/test_sync_nodes_by_id.py
@@ -1,0 +1,62 @@
+import unittest
+import os
+import sys
+import types
+from unittest.mock import patch
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import FaultTreeApp, FaultTreeNode
+
+
+class SyncNodesTests(unittest.TestCase):
+    def setUp(self):
+        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.original = FaultTreeNode("Orig", "BASIC EVENT")
+        self.clone1 = FaultTreeNode("Clone1", "BASIC EVENT")
+        self.clone1.is_primary_instance = False
+        self.clone1.original = self.original
+        self.clone1.display_label = "Orig (clone)"
+        self.clone2 = FaultTreeNode("Clone2", "BASIC EVENT")
+        self.clone2.is_primary_instance = False
+        self.clone2.original = self.original
+        self.clone2.display_label = "Orig (clone)"
+        self.app.get_all_nodes = lambda *_args, **_kwargs: [self.original, self.clone1, self.clone2]
+        self.app.get_all_fmea_entries = lambda: []
+        self.app.root_node = self.original
+
+    def test_original_updates_clones(self):
+        self.original.description = "new desc"
+        self.app.sync_nodes_by_id(self.original)
+        self.assertEqual(self.clone1.description, "new desc")
+        self.assertEqual(self.clone2.description, "new desc")
+
+    def test_clone_updates_all(self):
+        self.clone1.description = "clone desc"
+        self.clone1.display_label = "New Label (clone)"
+        self.app.sync_nodes_by_id(self.clone1)
+        self.assertEqual(self.original.description, "clone desc")
+        self.assertEqual(self.clone2.description, "clone desc")
+        self.assertEqual(self.original.display_label, "New Label")
+        self.assertEqual(self.clone2.display_label, "New Label (clone)")
+        self.assertEqual(self.clone1.display_label, "New Label (clone)")
+
+    @patch("AutoML.simpledialog.askstring", return_value="patched desc")
+    def test_edit_description_propagates(self, mock_ask):
+        self.app.update_views = lambda: None
+        self.app.selected_node = self.clone1
+        self.app.edit_description()
+        self.assertEqual(self.original.description, "patched desc")
+        self.assertEqual(self.clone2.description, "patched desc")
+        self.assertEqual(self.clone1.description, "patched desc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Call `sync_nodes_by_id` from edit dialogs so edits propagate between clones and originals
- Add regression test ensuring description edits on a clone propagate to all linked nodes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c3068629c832599a246d1e4efefef