### PR TITLE
Track diagram elements by phase

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1830,6 +1830,7 @@ class SysMLObject:
     locked: bool = False
     hidden: bool = False
     collapsed: Dict[str, bool] = field(default_factory=dict)
+    phase: str | None = field(default_factory=lambda: SysMLRepository.get_instance().active_phase)
 
 
 @dataclass
@@ -2466,6 +2467,7 @@ class DiagramConnection:
     stereotype: str = ""
     multiplicity: str = ""
     stereotype: str = ""
+    phase: str | None = field(default_factory=lambda: SysMLRepository.get_instance().active_phase)
 
 
 def format_control_flow_label(
@@ -2546,7 +2548,7 @@ class SysMLDiagramWindow(tk.Frame):
 
         # Load any saved objects and connections for this diagram
         self.objects: List[SysMLObject] = []
-        for data in getattr(diagram, "objects", []):
+        for data in self.repo.visible_objects(diagram.diag_id):
             if "requirements" not in data:
                 data["requirements"] = []
             obj = SysMLObject(**data)
@@ -2560,7 +2562,8 @@ class SysMLDiagramWindow(tk.Frame):
             self.objects.append(obj)
         self.sort_objects()
         self.connections: List[DiagramConnection] = [
-            DiagramConnection(**data) for data in getattr(diagram, "connections", [])
+            DiagramConnection(**data)
+            for data in self.repo.visible_connections(diagram.diag_id)
         ]
         if self.objects:
             global _next_obj_id
@@ -6622,8 +6625,12 @@ class SysMLDiagramWindow(tk.Frame):
         self.repo.push_undo_state()
         diag = self.repo.diagrams.get(self.diagram_id)
         if diag:
-            diag.objects = [obj.__dict__ for obj in self.objects]
-            diag.connections = [conn.__dict__ for conn in self.connections]
+            existing_objs = getattr(diag, "objects", [])
+            hidden_objs = [o for o in existing_objs if not self.repo.object_visible(o)]
+            diag.objects = hidden_objs + [obj.__dict__ for obj in self.objects]
+            existing_conns = getattr(diag, "connections", [])
+            hidden_conns = [c for c in existing_conns if not self.repo.connection_visible(c)]
+            diag.connections = hidden_conns + [conn.__dict__ for conn in self.connections]
             update_block_parts_from_ibd(self.repo, diag)
             self.repo.touch_diagram(self.diagram_id)
             _sync_block_parts_from_ibd(self.repo, self.diagram_id)
@@ -6656,7 +6663,7 @@ class SysMLDiagramWindow(tk.Frame):
         if not diag:
             return
         self.objects = []
-        for data in getattr(diag, "objects", []):
+        for data in self.repo.visible_objects(diag.diag_id):
             if "requirements" not in data:
                 data["requirements"] = []
             obj = SysMLObject(**data)
@@ -6670,7 +6677,7 @@ class SysMLDiagramWindow(tk.Frame):
             self.objects.append(obj)
         self.sort_objects()
         self.connections = []
-        for data in getattr(diag, "connections", []):
+        for data in self.repo.visible_connections(diag.diag_id):
             data.setdefault("stereotype", data.get("conn_type", "").lower())
             self.connections.append(DiagramConnection(**data))
         if self.objects:

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -425,6 +425,32 @@ class SysMLRepository:
         """Return mapping of diagram IDs to diagrams visible in the active phase."""
         return {did: d for did, d in self.diagrams.items() if self.diagram_visible(did)}
 
+    def object_visible(self, obj: dict) -> bool:
+        """Return True if a diagram object should be visible in the active phase."""
+        if self.active_phase is None or obj.get("phase") is None:
+            return True
+        return obj.get("phase") == self.active_phase
+
+    def connection_visible(self, conn: dict) -> bool:
+        """Return True if a diagram connection should be visible in the active phase."""
+        if self.active_phase is None or conn.get("phase") is None:
+            return True
+        return conn.get("phase") == self.active_phase
+
+    def visible_objects(self, diag_id: str) -> list[dict]:
+        """Return list of objects in diagram ``diag_id`` visible in the active phase."""
+        diag = self.diagrams.get(diag_id)
+        if not diag:
+            return []
+        return [o for o in getattr(diag, "objects", []) if self.object_visible(o)]
+
+    def visible_connections(self, diag_id: str) -> list[dict]:
+        """Return list of connections in diagram ``diag_id`` visible in the active phase."""
+        diag = self.diagrams.get(diag_id)
+        if not diag:
+            return []
+        return [c for c in getattr(diag, "connections", []) if self.connection_visible(c)]
+
     # ------------------------------------------------------------
     # Diagram linkage helpers
     # ------------------------------------------------------------

--- a/tests/test_phase_visibility.py
+++ b/tests/test_phase_visibility.py
@@ -1,5 +1,27 @@
 from sysml.sysml_repository import SysMLRepository
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from dataclasses import asdict
+import types
+import sys
+from gui.architecture import (
+    SysMLObject,
+    DiagramConnection,
+    SysMLDiagramWindow,
+    BPMNDiagramWindow,
+)
+
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace()
+PIL_stub.ImageTk = types.SimpleNamespace()
+PIL_stub.ImageDraw = types.SimpleNamespace()
+PIL_stub.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+sys.modules.setdefault("PIL.Image", PIL_stub.Image)
+sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
+sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
+sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
+
+from AutoML import FaultTreeApp
 
 def test_elements_follow_phase_visibility():
     repo = SysMLRepository.reset_instance()
@@ -19,3 +41,91 @@ def test_elements_follow_phase_visibility():
     assert repo.element_visible(elem.elem_id)
     visible = set(repo.visible_elements().keys())
     assert elem.elem_id in visible
+
+
+def test_diagram_objects_and_connections_follow_phase_visibility():
+    repo = SysMLRepository.reset_instance()
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
+    toolbox.set_active_module("P1")
+    diag = repo.create_diagram("Block Definition Diagram")
+    obj = SysMLObject(1, "Block", 0.0, 0.0)
+    diag.objects.append(asdict(obj))
+    conn = DiagramConnection(1, 2, "Association")
+    diag.connections.append(asdict(conn))
+    assert repo.visible_objects(diag.diag_id)
+    assert repo.visible_connections(diag.diag_id)
+
+
+def test_diagram_window_respects_phase():
+    repo = SysMLRepository.reset_instance()
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
+    toolbox.set_active_module("P1")
+    diag = repo.create_diagram("Block Definition Diagram")
+    obj = SysMLObject(1, "Block", 0.0, 0.0)
+    diag.objects.append(asdict(obj))
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.sort_objects = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    SysMLDiagramWindow.refresh_from_repository(win)
+    assert len(win.objects) == 1
+    toolbox.set_active_module("P2")
+    SysMLDiagramWindow.refresh_from_repository(win)
+    assert len(win.objects) == 0
+
+
+def test_diagram_objects_preserved_across_phases():
+    repo = SysMLRepository.reset_instance()
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
+    toolbox.set_active_module("P1")
+    diag = repo.create_diagram("BPMN Diagram")
+    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win._sync_to_repository = BPMNDiagramWindow._sync_to_repository.__get__(win, BPMNDiagramWindow)
+    obj1 = SysMLObject(1, "Spec", 0.0, 0.0)
+    win.objects.append(obj1)
+    win._sync_to_repository()
+    toolbox.set_active_module("P2")
+    obj2 = SysMLObject(2, "Spec", 0.0, 0.0)
+    win.objects = [obj2]
+    win._sync_to_repository()
+    toolbox.set_active_module("P1")
+    assert any(o["obj_id"] == 1 for o in repo.visible_objects(diag.diag_id))
+    toolbox.set_active_module("P2")
+    assert any(o["obj_id"] == 2 for o in repo.visible_objects(diag.diag_id))
+
+
+def test_on_lifecycle_selected_refreshes_diagrams():
+    repo = SysMLRepository.reset_instance()
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1")]
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.lifecycle_var = types.SimpleNamespace(get=lambda: "P1")
+    app.safety_mgmt_toolbox = toolbox
+    refreshed = {"count": 0}
+
+    class DummyChild:
+        def refresh_from_repository(self):
+            refreshed["count"] += 1
+
+    class DummyTab:
+        def __init__(self):
+            self.child = DummyChild()
+
+        def winfo_children(self):
+            return [self.child]
+
+    app.diagram_tabs = {"d": DummyTab()}
+    app.update_views = lambda: None
+    app.refresh_tool_enablement = lambda: None
+    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(app, FaultTreeApp)
+    app.on_lifecycle_selected()
+    assert refreshed["count"] == 1


### PR DESCRIPTION
## Summary
- Preserve hidden diagram objects and connections when saving diagrams so phase-specific items are not lost
- Ensure governance specifications reappear when their creation phase becomes active
- Test that BPMN diagram elements persist across lifecycle phase switches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d336f9d008325aae2be4a4791965a