### PR TITLE
Add governance diagram hierarchy helper

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -243,6 +243,7 @@ from gui.review_toolbox import (
 )
 from gui.safety_management_toolbox import SafetyManagementToolbox
 from gui.gsn_explorer import GSNExplorer
+from gui.safety_management_explorer import SafetyManagementExplorer
 from gui.gsn_diagram_window import GSNDiagramWindow
 from gui.gsn_config_window import GSNElementConfig
 from gsn import GSNDiagram, GSNModule
@@ -2167,6 +2168,9 @@ class FaultTreeApp:
 
         gsn_menu = tk.Menu(menubar, tearoff=0)
         gsn_menu.add_command(label="GSN Explorer", command=self.manage_gsn)
+        gsn_menu.add_command(
+            label="Safety Management Explorer", command=self.manage_safety_management
+        )
 
         # Add menus to the bar in the desired order
         menubar.add_cascade(label="File", menu=file_menu)
@@ -15730,6 +15734,21 @@ class FaultTreeApp:
             self._gsn_tab = self._new_tab("GSN Explorer")
             self._gsn_window = GSNExplorer(self._gsn_tab, self)
             self._gsn_window.pack(fill=tk.BOTH, expand=True)
+        self.refresh_all()
+
+    def manage_safety_management(self):
+        if not hasattr(self, "safety_mgmt_toolbox"):
+            from analysis import SafetyManagementToolbox as _SMT
+
+            self.safety_mgmt_toolbox = _SMT()
+        if hasattr(self, "_safety_exp_tab") and self._safety_exp_tab.winfo_exists():
+            self.doc_nb.select(self._safety_exp_tab)
+        else:
+            self._safety_exp_tab = self._new_tab("Safety Management Explorer")
+            self._safety_exp_window = SafetyManagementExplorer(
+                self._safety_exp_tab, self, self.safety_mgmt_toolbox
+            )
+            self._safety_exp_window.pack(fill=tk.BOTH, expand=True)
         self.refresh_all()
 
     def open_gsn_diagram(self, diagram):

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -34,6 +34,15 @@ class Workflow:
 
 
 @dataclass
+class GovernanceModule:
+    """Container for organising governance diagrams into folders."""
+
+    name: str
+    modules: List["GovernanceModule"] = field(default_factory=list)
+    diagrams: List[str] = field(default_factory=list)
+
+
+@dataclass
 class SafetyManagementToolbox:
     """Collect work products and governance artifacts for safety management.
 
@@ -46,6 +55,7 @@ class SafetyManagementToolbox:
     lifecycle: List[str] = field(default_factory=list)
     workflows: Dict[str, List[str]] = field(default_factory=dict)
     diagrams: Dict[str, str] = field(default_factory=dict)
+    modules: List[GovernanceModule] = field(default_factory=list)
 
     def add_work_product(self, diagram: str, analysis: str, rationale: str) -> None:
         """Add a work product linking a diagram to an analysis with rationale."""
@@ -139,6 +149,76 @@ class SafetyManagementToolbox:
         """
         self._sync_diagrams()
         return list(self.diagrams.keys())
