### PR TITLE
Use combobox for selecting GSN diagram

### DIFF
--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -5,6 +5,33 @@ import tkinter as tk
 from tkinter import ttk, simpledialog
 from typing import Dict, Tuple
 
+
+class DiagramSelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
+    """Dialog presenting a read-only list of diagram names."""
+
+    def __init__(self, parent, title: str, options: list[str], initial: str | None = None):
+        self.options = options
+        self.initial = initial
+        self.selection = ""
+        super().__init__(parent, title)
+
+    def body(self, master):  # pragma: no cover - requires tkinter
+        ttk.Label(master, text="Diagram:").pack(padx=5, pady=5)
+        self.var = tk.StringVar(
+            value=self.initial if self.initial is not None else (self.options[0] if self.options else "")
+        )
+        combo = ttk.Combobox(
+            master,
+            textvariable=self.var,
+            values=self.options,
+            state="readonly",
+        )
+        combo.pack(padx=5, pady=5)
+        return combo
+
+    def apply(self):  # pragma: no cover - requires tkinter
+        self.selection = self.var.get()
+
 from analysis.safety_case import SafetyCaseLibrary, SafetyCase
 from gui import messagebox
 
@@ -94,8 +121,8 @@ class SafetyCaseExplorer(tk.Frame):
         if not name:
             return
         diag_names = [d.root.user_name for d in diagrams]
-        prompt = "Diagram name:\n" + "\n".join(diag_names)
-        diag_name = simpledialog.askstring("GSN Diagram", prompt, parent=self)
+        dlg = DiagramSelectDialog(self, "GSN Diagram", diag_names)
+        diag_name = dlg.selection
         if not diag_name:
             return
         diag = next((d for d in diagrams if d.root.user_name == diag_name), None)
@@ -121,10 +148,10 @@ class SafetyCaseExplorer(tk.Frame):
             return
         diagrams = self._available_diagrams()
         diag_names = [d.root.user_name for d in diagrams]
-        prompt = "Diagram name:\n" + "\n".join(diag_names)
-        new_diag_name = simpledialog.askstring(
-            "GSN Diagram", prompt, initialvalue=obj.diagram.root.user_name, parent=self
+        dlg = DiagramSelectDialog(
+            self, "GSN Diagram", diag_names, obj.diagram.root.user_name
         )
+        new_diag_name = dlg.selection
         if not new_diag_name:
             return
         new_diag = next((d for d in diagrams if d.root.user_name == new_diag_name), None)

--- a/tests/test_safety_case_explorer.py
+++ b/tests/test_safety_case_explorer.py
@@ -2,7 +2,7 @@ import types
 from tkinter import simpledialog
 from gsn import GSNNode, GSNDiagram, GSNModule
 from analysis.safety_case import SafetyCaseLibrary
-from gui.safety_case_explorer import SafetyCaseExplorer
+import gui.safety_case_explorer as safety_case_explorer
 from gui import messagebox
 
 class DummyTree:
@@ -33,18 +33,22 @@ def test_create_edit_delete_case(monkeypatch):
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
-    explorer = SafetyCaseExplorer.__new__(SafetyCaseExplorer)
+    explorer = safety_case_explorer.SafetyCaseExplorer.__new__(safety_case_explorer.SafetyCaseExplorer)
     explorer.tree = DummyTree()
     explorer.app = types.SimpleNamespace(gsn_diagrams=[diag])
     explorer.library = SafetyCaseLibrary()
     explorer.item_map = {}
     explorer.case_icon = explorer.solution_icon = None
 
-    SafetyCaseExplorer.populate(explorer)
+    safety_case_explorer.SafetyCaseExplorer.populate(explorer)
 
-    inputs = iter(["Case1", root.user_name])
+    inputs = iter(["Case1"])
     monkeypatch.setattr(simpledialog, "askstring", lambda *a, **k: next(inputs))
-    SafetyCaseExplorer.new_case(explorer)
+    class DummyDialog:
+        def __init__(self, *a, **k):
+            self.selection = root.user_name
+    monkeypatch.setattr(safety_case_explorer, "DiagramSelectDialog", DummyDialog)
+    safety_case_explorer.SafetyCaseExplorer.new_case(explorer)
     assert len(explorer.library.cases) == 1
     texts = [meta["text"] for meta in explorer.tree.items.values()]
     assert "Case1" in texts
@@ -54,16 +58,20 @@ def test_create_edit_delete_case(monkeypatch):
         if typ == "case":
             explorer.tree.selection_item = iid
             break
-    inputs = iter(["Renamed", root.user_name])
+    inputs = iter(["Renamed"])
     monkeypatch.setattr(simpledialog, "askstring", lambda *a, **k: next(inputs))
-    SafetyCaseExplorer.edit_case(explorer)
+    class DummyDialog2:
+        def __init__(self, *a, **k):
+            self.selection = root.user_name
+    monkeypatch.setattr(safety_case_explorer, "DiagramSelectDialog", DummyDialog2)
+    safety_case_explorer.SafetyCaseExplorer.edit_case(explorer)
     assert explorer.library.cases[0].name == "Renamed"
     for iid, (typ, obj) in explorer.item_map.items():
         if typ == "case":
             explorer.tree.selection_item = iid
             break
     monkeypatch.setattr(messagebox, "askokcancel", lambda *a, **k: True)
-    SafetyCaseExplorer.delete_case(explorer)
+    safety_case_explorer.SafetyCaseExplorer.delete_case(explorer)
     assert explorer.library.cases == []
 
 
@@ -73,16 +81,20 @@ def test_create_case_from_module(monkeypatch):
     module = GSNModule("M")
     module.diagrams.append(diag)
 
-    explorer = SafetyCaseExplorer.__new__(SafetyCaseExplorer)
+    explorer = safety_case_explorer.SafetyCaseExplorer.__new__(safety_case_explorer.SafetyCaseExplorer)
     explorer.tree = DummyTree()
     explorer.app = types.SimpleNamespace(gsn_diagrams=[], gsn_modules=[module])
     explorer.library = SafetyCaseLibrary()
     explorer.item_map = {}
     explorer.case_icon = explorer.solution_icon = None
 
-    SafetyCaseExplorer.populate(explorer)
+    safety_case_explorer.SafetyCaseExplorer.populate(explorer)
 
-    inputs = iter(["Case2", root.user_name])
+    inputs = iter(["Case2"])
     monkeypatch.setattr(simpledialog, "askstring", lambda *a, **k: next(inputs))
-    SafetyCaseExplorer.new_case(explorer)
+    class DummyDialog3:
+        def __init__(self, *a, **k):
+            self.selection = root.user_name
+    monkeypatch.setattr(safety_case_explorer, "DiagramSelectDialog", DummyDialog3)
+    safety_case_explorer.SafetyCaseExplorer.new_case(explorer)
     assert explorer.library.cases and explorer.library.cases[0].diagram is diag


### PR DESCRIPTION
## Summary
- Replace free-text GSN diagram entry with a combobox dialog when creating or editing a safety & security case
- Add `DiagramSelectDialog` to present available diagrams in a drop-down list
- Update safety case explorer tests to mock the new combobox dialog

## Testing
- `pytest`
- `PYTHONPATH=. pytest tests/test_safety_case_explorer.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689cfe845028832595852d0cdf6d41f0