### PR TITLE
Allow root-level diagrams in Safety & Security explorer

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -222,6 +222,18 @@ class SafetyManagementToolbox:
         _collect(mod)
         return names
 
+    def list_modules(self) -> List[str]:
+        """Return names of all governance modules including submodules."""
+        names: List[str] = []
+
+        def _collect(mods: List[GovernanceModule]) -> None:
+            for m in mods:
+                names.append(m.name)
+                _collect(m.modules)
+
+        _collect(self.modules)
+        return names
+
     # ------------------------------------------------------------------
     def propagation_type(self, source: str, target: str) -> Optional[str]:
         """Return propagation relationship type from ``source`` to ``target``.


### PR DESCRIPTION
## Summary
- add explicit root node so governance diagrams can be created outside folders
- support root-level drag-and-drop and module listing
- test root diagram creation and list_modules helper

## Testing
- `pytest tests/test_safety_management.py::test_safety_management_explorer_creates_folders_and_diagrams -q`
- `pytest tests/test_safety_management.py::test_explorer_prevents_diagrams_outside_folders -q`
- `pytest tests/test_safety_management.py::test_explorer_allows_diagram_at_root -q`
- `pytest tests/test_safety_management.py::test_diagram_drag_and_drop_between_modules -q`
- `pytest tests/test_safety_management.py::test_list_modules_includes_submodules -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ce67eb930832590dca0dac6ea8cc1