### PR TITLE
Add governance propagation relationships with review gating

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -184,6 +184,33 @@ class SafetyManagementToolbox:
         return self.workflows.get(name, [])
 
     # ------------------------------------------------------------------
+    def propagation_type(self, src: str, dst: str) -> str | None:
+        """Return the propagation relationship between two work products.
+
+        The method scans all governance diagrams for a connection between
+        work products named *src* and *dst*. If a connection with one of the
+        propagation types is found, its connection type string is returned.
+        Otherwise ``None`` is returned.
+        """
+        repo = SysMLRepository.get_instance()
+        for diag_id in self.diagrams.values():
+            diag = repo.diagrams.get(diag_id)
+            if not diag:
+                continue
+            objs = {o["obj_id"]: o for o in getattr(diag, "objects", [])}
+            for conn in getattr(diag, "connections", []):
+                ctype = conn.get("conn_type")
+                if ctype not in {"Propagate", "Propagate by Review", "Propagate by Approval"}:
+                    continue
+                src_obj = objs.get(conn.get("src"))
+                dst_obj = objs.get(conn.get("dst"))
+                if not src_obj or not dst_obj:
+                    continue
+                if src_obj.get("properties", {}).get("name") == src and dst_obj.get("properties", {}).get("name") == dst:
+                    return ctype
+        return None
+
+    # ------------------------------------------------------------------
     # Persistence helpers
     # ------------------------------------------------------------------
     def to_dict(self) -> dict:

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -28,6 +28,15 @@ _next_obj_id = 1
 # Pixel distance used when detecting clicks on connection lines
 CONNECTION_SELECT_RADIUS = 15
 
+# Allowed propagation links between work products in governance diagrams
+ALLOWED_PROPAGATIONS = {
+    ("Risk Assessment", "FTA"),
+    ("Risk Assessment", "FMEA"),
+    ("Risk Assessment", "FMEDA"),
+    ("FMEA", "FTA"),
+    ("FTA", "Safety Goal"),
+}
+
 
 def _get_next_id() -> int:
     global _next_obj_id
@@ -2734,6 +2743,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Composite Aggregation",
             "Control Action",
             "Feedback",
+            "Propagate",
+            "Propagate by Review",
+            "Propagate by Approval",
         ):
             if src == dst:
                 return False, "Cannot connect an element to itself"
@@ -2825,6 +2837,14 @@ class SysMLDiagramWindow(tk.Frame):
                             ex = flow_dir(c, dst.obj_id)
                             if ex and ex != new_dir_b:
                                 return False, "Inconsistent data flow on port"
+
+        elif diag_type == "BPMN Diagram":
+            if conn_type in ("Propagate", "Propagate by Review", "Propagate by Approval"):
+                if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
+                    return False, "Propagation links require two work products"
+                pair = (src.properties.get("name"), dst.properties.get("name"))
+                if pair not in ALLOWED_PROPAGATIONS:
+                    return False, f"{pair[0]} cannot propagate to {pair[1]}"
 
         elif diag_type == "Control Flow Diagram":
             if conn_type in ("Control Action", "Feedback"):
@@ -3140,6 +3160,9 @@ class SysMLDiagramWindow(tk.Frame):
                             "Generalization",
                             "Include",
                             "Extend",
+                            "Propagate",
+                            "Propagate by Review",
+                            "Propagate by Approval",
                         ):
                             arrow_default = "forward"
                         else:
@@ -3623,6 +3646,9 @@ class SysMLDiagramWindow(tk.Frame):
                         "Generalization",
                         "Include",
                         "Extend",
+                        "Propagate",
+                        "Propagate by Review",
+                        "Propagate by Approval",
                     ):
                         arrow_default = "forward"
                     else:
@@ -8035,6 +8061,9 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             "Decision",
             "Merge",
             "Flow",
+            "Propagate",
+            "Propagate by Review",
+            "Propagate by Approval",
             "System Boundary",
         ]
         super().__init__(master, "BPMN Diagram", tools, diagram_id, app=app, history=history)

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -21,7 +21,12 @@ sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 from AutoML import FaultTreeApp
 import AutoML
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
-from gui.architecture import BPMNDiagramWindow, SysMLObject, ArchitectureManagerDialog
+from gui.architecture import (
+    BPMNDiagramWindow,
+    SysMLObject,
+    DiagramConnection,
+    ArchitectureManagerDialog,
+)
 from gui.safety_management_explorer import SafetyManagementExplorer
 from gui.review_toolbox import ReviewData
 from sysml.sysml_repository import SysMLRepository
@@ -1000,4 +1005,51 @@ def test_work_product_color_and_text_wrapping():
     win.draw_object(obj)
     _, rect_kwargs = win.canvas.rect_calls[0]
     assert rect_kwargs["fill"] == "lightgreen"
+
+
+def _make_toolbox_with_connection(conn_type: str):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    diag_id = toolbox.create_diagram("Gov")
+    diag = repo.diagrams[diag_id]
+    a = SysMLObject(1, "Work Product", 0.0, 0.0, properties={"name": "Risk Assessment"})
+    b = SysMLObject(2, "Work Product", 100.0, 0.0, properties={"name": "FTA"})
+    diag.objects = [a.__dict__, b.__dict__]
+    conn = DiagramConnection(a.obj_id, b.obj_id, conn_type, arrow="forward")
+    diag.connections = [conn.__dict__]
+    return toolbox
+
+
+def test_propagation_connection_validation():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("BPMN Diagram")
+    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.connections = []
+    a = SysMLObject(1, "Work Product", 0, 0, properties={"name": "Risk Assessment"})
+    b = SysMLObject(2, "Work Product", 0, 0, properties={"name": "FTA"})
+    c = SysMLObject(3, "Work Product", 0, 0, properties={"name": "HAZOP"})
+    win.objects = [a, b, c]
+    valid, _ = win.validate_connection(a, b, "Propagate")
+    assert valid
+    valid, msg = win.validate_connection(c, b, "Propagate")
+    assert not valid
+
+
+def test_allow_propagation_requires_reviews():
+    toolbox = _make_toolbox_with_connection("Propagate by Review")
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.safety_mgmt_toolbox = toolbox
+    app.reviews = []
+    assert not app._allow_propagation("Risk Assessment", "FTA")
+    app.reviews = [ReviewData(name="r", reviewed=True)]
+    assert app._allow_propagation("Risk Assessment", "FTA")
+
+    toolbox = _make_toolbox_with_connection("Propagate by Approval")
+    app.safety_mgmt_toolbox = toolbox
+    app.reviews = [ReviewData(name="j", mode="joint", approved=True)]
+    assert app._allow_propagation("Risk Assessment", "FTA")
 


### PR DESCRIPTION
## Summary
- add 'Propagate', 'Propagate by Review', and 'Propagate by Approval' relationships to governance diagrams
- enforce allowed propagation pairs and review/approval gating before data flows downstream
- test new propagation rules and review requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ccc69e60c8325bfa2af98b1579383