### PR TITLE
Track work product phases and counts

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -197,6 +197,8 @@ class StpaWindow(tk.Frame):
         self.app.stpa_docs.append(doc)
         self.app.active_stpa = doc
         self.app.stpa_entries = doc.entries
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_created_work_product("STPA", doc.name)
         self.refresh_docs()
         self.refresh()
         self.app.update_views()
@@ -204,12 +206,15 @@ class StpaWindow(tk.Frame):
     def rename_doc(self):
         if not self.app.active_stpa:
             return
+        old = self.app.active_stpa.name
         name = simpledialog.askstring(
-            "Rename STPA", "Name:", initialvalue=self.app.active_stpa.name
+            "Rename STPA", "Name:", initialvalue=old
         )
         if not name:
             return
         self.app.active_stpa.name = name
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.rename_document("STPA", old, name)
         self.refresh_docs()
         self.app.update_views()
 
@@ -235,6 +240,8 @@ class StpaWindow(tk.Frame):
         if not messagebox.askyesno("Delete", f"Delete STPA '{doc.name}'?"):
             return
         self.app.stpa_docs.remove(doc)
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_deleted_work_product("STPA", doc.name)
         if self.app.stpa_docs:
             self.app.active_stpa = self.app.stpa_docs[0]
         else:

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -208,6 +208,8 @@ class ThreatWindow(tk.Frame):
         self.app.threat_docs.append(doc)
         self.app.active_threat = doc
         self.app.threat_entries = doc.entries
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_created_work_product("Threat Analysis", doc.name)
         self.refresh_docs()
         self.refresh()
         self.app.update_views()
@@ -215,12 +217,15 @@ class ThreatWindow(tk.Frame):
     def rename_doc(self):
         if not self.app.active_threat:
             return
+        old = self.app.active_threat.name
         name = simpledialog.askstring(
-            "Rename Threat Analysis", "Name:", initialvalue=self.app.active_threat.name
+            "Rename Threat Analysis", "Name:", initialvalue=old
         )
         if not name:
             return
         self.app.active_threat.name = name
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.rename_document("Threat Analysis", old, name)
         self.refresh_docs()
         self.app.update_views()
 
@@ -246,6 +251,8 @@ class ThreatWindow(tk.Frame):
         if not messagebox.askyesno("Delete", f"Delete Threat '{doc.name}'?"):
             return
         self.app.threat_docs.remove(doc)
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_deleted_work_product("Threat Analysis", doc.name)
         if self.app.threat_docs:
             self.app.active_threat = self.app.threat_docs[0]
             self.app.threat_entries = self.app.active_threat.entries

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -1549,6 +1549,8 @@ class FI2TCWindow(tk.Frame):
         self.app.fi2tc_docs.append(doc)
         self.app.active_fi2tc = doc
         self.app.fi2tc_entries = doc.entries
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_created_work_product("FI2TC", doc.name)
         self.refresh_docs()
         self.refresh()
         self.app.update_views()
@@ -1556,12 +1558,15 @@ class FI2TCWindow(tk.Frame):
     def rename_doc(self):
         if not self.app.active_fi2tc:
             return
+        old = self.app.active_fi2tc.name
         name = simpledialog.askstring(
-            "Rename FI2TC", "Name:", initialvalue=self.app.active_fi2tc.name
+            "Rename FI2TC", "Name:", initialvalue=old
         )
         if not name:
             return
         self.app.active_fi2tc.name = name
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.rename_document("FI2TC", old, name)
         self.refresh_docs()
         self.app.update_views()
 
@@ -1572,6 +1577,8 @@ class FI2TCWindow(tk.Frame):
         if not messagebox.askyesno("Delete", f"Delete FI2TC '{doc.name}'?"):
             return
         self.app.fi2tc_docs.remove(doc)
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_deleted_work_product("FI2TC", doc.name)
         if self.app.fi2tc_docs:
             self.app.active_fi2tc = self.app.fi2tc_docs[0]
         else:
@@ -3526,6 +3533,8 @@ class TC2FIWindow(tk.Frame):
         self.app.tc2fi_docs.append(doc)
         self.app.active_tc2fi = doc
         self.app.tc2fi_entries = doc.entries
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_created_work_product("TC2FI", doc.name)
         self.refresh_docs()
         self.refresh()
         self.app.update_views()
@@ -3533,12 +3542,15 @@ class TC2FIWindow(tk.Frame):
     def rename_doc(self):
         if not self.app.active_tc2fi:
             return
+        old = self.app.active_tc2fi.name
         name = simpledialog.askstring(
-            "Rename TC2FI", "Name:", initialvalue=self.app.active_tc2fi.name
+            "Rename TC2FI", "Name:", initialvalue=old
         )
         if not name:
             return
         self.app.active_tc2fi.name = name
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.rename_document("TC2FI", old, name)
         self.refresh_docs()
         self.app.update_views()
 
@@ -3549,6 +3561,8 @@ class TC2FIWindow(tk.Frame):
         if not messagebox.askyesno("Delete", f"Delete TC2FI '{doc.name}'?"):
             return
         self.app.tc2fi_docs.remove(doc)
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_deleted_work_product("TC2FI", doc.name)
         if self.app.tc2fi_docs:
             self.app.active_tc2fi = self.app.tc2fi_docs[0]
         else:


### PR DESCRIPTION
## Summary
- record FI2TC and TC2FI document lifecycle events with the Safety Management Toolbox
- hook STPA and Threat Analysis windows into work product tracking
- register FTA top events and re-register documents on load to maintain phase counts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689d0d587a5883259932a38c53a041a5