### PR TITLE
Rename Safety Management to Safety & Security Management

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2296,10 +2296,10 @@ class FaultTreeApp:
             "Product Goals Export": self.export_product_goal_requirements,
             "FTA Cut Sets": self.show_cut_sets,
             "FTA-FMEA Traceability": self.show_traceability_matrix,
-            "Safety Management": self.open_safety_management_toolbox,
+            "Safety & Security Management": self.open_safety_management_toolbox,
             "Safety Performance Indicators": self.show_safety_performance_indicators,
             "Safety Case": self.show_safety_case,
-            "Safety Management Explorer": self.manage_safety_management,
+            "Safety & Security Management Explorer": self.manage_safety_management,
             "GSN Explorer": self.manage_gsn,
         }
 
@@ -2353,9 +2353,9 @@ class FaultTreeApp:
                 "Cause & Effect Chain",
                 "Fault Prioritization",
             ],
-            "Safety Management": [
-                "Safety Management",
-                "Safety Management Explorer",
+            "Safety & Security Management": [
+                "Safety & Security Management",
+                "Safety & Security Management Explorer",
                 "Safety Case",
                 "Safety Performance Indicators",
                 "GSN Explorer",
@@ -9368,7 +9368,7 @@ class FaultTreeApp:
 
             repo = SysMLRepository.get_instance()
 
-            # --- Safety Management Section ---
+            # --- Safety & Security Management Section ---
             self.management_diagrams = sorted(
                 [
                     d
@@ -9377,7 +9377,7 @@ class FaultTreeApp:
                 ],
                 key=lambda d: d.name or d.diag_id,
             )
-            mgmt_root = tree.insert("", "end", text="Safety Management", open=True)
+            mgmt_root = tree.insert("", "end", text="Safety & Security Management", open=True)
             gov_root = tree.insert(
                 mgmt_root,
                 "end",
@@ -9583,7 +9583,7 @@ class FaultTreeApp:
             )
             tree.insert(sc_root, "end", text="Requirements Editor", tags=("reqs", "0"))
             tree.insert(sc_root, "end", text="Requirements Explorer", tags=("reqexp", "0"))
-            tree.insert(sc_root, "end", text="Safety Management Explorer", tags=("safetyexp", "0"))
+            tree.insert(sc_root, "end", text="Safety & Security Management Explorer", tags=("safetyexp", "0"))
             tree.insert(sc_root, "end", text="GSN Explorer", tags=("gsnexp", "0"))
 
             # --- Hazard & Threat Analysis Section ---
@@ -15568,12 +15568,12 @@ class FaultTreeApp:
         self.refresh_all()
 
     def open_safety_management_toolbox(self):
-        """Open a placeholder tab for the Safety Management toolbox."""
+        """Open a placeholder tab for the Safety & Security Management toolbox."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
             return
 
-        self._safety_mgmt_tab = self._new_tab("Safety Management")
+        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
 
         from analysis.safety_management import SafetyManagementToolbox
 
@@ -15581,7 +15581,7 @@ class FaultTreeApp:
         self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
 
         msg = (
-            "Safety Management toolbox initialized.\n"
+            "Safety & Security Management toolbox initialized.\n"
             "Future versions will provide a full graphical interface."
         )
         ttk.Label(self._safety_mgmt_tab, text=msg, justify=tk.CENTER).pack(
@@ -15589,12 +15589,12 @@ class FaultTreeApp:
         )
 
     def open_safety_management_toolbox(self):
-        """Open a placeholder tab for the Safety Management toolbox."""
+        """Open a placeholder tab for the Safety & Security Management toolbox."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
             return
 
-        self._safety_mgmt_tab = self._new_tab("Safety Management")
+        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
 
         from analysis.safety_management import SafetyManagementToolbox
 
@@ -15602,7 +15602,7 @@ class FaultTreeApp:
         self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
 
         msg = (
-            "Safety Management toolbox initialized.\n"
+            "Safety & Security Management toolbox initialized.\n"
             "Future versions will provide a full graphical interface."
         )
         ttk.Label(self._safety_mgmt_tab, text=msg, justify=tk.CENTER).pack(
@@ -15610,12 +15610,12 @@ class FaultTreeApp:
         )
 
     def open_safety_management_toolbox(self):
-        """Open the Safety Management toolbox tab."""
+        """Open the Safety & Security Management toolbox tab."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
             return
 
-        self._safety_mgmt_tab = self._new_tab("Safety Management")
+        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
 
         from analysis.safety_management import SafetyManagementToolbox
         from gui.safety_management_toolbox import SafetyManagementToolbox as SMTGUI
@@ -15627,12 +15627,12 @@ class FaultTreeApp:
         gui.pack(fill=tk.BOTH, expand=True)
 
     def open_safety_management_toolbox(self):
-        """Open the Safety Management toolbox tab."""
+        """Open the Safety & Security Management toolbox tab."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
             return
 
-        self._safety_mgmt_tab = self._new_tab("Safety Management")
+        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
 
         from analysis.safety_management import SafetyManagementToolbox
         from gui.safety_management_toolbox import SafetyManagementToolbox as SMTGUI
@@ -15644,24 +15644,24 @@ class FaultTreeApp:
         gui.pack(fill=tk.BOTH, expand=True)
 
     def open_safety_management_toolbox(self):
-        """Open a Safety Management tab with an Activity Diagram."""
+        """Open a Safety & Security Management tab with an Activity Diagram."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
             return
 
-        self._safety_mgmt_tab = self._new_tab("Safety Management")
+        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
 
         from gui.architecture import ActivityDiagramWindow
 
         ActivityDiagramWindow(self._safety_mgmt_tab, self)
 
     def open_safety_management_toolbox(self):
-        """Open the Safety Management editor and browser."""
+        """Open the Safety & Security Management editor and browser."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
             return
 
-        self._safety_mgmt_tab = self._new_tab("Safety Management")
+        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
 
         from gui.safety_management_toolbox import SafetyManagementWindow
         from analysis import SafetyManagementToolbox
@@ -15674,12 +15674,12 @@ class FaultTreeApp:
         )
 
     def open_safety_management_toolbox(self):
-        """Open the Safety Management editor and browser."""
+        """Open the Safety & Security Management editor and browser."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
             return
 
-        self._safety_mgmt_tab = self._new_tab("Safety Management")
+        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
 
         from gui.safety_management_toolbox import SafetyManagementWindow
         from analysis import SafetyManagementToolbox
@@ -15692,12 +15692,12 @@ class FaultTreeApp:
         )
 
     def open_safety_management_toolbox(self):
-        """Open the Safety Management editor and browser."""
+        """Open the Safety & Security Management editor and browser."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
             return
 
-        self._safety_mgmt_tab = self._new_tab("Safety Management")
+        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
 
         from gui.safety_management_toolbox import SafetyManagementWindow
         from analysis import SafetyManagementToolbox
@@ -15710,12 +15710,12 @@ class FaultTreeApp:
         )
 
     def open_safety_management_toolbox(self):
