### PR TITLE
Filter tools by lifecycle phase

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8804,19 +8804,33 @@ class FaultTreeApp:
         else:
             phase_enabled = global_enabled
         enabled = global_enabled & phase_enabled
+        mapping = getattr(self, "tool_to_work_product", {})
+        categories = getattr(self, "tool_categories", {})
         for lb in self.tool_listboxes.values():
-            for i, tool_name in enumerate(lb.get(0, tk.END)):
-                analysis_names = getattr(self, "tool_to_work_product", {}).get(tool_name, set())
-                if isinstance(analysis_names, str):
-                    analysis_names = {analysis_names}
-                if not analysis_names:
-                    in_enabled = tool_name in enabled
-                else:
-                    in_enabled = any(n in enabled for n in analysis_names)
-                if not in_enabled:
-                    lb.itemconfig(i, foreground="gray")
-                else:
-                    lb.itemconfig(i, foreground="black")
+            lb.delete(0, tk.END)
+        for tool_name in sorted(getattr(self, "tool_actions", {}).keys()):
+            analysis_names = mapping.get(tool_name, set())
+            if isinstance(analysis_names, str):
+                analysis_names = {analysis_names}
+            if not analysis_names:
+                in_enabled = True
+            else:
+                in_enabled = any(n in enabled for n in analysis_names)
+            if not in_enabled:
+                continue
+            if analysis_names:
+                area = None
+                for name in analysis_names:
+                    info = self.WORK_PRODUCT_INFO.get(name)
+                    if info:
+                        area = info[0]
+                        break
+            else:
+                area = next((cat for cat, names in categories.items() if tool_name in names), None)
+            if area:
+                lb = self.tool_listboxes.get(area)
+                if lb:
+                    lb.insert(tk.END, tool_name)
         for wp, menus in getattr(self, "work_product_menus", {}).items():
             state = tk.NORMAL if wp in enabled else tk.DISABLED
             for menu, idx in menus:

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -209,12 +209,22 @@ class SafetyManagementToolbox:
     def enabled_products(self) -> set[str]:
         """Return the set of analysis names enabled for the active phase."""
         all_products = {wp.analysis for wp in self.work_products}
+        all_products.update(self.doc_phases.keys())
         if not self.active_module:
             return all_products
         diagrams = self.diagrams_in_module(self.active_module)
-        if not diagrams:
+        result = {
+            wp.analysis for wp in self.work_products if wp.diagram in diagrams
+        }
+        phase_docs = {
+            analysis
+            for analysis, docs in self.doc_phases.items()
+            if any(phase == self.active_module for phase in docs.values())
+        }
+        result.update(phase_docs)
+        if not diagrams and not phase_docs:
             return all_products
-        return {wp.analysis for wp in self.work_products if wp.diagram in diagrams}
+        return result
 
     # ------------------------------------------------------------------
     def is_enabled(self, analysis: str) -> bool:

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -77,9 +77,14 @@ class SafetyManagementWindow(tk.Frame):
     def select_phase(self, *_):
         phase = self.phase_var.get()
         if phase == "All" or not phase:
+            phase = ""
             self.toolbox.set_active_module(None)
         else:
             self.toolbox.set_active_module(phase)
+        if hasattr(self.app, "lifecycle_var"):
+            self.app.lifecycle_var.set(phase)
+            if hasattr(self.app, "on_lifecycle_selected"):
+                self.app.on_lifecycle_selected()
         self.refresh_diagrams()
 
     def new_diagram(self):

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -27,6 +27,7 @@ from analysis.safety_management import (
 )
 from gui.architecture import BPMNDiagramWindow, SysMLObject, ArchitectureManagerDialog
 from gui.safety_management_explorer import SafetyManagementExplorer
+from gui.safety_management_toolbox import SafetyManagementWindow
 from gui.review_toolbox import ReviewData
 from sysml.sysml_repository import SysMLRepository
 from tkinter import simpledialog
@@ -798,6 +799,10 @@ def test_work_products_filtered_by_phase_in_tree():
     app.fmeas = []
     app.fmedas = []
     app.tool_listboxes = {}
+    app.tool_categories = {}
+    app.tool_actions = {}
+    app.enabled_work_products = {"HAZOP", "STPA"}
+    app.work_product_menus = {}
     app.analysis_tree = DummyTree()
     app.safety_mgmt_toolbox = toolbox
 
@@ -868,9 +873,77 @@ def test_governance_enables_tools_per_phase():
         def size(self):
             return len(self.items)
 
