### PR TITLE
Fix duplicate governance diagram entries in Safety & Security Manager

### DIFF
--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -119,6 +119,24 @@ def test_toolbox_manages_diagram_lifecycle():
     assert not toolbox.diagrams
 
 
+def test_sync_diagrams_updates_module_references():
+    """Renamed diagrams should update module references and avoid duplicates."""
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    diag_id = toolbox.create_diagram("Orig")
+    toolbox.modules = [GovernanceModule("Mod1", diagrams=["Orig"])]
+
+    # Rename the diagram directly in the repository to simulate external change
+    repo.diagrams[diag_id].name = "Renamed"
+
+    # Trigger a sync and ensure the module reflects the new name
+    toolbox.list_diagrams()
+    assert toolbox.modules[0].diagrams == ["Renamed"]
+    assert "Orig" not in toolbox.diagrams
+
+
 def test_rename_module_updates_active():
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule("Phase1")]


### PR DESCRIPTION
## Summary
- keep governance modules in sync with repository diagram names
- remove stale diagram references so icons aren't duplicated
- test renaming diagrams updates module mapping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689d21f8611c83258265a05cf24d5328