-        """Open the Safety Management editor and browser."""
+        """Open the Safety & Security Management editor and browser."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
             return
 
-        self._safety_mgmt_tab = self._new_tab("Safety Management")
+        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
 
         from gui.safety_management_toolbox import SafetyManagementWindow
         from analysis import SafetyManagementToolbox
@@ -15971,7 +15971,7 @@ class FaultTreeApp:
         if hasattr(self, "_safety_exp_tab") and self._safety_exp_tab.winfo_exists():
             self.doc_nb.select(self._safety_exp_tab)
         else:
-            self._safety_exp_tab = self._new_tab("Safety Management Explorer")
+            self._safety_exp_tab = self._new_tab("Safety & Security Management Explorer")
             self._safety_exp_window = SafetyManagementExplorer(
                 self._safety_exp_tab, self, self.safety_mgmt_toolbox
             )

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Recent updates add a **Review Toolbox** supporting peer and joint review workflo
   - [Risk & Assurance Gate Calculator](#risk--assurance-gate-calculator)
   - [Product Goals Export](#product-goals-export)
   - [Safety Performance Indicators](#safety-performance-indicators)
-  - [Safety Management Toolbox](#safety-management-toolbox)
+  - [Safety & Security Management Toolbox](#safety--security-management-toolbox)
 - [Email Setup](#email-setup)
 - [Dependencies](#dependencies)
 - [Diagram Styles](#diagram-styles)
@@ -1267,7 +1267,7 @@ Use **Export Product Goal Requirements** in the Requirements menu to generate a 
 
 ### Safety Performance Indicators
 
-The **Safety Performance Indicators** tool in the Safety Management tab
+The **Safety Performance Indicators** tool in the Safety & Security Management tab
 aggregates each product goal's validation target and acceptance criteria with
 its safety and AI metrics. Safety metrics such as SPFM, LPFM and DC, along with
 AI-specific measures like false-negative or precision rates, can be compared
@@ -1275,9 +1275,9 @@ against the planned validation targets. This view highlights how acceptance
 criteria translate into measurable indicators and whether current performance
 meets the required safety objectives.
 
-### Safety Management Toolbox
+### Safety & Security Management Toolbox
 
-The **Safety Management Toolbox** lets you organize safety work products across the entire lifecycle. You can define phases, attach tailored work products from any diagram or analysis with a supporting rationale, and capture workflows that govern how these items interact. The resulting lifecycle and workflow definition can be exported as a JSON business diagram to document your safety governance process.
+The **Safety & Security Management Toolbox** lets you organize safety work products across the entire lifecycle. You can define phases, attach tailored work products from any diagram or analysis with a supporting rationale, and capture workflows that govern how these items interact. The resulting lifecycle and workflow definition can be exported as a JSON business diagram to document your safety governance process.
 
 ### Acceptance Criteria and Validation Targets
 

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -1,4 +1,4 @@
-"""Safety management data structures.
+"""Safety & Security management data structures.
 
 This module defines simple data classes used by the GUI and other modules to
 collect work products, lifecycle information and workflows related to safety
@@ -236,7 +236,7 @@ class SafetyManagementToolbox:
         """Create a toolbox instance from serialized *data*.
 
         The folder structure is reconstructed using
