### PR TITLE
Display stereotypes for all connections

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -300,7 +300,7 @@ class StpaWindow(tk.Frame):
             rel_stereo = (rel.stereotype or "").lower()
             if rel.rel_type != "Control Action" and rel_stereo != "control action":
                 continue
-            conn = DiagramConnection(0, 0, "Control Action")
+            conn = DiagramConnection(0, 0, "Control Action", stereotype=rel.stereotype or "")
             conn.name = rel.properties.get("name", "")
             elem_id = rel.properties.get("element_id")
             if elem_id:

--- a/tests/test_control_flow_stereotype.py
+++ b/tests/test_control_flow_stereotype.py
@@ -1,7 +1,6 @@
 import types
-import types
 import unittest
-from gui.architecture import SysMLDiagramWindow, SysMLObject
+from gui.architecture import SysMLDiagramWindow, SysMLObject, format_control_flow_label
 from sysml.sysml_repository import SysMLRepository
 
 
@@ -63,6 +62,11 @@ class ControlFlowStereotypeTests(unittest.TestCase):
         event2 = types.SimpleNamespace(x=0, y=100, state=0)
         SysMLDiagramWindow.on_left_press(win, event2)
         self.assertEqual(repo.relationships[0].stereotype, "control action")
+        self.assertEqual(win.connections[0].stereotype, "control action")
+        self.assertEqual(
+            format_control_flow_label(win.connections[0], repo, diag.diag_type),
+            "<<control action>>",
+        )
 
     def test_feedback_relationship_stereotype(self):
         repo = self.repo
@@ -80,6 +84,11 @@ class ControlFlowStereotypeTests(unittest.TestCase):
         event2 = types.SimpleNamespace(x=0, y=100, state=0)
         SysMLDiagramWindow.on_left_press(win, event2)
         self.assertEqual(repo.relationships[0].stereotype, "feedback")
+        self.assertEqual(win.connections[0].stereotype, "feedback")
+        self.assertEqual(
+            format_control_flow_label(win.connections[0], repo, diag.diag_type),
+            "<<feedback>>",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- store connection stereotypes in `DiagramConnection`
- prefix connection labels with `<<stereotype>>`
- propagate stereotypes when creating connections and retrieving labels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689cdb6c8cc48325b4ef2d69b94edc6e