### PR TITLE
Track work product phases

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -124,6 +124,10 @@ class SafetyManagementToolbox:
     # toolbox to prevent removal of work product declarations when documents
     # are present.
     work_product_counts: Dict[str, int] = field(default_factory=dict)
+    # Map analysis names to document names and their creating module so work
+    # products can be filtered by lifecycle phase. Documents without an entry
+    # are visible in all phases for backwards compatibility.
+    doc_phases: Dict[str, Dict[str, str]] = field(default_factory=dict)
     # Optional callback invoked whenever the enabled work product set changes.
     on_change: Optional[Callable[[], None]] = field(default=None, repr=False)
 
@@ -165,22 +169,51 @@ class SafetyManagementToolbox:
         return False
 
     # ------------------------------------------------------------------
-    def register_created_work_product(self, analysis: str) -> None:
+    def register_created_work_product(self, analysis: str, name: str) -> None:
         """Record creation of a work product document of type ``analysis``."""
+        self.work_product_counts[analysis] = self.work_product_counts.get(analysis, 0) + 1
+        if self.active_module:
+            self.doc_phases.setdefault(analysis, {})[name] = self.active_module
+
+    # ------------------------------------------------------------------
+    def register_loaded_work_product(self, analysis: str, name: str) -> None:
+        """Record a document loaded from disk without changing its phase."""
         self.work_product_counts[analysis] = self.work_product_counts.get(analysis, 0) + 1
 
     # ------------------------------------------------------------------
-    def register_deleted_work_product(self, analysis: str) -> None:
+    def register_deleted_work_product(self, analysis: str, name: str) -> None:
         """Record deletion of a work product document of type ``analysis``."""
         if self.work_product_counts.get(analysis, 0) > 0:
             self.work_product_counts[analysis] -= 1
+        if name:
+            self.doc_phases.get(analysis, {}).pop(name, None)
+
+    # ------------------------------------------------------------------
+    def rename_document(self, analysis: str, old: str, new: str) -> None:
+        """Update phase mapping when a document is renamed."""
+        phase = self.doc_phases.get(analysis, {}).pop(old, None)
+        if phase:
+            self.doc_phases.setdefault(analysis, {})[new] = phase
+
+    # ------------------------------------------------------------------
+    def document_visible(self, analysis: str, name: str) -> bool:
+        """Return ``True`` if the document should be visible in the active phase."""
+        if not self.active_module:
+            return True
+        phase = self.doc_phases.get(analysis, {}).get(name)
+        if phase is None:
+            return True
+        return phase == self.active_module
 
     # ------------------------------------------------------------------
     def enabled_products(self) -> set[str]:
         """Return the set of analysis names enabled for the active phase."""
+        all_products = {wp.analysis for wp in self.work_products}
         if not self.active_module:
-            return {wp.analysis for wp in self.work_products}
+            return all_products
         diagrams = self.diagrams_in_module(self.active_module)
+        if not diagrams:
+            return all_products
         return {wp.analysis for wp in self.work_products if wp.diagram in diagrams}
 
     # ------------------------------------------------------------------
@@ -320,38 +353,6 @@ class SafetyManagementToolbox:
         return self.workflows.get(name, [])
 
     # ------------------------------------------------------------------
-    # Persistence helpers
-    # ------------------------------------------------------------------
-    def to_dict(self) -> dict:
-        """Return a serialisable representation of the toolbox."""
-        return {
-            "work_products": [wp.to_dict() for wp in self.work_products],
-            "lifecycle": list(self.lifecycle),
-            "workflows": {k: list(v) for k, v in self.workflows.items()},
-            "diagrams": dict(self.diagrams),
-            "modules": [m.to_dict() for m in self.modules],
-            "active_module": self.active_module,
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "SafetyManagementToolbox":
-        """Create a toolbox instance from *data* mapping."""
-        toolbox = cls()
-        toolbox.work_products = [
-            SafetyWorkProduct.from_dict(w) for w in data.get("work_products", [])
-        ]
-        toolbox.lifecycle = list(data.get("lifecycle", []))
-        toolbox.workflows = {
-            k: list(v) for k, v in data.get("workflows", {}).items()
-        }
-        toolbox.diagrams = dict(data.get("diagrams", {}))
-        toolbox.modules = [
-            GovernanceModule.from_dict(m) for m in data.get("modules", [])
-        ]
-        toolbox.active_module = data.get("active_module")
-        return toolbox
-
-    # ------------------------------------------------------------------
     # Diagram management helpers
     # ------------------------------------------------------------------
     def create_diagram(self, name: str) -> str:
@@ -440,6 +441,8 @@ class SafetyManagementToolbox:
             "workflows": {k: list(v) for k, v in self.workflows.items()},
             "diagrams": dict(self.diagrams),
             "modules": [m.to_dict() for m in self.modules],
+            "active_module": self.active_module,
+            "doc_phases": {k: dict(v) for k, v in self.doc_phases.items()},
         }
 
     # ------------------------------------------------------------------
