### PR TITLE
Add requirement-specific governance work products

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2022,6 +2022,17 @@ class FaultTreeApp:
         ),
     }
 
+    WORK_PRODUCT_INFO.update(
+        {
+            f"{' '.join(word.upper() if word.isupper() else word.capitalize() for word in _req.split())} Requirement Specification": (
+                "System Design (Item Definition)",
+                "Requirements Editor",
+                "show_requirements_editor",
+            )
+            for _req in REQUIREMENT_TYPE_OPTIONS
+        }
+    )
+
     def __init__(self, root):
         self.root = root
         self.top_events = []

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -14,7 +14,12 @@ from sysml.sysml_repository import SysMLRepository, SysMLDiagram, SysMLElement
 from gui.style_manager import StyleManager
 
 from sysml.sysml_spec import SYSML_PROPERTIES
-from analysis.models import global_requirements, ASIL_ORDER, StpaDoc
+from analysis.models import (
+    global_requirements,
+    ASIL_ORDER,
+    StpaDoc,
+    REQUIREMENT_TYPE_OPTIONS,
+)
 from analysis.safety_management import ALLOWED_PROPAGATIONS
 
 # ---------------------------------------------------------------------------
@@ -8204,6 +8209,12 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             self.selection = self.var.get()
 
     def add_work_product(self):  # pragma: no cover - requires tkinter
+        def _fmt(req: str) -> str:
+            return " ".join(
+                word.upper() if word.isupper() else word.capitalize()
+                for word in req.split()
+            )
+
         options = [
             "Architecture Diagram",
             "Safety & Security Concept",
@@ -8219,6 +8230,9 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             "FMEA",
             "FMEDA",
         ]
+        options.extend(
+            f"{_fmt(rt)} Requirement Specification" for rt in REQUIREMENT_TYPE_OPTIONS
+        )
         dlg = self._SelectDialog(self, "Add Work Product", options)
         name = getattr(dlg, "selection", "")
         if not name:
@@ -8238,6 +8252,8 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             "FMEA": "Safety Analysis",
             "FMEDA": "Safety Analysis",
         }
+        for rt in REQUIREMENT_TYPE_OPTIONS:
+            area_map[f"{_fmt(rt)} Requirement Specification"] = "System Design (Item Definition)"
         required = area_map.get(name)
         if required and not any(
             o.obj_type == "System Boundary" and o.properties.get("name") == required

--- a/tests/test_requirement_work_products.py
+++ b/tests/test_requirement_work_products.py
@@ -1,0 +1,57 @@
+import types
+
+from analysis.models import REQUIREMENT_TYPE_OPTIONS
+from gui.architecture import BPMNDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+from AutoML import FaultTreeApp
+
+
+def _fmt(req: str) -> str:
+    return " ".join(
+        word.upper() if word.isupper() else word.capitalize() for word in req.split()
+    )
+
+
+def test_work_product_created_for_each_requirement_type():
+    for req in REQUIREMENT_TYPE_OPTIONS:
+        name = f"{_fmt(req)} Requirement Specification"
+        assert name in FaultTreeApp.WORK_PRODUCT_INFO
+
+
+def test_add_requirement_work_product(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Gov")
+    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = [
+        SysMLObject(
+            1,
+            "System Boundary",
+            0.0,
+            0.0,
+            width=200.0,
+            height=150.0,
+            properties={"name": "System Design (Item Definition)"},
+        )
+    ]
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    added = []
+    win.app = types.SimpleNamespace(enable_work_product=lambda name: added.append(name))
+
+    name = f"{_fmt(REQUIREMENT_TYPE_OPTIONS[2])} Requirement Specification"
+
+    class FakeDialog:
+        def __init__(self, *args, **kwargs):
+            self.selection = name
+
+    monkeypatch.setattr(BPMNDiagramWindow, "_SelectDialog", FakeDialog)
+
+    win.add_work_product()
+
+    assert added == [name]
+    assert any(o.properties.get("name") == name for o in win.objects)
+


### PR DESCRIPTION
## Summary
- allow BPMN governance diagrams to add work products for each requirement type
- map requirement-specific work products to the System Design process area and enable corresponding tools
- test that every requirement type has a work product and can be added

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ceeff5c9483259e961fd58c10a27d