### PR TITLE
Propagate lifecycle phase selection to main app

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -8792,9 +8792,15 @@ class FaultTreeApp:
                 except Exception:
                     self.enabled_work_products.add(name)
             if getattr(toolbox, "work_products", None):
+                declared_all = {wp.analysis for wp in toolbox.work_products}
                 for name in current - declared:
                     try:
-                        self.disable_work_product(name)
+                        if name in declared_all:
+                            # Temporarily hide work products not declared in
+                            # the active phase even if documents exist.
+                            self.disable_work_product(name, force=True)
+                        else:
+                            self.disable_work_product(name)
                     except Exception:
                         pass
         global_enabled = getattr(self, "enabled_work_products", set())
@@ -8951,15 +8957,26 @@ class FaultTreeApp:
         return not getattr(self, attr, [])
 
     # ------------------------------------------------------------------
-    def disable_work_product(self, name: str) -> bool:
+    def disable_work_product(self, name: str, *, force: bool = False) -> bool:
         """Disable menu and toolbox entries for the given work product.
 
-        Returns ``True`` if the work product was disabled. If existing
-        documents of that type are present the work product remains enabled
-        and ``False`` is returned.
+        Parameters
+        ----------
+        name:
+            Work product type to disable.
+        force:
+            When ``True`` the work product is hidden even when existing
+            documents of that type remain.
+
+        Returns
+        -------
+        bool
+            ``True`` if the work product was disabled. If ``force`` is
+            ``False`` and existing documents of that type are present the
+            work product remains enabled and ``False`` is returned.
         """
 
-        if not self.can_remove_work_product(name):
+        if not force and not self.can_remove_work_product(name):
             return False
         self.enabled_work_products.discard(name)
         for menu, idx in self.work_product_menus.get(name, []):

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -78,8 +78,29 @@ class SafetyManagementWindow(tk.Frame):
         phase = self.phase_var.get()
         if phase == "All" or not phase:
             self.toolbox.set_active_module(None)
+            phase_name = ""
         else:
             self.toolbox.set_active_module(phase)
+            phase_name = phase
+
+        app = getattr(self, "app", None)
+        if app:
+            if hasattr(app, "lifecycle_var"):
+                try:
+                    app.lifecycle_var.set(phase_name)
+                except Exception:
+                    pass
+            if hasattr(app, "on_lifecycle_selected"):
+                try:
+                    app.on_lifecycle_selected()
+                except Exception:
+                    pass
+            elif hasattr(app, "refresh_tool_enablement"):
+                try:
+                    app.refresh_tool_enablement()
+                except Exception:
+                    pass
+
         self.refresh_diagrams()
 
     def new_diagram(self):

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -27,6 +27,7 @@ from analysis.safety_management import (
 )
 from gui.architecture import BPMNDiagramWindow, SysMLObject, ArchitectureManagerDialog
 from gui.safety_management_explorer import SafetyManagementExplorer
+from gui.safety_management_toolbox import SafetyManagementWindow
 from gui.review_toolbox import ReviewData
 from sysml.sysml_repository import SysMLRepository
 from tkinter import simpledialog
@@ -949,6 +950,11 @@ def test_governance_enables_tools_per_phase():
 
     toolbox.add_work_product("Gov1", "Architecture Diagram", "r")
     toolbox.add_work_product("Gov2", "Requirement Specification", "r")
+    toolbox.set_active_module("P1")
+    toolbox.register_created_work_product("Architecture Diagram", "Arch1")
+    toolbox.set_active_module("P2")
+    toolbox.register_created_work_product("Requirement Specification", "Req1")
+    toolbox.set_active_module(None)
 
     app.lifecycle_var = DummyVar("P1")
     app.on_lifecycle_selected()
@@ -967,6 +973,45 @@ def test_governance_enables_tools_per_phase():
     assert menu_arch.state == tk.NORMAL and menu_req.state == tk.DISABLED
     assert lb.items == ["AutoML Explorer"]
     assert lb.colors == ["black"]
+
+
+def test_phase_selection_updates_app(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("BPMN Diagram", name="Gov1")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov1"])]
+    toolbox.diagrams = {"Gov1": diag.diag_id}
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    app = types.SimpleNamespace(lifecycle_var=DummyVar(), called=False)
+
+    def on_lifecycle_selected(_event=None):
+        app.called = True
+
+    app.on_lifecycle_selected = on_lifecycle_selected
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = app
+    win.phase_var = DummyVar("P1")
+    win.refresh_diagrams = lambda: None
+
+    SafetyManagementWindow.select_phase(win)
+
+    assert toolbox.active_module == "P1"
+    assert app.lifecycle_var.get() == "P1"
+    assert app.called
 
 
 def test_governance_without_declarations_keeps_tools_enabled():


### PR DESCRIPTION
## Summary
- Ensure work products not declared in the selected lifecycle phase are disabled even if documents exist
- Add regression test verifying phase switches disable and enable tools appropriately

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d2670da388325a56deb195006d5bf