### PR TITLE
Enforce valid GSN relationships

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -345,7 +345,12 @@ class GSNDiagramWindow(tk.Frame):
                 undo = getattr(app, "push_undo_state", None)
                 if undo:
                     undo()
-                self._connect_parent.add_child(node, relation=relation)
+                try:
+                    self._connect_parent.add_child(node, relation=relation)
+                except ValueError as exc:
+                    showerror = getattr(messagebox, "showerror", None)
+                    if showerror:
+                        showerror("Invalid Relationship", str(exc))
             self._connect_mode = None
             self._connect_parent = None
             # Restore the default cursor once the connection is made.

--- a/tests/test_gsn_connection_edit.py
+++ b/tests/test_gsn_connection_edit.py
@@ -84,7 +84,7 @@ def test_move_connection_updates_links():
 
 def test_delete_connection_removes_links():
     p = GSNNode("p", "Goal")
-    c = GSNNode("c", "Goal")
+    c = GSNNode("c", "Context")
     p.add_child(c, relation="context")
     diag = GSNDiagram(p)
     win = GSNDiagramWindow.__new__(GSNDiagramWindow)

--- a/tests/test_gsn_diagram_draw.py
+++ b/tests/test_gsn_diagram_draw.py
@@ -86,9 +86,9 @@ def test_draw_tags_and_zoom_scaling():
 
 
 def test_draw_respects_context_links():
-    """Connections use the stored relationship type, not node type."""
+    """Context links are rendered with the correct connector style."""
     root = GSNNode("Root", "Goal")
-    child = GSNNode("Child", "Goal")
+    child = GSNNode("Child", "Context")
     root.add_child(child, relation="context")
     diag = GSNDiagram(root, drawing_helper=DummyHelper())
     diag.add_node(child)

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -90,7 +90,7 @@ def test_on_release_creates_context_link():
     """Releasing in context mode should mark the relation accordingly."""
     win = GSNDiagramWindow.__new__(GSNDiagramWindow)
     parent = GSNNode("p", "Goal")
-    child = GSNNode("c", "Goal")
+    child = GSNNode("c", "Context")
 
     class CanvasStub:
         def __init__(self):

--- a/tests/test_gsn_horizontal_connection.py
+++ b/tests/test_gsn_horizontal_connection.py
@@ -68,7 +68,7 @@ class ArrowHelper(GSNDrawingHelper):
 
 def test_horizontal_connection_uses_side_and_arrow_points_right():
     parent = GSNNode("p", "Goal", x=0, y=0)
-    child = GSNNode("c", "Assumption", x=100, y=0)
+    child = GSNNode("c", "Goal", x=100, y=0)
     parent.add_child(child)
 
     helper = ArrowHelper()

--- a/tests/test_gsn_relationship_validation.py
+++ b/tests/test_gsn_relationship_validation.py
@@ -1,0 +1,23 @@
+import pytest
+from gsn import GSNNode
+
+
+def test_context_between_goals_disallowed():
+    g1 = GSNNode("g1", "Goal")
+    g2 = GSNNode("g2", "Goal")
+    with pytest.raises(ValueError):
+        g1.add_child(g2, relation="context")
+
+
+def test_solved_with_context_child_disallowed():
+    goal = GSNNode("g", "Goal")
+    ctx = GSNNode("c", "Context")
+    with pytest.raises(ValueError):
+        goal.add_child(ctx, relation="solved")
+
+
+def test_assumption_cannot_have_children():
+    assump = GSNNode("a", "Assumption")
+    goal = GSNNode("g", "Goal")
+    with pytest.raises(ValueError):
+        assump.add_child(goal)


### PR DESCRIPTION
## Summary
- validate GSNNode relationships against the GSN standard
- guard GUI connection creation and surface errors
- add and update tests for invalid relationship handling

## Testing
- `pytest tests/test_gsn*.py`


------
https://chatgpt.com/codex/tasks/task_b_689c871b89dc832594bc08cefc91a357