### PR TITLE
Separate FUSA and SOTIF SPI calculations

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -179,11 +179,12 @@ class GSNDiagram:
         app = getattr(self, "app", None)
         if not app:
             return None
-        name, _typ = self._parse_spi_target(target)
+        name, spi_type = self._parse_spi_target(target)
         for te in getattr(app, "top_events", []):
             te_name = getattr(te, "user_name", "") or f"SG {getattr(te, 'unique_id', '')}"
             if te_name == name:
-                return getattr(te, "probability", None)
+                attr = "probability" if spi_type == "FUSA" else "spi_probability"
+                return getattr(te, attr, None)
         return None
 
     # ------------------------------------------------------------------

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -101,7 +101,7 @@ def test_format_text_shows_calculated_spi():
             self.user_name = "Brake Time"
             self.validation_desc = "Brake Time"
             self.validation_target = 1e-4
-            self.probability = 1e-5
+            self.spi_probability = 1e-5
 
     diag.app = types.SimpleNamespace(top_events=[TopEvent()])
     text = diag._format_text(sol)

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -119,7 +119,7 @@ def test_edit_probability_updates_spi(monkeypatch):
     te = types.SimpleNamespace(
         user_name="SG1",
         validation_target=1e-5,
-        probability=1e-4,
+        spi_probability=1e-4,
         validation_desc="",
         safety_goal_description="",
         acceptance_criteria="AC",
@@ -145,7 +145,7 @@ def test_edit_probability_updates_spi(monkeypatch):
     tree.next_column = "Achieved Probability"
     event = types.SimpleNamespace(x=0, y=0)
     tree.bindings["<Double-Button-1>"](event)
-    assert te.probability == 2e-4
+    assert te.spi_probability == 2e-4
     row = next(iter(tree.data))
     assert tree.data[row]["values"][5] == f"{2e-4:.2e}"
     expected_spi = math.log10(1e-5 / 2e-4)
@@ -178,7 +178,7 @@ def test_safety_case_shows_validation_target(monkeypatch):
     te = types.SimpleNamespace(
         user_name="SG1",
         validation_target=1e-5,
-        probability=1e-4,
+        spi_probability=1e-4,
         validation_desc="",
         safety_goal_description="",
         acceptance_criteria="AC",
@@ -266,7 +266,7 @@ def test_edit_probability_in_spi_explorer(monkeypatch):
     te = types.SimpleNamespace(
         user_name="SG1",
         validation_target=1e-5,
-        probability=1e-4,
+        spi_probability=1e-4,
         validation_desc="",
         safety_goal_description="",
         acceptance_criteria="AC",
@@ -293,7 +293,7 @@ def test_edit_probability_in_spi_explorer(monkeypatch):
     tree.selection_set(iid)
     app._edit_spi_item()
     iid = next(iter(tree.data))
-    assert te.probability == 5e-5
+    assert te.spi_probability == 5e-5
     assert tree.data[iid]["values"][2] == f"{5e-5:.2e}"
     expected_spi = math.log10(1e-5 / 5e-5)
     assert tree.data[iid]["values"][3] == f"{expected_spi:.2f}"
@@ -304,6 +304,7 @@ def test_spi_shows_pmhf_and_validation(monkeypatch):
         user_name="SG1",
         validation_target=1e-5,
         probability=2e-6,
+        spi_probability=2e-6,
         safety_goal_asil="D",
         validation_desc="",
         safety_goal_description="",


### PR DESCRIPTION
## Summary
- Distinguish FUSA vs SOTIF Safety Performance Indicators
- Use PMHF targets and FTA probability for FUSA SPI
- Track user-specified probability for SOTIF SPI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ca8f34f9083258d372dcdbed635ec