### PR TITLE
Remove redundant explorers from Safety & Security concept group

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8379,10 +8379,6 @@ class FaultTreeApp:
             self.show_safety_concept_editor()
         elif kind == "arch":
             self.open_arch_window(ident)
-        elif kind == "safetyexp":
-            self.manage_safety_management()
-        elif kind == "gsnexp":
-            self.manage_gsn()
         elif kind == "pkg":
             self.manage_architecture()
 
@@ -9583,8 +9579,6 @@ class FaultTreeApp:
             )
             tree.insert(sc_root, "end", text="Requirements Editor", tags=("reqs", "0"))
             tree.insert(sc_root, "end", text="Requirements Explorer", tags=("reqexp", "0"))
-            tree.insert(sc_root, "end", text="Safety & Security Management Explorer", tags=("safetyexp", "0"))
-            tree.insert(sc_root, "end", text="GSN Explorer", tags=("gsnexp", "0"))
 
             # --- Hazard & Threat Analysis Section ---
             haz_root = tree.insert("", "end", text="Hazard & Threat Analysis", open=True)

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -299,6 +299,49 @@ def test_gsn_diagrams_visible_in_analysis_tree():
     assert "Goal1" in texts
 
 
+def test_explorers_removed_from_safety_concept_group():
+    SysMLRepository._instance = None
+    SysMLRepository.get_instance()
+
+    class DummyTree:
+        def __init__(self):
+            self.items = {}
+            self.counter = 0
+
+        def delete(self, *items):
+            pass
+
+        def get_children(self, item=""):
+            return [iid for iid, meta in self.items.items() if meta["parent"] == item]
+
+        def insert(self, parent, index, iid=None, text="", tags=(), **kwargs):
+            if iid is None:
+                iid = f"i{self.counter}"
+                self.counter += 1
+            self.items[iid] = {"parent": parent, "text": text, "tags": tags}
+            return iid
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.refresh_model = lambda: None
+    app.compute_occurrence_counts = lambda: {}
+    app.diagram_icons = {}
+    app.hazop_docs = []
+    app.stpa_docs = []
+    app.threat_docs = []
+    app.fi2tc_docs = []
+    app.tc2fi_docs = []
+    app.hara_docs = []
+    app.top_events = []
+    app.fmeas = []
+    app.fmedas = []
+    app.analysis_tree = DummyTree()
+
+    app.update_views()
+    texts = [meta["text"] for meta in app.analysis_tree.items.values()]
+    assert "Safety & Security Management Explorer" not in texts
+    assert "GSN Explorer" not in texts
+
+
 def test_joint_reviews_visible_in_analysis_tree():
     SysMLRepository._instance = None
     SysMLRepository.get_instance()


### PR DESCRIPTION
## Summary
- drop Safety & Security Management Explorer and GSN Explorer from the Safety & Security Concept section
- clean up analysis tree double-click handler for removed explorers
- add regression test ensuring concept group no longer lists these explorers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ca3104d34832588b24645da5952fc