### PR TITLE
Group product goal editor options by ISO standard

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12831,108 +12831,124 @@ class FaultTreeApp:
                 super().__init__(parent, title=title)
 
             def body(self, master):
-                ttk.Label(master, text="ID:").grid(row=0, column=0, sticky="e")
-                self.id_var = tk.StringVar(value=getattr(self.initial, "user_name", ""))
-                tk.Entry(master, textvariable=self.id_var).grid(row=0, column=1, padx=5, pady=5)
+                nb = ttk.Notebook(master)
+                nb.pack(fill=tk.BOTH, expand=True)
 
-                ttk.Label(master, text="ASIL:").grid(row=1, column=0, sticky="e")
+                fs_tab = ttk.Frame(nb)
+                sotif_tab = ttk.Frame(nb)
+                cyber_tab = ttk.Frame(nb)
+                nb.add(fs_tab, text="Functional Safety")
+                nb.add(sotif_tab, text="SOTIF")
+                nb.add(cyber_tab, text="Cybersecurity")
+
+                # --- Functional Safety fields ---
+                ttk.Label(fs_tab, text="ID:").grid(row=0, column=0, sticky="e")
+                self.id_var = tk.StringVar(value=getattr(self.initial, "user_name", ""))
+                self.id_entry = tk.Entry(fs_tab, textvariable=self.id_var)
+                self.id_entry.grid(row=0, column=1, padx=5, pady=5)
+
+                ttk.Label(fs_tab, text="ASIL:").grid(row=1, column=0, sticky="e")
                 name = getattr(self.initial, "safety_goal_description", "") or getattr(self.initial, "user_name", "")
                 self.asil_var = tk.StringVar(value=self.app.get_hara_goal_asil(name))
-                ttk.Label(master, textvariable=self.asil_var).grid(row=1, column=1, padx=5, pady=5, sticky="w")
+                ttk.Label(fs_tab, textvariable=self.asil_var).grid(row=1, column=1, padx=5, pady=5, sticky="w")
 
-                ttk.Label(master, text="CAL:").grid(row=2, column=0, sticky="e")
-                self.cal_var = tk.StringVar(value=self.app.get_cyber_goal_cal(name))
-                ttk.Label(master, textvariable=self.cal_var).grid(row=2, column=1, padx=5, pady=5, sticky="w")
-
-                ttk.Label(master, text="Safe State:").grid(row=3, column=0, sticky="e")
+                ttk.Label(fs_tab, text="Safe State:").grid(row=2, column=0, sticky="e")
                 self.state_var = tk.StringVar(value=getattr(self.initial, "safe_state", ""))
-                tk.Entry(master, textvariable=self.state_var).grid(row=3, column=1, padx=5, pady=5)
+                tk.Entry(fs_tab, textvariable=self.state_var).grid(row=2, column=1, padx=5, pady=5)
 
-                ttk.Label(master, text="FTTI:").grid(row=4, column=0, sticky="e")
+                ttk.Label(fs_tab, text="FTTI:").grid(row=3, column=0, sticky="e")
                 self.ftti_var = tk.StringVar(value=getattr(self.initial, "ftti", ""))
                 tk.Entry(
-                    master,
+                    fs_tab,
                     textvariable=self.ftti_var,
+                    validate="key",
+                    validatecommand=(master.register(self.app.validate_float), "%P"),
+                ).grid(row=3, column=1, padx=5, pady=5)
+
+                ttk.Label(fs_tab, text="Acceptance Rate (1/h):").grid(row=4, column=0, sticky="e")
+                self.accept_rate_var = tk.StringVar(value=str(getattr(self.initial, "acceptance_rate", 0.0)))
+                tk.Entry(
+                    fs_tab,
+                    textvariable=self.accept_rate_var,
                     validate="key",
                     validatecommand=(master.register(self.app.validate_float), "%P"),
                 ).grid(row=4, column=1, padx=5, pady=5)
 
