### PR TITLE
Tie work product tools to lifecycle phase

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -213,7 +213,7 @@ class SafetyManagementToolbox:
             return all_products
         diagrams = self.diagrams_in_module(self.active_module)
         if not diagrams:
-            return all_products
+            return set()
         return {wp.analysis for wp in self.work_products if wp.diagram in diagrams}
 
     # ------------------------------------------------------------------
@@ -225,6 +225,7 @@ class SafetyManagementToolbox:
     def set_active_module(self, name: Optional[str]) -> None:
         """Select the active lifecycle phase by module *name*."""
         self.active_module = name
+        SysMLRepository.get_instance().active_phase = name
         if self.on_change:
             self.on_change()
 

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -8327,6 +8327,11 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
         self.redraw()
         if getattr(self.app, "enable_work_product", None):
             self.app.enable_work_product(name)
+        toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+        if toolbox:
+            diag = self.repo.diagrams.get(self.diagram_id)
+            diagram_name = diag.name if diag else ""
+            toolbox.add_work_product(diagram_name, name, "")
 
     def add_process_area(self):  # pragma: no cover - requires tkinter
         options = [

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -22,6 +22,7 @@ class SysMLElement:
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
     modified_by: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
     modified_by_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
+    phase: Optional[str] = None
 
 @dataclass
 class SysMLRelationship:
@@ -37,6 +38,7 @@ class SysMLRelationship:
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
     modified_by: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
     modified_by_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
+    phase: Optional[str] = None
 
 @dataclass
 class SysMLDiagram:
@@ -58,6 +60,7 @@ class SysMLDiagram:
     modified: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
     modified_by: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
     modified_by_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
+    phase: Optional[str] = None
 
 class SysMLRepository:
     """Singleton repository for all AutoML elements and relationships."""
@@ -72,6 +75,7 @@ class SysMLRepository:
         # maintain undo and redo history of repository snapshots
         self._undo_stack: list[dict] = []
         self._redo_stack: list[dict] = []
+        self.active_phase: Optional[str] = None
         self.root_package = self.create_element("Package", name="Root")
 
     def touch_element(self, elem_id: str) -> None:
@@ -189,6 +193,7 @@ class SysMLRepository:
             author_email=user_config.CURRENT_USER_EMAIL,
             modified_by=user_config.CURRENT_USER_NAME,
             modified_by_email=user_config.CURRENT_USER_EMAIL,
+            phase=self.active_phase,
         )
         self.elements[elem_id] = elem
         return elem
@@ -272,6 +277,7 @@ class SysMLRepository:
             author_email=user_config.CURRENT_USER_EMAIL,
             modified_by=user_config.CURRENT_USER_NAME,
             modified_by_email=user_config.CURRENT_USER_EMAIL,
+            phase=self.active_phase,
         )
         self.diagrams[diag_id] = diagram
         return diagram
@@ -385,9 +391,39 @@ class SysMLRepository:
             author_email=user_config.CURRENT_USER_EMAIL,
             modified_by=user_config.CURRENT_USER_NAME,
             modified_by_email=user_config.CURRENT_USER_EMAIL,
+            phase=self.active_phase,
         )
         self.relationships.append(rel)
         return rel
+
+    # ------------------------------------------------------------
+    # Phase visibility helpers
+    # ------------------------------------------------------------
+    def element_visible(self, elem_id: str) -> bool:
+        """Return True if ``elem_id`` should be visible in the active phase."""
+        elem = self.elements.get(elem_id)
+        if not elem:
+            return False
+        if self.active_phase is None or elem.phase is None:
+            return True
+        return elem.phase == self.active_phase
+
+    def diagram_visible(self, diag_id: str) -> bool:
+        """Return True if ``diag_id`` should be visible in the active phase."""
+        diag = self.diagrams.get(diag_id)
+        if not diag:
+            return False
+        if self.active_phase is None or diag.phase is None:
+            return True
+        return diag.phase == self.active_phase
+
+    def visible_elements(self) -> dict[str, SysMLElement]:
+        """Return mapping of element IDs to elements visible in the active phase."""
+        return {eid: e for eid, e in self.elements.items() if self.element_visible(eid)}
+
+    def visible_diagrams(self) -> dict[str, SysMLDiagram]:
+        """Return mapping of diagram IDs to diagrams visible in the active phase."""
+        return {did: d for did, d in self.diagrams.items() if self.diagram_visible(did)}
 
     # ------------------------------------------------------------
     # Diagram linkage helpers

--- a/tests/test_bpmn_phase_toggle.py
+++ b/tests/test_bpmn_phase_toggle.py
@@ -1,8 +1,13 @@
 import types
+import tkinter as tk
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from sysml.sysml_repository import SysMLRepository
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
-from gui.architecture import BPMNDiagramWindow
+from gui.architecture import BPMNDiagramWindow, SysMLObject
 
 
 class DummyVar:
@@ -47,3 +52,121 @@ def test_open_bpmn_diagram_activates_phase():
     assert toolbox.active_module == "Phase1"
     assert app.lifecycle_var.get() == "Phase1"
     assert app.refresh_tool_enablement_called
