### PR TITLE
Track work product phases for lifecycle filtering

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8620,17 +8620,29 @@ class FaultTreeApp:
         if not new:
             return
         if kind == "fmea":
+            old = self.fmeas[idx]["name"]
             self.fmeas[idx]["name"] = new
+            self.safety_mgmt_toolbox.rename_document("FMEA", old, new)
         elif kind == "fmeda":
+            old = self.fmedas[idx]["name"]
             self.fmedas[idx]["name"] = new
+            self.safety_mgmt_toolbox.rename_document("FMEDA", old, new)
         elif kind == "hazop":
+            old = self.hazop_docs[idx].name
             self.hazop_docs[idx].name = new
+            self.safety_mgmt_toolbox.rename_document("HAZOP", old, new)
         elif kind == "hara":
+            old = self.hara_docs[idx].name
             self.hara_docs[idx].name = new
+            self.safety_mgmt_toolbox.rename_document("Risk Assessment", old, new)
         elif kind == "fi2tc":
+            old = self.fi2tc_docs[idx].name
             self.fi2tc_docs[idx].name = new
+            self.safety_mgmt_toolbox.rename_document("FI2TC", old, new)
         elif kind == "tc2fi":
+            old = self.tc2fi_docs[idx].name
             self.tc2fi_docs[idx].name = new
+            self.safety_mgmt_toolbox.rename_document("TC2FI", old, new)
         elif kind == "arch" and repo.diagrams.get(ident):
             repo.diagrams[ident].name = new
         elif kind == "gov":
@@ -8647,7 +8659,9 @@ class FaultTreeApp:
             if any(r.name == new for r in self.reviews if r is not self.joint_reviews[idx]):
                 messagebox.showerror("Review", "Name already exists")
                 return
+            old = self.joint_reviews[idx].name
             self.joint_reviews[idx].name = new
+            self.safety_mgmt_toolbox.rename_document("Joint Review", old, new)
         elif kind == "fta" and node:
             node.user_name = new
         elif kind == "pkg" and repo.elements.get(ident):
@@ -8676,11 +8690,27 @@ class FaultTreeApp:
     def refresh_tool_enablement(self) -> None:
         if not hasattr(self, "tool_listboxes"):
             return
-        enabled = (
-            self.safety_mgmt_toolbox.enabled_products()
-            if self.safety_mgmt_toolbox
-            else set()
-        )
+        toolbox = getattr(self, "safety_mgmt_toolbox", None)
+        if toolbox:
+            declared = toolbox.enabled_products()
+            current = set(getattr(self, "enabled_work_products", set()))
+            for name in declared - current:
+                try:
+                    self.enable_work_product(name)
+                except Exception:
+                    self.enabled_work_products.add(name)
+            if getattr(toolbox, "work_products", None):
+                for name in current - declared:
+                    try:
+                        self.disable_work_product(name)
+                    except Exception:
+                        pass
+        global_enabled = getattr(self, "enabled_work_products", set())
+        if toolbox and getattr(toolbox, "work_products", None):
+            phase_enabled = toolbox.enabled_products()
+        else:
+            phase_enabled = global_enabled
+        enabled = global_enabled & phase_enabled
         for lb in self.tool_listboxes.values():
             for i, tool_name in enumerate(lb.get(0, tk.END)):
                 analysis_name = getattr(self, "tool_to_work_product", {}).get(tool_name)
@@ -8688,6 +8718,13 @@ class FaultTreeApp:
                     lb.itemconfig(i, foreground="gray")
                 else:
                     lb.itemconfig(i, foreground="black")
+        for wp, menus in getattr(self, "work_product_menus", {}).items():
+            state = tk.NORMAL if wp in enabled else tk.DISABLED
+            for menu, idx in menus:
+                try:
+                    menu.entryconfig(idx, state=state)
+                except tk.TclError:
+                    pass
 
     def on_lifecycle_selected(self, _event=None) -> None:
         phase = self.lifecycle_var.get()