-        def delete(self, index):
-            del self.items[index]
-            del self.colors[index]
+        def delete(self, start, end=None):
+            if end is None or end == start:
+                if start in (tk.END, "end"):
+                    start = len(self.items) - 1
+                del self.items[start]
+                del self.colors[start]
+            else:
+                if end in (tk.END, "end"):
+                    end = len(self.items) - 1
+                del self.items[start : end + 1]
+                del self.colors[start : end + 1]
+
+        def size(self):
+            return len(self.items)
+
+        def delete(self, start, end=None):
+            if end is None or end == start:
+                if start in (tk.END, "end"):
+                    start = len(self.items) - 1
+                del self.items[start]
+                del self.colors[start]
+            else:
+                if end in (tk.END, "end"):
+                    end = len(self.items) - 1
+                del self.items[start : end + 1]
+                del self.colors[start : end + 1]
+
+        def size(self):
+            return len(self.items)
+
+        def delete(self, start, end=None):
+            if end is None or end == start:
+                if start in (tk.END, "end"):
+                    start = len(self.items) - 1
+                del self.items[start]
+                del self.colors[start]
+            else:
+                if end in (tk.END, "end"):
+                    end = len(self.items) - 1
+                del self.items[start : end + 1]
+                del self.colors[start : end + 1]
+
+        def size(self):
+            return len(self.items)
+
+        def delete(self, start, end=None):
+            if end is None or end == start:
+                if start in (tk.END, "end"):
+                    start = len(self.items) - 1
+                del self.items[start]
+                del self.colors[start]
+            else:
+                if end in (tk.END, "end"):
+                    end = len(self.items) - 1
+                del self.items[start : end + 1]
+                del self.colors[start : end + 1]
+
+        def size(self):
+            return len(self.items)
+
+        def delete(self, start, end=None):
+            if end is None or end == start:
+                if start in (tk.END, "end"):
+                    start = len(self.items) - 1
+                del self.items[start]
+                del self.colors[start]
+            else:
+                if end in (tk.END, "end"):
+                    end = len(self.items) - 1
+                del self.items[start : end + 1]
+                del self.colors[start : end + 1]
 
     class DummyMenu:
         def __init__(self):
@@ -966,6 +1039,21 @@ def test_governance_without_declarations_keeps_tools_enabled():
 
         def itemconfig(self, index, foreground="black"):
             self.colors[index] = foreground
+
+        def size(self):
+            return len(self.items)
+
+        def delete(self, start, end=None):
+            if end is None or end == start:
+                if start in (tk.END, "end"):
+                    start = len(self.items) - 1
+                del self.items[start]
+                del self.colors[start]
+            else:
+                if end in (tk.END, "end"):
+                    end = len(self.items) - 1
+                del self.items[start : end + 1]
+                del self.colors[start : end + 1]
 
     class DummyMenu:
         def __init__(self):
@@ -1599,3 +1687,48 @@ def test_disable_requirement_work_product_keeps_editor():
     assert "Requirements Editor" in app.tool_actions
     FaultTreeApp.disable_work_product(app, wp2)
     assert "Requirements Editor" not in app.tool_actions
+
+
+def test_enabled_products_include_document_phases():
+    tb = SafetyManagementToolbox()
+    tb.set_active_module("Phase1")
+    tb.register_created_work_product("HAZOP", "HZ1")
+    tb.set_active_module("Phase2")
+    tb.register_created_work_product("STPA", "ST1")
+    tb.set_active_module("Phase1")
+    assert tb.enabled_products() == {"HAZOP"}
+    tb.set_active_module("Phase2")
+    assert tb.enabled_products() == {"STPA"}
+    tb.set_active_module(None)
+    assert tb.enabled_products() == {"HAZOP", "STPA"}
+
+
+def test_safety_management_window_select_phase_updates_app():
+    toolbox = SafetyManagementToolbox()
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    class DummyApp:
+        def __init__(self):
+            self.lifecycle_var = DummyVar("")
+            self.called = False
+
+        def on_lifecycle_selected(self, _event=None):
+            self.called = True
+
+    smw = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    smw.app = DummyApp()
+    smw.toolbox = toolbox
+    smw.phase_var = DummyVar("Phase1")
+    smw.refresh_diagrams = lambda: None
+    smw.select_phase()
+    assert smw.app.lifecycle_var.get() == "Phase1"
+    assert smw.app.called


### PR DESCRIPTION
## Summary
- Rebuild tool lists when lifecycle phases change so only active-phase work products are displayed
- Track document phases in `enabled_products` and update main app when selecting phases in safety management window
- Test phase-aware tool filtering and app synchronisation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d1ca62e94832591d6b1090f8440ae