+
+
+def test_added_work_product_respects_phase(monkeypatch):
+    import sys
+
+    PIL_stub = types.ModuleType("PIL")
+    PIL_stub.Image = types.SimpleNamespace()
+    PIL_stub.ImageTk = types.SimpleNamespace()
+    PIL_stub.ImageDraw = types.SimpleNamespace()
+    PIL_stub.ImageFont = types.SimpleNamespace()
+    sys.modules.setdefault("PIL", PIL_stub)
+    sys.modules.setdefault("PIL.Image", PIL_stub.Image)
+    sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
+    sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
+    sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
+    from AutoML import FaultTreeApp
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("BPMN Diagram", name="Gov2")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [
+        GovernanceModule(name="P1"),
+        GovernanceModule(name="P2", diagrams=["Gov2"]),
+    ]
+    toolbox.diagrams = {"Gov2": diag.diag_id}
+
+    class DummyListbox:
+        def __init__(self):
+            self.items = []
+            self.colors = []
+
+        def get(self, *_):
+            return self.items
+
+        def insert(self, index, item):
+            self.items.insert(index if isinstance(index, int) else len(self.items), item)
+
+        def itemconfig(self, index, foreground="black"):
+            self.colors.append(foreground)
+
+    class DummyMenu:
+        def __init__(self):
+            self.state = None
+
+        def entryconfig(self, _idx, state=tk.DISABLED):
+            self.state = state
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    lb = DummyListbox()
+    menu = DummyMenu()
+    app.tool_listboxes = {"Hazard & Threat Analysis": lb}
+    app.tool_categories = {"Hazard & Threat Analysis": []}
+    app.tool_actions = {}
+    app.work_product_menus = {"HAZOP": [(menu, 0)]}
+    app.enabled_work_products = set()
+    app.enable_process_area = lambda area: None
+    app.hazop_analysis = lambda: None
+    app.tool_to_work_product = {
+        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+    }
+    app.update_views = lambda: None
+    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
+        app, FaultTreeApp
+    )
+    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
+        app, FaultTreeApp
+    )
+    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
+        app, FaultTreeApp
+    )
+    app.lifecycle_var = DummyVar("P1")
+    app.safety_mgmt_toolbox = toolbox
+    toolbox.on_change = app.refresh_tool_enablement
+
+    app.on_lifecycle_selected()
+
+    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = [
+        SysMLObject(
+            1,
+            "System Boundary",
+            0.0,
+            0.0,
+            width=200.0,
+            height=150.0,
+            properties={"name": "Hazard & Threat Analysis"},
+        )
+    ]
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.app = app
+
+    class FakeDialog:
+        def __init__(self, *args, **kwargs):
+            self.selection = "HAZOP"
+
+    monkeypatch.setattr(BPMNDiagramWindow, "_SelectDialog", FakeDialog)
+
+    win.add_work_product()
+    assert menu.state == tk.DISABLED
+
+    app.lifecycle_var.set("P2")
+    app.on_lifecycle_selected()
+    assert menu.state == tk.NORMAL

--- a/tests/test_phase_visibility.py
+++ b/tests/test_phase_visibility.py
@@ -1,0 +1,21 @@
+from sysml.sysml_repository import SysMLRepository
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+
+def test_elements_follow_phase_visibility():
+    repo = SysMLRepository.reset_instance()
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
+    toolbox.set_active_module("P1")
+    elem = repo.create_element("Block")
+    assert repo.element_visible(elem.elem_id)
+    assert elem.phase == "P1"
+    visible = set(repo.visible_elements().keys())
+    assert elem.elem_id in visible
+    toolbox.set_active_module("P2")
+    assert not repo.element_visible(elem.elem_id)
+    visible = set(repo.visible_elements().keys())
+    assert elem.elem_id not in visible
+    toolbox.set_active_module("P1")
+    assert repo.element_visible(elem.elem_id)
+    visible = set(repo.visible_elements().keys())
+    assert elem.elem_id in visible

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -616,12 +616,12 @@ def test_open_work_product_requires_enablement():
     assert opened["count"] == 1
 
 
-def test_phase_without_diagrams_keeps_products_enabled():
+def test_phase_without_diagrams_disables_products():
     toolbox = SafetyManagementToolbox()
     toolbox.add_work_product("Gov1", "HAZOP", "link")
     toolbox.modules = [GovernanceModule(name="P1")]
     toolbox.set_active_module("P1")
-    assert toolbox.enabled_products() == {"HAZOP"}
+    assert toolbox.enabled_products() == set()
 
 
 def test_menu_work_products_toggle_and_guard_existing_docs():


### PR DESCRIPTION
## Summary
- Track lifecycle phase on repository elements, relationships and diagrams and expose helpers to determine visibility
- Sync Safety Management Toolbox's selected phase with the repository so phase changes hide non-matching items
- Test that elements disappear when switching to a different lifecycle phase and reappear when returning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d2b87577c83259d81bd06e16aa27b