### PR TITLE
Enforce valid GSN relationships

### DIFF
--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -60,13 +60,48 @@ class GSNNode:
         relation:
             Either ``"solved"`` for a solved-by connection or ``"context"``
             for an in-context-of relationship.  Defaults to ``"solved"``.
+
+        Raises
+        ------
+        ValueError
+            If the requested relationship between the two node types is not
+            allowed by the GSN standard.
         """
+
+        if relation not in {"solved", "context"}:
+            raise ValueError(f"Unknown relationship: {relation}")
+
+        if relation == "solved":
+            allowed = {
+                "Goal": {"Goal", "Strategy", "Solution", "Module"},
+                "Strategy": {"Goal"},
+                "Module": {"Goal", "Strategy", "Solution", "Module"},
+            }
+            if self.node_type not in allowed or child.node_type not in allowed[self.node_type]:
+                raise ValueError(
+                    f"{self.node_type} cannot be solved by {child.node_type}"
+                )
+        else:  # relation == "context"
+            allowed = {
+                "Goal": {"Context", "Assumption", "Justification"},
+                "Strategy": {"Context", "Assumption", "Justification"},
+                "Solution": {"Context", "Assumption", "Justification"},
+                "Module": {"Context", "Assumption", "Justification"},
+            }
+            if self.node_type not in allowed or child.node_type not in allowed[self.node_type]:
+                raise ValueError(
+                    f"{self.node_type} cannot have context {child.node_type}"
+                )
+
         if child not in self.children:
             self.children.append(child)
         if self not in child.parents:
             child.parents.append(self)
-        if relation == "context" and child not in self.context_children:
-            self.context_children.append(child)
+        if relation == "context":
+            if child not in self.context_children:
+                self.context_children.append(child)
+        elif child in self.context_children:
+            self.context_children.remove(child)
 
     # ------------------------------------------------------------------
     def clone(self, parent: Optional["GSNNode"] = None) -> "GSNNode":
@@ -154,12 +189,19 @@ class GSNNode:
     def resolve_references(nodes: dict) -> None:
         """Resolve child and original references after initial loading."""
         for node in nodes.values():
+            # ``children`` in previously saved models may contain context
+            # node identifiers as well as solved-by relationships.  To avoid
+            # loading errors when enforcing strict relationship validation we
+            # ignore any IDs that are also listed in ``context`` and handle
+            # them only as context links below.
+            context_ids = set(getattr(node, "_tmp_context", []))
             children_ids = getattr(node, "_tmp_children", [])
             for cid in children_ids:
+                if cid in context_ids:
+                    continue
                 child = nodes.get(cid)
                 if child:
                     node.add_child(child, relation="solved")
-            context_ids = getattr(node, "_tmp_context", [])
             for cid in context_ids:
                 child = nodes.get(cid)
                 if child:

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -345,7 +345,12 @@ class GSNDiagramWindow(tk.Frame):
                 undo = getattr(app, "push_undo_state", None)
                 if undo:
                     undo()
-                self._connect_parent.add_child(node, relation=relation)
+                try:
+                    self._connect_parent.add_child(node, relation=relation)
+                except ValueError as exc:
+                    showerror = getattr(messagebox, "showerror", None)
+                    if showerror:
+                        showerror("Invalid Relationship", str(exc))
             self._connect_mode = None
             self._connect_parent = None
             # Restore the default cursor once the connection is made.

--- a/tests/test_gsn_connection_edit.py
+++ b/tests/test_gsn_connection_edit.py
@@ -84,7 +84,7 @@ def test_move_connection_updates_links():
 
 def test_delete_connection_removes_links():
     p = GSNNode("p", "Goal")
-    c = GSNNode("c", "Goal")
+    c = GSNNode("c", "Context")
     p.add_child(c, relation="context")
     diag = GSNDiagram(p)
     win = GSNDiagramWindow.__new__(GSNDiagramWindow)

--- a/tests/test_gsn_context_migration.py
+++ b/tests/test_gsn_context_migration.py
@@ -1,0 +1,34 @@
+from gsn import GSNNode
+
+
+def test_legacy_context_entries_load_as_context():
+    """Older models stored context nodes in both ``children`` and ``context``.
+    Ensure they are treated purely as context relationships when loading."""
+
+    # Simulate legacy serialised data where the context node ID appears in both
+    # the ``children`` and ``context`` fields of the parent.
+    root_data = {
+        "unique_id": "1",
+        "user_name": "G",
+        "node_type": "Goal",
+        "children": ["2"],
+        "context": ["2"],
+    }
+    ctx_data = {
+        "unique_id": "2",
+        "user_name": "C",
+        "node_type": "Context",
+    }
+    nodes = {}
+    root = GSNNode.from_dict(root_data, nodes)
+    ctx = GSNNode.from_dict(ctx_data, nodes)
+
+    # Should not raise even though the ID is listed twice.
+    GSNNode.resolve_references(nodes)
+
+    assert ctx in root.children
+    assert ctx in root.context_children
+    assert root in ctx.parents
+    # The context node should only appear once in the children list.
+    assert root.children.count(ctx) == 1
+

--- a/tests/test_gsn_diagram_draw.py
+++ b/tests/test_gsn_diagram_draw.py
@@ -86,9 +86,9 @@ def test_draw_tags_and_zoom_scaling():
 
 
 def test_draw_respects_context_links():
-    """Connections use the stored relationship type, not node type."""
+    """Context links are rendered with the correct connector style."""
     root = GSNNode("Root", "Goal")
-    child = GSNNode("Child", "Goal")
+    child = GSNNode("Child", "Context")
     root.add_child(child, relation="context")
     diag = GSNDiagram(root, drawing_helper=DummyHelper())
     diag.add_node(child)

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -90,7 +90,7 @@ def test_on_release_creates_context_link():
     """Releasing in context mode should mark the relation accordingly."""
     win = GSNDiagramWindow.__new__(GSNDiagramWindow)
     parent = GSNNode("p", "Goal")
-    child = GSNNode("c", "Goal")
+    child = GSNNode("c", "Context")
 
     class CanvasStub:
         def __init__(self):

--- a/tests/test_gsn_horizontal_connection.py
+++ b/tests/test_gsn_horizontal_connection.py
@@ -68,7 +68,7 @@ class ArrowHelper(GSNDrawingHelper):
 
 def test_horizontal_connection_uses_side_and_arrow_points_right():
     parent = GSNNode("p", "Goal", x=0, y=0)
-    child = GSNNode("c", "Assumption", x=100, y=0)
+    child = GSNNode("c", "Goal", x=100, y=0)
     parent.add_child(child)
 
     helper = ArrowHelper()

--- a/tests/test_gsn_relationship_validation.py
+++ b/tests/test_gsn_relationship_validation.py
@@ -1,0 +1,23 @@
+import pytest
+from gsn import GSNNode
+
+
+def test_context_between_goals_disallowed():
+    g1 = GSNNode("g1", "Goal")
+    g2 = GSNNode("g2", "Goal")
+    with pytest.raises(ValueError):
+        g1.add_child(g2, relation="context")
+
+
+def test_solved_with_context_child_disallowed():
+    goal = GSNNode("g", "Goal")
+    ctx = GSNNode("c", "Context")
+    with pytest.raises(ValueError):
+        goal.add_child(ctx, relation="solved")
+
+
+def test_assumption_cannot_have_children():
+    assump = GSNNode("a", "Assumption")
+    goal = GSNNode("g", "Goal")
+    with pytest.raises(ValueError):
+        assump.add_child(goal)


### PR DESCRIPTION
## Summary
- validate GSNNode relationships against the GSN standard
- guard GUI connection creation and surface errors
- add and update tests for invalid relationship handling
- migrate legacy models by ignoring context nodes listed as solved children

## Testing
- `pytest tests/test_gsn*.py`


------
https://chatgpt.com/codex/tasks/task_b_689c871b89dc832594bc08cefc91a357