### PR TITLE
Track diagram elements by phase

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1830,6 +1830,7 @@ class SysMLObject:
     locked: bool = False
     hidden: bool = False
     collapsed: Dict[str, bool] = field(default_factory=dict)
+    phase: str | None = field(default_factory=lambda: SysMLRepository.get_instance().active_phase)
 
 
 @dataclass
@@ -2466,6 +2467,7 @@ class DiagramConnection:
     stereotype: str = ""
     multiplicity: str = ""
     stereotype: str = ""
+    phase: str | None = field(default_factory=lambda: SysMLRepository.get_instance().active_phase)
 
 
 def format_control_flow_label(

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -425,6 +425,32 @@ class SysMLRepository:
         """Return mapping of diagram IDs to diagrams visible in the active phase."""
         return {did: d for did, d in self.diagrams.items() if self.diagram_visible(did)}
 
+    def object_visible(self, obj: dict) -> bool:
+        """Return True if a diagram object should be visible in the active phase."""
+        if self.active_phase is None or obj.get("phase") is None:
+            return True
+        return obj.get("phase") == self.active_phase
+
+    def connection_visible(self, conn: dict) -> bool:
+        """Return True if a diagram connection should be visible in the active phase."""
+        if self.active_phase is None or conn.get("phase") is None:
+            return True
+        return conn.get("phase") == self.active_phase
+
+    def visible_objects(self, diag_id: str) -> list[dict]:
+        """Return list of objects in diagram ``diag_id`` visible in the active phase."""
+        diag = self.diagrams.get(diag_id)
+        if not diag:
+            return []
+        return [o for o in getattr(diag, "objects", []) if self.object_visible(o)]
+
+    def visible_connections(self, diag_id: str) -> list[dict]:
+        """Return list of connections in diagram ``diag_id`` visible in the active phase."""
+        diag = self.diagrams.get(diag_id)
+        if not diag:
+            return []
+        return [c for c in getattr(diag, "connections", []) if self.connection_visible(c)]
+
     # ------------------------------------------------------------
     # Diagram linkage helpers
     # ------------------------------------------------------------

--- a/tests/test_phase_visibility.py
+++ b/tests/test_phase_visibility.py
@@ -1,5 +1,7 @@
 from sysml.sysml_repository import SysMLRepository
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from dataclasses import asdict
+from gui.architecture import SysMLObject, DiagramConnection
 
 def test_elements_follow_phase_visibility():
     repo = SysMLRepository.reset_instance()
@@ -19,3 +21,23 @@ def test_elements_follow_phase_visibility():
     assert repo.element_visible(elem.elem_id)
     visible = set(repo.visible_elements().keys())
     assert elem.elem_id in visible
+
+
+def test_diagram_objects_and_connections_follow_phase_visibility():
+    repo = SysMLRepository.reset_instance()
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
+    toolbox.set_active_module("P1")
+    diag = repo.create_diagram("Block Definition Diagram")
+    obj = SysMLObject(1, "Block", 0.0, 0.0)
+    diag.objects.append(asdict(obj))
+    conn = DiagramConnection(1, 2, "Association")
+    diag.connections.append(asdict(conn))
+    assert repo.visible_objects(diag.diag_id)
+    assert repo.visible_connections(diag.diag_id)
+    toolbox.set_active_module("P2")
+    assert not repo.visible_objects(diag.diag_id)
+    assert not repo.visible_connections(diag.diag_id)
+    toolbox.set_active_module("P1")
+    assert repo.visible_objects(diag.diag_id)
+    assert repo.visible_connections(diag.diag_id)


### PR DESCRIPTION
## Summary
- Track the creating lifecycle phase for diagram objects and connections
- Add repository helpers to filter diagram content by active phase
- Test that diagram objects and connections respect phase visibility

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d336f9d008325aae2be4a4791965a