### PR TITLE
Refresh tool enablement on lifecycle phase switch

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -213,7 +213,10 @@ class SafetyManagementToolbox:
             return all_products
         diagrams = self.diagrams_in_module(self.active_module)
         if not diagrams:
-            return all_products
+            # No governance diagrams in the selected phase means nothing is
+            # explicitly allowed, so all tools should be disabled until a
+            # work product is declared.
+            return set()
         return {wp.analysis for wp in self.work_products if wp.diagram in diagrams}
 
     # ------------------------------------------------------------------

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -78,8 +78,29 @@ class SafetyManagementWindow(tk.Frame):
         phase = self.phase_var.get()
         if phase == "All" or not phase:
             self.toolbox.set_active_module(None)
+            phase_name = ""
         else:
             self.toolbox.set_active_module(phase)
+            phase_name = phase
+
+        app = getattr(self, "app", None)
+        if app:
+            if hasattr(app, "lifecycle_var"):
+                try:
+                    app.lifecycle_var.set(phase_name)
+                except Exception:
+                    pass
+            if hasattr(app, "on_lifecycle_selected"):
+                try:
+                    app.on_lifecycle_selected()
+                except Exception:
+                    pass
+            elif hasattr(app, "refresh_tool_enablement"):
+                try:
+                    app.refresh_tool_enablement()
+                except Exception:
+                    pass
+
         self.refresh_diagrams()
 
     def new_diagram(self):

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -27,6 +27,7 @@ from analysis.safety_management import (
 )
 from gui.architecture import BPMNDiagramWindow, SysMLObject, ArchitectureManagerDialog
 from gui.safety_management_explorer import SafetyManagementExplorer
+from gui.safety_management_toolbox import SafetyManagementWindow
 from gui.review_toolbox import ReviewData
 from sysml.sysml_repository import SysMLRepository
 from tkinter import simpledialog
@@ -615,12 +616,12 @@ def test_open_work_product_requires_enablement():
     assert opened["count"] == 1
 
 
-def test_phase_without_diagrams_keeps_products_enabled():
+def test_phase_without_diagrams_disables_products():
     toolbox = SafetyManagementToolbox()
     toolbox.add_work_product("Gov1", "HAZOP", "link")
     toolbox.modules = [GovernanceModule(name="P1")]
     toolbox.set_active_module("P1")
-    assert toolbox.enabled_products() == {"HAZOP"}
+    assert toolbox.enabled_products() == set()
 
 
 def test_menu_work_products_toggle_and_guard_existing_docs():
@@ -949,6 +950,11 @@ def test_governance_enables_tools_per_phase():
 
     toolbox.add_work_product("Gov1", "Architecture Diagram", "r")
     toolbox.add_work_product("Gov2", "Requirement Specification", "r")
+    toolbox.set_active_module("P1")
+    toolbox.register_created_work_product("Architecture Diagram", "Arch1")
+    toolbox.set_active_module("P2")
+    toolbox.register_created_work_product("Requirement Specification", "Req1")
+    toolbox.set_active_module(None)
 
     app.lifecycle_var = DummyVar("P1")
     app.on_lifecycle_selected()
@@ -967,6 +973,144 @@ def test_governance_enables_tools_per_phase():
     assert menu_arch.state == tk.NORMAL and menu_req.state == tk.DISABLED
     assert lb.items == ["AutoML Explorer"]
     assert lb.colors == ["black"]
+
+
+def test_phase_selection_updates_app(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("BPMN Diagram", name="Gov1")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov1"])]
+    toolbox.diagrams = {"Gov1": diag.diag_id}
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    app = types.SimpleNamespace(lifecycle_var=DummyVar(), called=False)
+
+    def on_lifecycle_selected(_event=None):
+        app.called = True
+
+    app.on_lifecycle_selected = on_lifecycle_selected
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = app
+    win.phase_var = DummyVar("P1")
+    win.refresh_diagrams = lambda: None
+
+    SafetyManagementWindow.select_phase(win)
+
+    assert toolbox.active_module == "P1"
+    assert app.lifecycle_var.get() == "P1"
+    assert app.called
+
+
+def test_phase_without_diagrams_disables_tools():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    d1 = repo.create_diagram("BPMN Diagram", name="Gov1")
+    d1.tags.append("safety-management")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [
+        GovernanceModule(name="P1", diagrams=["Gov1"]),
+        GovernanceModule(name="P2"),
+    ]
+    toolbox.diagrams = {"Gov1": d1.diag_id}
+
+    class DummyListbox:
+        def __init__(self):
+            self.items: list[str] = []
+            self.colors: list[str] = []
+
+        def get(self, *args):
+            if len(args) == 1:
+                return self.items[args[0]]
+            return list(self.items)
+
+        def insert(self, _index, item):
+            self.items.append(item)
+            self.colors.append("black")
+
+        def itemconfig(self, index, foreground="black"):
+            self.colors[index] = foreground
+
+        def size(self):
+            return len(self.items)
+
+        def delete(self, index):
+            del self.items[index]
+            del self.colors[index]
+
+    class DummyMenu:
+        def __init__(self):
+            self.state = None
+
+        def entryconfig(self, _idx, state=tk.DISABLED):
+            self.state = state
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    lb = DummyListbox()
+    menu_arch = DummyMenu()
+    app.tool_listboxes = {"System Design (Item Definition)": lb}
+    app.tool_categories = {"System Design (Item Definition)": []}
+    app.tool_actions = {}
+    app.work_product_menus = {"Architecture Diagram": [(menu_arch, 0)]}
+    app.enabled_work_products = set()
+    app.enable_process_area = lambda area: None
+    app.manage_architecture = lambda: None
+    app.tool_to_work_product = {
+        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+    }
+    app.update_views = lambda: None
+    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
+        app, FaultTreeApp
+    )
+    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
+        app, FaultTreeApp
+    )
+    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(
+        app, FaultTreeApp
+    )
+    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
+        app, FaultTreeApp
+    )
+    app.safety_mgmt_toolbox = toolbox
+    toolbox.on_change = app.refresh_tool_enablement
+
+    toolbox.add_work_product("Gov1", "Architecture Diagram", "r")
+    toolbox.set_active_module("P1")
+    toolbox.register_created_work_product("Architecture Diagram", "Arch1")
+    toolbox.set_active_module(None)
+
+    app.lifecycle_var = DummyVar("P1")
+    app.on_lifecycle_selected()
+    assert menu_arch.state == tk.NORMAL
+    assert lb.items == ["AutoML Explorer"]
+
+    app.lifecycle_var.set("P2")
+    app.on_lifecycle_selected()
+    assert menu_arch.state == tk.DISABLED
+    assert lb.items == []
 
 
 def test_governance_without_declarations_keeps_tools_enabled():


### PR DESCRIPTION
## Summary
- Refresh tool availability whenever the lifecycle phase changes
- Treat phases without governance diagrams as disabling all work products
- Add regression tests ensuring phases lacking diagrams disable tools and products

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d2670da388325a56deb195006d5bf