### PR TITLE
feat(gui): add left panel for BPMN actions

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -8089,9 +8089,6 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             "Decision",
             "Merge",
             "Flow",
-            "Propagate",
-            "Propagate by Review",
-            "Propagate by Approval",
             "System Boundary",
         ]
         super().__init__(master, "BPMN Diagram", tools, diagram_id, app=app, history=history)
@@ -8099,21 +8096,35 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             if isinstance(child, ttk.Button) and child.cget("text") == "Action":
                 child.configure(text="Task")
 
+        bpmn_panel = ttk.LabelFrame(self.toolbox, text="BPMN")
+        bpmn_panel.pack(fill=tk.X, padx=2, pady=2, before=self.prop_frame)
+
+        for name in (
+            "Propagate",
+            "Propagate by Review",
+            "Propagate by Approval",
+        ):
+            ttk.Button(
+                bpmn_panel,
+                text=name,
+                command=lambda t=name: self.select_tool(t),
+            ).pack(fill=tk.X, padx=2, pady=2)
+
         ttk.Button(
-            self.toolbox,
+            bpmn_panel,
             text="Add Work Product",
             command=self.add_work_product,
-        ).pack(fill=tk.X, padx=2, pady=2, before=self.prop_frame)
+        ).pack(fill=tk.X, padx=2, pady=2)
         ttk.Button(
-            self.toolbox,
+            bpmn_panel,
             text="Add Process Area",
             command=self.add_process_area,
-        ).pack(fill=tk.X, padx=2, pady=2, before=self.prop_frame)
+        ).pack(fill=tk.X, padx=2, pady=2)
         ttk.Button(
-            self.toolbox,
+            bpmn_panel,
             text="Add Lifecycle Phase",
             command=self.add_lifecycle_phase,
-        ).pack(fill=tk.X, padx=2, pady=2, before=self.prop_frame)
+        ).pack(fill=tk.X, padx=2, pady=2)
 
     class _SelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
         def __init__(self, parent, title: str, options: list[str]):


### PR DESCRIPTION
## Summary
- group propagate and work-product actions into a dedicated BPMN panel
- streamline BPMN toolbox by separating propagation links from core tools

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689cd376c0dc83259654585c008c2388