### PR TITLE
Enable undo/redo shortcuts for GSN editing

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -118,6 +118,7 @@ class GSNDiagramWindow(tk.Frame):
         # Provide a context menu for nodes and relationships via right-click.
         self.canvas.bind("<Button-3>", self._on_right_click)
         self.refresh()
+        self._bind_shortcuts()
 
     # ------------------------------------------------------------------
     def refresh(self):  # pragma: no cover - requires tkinter
@@ -147,6 +148,13 @@ class GSNDiagramWindow(tk.Frame):
         # update scroll region to encompass all drawn items
         bbox = self.canvas.bbox("all") or (0, 0, 0, 0)
         self.canvas.configure(scrollregion=bbox)
+
+    # ------------------------------------------------------------------
+    def _bind_shortcuts(self):
+        """Bind common keyboard shortcuts for undo/redo actions."""
+        if self.app:
+            self.bind("<Control-z>", lambda e: self.app.undo())
+            self.bind("<Control-y>", lambda e: self.app.redo())
 
     # The following methods simply extend the diagram with new nodes.
     # Placement is very rudimentary but sufficient for tests.

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -64,6 +64,7 @@ class GSNExplorer(tk.Frame):
         self.tree.bind("<ButtonPress-1>", self._on_drag_start)
         self.tree.bind("<ButtonRelease-1>", self._on_drag_end)
         self.populate()
+        self._bind_shortcuts()
 
     # ------------------------------------------------------------------
     def populate(self):
@@ -87,6 +88,13 @@ class GSNExplorer(tk.Frame):
     def refresh(self):
         """Refresh the explorer view to reflect the current model state."""
         self.populate()
+
+    # ------------------------------------------------------------------
+    def _bind_shortcuts(self):
+        """Bind keyboard shortcuts for undo and redo actions."""
+        if self.app:
+            self.bind("<Control-z>", lambda e: self.app.undo())
+            self.bind("<Control-y>", lambda e: self.app.redo())
 
     # ------------------------------------------------------------------
     def _add_module_children(self, parent_id: str, module: GSNModule):

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -415,3 +415,23 @@ def test_export_csv_writes_nodes(tmp_path, monkeypatch):
     assert rows[0] == ["ID", "Name", "Type", "Description", "Children", "Context"]
     assert [root.unique_id, "Root", "Goal", "", child.unique_id, ""] in rows
     assert [child.unique_id, "Child", "Solution", "", "", ""] in rows
+
+
+def test_gsn_diagram_window_binds_undo_redo():
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    bindings = {}
+
+    def fake_bind(seq, func):
+        bindings[seq] = func
+
+    win.bind = fake_bind
+    calls = []
+    win.app = types.SimpleNamespace(
+        undo=lambda: calls.append("undo"),
+        redo=lambda: calls.append("redo"),
+    )
+    GSNDiagramWindow._bind_shortcuts(win)
+    assert "<Control-z>" in bindings and "<Control-y>" in bindings
+    bindings["<Control-z>"](None)
+    bindings["<Control-y>"](None)
+    assert calls == ["undo", "redo"]

--- a/tests/test_gsn_explorer.py
+++ b/tests/test_gsn_explorer.py
@@ -497,3 +497,19 @@ def test_drag_diagram_to_root():
 
     assert diag not in mod.diagrams
     assert diag in explorer.app.gsn_diagrams
+
+
+def test_gsn_explorer_binds_undo_redo():
+    explorer = GSNExplorer.__new__(GSNExplorer)
+    bindings = {}
+    explorer.bind = lambda seq, func: bindings.setdefault(seq, func)
+    calls = []
+    explorer.app = types.SimpleNamespace(
+        undo=lambda: calls.append("undo"),
+        redo=lambda: calls.append("redo"),
+    )
+    GSNExplorer._bind_shortcuts(explorer)
+    assert "<Control-z>" in bindings and "<Control-y>" in bindings
+    bindings["<Control-z>"](None)
+    bindings["<Control-y>"](None)
+    assert calls == ["undo", "redo"]


### PR DESCRIPTION
## Summary
- bind Ctrl+Z/Ctrl+Y to undo/redo in GSN diagram and explorer windows
- add tests ensuring shortcut bindings execute the correct app actions

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_diagram_window.py tests/test_gsn_explorer.py tests/test_gsn_undo.py`


------
https://chatgpt.com/codex/tasks/task_b_689c3e8d681c8325ad4e8c9b949fe1bc