### PR TITLE
Enable drag-and-drop in Safety Management Explorer

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2301,6 +2301,7 @@ class FaultTreeApp:
             "Safety Management": self.open_safety_management_toolbox,
             "Safety Performance Indicators": self.show_safety_performance_indicators,
             "Safety Case": self.show_safety_case,
+            "Safety Management Explorer": self.manage_safety_management,
             "GSN Explorer": self.manage_gsn,
         }
 
@@ -2356,6 +2357,7 @@ class FaultTreeApp:
             ],
             "Safety Management": [
                 "Safety Management",
+                "Safety Management Explorer",
                 "Safety Case",
                 "Safety Performance Indicators",
                 "GSN Explorer",


### PR DESCRIPTION
## Summary
- Allow diagrams and folders to be reorganised via drag-and-drop in the Safety Management Explorer
- Expose Safety Management Explorer entry in Tools > Safety Management list
- Cover drag-and-drop and menu option with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c3567d1f88325886b635b57e1cc3f