### PR TITLE
Wrap governance work product labels

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5528,7 +5528,7 @@ class SysMLDiagramWindow(tk.Frame):
                 self.canvas.create_text(
                     x,
                     y,
-                    text=label,
+                    text=label.replace(" ", "\n"),
                     anchor="center",
                     font=self.font,
                     width=obj.width * self.zoom,

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1065,6 +1065,7 @@ def test_work_product_color_and_text_wrapping():
     _, rect_kwargs = win.canvas.rect_calls[0]
     assert rect_kwargs["fill"] == "lightblue"
     assert win.canvas.text_calls[0][2]["width"] == 60.0
+    assert win.canvas.text_calls[0][2]["text"] == "Architecture\nDiagram"
 
     win.canvas.rect_calls.clear()
     win.canvas.text_calls.clear()


### PR DESCRIPTION
## Summary
- Render work product names in governance diagrams on multiple lines to prevent text overlap
- Add regression test ensuring work product labels are multi-line and width constrained

## Testing
- `pytest tests/test_safety_management.py::test_work_product_color_and_text_wrapping -q`
- `pytest tests/test_safety_management.py -k 'Work and Product' -q`


------
https://chatgpt.com/codex/tasks/task_b_689cd73276588325b5ab34135368fcec