### PR TITLE
Fix SPI target listing in solution config

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -13048,8 +13048,23 @@ class FaultTreeApp:
         )
 
     def get_spi_targets(self) -> list[str]:
-        """Return sorted unique SPI target descriptions for the project."""
-        return sorted({self._spi_label(sg) for sg in getattr(self, "top_events", []) if self._spi_label(sg)})
+        """Return sorted unique SPI target descriptions for the project.
+
+        Only include product goals that define a validation target (or an
+        equivalent SPI) so dialogs referencing these targets do not present
+        goals without an associated SPI.
+        """
+
+        targets = set()
+        for sg in getattr(self, "top_events", []):
+            v_target = getattr(sg, "validation_target", None)
+            asil = getattr(sg, "safety_goal_asil", "")
+            if v_target in ("", None) and asil not in PMHF_TARGETS:
+                continue
+            label = self._spi_label(sg)
+            if label:
+                targets.add(label)
+        return sorted(targets)
 
     def show_safety_performance_indicators(self):
         """Display Safety Performance Indicators."""

--- a/gui/gsn_config_window.py
+++ b/gui/gsn_config_window.py
@@ -94,10 +94,13 @@ def _collect_spi_targets(diagram: GSNDiagram, app=None) -> list[str]:
             targets.update(app.get_spi_targets())
         else:
             for te in getattr(app, "top_events", []):
+                if getattr(te, "validation_target", None) in ("", None):
+                    continue
                 name = (
                     getattr(te, "validation_desc", "")
                     or getattr(te, "safety_goal_description", "")
                     or getattr(te, "user_name", "")
+                    or f"SG {getattr(te, 'unique_id', '')}"
                 )
                 if name:
                     targets.add(name)

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -319,6 +319,7 @@ def test_config_dialog_lists_project_spis(monkeypatch):
         def __init__(self, desc):
             self.validation_desc = ""
             self.safety_goal_description = desc
+            self.validation_target = 1e-5
 
     class App:
         def __init__(self):

--- a/tests/test_spi_targets.py
+++ b/tests/test_spi_targets.py
@@ -1,0 +1,18 @@
+from AutoML import FaultTreeApp
+
+
+def test_get_spi_targets_filters_missing_validation_targets():
+    class SG:
+        def __init__(self, desc, v_target=None):
+            self.validation_desc = ""
+            self.safety_goal_description = desc
+            self.user_name = desc
+            self.validation_target = v_target
+            self.safety_goal_asil = ""
+    class App:
+        _spi_label = FaultTreeApp._spi_label
+        get_spi_targets = FaultTreeApp.get_spi_targets
+        def __init__(self):
+            self.top_events = [SG("SPI1", 1e-5), SG("NoSPI", None)]
+    app = App()
+    assert app.get_spi_targets() == ["SPI1"]


### PR DESCRIPTION
## Summary
- filter `get_spi_targets` to only return product goals with validation targets
- update solution config dialog to list only existing SPIs
- add tests for SPI target filtering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c97863c848325ad89e650a10d7c4a