### PR TITLE
Fix undefined variable causing relationship creation error

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3718,11 +3718,18 @@ class SysMLDiagramWindow(tk.Frame):
                                     conn.arrow = "both"
                     self.connections.append(conn)
                     if self.start.element_id and obj.element_id:
+                        rel_stereo = (
+                            "control action"
+                            if self.current_tool == "Control Action"
+                            else "feedback"
+                            if self.current_tool == "Feedback"
+                            else None
+                        )
                         rel = self.repo.create_relationship(
                             self.current_tool,
                             self.start.element_id,
                             obj.element_id,
-                            stereotype=stereo,
+                            stereotype=rel_stereo,
                         )
                         self.repo.add_relationship_to_diagram(
                             self.diagram_id, rel.rel_id


### PR DESCRIPTION
## Summary
- prevent NameError when releasing mouse during connection creation
- ensure relationships use proper stereotype based on selected tool

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ce18b8e6c8325b70b72a796ddcadd