### PR TITLE
Refresh menu enablement after phase change

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -95,7 +95,7 @@ class SafetyManagementWindow(tk.Frame):
                     app.on_lifecycle_selected()
                 except Exception:
                     pass
-            elif hasattr(app, "refresh_tool_enablement"):
+            if hasattr(app, "refresh_tool_enablement"):
                 try:
                     app.refresh_tool_enablement()
                 except Exception:


### PR DESCRIPTION
## Summary
- Always refresh work-product menus when a lifecycle phase is selected
- Test that phase selection updates menu state even if the app's handler skips the refresh

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d4038e014832595aaa23d154ecb8e