### PR TITLE
Fix duplicate diagrams for reused names

### DIFF
--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -218,7 +218,13 @@ class SysMLRepository:
         if package is None:
             package = self.root_package.elem_id
         if name:
-            same_name_diagrams = [d for d in self.diagrams.values() if d.name == name]
+            same_name_diagrams = [
+                d
+                for d in self.diagrams.values()
+                if d.name == name
+                or d.name.startswith(f"{name} ")
+                or d.name.startswith(f"{name}_")
+            ]
             if same_name_diagrams:
                 if any(d.diag_type != diag_type for d in same_name_diagrams):
                     for d in same_name_diagrams:
@@ -241,13 +247,17 @@ class SysMLRepository:
                     }
                     base = name
                     suffix = 1
-                    while name in existing:
+                    while name in existing or any(
+                        n.startswith(f"{name} ") or n.startswith(f"{name}_") for n in existing
+                    ):
                         name = f"{base}_{suffix}"
                         suffix += 1
             existing_all = {d.name for d in self.diagrams.values()}
             base = name
             suffix = 1
-            while name in existing_all:
+            while name in existing_all or any(
+                n.startswith(f"{name} ") or n.startswith(f"{name}_") for n in existing_all
+            ):
                 name = f"{base}_{suffix}"
                 suffix += 1
         diagram = SysMLDiagram(

--- a/tests/test_diagram_name_unique.py
+++ b/tests/test_diagram_name_unique.py
@@ -15,6 +15,17 @@ class DiagramNameUniqueTests(unittest.TestCase):
         self.assertIn(ibd.diag_type, ibd.name)
         self.assertNotEqual(bdd.name, ibd.name)
 
+    def test_repeated_name_does_not_duplicate(self):
+        repo = self.repo
+        repo.create_diagram("Block Definition Diagram", name="Main")
+        repo.create_diagram("Internal Block Diagram", name="Main")
+        third = repo.create_diagram("Internal Block Diagram", name="Main")
+        fourth = repo.create_diagram("Block Definition Diagram", name="Main")
+        names = [d.name for d in repo.diagrams.values()]
+        self.assertEqual(len(names), len(set(names)))
+        self.assertEqual(third.name, "Main Internal Block Diagram_1")
+        self.assertEqual(fourth.name, "Main Block Definition Diagram_1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure SysML diagram creation checks existing names with prefixes or suffixes
- add regression test preventing duplicate diagram names after conflicts

## Testing
- `PYTHONPATH=. pytest tests/test_diagram_name_unique.py -q`
- `PYTHONPATH=. pytest -q` *(fails: SafetyCaseTable not defined; work product tests expecting different GUI color state; REQUIREMENT_WORK_PRODUCTS missing)*

------
https://chatgpt.com/codex/tasks/task_b_689d0882913c8325a98c01282acb672e