-        :meth:`GovernanceModule.from_dict` ensuring that the Safety Management
+        :meth:`GovernanceModule.from_dict` ensuring that the Safety & Security Management
         Explorer reflects the saved hierarchy on reload.
         """
         toolbox = cls()

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -21,7 +21,7 @@ class SafetyManagementExplorer(tk.Frame):
         self.app = app
         self.toolbox = toolbox or SafetyManagementToolbox()
         if isinstance(master, tk.Toplevel):
-            master.title("Safety Management Explorer")
+            master.title("Safety & Security Management Explorer")
             master.geometry("350x400")
             self.pack(fill=tk.BOTH, expand=True)
 

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -6,7 +6,7 @@ from gui.architecture import BPMNDiagramWindow
 
 
 class SafetyManagementWindow(tk.Frame):
-    """Editor and browser for Safety Management diagrams.
+    """Editor and browser for Safety & Security Management diagrams.
 
     Users can create, rename, and delete BPMN Diagrams that model the
     project's safety governance. Only diagrams registered in the provided

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -106,7 +106,7 @@ def test_toolbox_manages_diagram_lifecycle():
 
 
 def test_open_safety_management_toolbox_uses_browser():
-    """FaultTreeApp opens the Safety Management window and toolbox."""
+    """FaultTreeApp opens the Safety & Security Management window and toolbox."""
     SysMLRepository._instance = None
 
     class DummyTab:
@@ -243,7 +243,7 @@ def test_safety_diagrams_visible_in_analysis_tree():
 
     app.update_views()
     texts = [meta["text"] for meta in app.analysis_tree.items.values()]
-    assert "Safety Management" in texts
+    assert "Safety & Security Management" in texts
     assert "Safety & Security Governance Diagrams" in texts
     assert "Gov" in texts
     assert "Arch" in texts
@@ -546,24 +546,24 @@ def test_tools_include_safety_management_explorer():
     app.manage_gsn = lambda: None
 
     app.tools = {
-        "Safety Management": app.open_safety_management_toolbox,
+        "Safety & Security Management": app.open_safety_management_toolbox,
         "Safety Performance Indicators": app.show_safety_performance_indicators,
         "Safety Case": app.show_safety_case,
-        "Safety Management Explorer": app.manage_safety_management,
+        "Safety & Security Management Explorer": app.manage_safety_management,
         "GSN Explorer": app.manage_gsn,
     }
     app.tool_categories = {
-        "Safety Management": [
-            "Safety Management",
-            "Safety Management Explorer",
+        "Safety & Security Management": [
+            "Safety & Security Management",
+            "Safety & Security Management Explorer",
             "Safety Case",
             "Safety Performance Indicators",
             "GSN Explorer",
         ]
     }
 
-    assert "Safety Management Explorer" in app.tools
-    assert "Safety Management Explorer" in app.tool_categories["Safety Management"]
+    assert "Safety & Security Management Explorer" in app.tools
+    assert "Safety & Security Management Explorer" in app.tool_categories["Safety & Security Management"]
 
 
 def test_diagram_drag_and_drop_between_modules():


### PR DESCRIPTION
## Summary
- update documentation to refer to Safety & Security Management
- rename UI tool names and categories to Safety & Security Management
- adjust tests for renamed Safety & Security Management features

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689c9f23ff8083258ca1b90d87006659