@@ -8695,7 +8732,7 @@ class FaultTreeApp:
             self.safety_mgmt_toolbox.set_active_module(None)
         else:
             self.safety_mgmt_toolbox.set_active_module(phase)
-        self.refresh_tool_enablement()
+        self.update_views()
 
     def update_lifecycle_cb(self) -> None:
         if not hasattr(self, "lifecycle_cb"):
@@ -8835,7 +8872,13 @@ class FaultTreeApp:
             (wp for wp, info in self.WORK_PRODUCT_INFO.items() if info[1] == name or wp == name),
             None,
         )
-        if wp and wp not in self.enabled_work_products:
+        global_enabled = getattr(self, "enabled_work_products", set())
+        smt = getattr(self, "safety_mgmt_toolbox", None)
+        if smt and getattr(smt, "work_products", None):
+            phase_enabled = smt.enabled_products()
+        else:
+            phase_enabled = global_enabled
+        if wp and wp not in (global_enabled & phase_enabled):
             return
         action = self.tool_actions.get(name)
         if callable(action):
@@ -9707,7 +9750,13 @@ class FaultTreeApp:
             tree.delete(*tree.get_children())
 
             repo = SysMLRepository.get_instance()
-            enabled = getattr(self, "enabled_work_products", set())
+            global_enabled = getattr(self, "enabled_work_products", set())
+            smt = getattr(self, "safety_mgmt_toolbox", None)
+            if smt and getattr(smt, "work_products", None):
+                phase_enabled = smt.enabled_products()
+            else:
+                phase_enabled = global_enabled
+            enabled = global_enabled & phase_enabled
 
             # --- Safety & Security Management Section ---
             self.management_diagrams = sorted(
@@ -9732,6 +9781,9 @@ class FaultTreeApp:
             toolbox.list_diagrams()
             self.update_lifecycle_cb()
             self.refresh_tool_enablement()
+
+            def _visible(analysis_name: str, doc_name: str) -> bool:
+                return toolbox.document_visible(analysis_name, doc_name)
 
             index_map = {
                 (d.name or d.diag_id): idx
@@ -9945,26 +9997,36 @@ class FaultTreeApp:
                 _ensure_haz_root()
                 hazop_root = tree.insert(haz_root, "end", text="HAZOPs", open=True)
                 for idx, doc in enumerate(self.hazop_docs):
+                    if not _visible("HAZOP", doc.name):
+                        continue
                     tree.insert(hazop_root, "end", text=doc.name, tags=("hazop", str(idx)))
             if "STPA" in enabled or getattr(self, "stpa_docs", []):
                 _ensure_haz_root()
                 stpa_root = tree.insert(haz_root, "end", text="STPA Analyses", open=True)
                 for idx, doc in enumerate(self.stpa_docs):
+                    if not _visible("STPA", doc.name):
+                        continue
                     tree.insert(stpa_root, "end", text=doc.name, tags=("stpa", str(idx)))
             if "Threat Analysis" in enabled or getattr(self, "threat_docs", []):
                 _ensure_haz_root()
                 threat_root = tree.insert(haz_root, "end", text="Threat Analyses", open=True)
                 for idx, doc in enumerate(self.threat_docs):
+                    if not _visible("Threat Analysis", doc.name):
+                        continue
                     tree.insert(threat_root, "end", text=doc.name, tags=("threat", str(idx)))
             if "FI2TC" in enabled or getattr(self, "fi2tc_docs", []):
                 _ensure_haz_root()
                 fi2tc_root = tree.insert(haz_root, "end", text="FI2TC Analyses", open=True)
                 for idx, doc in enumerate(self.fi2tc_docs):
+                    if not _visible("FI2TC", doc.name):
+                        continue
                     tree.insert(fi2tc_root, "end", text=doc.name, tags=("fi2tc", str(idx)))
             if "TC2FI" in enabled or getattr(self, "tc2fi_docs", []):
                 _ensure_haz_root()
                 tc2fi_root = tree.insert(haz_root, "end", text="TC2FI Analyses", open=True)
                 for idx, doc in enumerate(self.tc2fi_docs):
+                    if not _visible("TC2FI", doc.name):
+                        continue
                     tree.insert(tc2fi_root, "end", text=doc.name, tags=("tc2fi", str(idx)))
 
             # --- Risk Assessment Section ---
@@ -9977,6 +10039,8 @@ class FaultTreeApp:
                 _ensure_risk_root()
                 assessment_root = tree.insert(risk_root, "end", text="Risk Assessments", open=True)
                 for idx, doc in enumerate(self.hara_docs):
+                    if not _visible("Risk Assessment", doc.name):
+                        continue
                     tree.insert(assessment_root, "end", text=doc.name, tags=("hara", str(idx)))
             if "Product Goal Specification" in enabled:
                 _ensure_risk_root()
@@ -9992,17 +10056,25 @@ class FaultTreeApp:
                 _ensure_safety_root()
                 fta_root = tree.insert(safety_root, "end", text="FTAs", open=True)
                 for idx, te in enumerate(self.top_events):
+                    if not _visible("FTA", te.name):
+                        continue
                     tree.insert(fta_root, "end", text=te.name, tags=("fta", str(te.unique_id)))
             if "FMEA" in enabled or getattr(self, "fmeas", []):
                 _ensure_safety_root()
                 fmea_root = tree.insert(safety_root, "end", text="FMEAs", open=True)
                 for idx, fmea in enumerate(self.fmeas):
-                    tree.insert(fmea_root, "end", text=fmea['name'], tags=("fmea", str(idx)))
+                    name = fmea['name']
+                    if not _visible("FMEA", name):
+                        continue
+                    tree.insert(fmea_root, "end", text=name, tags=("fmea", str(idx)))
             if "FMEDA" in enabled or getattr(self, "fmedas", []):
                 _ensure_safety_root()
                 fmeda_root = tree.insert(safety_root, "end", text="FMEDAs", open=True)
                 for idx, doc in enumerate(self.fmedas):
-                    tree.insert(fmeda_root, "end", text=doc['name'], tags=("fmeda", str(idx)))
+                    name = doc['name']
+                    if not _visible("FMEDA", name):
+                        continue
+                    tree.insert(fmeda_root, "end", text=name, tags=("fmeda", str(idx)))
 
         if hasattr(self, "page_diagram") and self.page_diagram is not None:
             if self.page_diagram.canvas.winfo_exists():
@@ -17165,14 +17237,7 @@ class FaultTreeApp:
         self.safety_mgmt_toolbox = SafetyManagementToolbox.from_dict(
             data.get("safety_mgmt_toolbox", {})
         )
-
-        # Enable work products declared in governance.  When no governance is
-        # present the set is empty and all work products remain disabled.
-        for name in self.safety_mgmt_toolbox.enabled_products():
-            try:
-                self.enable_work_product(name)
-            except Exception:
-                self.enabled_work_products.add(name)
+        self.safety_mgmt_toolbox.on_change = self.refresh_tool_enablement
         try:
             self.refresh_tool_enablement()
         except Exception:

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -1675,6 +1675,8 @@ class HazopWindow(tk.Frame):
         self.app.hazop_docs.append(doc)
         self.app.active_hazop = doc
         self.app.hazop_entries = doc.entries
+        # Tie the document to the currently selected lifecycle phase
+        self.app.safety_mgmt_toolbox.register_created_work_product("HAZOP", doc.name)
         self.refresh_docs()
         self.refresh()
         self.app.update_views()
@@ -1682,12 +1684,12 @@ class HazopWindow(tk.Frame):
     def rename_doc(self):
         if not self.app.active_hazop:
             return
-        name = simpledialog.askstring(
-            "Rename HAZOP", "Name:", initialvalue=self.app.active_hazop.name
-        )
+        old = self.app.active_hazop.name
+        name = simpledialog.askstring("Rename HAZOP", "Name:", initialvalue=old)
         if not name:
             return
         self.app.active_hazop.name = name
+        self.app.safety_mgmt_toolbox.rename_document("HAZOP", old, name)
         self.refresh_docs()
         self.app.update_views()
 
@@ -1698,6 +1700,7 @@ class HazopWindow(tk.Frame):
         if not messagebox.askyesno("Delete", f"Delete HAZOP '{doc.name}'?"):
             return
         self.app.hazop_docs.remove(doc)
+        self.app.safety_mgmt_toolbox.register_deleted_work_product("HAZOP", doc.name)
         if self.app.hazop_docs:
             self.app.active_hazop = self.app.hazop_docs[0]
         else:
@@ -2258,6 +2261,7 @@ class RiskAssessmentWindow(tk.Frame):
         self.app.active_hara = doc
         self.app.hara_entries = doc.entries
         self.status_lbl.config(text=f"Status: {doc.status}")
+        self.app.safety_mgmt_toolbox.register_created_work_product("Risk Assessment", doc.name)
         self.refresh_docs()
         self.refresh()
         self.app.update_views()
@@ -2280,12 +2284,12 @@ class RiskAssessmentWindow(tk.Frame):
     def rename_doc(self):
         if not self.app.active_hara:
             return
-        name = simpledialog.askstring(
-            "Rename Risk Assessment", "Name:", initialvalue=self.app.active_hara.name
-        )
+        old = self.app.active_hara.name
+        name = simpledialog.askstring("Rename Risk Assessment", "Name:", initialvalue=old)
         if not name:
             return
         self.app.active_hara.name = name
+        self.app.safety_mgmt_toolbox.rename_document("Risk Assessment", old, name)
         self.refresh_docs()
         self.app.update_views()
 
@@ -2296,6 +2300,7 @@ class RiskAssessmentWindow(tk.Frame):
         if not messagebox.askyesno("Delete", f"Delete risk assessment '{doc.name}'?"):
             return
         self.app.hara_docs.remove(doc)
+        self.app.safety_mgmt_toolbox.register_deleted_work_product("Risk Assessment", doc.name)
         if self.app.hara_docs:
             self.app.active_hara = self.app.hara_docs[0]
         else:

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -30,6 +30,7 @@ from gui.safety_management_explorer import SafetyManagementExplorer
 from gui.review_toolbox import ReviewData
 from sysml.sysml_repository import SysMLRepository
 from tkinter import simpledialog
+from analysis.models import HazopDoc
 
 
 def test_work_product_registration():
@@ -243,12 +244,12 @@ def test_work_product_enabling_and_deletion_guard():
     assert toolbox.is_enabled("HAZOP")
 
     # An existing document blocks removal of the work product declaration
-    toolbox.register_created_work_product("HAZOP")
+    toolbox.register_created_work_product("HAZOP", "Doc1")
     removed = toolbox.remove_work_product("Gov", "HAZOP")
     assert removed is False
 
     # After deleting the document removal succeeds
-    toolbox.register_deleted_work_product("HAZOP")
+    toolbox.register_deleted_work_product("HAZOP", "Doc1")
     removed = toolbox.remove_work_product("Gov", "HAZOP")
     assert removed is True
     assert not toolbox.is_enabled("HAZOP")
@@ -581,6 +582,14 @@ def test_open_work_product_requires_enablement():
     assert opened["count"] == 1
 
 
+def test_phase_without_diagrams_keeps_products_enabled():
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Gov1", "HAZOP", "link")
+    toolbox.modules = [GovernanceModule(name="P1")]
+    toolbox.set_active_module("P1")
+    assert toolbox.enabled_products() == {"HAZOP"}
+
+
 def test_menu_work_products_toggle_and_guard_existing_docs():
     app = FaultTreeApp.__new__(FaultTreeApp)
     app.tool_listboxes = {}
@@ -729,6 +738,266 @@ def test_diagram_hierarchy_from_object_properties():
 
     hierarchy = toolbox.diagram_hierarchy()
     assert hierarchy == [["Parent"], ["Child"]]
+
+
+def test_work_products_filtered_by_phase_in_tree():
+    """Documents appear only when their creation phase is active."""
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+
+    d1 = repo.create_diagram("BPMN Diagram", name="Gov1")
+    d2 = repo.create_diagram("BPMN Diagram", name="Gov2")
+    for d in (d1, d2):
+        d.tags.append("safety-management")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.list_diagrams()
+    toolbox.modules = [
+        GovernanceModule(name="P1", diagrams=["Gov1"]),
+        GovernanceModule(name="P2", diagrams=["Gov2"]),
+    ]
+
+    class DummyTree:
+        def __init__(self):
+            self.items = {}
+            self.counter = 0
+
+        def delete(self, *items):
+            self.items = {}
+
+        def get_children(self, item=""):
+            return [iid for iid, meta in self.items.items() if meta["parent"] == item]
+
+        def insert(self, parent, index, iid=None, text="", **kwargs):
+            if iid is None:
+                iid = f"i{self.counter}"
+                self.counter += 1
+            self.items[iid] = {"parent": parent, "text": text}
+            return iid
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.refresh_model = lambda: None
+    app.compute_occurrence_counts = lambda: {}
+    app.diagram_icons = {}
+    app.hazop_docs = [HazopDoc("HZ1", []), HazopDoc("HZ2", [])]
+    app.stpa_docs = []
+    app.threat_docs = []
+    app.fi2tc_docs = []
+    app.tc2fi_docs = []
+    app.hara_docs = []
+    app.top_events = []
+    app.fmeas = []
+    app.fmedas = []
+    app.tool_listboxes = {}
+    app.analysis_tree = DummyTree()
+    app.safety_mgmt_toolbox = toolbox
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    app.lifecycle_var = DummyVar("P1")
+    app.on_lifecycle_selected()
+    toolbox.register_created_work_product("HAZOP", "HZ1")
+    app.lifecycle_var.set("P2")
+    app.on_lifecycle_selected()
+    toolbox.register_created_work_product("HAZOP", "HZ2")
+
+    app.lifecycle_var.set("P1")
+    app.on_lifecycle_selected()
+    names = [meta["text"] for meta in app.analysis_tree.items.values()]
+    assert "HZ1" in names and "HZ2" not in names
+
+    app.lifecycle_var.set("P2")
+    app.on_lifecycle_selected()
+    names = [meta["text"] for meta in app.analysis_tree.items.values()]
+    assert "HZ2" in names and "HZ1" not in names
+
+
+def test_governance_enables_tools_per_phase():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    d1 = repo.create_diagram("BPMN Diagram", name="Gov1")
+    d2 = repo.create_diagram("BPMN Diagram", name="Gov2")
+    for d in (d1, d2):
+        d.tags.append("safety-management")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.list_diagrams()
+    toolbox.modules = [
+        GovernanceModule(name="P1", diagrams=["Gov1"]),
+        GovernanceModule(name="P2", diagrams=["Gov2"]),
+    ]
+
+    class DummyListbox:
+        def __init__(self):
+            self.items: list[str] = []
+            self.colors: list[str] = []
+
+        def get(self, *args):
+            if len(args) == 1:
+                return self.items[args[0]]
+            return list(self.items)
+
+        def insert(self, _index, item):
+            self.items.append(item)
+            self.colors.append("black")
+
+        def itemconfig(self, index, foreground="black"):
+            self.colors[index] = foreground
+
+        def size(self):
+            return len(self.items)
+
+        def delete(self, index):
+            del self.items[index]
+            del self.colors[index]
+
+    class DummyMenu:
+        def __init__(self):
+            self.state = None
+
+        def entryconfig(self, _idx, state=tk.DISABLED):
+            self.state = state
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    lb = DummyListbox()
+    menu_arch = DummyMenu()
+    menu_req = DummyMenu()
+    app.tool_listboxes = {"System Design (Item Definition)": lb}
+    app.tool_categories = {"System Design (Item Definition)": []}
+    app.tool_actions = {}
+    app.work_product_menus = {
+        "Architecture Diagram": [(menu_arch, 0)],
+        "Requirement Specification": [(menu_req, 0)],
+    }
+    app.enabled_work_products = set()
+    app.enable_process_area = lambda area: None
+    app.manage_architecture = lambda: None
+    app.show_requirements_editor = lambda: None
+    app.tool_to_work_product = {
+        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+    }
+    app.update_views = lambda: None
+    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
+        app, FaultTreeApp
+    )
+    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
+        app, FaultTreeApp
+    )
+    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(
+        app, FaultTreeApp
+    )
+    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
+        app, FaultTreeApp
+    )
+    app.safety_mgmt_toolbox = toolbox
+    toolbox.on_change = app.refresh_tool_enablement
+
+    toolbox.add_work_product("Gov1", "Architecture Diagram", "r")
+    toolbox.add_work_product("Gov2", "Requirement Specification", "r")
+
+    app.lifecycle_var = DummyVar("P1")
+    app.on_lifecycle_selected()
+    assert menu_arch.state == tk.NORMAL and menu_req.state == tk.DISABLED
+    assert lb.items == ["AutoML Explorer"]
+    assert lb.colors == ["black"]
+
+    app.lifecycle_var.set("P2")
+    app.on_lifecycle_selected()
+    assert menu_arch.state == tk.DISABLED and menu_req.state == tk.NORMAL
+    assert lb.items == ["Requirements Editor"]
+    assert lb.colors == ["black"]
+
+    app.lifecycle_var.set("P1")
+    app.on_lifecycle_selected()
+    assert menu_arch.state == tk.NORMAL and menu_req.state == tk.DISABLED
+    assert lb.items == ["AutoML Explorer"]
+    assert lb.colors == ["black"]
+
+
+def test_governance_without_declarations_keeps_tools_enabled():
+    """Tools remain enabled when no work products are declared."""
+
+    toolbox = SafetyManagementToolbox()
+
+    class DummyListbox:
+        def __init__(self):
+            self.items: list[str] = []
+            self.colors: list[str] = []
+
+        def get(self, *args):
+            if len(args) == 1:
+                return self.items[args[0]]
+            return list(self.items)
+
+        def insert(self, _index, item):
+            self.items.append(item)
+            self.colors.append("black")
+
+        def itemconfig(self, index, foreground="black"):
+            self.colors[index] = foreground
+
+    class DummyMenu:
+        def __init__(self):
+            self.state = None
+
+        def entryconfig(self, _idx, state=tk.DISABLED):
+            self.state = state
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    lb = DummyListbox()
+    menu_arch = DummyMenu()
+    menu_req = DummyMenu()
+    app.tool_listboxes = {"System Design (Item Definition)": lb}
+    app.tool_categories = {"System Design (Item Definition)": []}
+    app.tool_actions = {}
+    app.work_product_menus = {
+        "Architecture Diagram": [(menu_arch, 0)],
+        "Requirement Specification": [(menu_req, 0)],
+    }
+    app.enabled_work_products = set()
+    app.enable_process_area = lambda area: None
+    app.manage_architecture = lambda: None
+    app.show_requirements_editor = lambda: None
+    app.tool_to_work_product = {
+        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+    }
+    app.update_views = lambda: None
+    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
+        app, FaultTreeApp
+    )
+    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
+        app, FaultTreeApp
+    )
+    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(
+        app, FaultTreeApp
+    )
+    app.safety_mgmt_toolbox = toolbox
+
+    app.enable_work_product("Architecture Diagram")
+    app.enable_work_product("Requirement Specification")
+
+    app.refresh_tool_enablement()
+
+    assert menu_arch.state == tk.NORMAL and menu_req.state == tk.NORMAL
+    assert lb.colors == ["black", "black"]
 
 
 def test_safety_management_explorer_creates_folders_and_diagrams(monkeypatch):


### PR DESCRIPTION
## Summary
- Restrict declared work products to the diagrams of the active lifecycle phase so each phase applies its own governance
- Add regression test verifying tool enablement switches when changing phases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ce943fcb88325ae8206d7ed589466