### PR TITLE
Require folder selection for governance diagrams

### DIFF
--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk, simpledialog
+from gui import messagebox
 from dataclasses import dataclass, field
 from typing import List, Dict
 
@@ -100,15 +101,19 @@ class SafetyManagementExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def new_diagram(self):
+        sel = self.tree.selection()
+        if not sel:
+            messagebox.showerror("New Diagram", "Please select a folder for the diagram")
+            return
+        typ, obj = self.item_map.get(sel[0], (None, None))
+        if typ != "module":
+            messagebox.showerror("New Diagram", "Please select a folder for the diagram")
+            return
         name = simpledialog.askstring("New Diagram", "Name:", parent=self)
         if not name:
             return
         self.toolbox.create_diagram(name)
-        sel = self.tree.selection()
-        if sel:
-            typ, obj = self.item_map.get(sel[0], (None, None))
-            if typ == "module":
-                obj.diagrams.append(name)
+        obj.diagrams.append(name)
         self.populate()
 
     # ------------------------------------------------------------------

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -3,6 +3,7 @@ from tkinter import ttk, simpledialog
 
 from analysis import SafetyManagementToolbox
 from gui.architecture import BPMNDiagramWindow
+from gui import messagebox
 
 
 class SafetyManagementWindow(tk.Frame):
@@ -55,13 +56,10 @@ class SafetyManagementWindow(tk.Frame):
             self.open_diagram(None)
 
     def new_diagram(self):
-        name = simpledialog.askstring("New Diagram", "Name:", parent=self)
-        if not name:
-            return
-        self.toolbox.create_diagram(name)
-        self.refresh_diagrams()
-        self.diag_var.set(name)
-        self.open_diagram(name)
+        messagebox.showerror(
+            "New Diagram",
+            "Governance diagrams must be created inside a folder in the Explorer",
+        )
 
     def delete_diagram(self):
         name = self.diag_var.get()


### PR DESCRIPTION
## Summary
- enforce that governance diagrams can only be created within an existing folder
- block diagram creation from the toolbox window outside the explorer
- add regression test ensuring diagrams cannot be created at the root

## Testing
- `pytest tests/test_safety_management.py::test_safety_management_explorer_creates_folders_and_diagrams tests/test_safety_management.py::test_explorer_prevents_diagrams_outside_folders -q`


------
https://chatgpt.com/codex/tasks/task_b_689ccd0bc604832582a7f7339e61b7a1