-                ttk.Label(master, text="Acceptance Rate (1/h):").grid(row=5, column=0, sticky="e")
-                self.accept_rate_var = tk.StringVar(value=str(getattr(self.initial, "acceptance_rate", 0.0)))
+                ttk.Label(fs_tab, text="On Hours:").grid(row=5, column=0, sticky="e")
+                self.op_hours_var = tk.StringVar(value=str(getattr(self.initial, "operational_hours_on", 0.0)))
                 tk.Entry(
-                    master,
-                    textvariable=self.accept_rate_var,
+                    fs_tab,
+                    textvariable=self.op_hours_var,
                     validate="key",
                     validatecommand=(master.register(self.app.validate_float), "%P"),
                 ).grid(row=5, column=1, padx=5, pady=5)
 
-                ttk.Label(master, text="On Hours:").grid(row=6, column=0, sticky="e")
-                self.op_hours_var = tk.StringVar(value=str(getattr(self.initial, "operational_hours_on", 0.0)))
-                tk.Entry(
-                    master,
-                    textvariable=self.op_hours_var,
-                    validate="key",
-                    validatecommand=(master.register(self.app.validate_float), "%P"),
-                ).grid(row=6, column=1, padx=5, pady=5)
-
+                ttk.Label(fs_tab, text="Validation Target (1/h):").grid(row=6, column=0, sticky="e")
                 exp = exposure_to_probability(getattr(self.initial, "exposure", 1))
                 ctrl = controllability_to_probability(getattr(self.initial, "controllability", 1))
                 sev = severity_to_probability(getattr(self.initial, "severity", 1))
-
-                ttk.Label(master, text="P(E|HB):").grid(row=7, column=0, sticky="e")
-                self.pehb_var = tk.StringVar(value=str(exp))
-                tk.Entry(master, textvariable=self.pehb_var, state="readonly").grid(row=7, column=1, padx=5, pady=5)
-
-                ttk.Label(master, text="P(C|E):").grid(row=8, column=0, sticky="e")
-                self.pce_var = tk.StringVar(value=str(ctrl))
-                tk.Entry(master, textvariable=self.pce_var, state="readonly").grid(row=8, column=1, padx=5, pady=5)
-
-                ttk.Label(master, text="P(S|C):").grid(row=9, column=0, sticky="e")
-                self.psc_var = tk.StringVar(value=str(sev))
-                tk.Entry(master, textvariable=self.psc_var, state="readonly").grid(row=9, column=1, padx=5, pady=5)
-
-                ttk.Label(master, text="Validation Target (1/h):").grid(row=10, column=0, sticky="e")
                 try:
                     val = derive_validation_target(float(self.accept_rate_var.get() or 0.0), exp, ctrl, sev)
                 except Exception:
                     val = 1.0
                 self.val_var = tk.StringVar(value=str(val))