@@ -463,6 +466,10 @@ class SafetyManagementToolbox:
         toolbox.modules = [
             GovernanceModule.from_dict(m) for m in data.get("modules", [])
         ]
+        toolbox.active_module = data.get("active_module")
+        toolbox.doc_phases = {
+            k: dict(v) for k, v in data.get("doc_phases", {}).items()
+        }
         return toolbox
 
     # ------------------------------------------------------------------

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -88,9 +88,17 @@ class ThreatWindow(tk.Frame):
     # Document management
     # ------------------------------------------------------------------
     def refresh_docs(self):
-        names = [d.name for d in self.app.threat_docs]
+        toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+        names = [
+            d.name
+            for d in self.app.threat_docs
+            if not toolbox or toolbox.document_visible("Threat Analysis", d.name)
+        ]
         self.doc_cb["values"] = names
-        if self.app.active_threat:
+        if (
+            self.app.active_threat
+            and self.app.active_threat.name in names
+        ):
             self.doc_var.set(self.app.active_threat.name)
             repo = SysMLRepository.get_instance()
             diag = repo.diagrams.get(self.app.active_threat.diagram)
@@ -99,6 +107,9 @@ class ThreatWindow(tk.Frame):
             self.doc_var.set(names[0])
             self.select_doc()
         else:
+            self.doc_var.set("")
+            self.app.active_threat = None
+            self.app.threat_entries = []
             self.diag_lbl.config(text="")
 
     def select_doc(self, *_):
@@ -208,6 +219,11 @@ class ThreatWindow(tk.Frame):
         self.app.threat_docs.append(doc)
         self.app.active_threat = doc
         self.app.threat_entries = doc.entries
+        # Record the creation phase for lifecycle filtering
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_created_work_product(
+                "Threat Analysis", doc.name
+            )
         self.refresh_docs()
         self.refresh()
         self.app.update_views()
@@ -215,12 +231,17 @@ class ThreatWindow(tk.Frame):
     def rename_doc(self):
         if not self.app.active_threat:
             return
+        old = self.app.active_threat.name
         name = simpledialog.askstring(
-            "Rename Threat Analysis", "Name:", initialvalue=self.app.active_threat.name
+            "Rename Threat Analysis", "Name:", initialvalue=old
         )
         if not name:
             return
         self.app.active_threat.name = name
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.rename_document(
+                "Threat Analysis", old, name
+            )
         self.refresh_docs()
         self.app.update_views()
 
@@ -246,6 +267,10 @@ class ThreatWindow(tk.Frame):
         if not messagebox.askyesno("Delete", f"Delete Threat '{doc.name}'?"):
             return
         self.app.threat_docs.remove(doc)
+        if hasattr(self.app, "safety_mgmt_toolbox"):
+            self.app.safety_mgmt_toolbox.register_deleted_work_product(
+                "Threat Analysis", doc.name
+            )
         if self.app.threat_docs:
             self.app.active_threat = self.app.threat_docs[0]
             self.app.threat_entries = self.app.active_threat.entries


### PR DESCRIPTION
## Summary
- filter analysis windows so work-product documents created in other lifecycle phases are hidden
- refresh open analysis windows when the active phase changes to apply phase-specific governance rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ce943fcb88325ae8206d7ed589466