### PR TITLE
List SPI options by product goal and type

### DIFF
--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -354,13 +354,14 @@ def test_right_click_connection_shows_menu(monkeypatch):
 def test_refresh_sets_app_for_spi_lookup():
     root = GSNNode("Root", "Goal")
     sol = GSNNode("Sol", "Solution")
-    sol.spi_target = "Brake Time"
+    sol.spi_target = "Brake Time (SOTIF)"
     root.add_child(sol)
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
     class TopEvent:
         def __init__(self):
+            self.user_name = "Brake Time"
             self.validation_desc = "Brake Time"
             self.validation_target = "1e-5"
 

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -55,7 +55,7 @@ def test_solution_requires_matching_spi_for_clone():
     diag = GSNDiagram(root)
     original = GSNNode("Orig", "Solution")
     original.work_product = "WP1"
-    original.spi_target = "Brake Time"
+    original.spi_target = "Brake Time (SOTIF)"
     diag.add_node(original)
 
     node = GSNNode("New", "Solution")
@@ -67,7 +67,7 @@ def test_solution_requires_matching_spi_for_clone():
     cfg.desc_text = DummyText(node.description)
     cfg.work_var = DummyVar("WP1")
     cfg.link_var = DummyVar("")
-    cfg.spi_var = DummyVar("Other SPI")
+    cfg.spi_var = DummyVar("Other SPI (SOTIF)")
     cfg.destroy = lambda: None
     cfg._on_ok()
 
@@ -82,7 +82,7 @@ def test_solution_requires_matching_spi_for_clone():
     cfg2.desc_text = DummyText(node2.description)
     cfg2.work_var = DummyVar("WP1")
     cfg2.link_var = DummyVar("")
-    cfg2.spi_var = DummyVar("Brake Time")
+    cfg2.spi_var = DummyVar("Brake Time (SOTIF)")
     cfg2.destroy = lambda: None
     cfg2._on_ok()
 
@@ -92,12 +92,13 @@ def test_solution_requires_matching_spi_for_clone():
 def test_format_text_shows_calculated_spi():
     root = GSNNode("Root", "Goal")
     sol = GSNNode("Sol", "Solution")
-    sol.spi_target = "Brake Time"
+    sol.spi_target = "Brake Time (SOTIF)"
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
     class TopEvent:
         def __init__(self):
+            self.user_name = "Brake Time"
             self.validation_desc = "Brake Time"
             self.validation_target = 1e-4
             self.probability = 1e-5
@@ -111,12 +112,13 @@ def test_format_text_shows_calculated_spi():
 def test_format_text_shows_validation_target_when_no_probability():
     root = GSNNode("Root", "Goal")
     sol = GSNNode("Sol", "Solution")
-    sol.spi_target = "Brake Time"
+    sol.spi_target = "Brake Time (SOTIF)"
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
     class TopEvent:
         def __init__(self):
+            self.user_name = "Brake Time"
             self.validation_desc = "Brake Time"
             self.validation_target = "1e-5"
 
@@ -225,7 +227,7 @@ def test_config_dialog_populates_comboboxes(monkeypatch):
     diag = GSNDiagram(root)
     existing = GSNNode("Orig", "Solution")
     existing.work_product = "WP1"
-    existing.spi_target = "SPI1"
+    existing.spi_target = "SPI1 (SOTIF)"
     diag.add_node(existing)
 
     node = GSNNode("New", "Solution")
@@ -301,7 +303,7 @@ def test_config_dialog_populates_comboboxes(monkeypatch):
     assert wp_cb.init_values is None
     assert spi_cb.init_values is None
     assert wp_cb.configured["values"] == ["WP1"]
-    assert spi_cb.configured["values"] == ["SPI1"]
+    assert spi_cb.configured["values"] == ["SPI1 (SOTIF)"]
     # Both comboboxes should remain blank until the user picks an option.
     assert cfg.work_var.get() == ""
     assert cfg.spi_var.get() == ""
@@ -325,7 +327,7 @@ def test_config_dialog_lists_project_spis(monkeypatch):
             self.top_events = [TopEvent("SPI1")]
 
         def get_spi_targets(self):
-            return ["SPI1"]
+            return ["SPI1 (SOTIF)"]
 
     class Master:
         def __init__(self):
@@ -398,7 +400,7 @@ def test_config_dialog_lists_project_spis(monkeypatch):
 
     # work product combobox is first, spi combobox second
     _, spi_cb = combo_holder
-    assert spi_cb.configured["values"] == ["SPI1"]
+    assert spi_cb.configured["values"] == ["SPI1 (SOTIF)"]
     assert cfg.spi_var.get() == ""
 
 

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -111,7 +111,7 @@ class DummyMenu:
 def test_edit_probability_updates_spi(monkeypatch):
     root = GSNNode("G", "Goal")
     sol = GSNNode("E", "Solution")
-    sol.spi_target = "SG1"
+    sol.spi_target = "SG1 (SOTIF)"
     root.add_child(sol)
     diag = GSNDiagram(root)
     diag.add_node(sol)
@@ -170,7 +170,7 @@ def test_edit_probability_updates_spi(monkeypatch):
 def test_safety_case_shows_validation_target(monkeypatch):
     root = GSNNode("G", "Goal")
     sol = GSNNode("E", "Solution")
-    sol.spi_target = "SG1"
+    sol.spi_target = "SG1 (SOTIF)"
     root.add_child(sol)
     diag = GSNDiagram(root)
     diag.add_node(sol)
@@ -209,7 +209,7 @@ def test_safety_case_shows_validation_target(monkeypatch):
 def test_pmfh_autopopulates_validation_target_and_probability(monkeypatch):
     root = GSNNode("G", "Goal")
     sol = GSNNode("E", "Solution")
-    sol.spi_target = "SG1"
+    sol.spi_target = "SG1 (FUSA)"
     root.add_child(sol)
     diag = GSNDiagram(root)
     diag.add_node(sol)
@@ -258,7 +258,7 @@ def test_pmfh_autopopulates_validation_target_and_probability(monkeypatch):
 def test_edit_probability_in_spi_explorer(monkeypatch):
     root = GSNNode("G", "Goal")
     sol = GSNNode("E", "Solution")
-    sol.spi_target = "SG1"
+    sol.spi_target = "SG1 (SOTIF)"
     root.add_child(sol)
     diag = GSNDiagram(root)
     diag.add_node(sol)


### PR DESCRIPTION
## Summary
- Show Safety Performance Indicators in solution config as "Product Goal (SOTIF/FUSA)" choices
- Parse SPI selections to fetch correct validation targets and PMHF values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c9952cf708325a87c29033ca0e3c0