### PR TITLE
Allow renaming governance modules and diagrams

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -235,6 +235,39 @@ class SafetyManagementToolbox:
         return names
 
     # ------------------------------------------------------------------
+    def rename_module(self, old: str, new: str) -> None:
+        """Rename a governance module ensuring uniqueness.
+
+        If ``new`` conflicts with an existing module name the method appends
+        a numeric suffix to make it unique. The :attr:`active_module` is updated
+        when it references the renamed module.
+        """
+
+        if not new or old == new:
+            return
+
+        existing = set(self.list_modules())
+        existing.discard(old)
+        base = new
+        suffix = 1
+        while new in existing:
+            new = f"{base}_{suffix}"
+            suffix += 1
+
+        def _rename(mods: List[GovernanceModule]) -> bool:
+            for mod in mods:
+                if mod.name == old:
+                    mod.name = new
+                    if self.active_module == old:
+                        self.active_module = new
+                    return True
+                if _rename(mod.modules):
+                    return True
+            return False
+
+        _rename(self.modules)
+
+    # ------------------------------------------------------------------
     def propagation_type(self, source: str, target: str) -> Optional[str]:
         """Return propagation relationship type from ``source`` to ``target``.
 

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -137,13 +137,23 @@ class SafetyManagementExplorer(tk.Frame):
         if not sel:
             return
         typ, obj = self.item_map.get(sel[0], (None, None))
-        if typ != "diagram":
+        if typ == "diagram":
+            new = simpledialog.askstring(
+                "Rename Diagram", "Name:", initialvalue=obj, parent=self
+            )
+            if not new or new == obj:
+                return
+            self.toolbox.rename_diagram(obj, new)
+            self._replace_name_in_modules(obj, new, self.toolbox.modules)
+        elif typ == "module":
+            new = simpledialog.askstring(
+                "Rename Folder", "Name:", initialvalue=obj.name, parent=self
+            )
+            if not new or new == obj.name:
+                return
+            self.toolbox.rename_module(obj.name, new)
+        else:
             return
-        new = simpledialog.askstring("Rename Diagram", "Name:", initialvalue=obj, parent=self)
-        if not new or new == obj:
-            return
-        self.toolbox.rename_diagram(obj, new)
-        self._replace_name_in_modules(obj, new, self.toolbox.modules)
         self.populate()
 
     # ------------------------------------------------------------------

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -112,6 +112,15 @@ def test_toolbox_manages_diagram_lifecycle():
     assert not toolbox.diagrams
 
 
+def test_rename_module_updates_active():
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("Phase1")]
+    toolbox.set_active_module("Phase1")
+    toolbox.rename_module("Phase1", "PhaseX")
+    assert toolbox.modules[0].name == "PhaseX"
+    assert toolbox.active_module == "PhaseX"
+
+
 def test_disable_work_product_rejects_existing_docs():
     """Work product types with existing documents cannot be removed."""
     app = FaultTreeApp.__new__(FaultTreeApp)
@@ -782,6 +791,80 @@ def test_safety_management_explorer_creates_folders_and_diagrams(monkeypatch):
     explorer.new_diagram()
     assert "Diag" in toolbox.modules[0].diagrams
     assert "Diag" in toolbox.diagrams
+
+
+def test_explorer_renames_folders_and_diagrams(monkeypatch):
+    SysMLRepository._instance = None
+    SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    explorer = SafetyManagementExplorer.__new__(SafetyManagementExplorer)
+
+    class DummyTree:
+        def __init__(self):
+            self.items = {}
+            self.counter = 0
+            self.selection_item = None
+
+        def delete(self, *items):
+            self.items = {}
+
+        def get_children(self, item=""):
+            return [iid for iid, meta in self.items.items() if meta["parent"] == item]
+
+        def insert(self, parent, index, text="", image=None, **_kwargs):
+            iid = f"i{self.counter}"
+            self.counter += 1
+            self.items[iid] = {"parent": parent, "text": text}
+            return iid
+
+        def parent(self, item):
+            return self.items[item]["parent"]
+
+        def selection(self):
+            return (self.selection_item,) if self.selection_item else ()
+
+    explorer.tree = DummyTree()
+    explorer.toolbox = toolbox
+    explorer.item_map = {}
+    explorer.folder_icon = None
+    explorer.diagram_icon = None
+    explorer.app = types.SimpleNamespace(open_arch_window=lambda _id: None)
+
+    SafetyManagementExplorer.populate(explorer)
+    monkeypatch.setattr(simpledialog, "askstring", lambda *args, **kwargs: "Pkg")
+    explorer.new_folder()
+
+    # Find folder iid
+    for iid, (typ, obj) in explorer.item_map.items():
+        if typ == "module" and obj.name == "Pkg":
+            explorer.tree.selection_item = iid
+            break
+
+    monkeypatch.setattr(simpledialog, "askstring", lambda *args, **kwargs: "Diag")
+    explorer.new_diagram()
+
+    # Locate folder iid again after repopulate
+    for fid, (typ, obj) in explorer.item_map.items():
+        if typ == "module" and obj.name == "Pkg":
+            iid = fid
+            break
+
+    # Rename folder
+    explorer.tree.selection_item = iid
+    monkeypatch.setattr(simpledialog, "askstring", lambda *args, **kwargs: "PkgRen")
+    explorer.rename_item()
+    assert toolbox.modules[0].name == "PkgRen"
+
+    # Find diagram iid and rename
+    for di, (typ, obj) in explorer.item_map.items():
+        if typ == "diagram" and obj == "Diag":
+            explorer.tree.selection_item = di
+            break
+    monkeypatch.setattr(simpledialog, "askstring", lambda *args, **kwargs: "DiagRen")
+    explorer.rename_item()
+    assert "DiagRen" in toolbox.modules[0].diagrams
+    assert "DiagRen" in toolbox.diagrams
 
 
 def test_explorer_prevents_diagrams_outside_folders(monkeypatch):


### PR DESCRIPTION
## Summary
- enable renaming of governance folders and keep active module in sync
- allow Safety Management Explorer to rename folders and diagrams
- test renaming operations for toolbox and explorer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ce98d9bbc83258042fa80ab65c20d