### PR TITLE
Fix toolbox double-click enablement for AutoML Explorer

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8760,15 +8760,14 @@ class FaultTreeApp:
             return
         name = lb.get(sel[0])
         analysis_names = self.tool_to_work_product.get(name, set())
-        if (
-            analysis_names
-            and self.safety_mgmt_toolbox
-            and not any(
-                n in self.safety_mgmt_toolbox.enabled_products()
-                for n in analysis_names
-            )
-        ):
-            return
+        if isinstance(analysis_names, str):
+            analysis_names = {analysis_names}
+        if analysis_names:
+            enabled = set(getattr(self, "enabled_work_products", set()))
+            if self.safety_mgmt_toolbox:
+                enabled.update(self.safety_mgmt_toolbox.enabled_products())
+            if not any(n in enabled for n in analysis_names):
+                return
         action = self.tool_actions.get(name)
         if action:
             action()


### PR DESCRIPTION
## Summary
- Ensure toolbox double-click honors globally enabled work products
- Add regression test validating AutoML Explorer opens when its work product is enabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d21bb74588325bc70bff34ad9bd7d