-                tk.Entry(master, textvariable=self.val_var, state="readonly").grid(row=10, column=1, padx=5, pady=5)
+                tk.Entry(fs_tab, textvariable=self.val_var, state="readonly").grid(row=6, column=1, padx=5, pady=5)
+
+                ttk.Label(fs_tab, text="Mission Profile:").grid(row=7, column=0, sticky="e")
+                self.profile_var = tk.StringVar(value=getattr(self.initial, "mission_profile", ""))
+                ttk.Combobox(
+                    fs_tab,
+                    textvariable=self.profile_var,
+                    values=[mp.name for mp in self.app.mission_profiles],
+                    state="readonly",
+                ).grid(row=7, column=1, padx=5, pady=5)
+
+                ttk.Label(fs_tab, text="Val Target Desc:").grid(row=8, column=0, sticky="ne")
+                self.val_desc_text = tk.Text(fs_tab, width=30, height=3, wrap="word")
+                self.val_desc_text.insert("1.0", getattr(self.initial, "validation_desc", ""))
+                self.val_desc_text.grid(row=8, column=1, padx=5, pady=5)
+
+                ttk.Label(fs_tab, text="Acceptance Criteria:").grid(row=9, column=0, sticky="ne")
+                self.acc_text = tk.Text(fs_tab, width=30, height=3, wrap="word")
+                self.acc_text.insert("1.0", getattr(self.initial, "acceptance_criteria", ""))
+                self.acc_text.grid(row=9, column=1, padx=5, pady=5)
+
+                ttk.Label(fs_tab, text="Description:").grid(row=10, column=0, sticky="ne")
+                self.desc_text = tk.Text(fs_tab, width=30, height=3, wrap="word")
+                self.desc_text.insert("1.0", getattr(self.initial, "safety_goal_description", ""))
+                self.desc_text.grid(row=10, column=1, padx=5, pady=5)
+
+                # --- SOTIF fields ---
+                ttk.Label(sotif_tab, text="P(E|HB):").grid(row=0, column=0, sticky="e")
+                self.pehb_var = tk.StringVar(value=str(exp))
+                tk.Entry(sotif_tab, textvariable=self.pehb_var, state="readonly").grid(row=0, column=1, padx=5, pady=5)
+
+                ttk.Label(sotif_tab, text="P(C|E):").grid(row=1, column=0, sticky="e")
+                self.pce_var = tk.StringVar(value=str(ctrl))
+                tk.Entry(sotif_tab, textvariable=self.pce_var, state="readonly").grid(row=1, column=1, padx=5, pady=5)
+
+                ttk.Label(sotif_tab, text="P(S|C):").grid(row=2, column=0, sticky="e")
+                self.psc_var = tk.StringVar(value=str(sev))
+                tk.Entry(sotif_tab, textvariable=self.psc_var, state="readonly").grid(row=2, column=1, padx=5, pady=5)
+
+                # --- Cybersecurity fields ---
+                ttk.Label(cyber_tab, text="CAL:").grid(row=0, column=0, sticky="e")
+                self.cal_var = tk.StringVar(value=self.app.get_cyber_goal_cal(name))
+                ttk.Label(cyber_tab, textvariable=self.cal_var).grid(row=0, column=1, padx=5, pady=5, sticky="w")
 
                 def _update_val(*_):
                     try:
                         acc = float(self.accept_rate_var.get())
-                        v = derive_validation_target(acc, float(self.pehb_var.get()), float(self.pce_var.get()), float(self.psc_var.get()))
+                        v = derive_validation_target(
+                            acc, float(self.pehb_var.get()), float(self.pce_var.get()), float(self.psc_var.get())
+                        )
                     except Exception:
                         v = 1.0
                     self.val_var.set(str(v))
 
                 self.accept_rate_var.trace_add("write", _update_val)
 
-                ttk.Label(master, text="Mission Profile:").grid(row=11, column=0, sticky="e")
-                self.profile_var = tk.StringVar(value=getattr(self.initial, "mission_profile", ""))
-                ttk.Combobox(
-                    master,
-                    textvariable=self.profile_var,
-                    values=[mp.name for mp in self.app.mission_profiles],
-                    state="readonly",
-                ).grid(row=11, column=1, padx=5, pady=5)
-
-                ttk.Label(master, text="Val Target Desc:").grid(row=12, column=0, sticky="ne")
-                self.val_desc_text = tk.Text(master, width=30, height=3, wrap="word")
-                self.val_desc_text.insert("1.0", getattr(self.initial, "validation_desc", ""))
-                self.val_desc_text.grid(row=12, column=1, padx=5, pady=5)
-
-                ttk.Label(master, text="Acceptance Criteria:").grid(row=13, column=0, sticky="ne")
-                self.acc_text = tk.Text(master, width=30, height=3, wrap="word")
-                self.acc_text.insert("1.0", getattr(self.initial, "acceptance_criteria", ""))
-                self.acc_text.grid(row=13, column=1, padx=5, pady=5)
-
-                ttk.Label(master, text="Description:").grid(row=14, column=0, sticky="ne")
-                self.desc_text = tk.Text(master, width=30, height=3, wrap="word")
-                self.desc_text.insert("1.0", getattr(self.initial, "safety_goal_description", ""))
-                self.desc_text.grid(row=14, column=1, padx=5, pady=5)
-                return master
+                return self.id_entry
 
             def apply(self):
                 desc = self.desc_text.get("1.0", "end-1c").strip()


### PR DESCRIPTION
## Summary
- Organize the product goal editor into a notebook with separate tabs for Functional Safety, SOTIF, and Cybersecurity
- Display CAL information in its own Cybersecurity tab

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c957a6e0c8325ac579867a24c979c