### PR TITLE
Auto-select BPMN lifecycle phase and filter tools

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -255,6 +255,29 @@ class SafetyManagementToolbox:
         _collect(mod)
         return names
 
+    def module_for_diagram(self, name: str) -> Optional[str]:
+        """Return the top-level module name containing diagram ``name``.
+
+        Diagrams may be organised inside nested :class:`GovernanceModule`
+        objects. This helper walks the module hierarchy and returns the name
+        of the outermost module that lists *name* among its diagrams. ``None``
+        is returned when the diagram is not registered in any module."""
+
+        def _search(mod: GovernanceModule, top: str) -> Optional[str]:
+            if name in mod.diagrams:
+                return top
+            for sub in mod.modules:
+                found = _search(sub, top)
+                if found:
+                    return found
+            return None
+
+        for mod in self.modules:
+            result = _search(mod, mod.name)
+            if result:
+                return result
+        return None
+
     def list_modules(self) -> List[str]:
         """Return names of all governance modules including submodules."""
         names: List[str] = []

--- a/tests/test_bpmn_phase_toggle.py
+++ b/tests/test_bpmn_phase_toggle.py
@@ -1,0 +1,49 @@
+import types
+
+from sysml.sysml_repository import SysMLRepository
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from gui.architecture import BPMNDiagramWindow
+
+
+class DummyVar:
+    def __init__(self):
+        self.value = ""
+
+    def set(self, val):
+        self.value = val
+
+    def get(self):
+        return self.value
+
+
+def test_open_bpmn_diagram_activates_phase():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("BPMN Diagram", name="Gov1")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="Phase1", diagrams=["Gov1"])]
+    toolbox.diagrams = {"Gov1": diag.diag_id}
+
+    app = types.SimpleNamespace(
+        safety_mgmt_toolbox=toolbox,
+        lifecycle_var=DummyVar(),
+        refresh_tool_enablement_called=False,
+    )
+
+    def on_lifecycle_selected(_event=None):
+        app.safety_mgmt_toolbox.set_active_module(app.lifecycle_var.get())
+        app.refresh_tool_enablement_called = True
+
+    app.on_lifecycle_selected = on_lifecycle_selected
+
+    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.app = app
+
+    BPMNDiagramWindow._activate_parent_phase(win)
+
+    assert toolbox.active_module == "Phase1"
+    assert app.lifecycle_var.get() == "Phase1"
+    assert app.refresh_tool_enablement_called


### PR DESCRIPTION
## Summary
- When opening a BPMN diagram, automatically select the parent lifecycle phase and refresh enabled tools
- Added helper to locate the owning module for a governance diagram
- Covered new behavior with unit tests

## Testing
- `python -m pytest tests/test_bpmn_actions.py tests/test_bpmn_action_drop.py tests/test_bpmn_phase_toggle.py -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689d20daefcc8325a573d46787b73e3b