+
+    # ------------------------------------------------------------------
+    def diagram_hierarchy(self) -> List[List[str]]:
+        """Return governance diagrams arranged into hierarchy levels.
+
+        Diagrams appear in successive levels when a task in one diagram links
+        to another diagram. Any diagrams not referenced by others start at the
+        top level. Each level lists diagram names sorted alphabetically.
+        """
+        self._sync_diagrams()
+        repo = SysMLRepository.get_instance()
+
+        edges: dict[str, set[str]] = {d: set() for d in self.diagrams.values()}
+        reverse: dict[str, set[str]] = {d: set() for d in self.diagrams.values()}
+
+        for diag_id in edges:
+            diag = repo.diagrams.get(diag_id)
+            if not diag:
+                continue
+            for obj in getattr(diag, "objects", []):
+                # ``objects`` may contain plain dictionaries from the repository
+                # or ``SysMLObject`` instances used by the GUI.  Support both.
+                elem_id = (
+                    obj.get("element_id") if isinstance(obj, dict) else getattr(obj, "element_id", None)
+                )
+                if not elem_id:
+                    continue
+
+                target = repo.get_linked_diagram(elem_id)
+
+                if not target:
+                    # Some diagrams reference others through object properties
+                    # rather than explicit repository links. These appear as
+                    # ``view`` or ``diagram`` identifiers within the object's
+                    # property mapping. Support both dictionary and dataclass
+                    # representations.
+                    props = (
+                        obj.get("properties", {})
+                        if isinstance(obj, dict)
+                        else getattr(obj, "properties", {})
+                    )
+                    target = props.get("view") or props.get("diagram")
+
+                if target in edges:
+                    edges[diag_id].add(target)
+                    reverse[target].add(diag_id)
+
+        roots = sorted(
+            (d for d in edges if not reverse[d]),
+            key=lambda d: repo.diagrams[d].name,
+        )
+        levels: List[List[str]] = []
+        visited: set[str] = set()
+        current = roots
+        while current:
+            levels.append(sorted(repo.diagrams[d].name for d in current))
+            visited.update(current)
+            next_level: set[str] = set()
+            for d in current:
+                next_level.update(child for child in edges[d] if child not in visited)
+            current = sorted(next_level, key=lambda d: repo.diagrams[d].name)
+
+        remaining = sorted(
+            [d for d in edges if d not in visited],
+            key=lambda d: repo.diagrams[d].name,
+        )
+        for d in remaining:
+            levels.append([repo.diagrams[d].name])
+
+        return levels
 
     # ------------------------------------------------------------------
     def _sync_diagrams(self) -> None:

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -1,0 +1,193 @@
+"""Explorer window for safety governance diagrams."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk, simpledialog
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+
+
+class SafetyManagementExplorer(tk.Frame):
+    """Browse and organise safety governance diagrams in folders."""
+
+    def __init__(self, master, app=None, toolbox: SafetyManagementToolbox | None = None):
+        if isinstance(master, tk.Toplevel):
+            container = master
+        else:
+            container = master
+        super().__init__(container)
+        self.app = app
+        self.toolbox = toolbox or SafetyManagementToolbox()
+        if isinstance(master, tk.Toplevel):
+            master.title("Safety Management Explorer")
+            master.geometry("350x400")
+            self.pack(fill=tk.BOTH, expand=True)
+
+        tree_frame = ttk.Frame(self)
+        tree_frame.pack(fill=tk.BOTH, expand=True, padx=4, pady=4)
+        self.tree = ttk.Treeview(tree_frame)
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        self.folder_icon = self._create_icon("folder", "#b8860b")
+        self.diagram_icon = self._create_icon("rect", "#4682b4")
+        self.item_map: Dict[str, tuple[str, object]] = {}
+
+        btns = ttk.Frame(self)
+        btns.pack(fill=tk.X, padx=4, pady=4)
+        ttk.Button(btns, text="Open", command=self.open_item).pack(side=tk.LEFT)
+        ttk.Button(btns, text="New Folder", command=self.new_folder).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="New Diagram", command=self.new_diagram).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="Rename", command=self.rename_item).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="Delete", command=self.delete_item).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btns, text="Refresh", command=self.populate).pack(side=tk.RIGHT)
+
+        self.tree.bind("<Double-1>", self._on_double_click)
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def populate(self):
+        """Fill the tree with folders and diagrams."""
+        self.item_map.clear()
+        self.tree.delete(*self.tree.get_children(""))
+        self.toolbox.list_diagrams()
+
+        def _add_module(parent: str, mod: GovernanceModule) -> None:
+            for sub in mod.modules:
+                sub_id = self.tree.insert(parent, "end", text=sub.name, image=self.folder_icon)
+                self.item_map[sub_id] = ("module", sub)
+                _add_module(sub_id, sub)
+            for name in mod.diagrams:
+                diag_id = self.tree.insert(parent, "end", text=name, image=self.diagram_icon)
+                self.item_map[diag_id] = ("diagram", name)
+
+        for mod in self.toolbox.modules:
+            mod_id = self.tree.insert("", "end", text=mod.name, image=self.folder_icon)
+            self.item_map[mod_id] = ("module", mod)
+            _add_module(mod_id, mod)
+
+        for name in sorted(self.toolbox.diagrams.keys()):
+            if not self._in_any_module(name, self.toolbox.modules):
+                iid = self.tree.insert("", "end", text=name, image=self.diagram_icon)
+                self.item_map[iid] = ("diagram", name)
+
+    # ------------------------------------------------------------------
+    def new_folder(self):
+        name = simpledialog.askstring("New Folder", "Name:", parent=self)
+        if not name:
+            return
+        folder = GovernanceModule(name)
+        sel = self.tree.selection()
+        if sel:
+            typ, obj = self.item_map.get(sel[0], (None, None))
+            if typ == "module":
+                obj.modules.append(folder)
+            else:
+                self.toolbox.modules.append(folder)
+        else:
+            self.toolbox.modules.append(folder)
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def new_diagram(self):
+        name = simpledialog.askstring("New Diagram", "Name:", parent=self)
+        if not name:
+            return
+        self.toolbox.create_diagram(name)
+        sel = self.tree.selection()
+        if sel:
+            typ, obj = self.item_map.get(sel[0], (None, None))
+            if typ == "module":
+                obj.diagrams.append(name)
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def rename_item(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        typ, obj = self.item_map.get(sel[0], (None, None))
+        if typ != "diagram":
+            return
+        new = simpledialog.askstring("Rename Diagram", "Name:", initialvalue=obj, parent=self)
+        if not new or new == obj:
+            return
+        self.toolbox.rename_diagram(obj, new)
+        self._replace_name_in_modules(obj, new, self.toolbox.modules)
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def delete_item(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        typ, obj = self.item_map.get(sel[0], (None, None))
+        if typ == "diagram":
+            self.toolbox.delete_diagram(obj)
+            self._remove_name(obj, self.toolbox.modules)
+        elif typ == "module":
+            if obj.modules or obj.diagrams:
+                return
+            parent = self.tree.parent(sel[0])
+            if parent:
+                ptyp, pobj = self.item_map.get(parent, (None, None))
+                if ptyp == "module":
+                    pobj.modules.remove(obj)
+            else:
+                self.toolbox.modules.remove(obj)
+        self.populate()
+
+    # ------------------------------------------------------------------
+    def open_item(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        typ, obj = self.item_map.get(sel[0], (None, None))
+        if typ != "diagram":
+            return
+        diag_id = self.toolbox.diagrams.get(obj)
+        if diag_id and self.app:
+            self.app.open_arch_window(diag_id)
+
+    # ------------------------------------------------------------------
+    def _on_double_click(self, _event):  # pragma: no cover - UI event
+        self.open_item()
+
+    # ------------------------------------------------------------------
+    def _in_any_module(self, name: str, mods: List[GovernanceModule]) -> bool:
+        for mod in mods:
+            if name in mod.diagrams or self._in_any_module(name, mod.modules):
+                return True
+        return False
+
+    def _replace_name_in_modules(self, old: str, new: str, mods: List[GovernanceModule]) -> None:
+        for mod in mods:
+            mod.diagrams = [new if d == old else d for d in mod.diagrams]
+            self._replace_name_in_modules(old, new, mod.modules)
+
+    def _remove_name(self, name: str, mods: List[GovernanceModule]) -> None:
+        for mod in mods:
+            if name in mod.diagrams:
+                mod.diagrams.remove(name)
+            self._remove_name(name, mod.modules)
+
+    # ------------------------------------------------------------------
+    def _create_icon(self, shape: str, color: str = "black"):
+        """Create a tiny tkinter drawing for treeview icons."""
+        img = tk.PhotoImage(width=16, height=16)
+        if shape == "folder":
+            img.put(color, to=(0, 4, 15, 15))
+            img.put("white", to=(3, 0, 15, 5))
+        elif shape == "rect":
+            img.put(color, to=(1, 1, 15, 15))
+        else:
+            img.put(color, to=(1, 1, 15, 15))
+        return img


### PR DESCRIPTION
## Summary
- Add `GovernanceModule` to organise safety governance diagrams in folders
- Introduce `SafetyManagementExplorer` to browse and manage diagrams with folder support
- Integrate explorer into main application via new menu and management method

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c2e50ed0c8325b58ac6864b6e3f91