### PR TITLE
Display stereotypes for relationships and connectors

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -209,13 +209,19 @@ class SafetyManagementToolbox:
             if src_id is None or dst_id is None:
                 continue
             for c in getattr(diag, "connections", []):
+                stereo = (c.get("stereotype") or c.get("conn_type") or "").lower()
                 if (
                     c.get("src") == src_id
                     and c.get("dst") == dst_id
-                    and c.get("conn_type")
-                    in {"Propagate", "Propagate by Review", "Propagate by Approval"}
+                    and stereo
+                    in {"propagate", "propagate by review", "propagate by approval"}
                 ):
-                    return c.get("conn_type")
+                    mapping = {
+                        "propagate": "Propagate",
+                        "propagate by review": "Propagate by Review",
+                        "propagate by approval": "Propagate by Approval",
+                    }
+                    return c.get("conn_type") or mapping[stereo]
         return None
 
     # ------------------------------------------------------------------

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -352,7 +352,15 @@ class SysMLRepository:
         if self.root_package is None:
             self.root_package = self.create_element("Package", name="Root")
 
-    def create_relationship(self, rel_type: str, source: str, target: str, stereotype: Optional[str] = None, properties: Optional[Dict[str, str]] = None, record_undo: bool = True) -> SysMLRelationship:
+    def create_relationship(
+        self,
+        rel_type: str,
+        source: str,
+        target: str,
+        stereotype: Optional[str] = None,
+        properties: Optional[Dict[str, str]] = None,
+        record_undo: bool = True,
+    ) -> SysMLRelationship:
         if record_undo:
             self.push_undo_state()
         rel_id = str(uuid.uuid4())
@@ -361,7 +369,7 @@ class SysMLRepository:
             rel_type,
             source,
             target,
-            stereotype,
+            stereotype or rel_type.lower(),
             properties or {},
             author=user_config.CURRENT_USER_NAME,
             author_email=user_config.CURRENT_USER_EMAIL,

--- a/tests/test_connection_stereotype_label.py
+++ b/tests/test_connection_stereotype_label.py
@@ -1,0 +1,28 @@
+import unittest
+from gui.architecture import DiagramConnection, format_control_flow_label
+from sysml.sysml_repository import SysMLRepository
+
+
+class ConnectionStereotypeLabelTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def test_association_label_stereotype(self):
+        conn = DiagramConnection(1, 2, "Association")
+        label = format_control_flow_label(conn, self.repo, None)
+        self.assertEqual(label, "<<association>>")
+
+    def test_association_label_with_name(self):
+        conn = DiagramConnection(1, 2, "Association", name="rel")
+        label = format_control_flow_label(conn, self.repo, None)
+        self.assertEqual(label, "<<association>> rel")
+
+    def test_propagate_label_stereotype(self):
+        conn = DiagramConnection(1, 2, "Propagate")
+        label = format_control_flow_label(conn, self.repo, "BPMN Diagram")
+        self.assertEqual(label, "<<propagate>>")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -1,0 +1,86 @@
+import types
+import unittest
+
+from gui.architecture import BPMNDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+class DummyCanvas:
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+    def configure(self, **kwargs):
+        pass
+
+
+class GovernanceRelationshipStereotypeTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+        from gui import architecture
+        self._orig_conn_dialog = architecture.ConnectionDialog
+
+    def tearDown(self):
+        from gui import architecture
+        architecture.ConnectionDialog = self._orig_conn_dialog
+
+    def _create_window(self, tool, src, dst, diag):
+        win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+        win.repo = self.repo
+        win.diagram_id = diag.diag_id
+        win.zoom = 1
+        win.canvas = DummyCanvas()
+        win.find_object = lambda x, y, prefer_port=False: src if win.start is None else dst
+        win.validate_connection = BPMNDiagramWindow.validate_connection.__get__(
+            win, BPMNDiagramWindow
+        )
+        win.update_property_view = lambda: None
+        win.redraw = lambda: None
+        win.current_tool = tool
+        win.start = None
+        win.temp_line_end = None
+        win.selected_obj = None
+        win.connections = []
+        win._sync_to_repository = lambda: None
+        from gui import architecture
+        architecture.ConnectionDialog = lambda *args, **kwargs: None
+        return win
+
+    def test_propagate_relationship_stereotype(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("BPMN Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Risk Assessment"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Propagate", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        BPMNDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        BPMNDiagramWindow.on_left_press(win, event2)
+        self.assertEqual(repo.relationships[0].stereotype, "propagate")
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1112,3 +1112,17 @@ def test_can_propagate_respects_review_states():
     assert toolbox.can_propagate("Risk Assessment", "FTA", joint_review=True)
     diag.connections = [{"src": 1, "dst": 2, "conn_type": "Propagate"}]
     assert toolbox.can_propagate("Risk Assessment", "FTA", reviewed=False)
+
+
+def test_propagation_type_uses_stereotype_when_conn_type_missing():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    diag = repo.create_diagram("BPMN Diagram", name="Gov")
+    toolbox.diagrams["Gov"] = diag.diag_id
+    diag.objects = [
+        {"obj_id": 1, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Risk Assessment"}},
+        {"obj_id": 2, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "FTA"}},
+    ]
+    diag.connections = [{"src": 1, "dst": 2, "stereotype": "propagate by review"}]
+    assert toolbox.propagation_type("Risk Assessment", "FTA") == "Propagate by Review"


### PR DESCRIPTION
## Summary
- Show stereotypes for all diagram connections using the <<stereotype>> notation
- Default relationship stereotypes to their type in the repository
- Recognize stereotypes on governance propagation links so propagation rules work even without `conn_type`
- Test association and governance connection labels and relationship stereotypes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cdb6c8cc48325b4ef2d69b94edc6e