### PR TITLE
Add BPMN re-use relationship and visibility

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2709,6 +2709,7 @@ class SysMLDiagramWindow(tk.Frame):
                     "Propagate",
                     "Propagate by Review",
                     "Propagate by Approval",
+                    "Re-use",
                     "Connector",
                     "Generalize",
                     "Generalization",
@@ -2741,6 +2742,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalize",
             "Generalization",
@@ -2930,6 +2932,13 @@ class SysMLDiagramWindow(tk.Frame):
                 dst_name = dst.properties.get("name")
                 if (src_name, dst_name) not in ALLOWED_PROPAGATIONS:
                     return False, f"Propagation from {src_name} to {dst_name} is not allowed"
+            elif conn_type == "Re-use":
+                if dst.obj_type != "Lifecycle Phase":
+                    return False, "Re-use links must target a Lifecycle Phase"
+                if src.obj_type not in {"Work Product", "Lifecycle Phase"}:
+                    return False, (
+                        "Re-use links must originate from a Work Product or Lifecycle Phase"
+                    )
             else:
                 allowed = {
                     "Initial": {
@@ -3022,6 +3031,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3142,6 +3152,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3162,53 +3173,54 @@ class SysMLDiagramWindow(tk.Frame):
             else:
                 if obj and obj != self.start:
                     valid, msg = self.validate_connection(self.start, obj, t)
-                    if valid:
-                        if t == "Control Action":
-                            arrow_default = "forward"
-                        elif t == "Feedback":
-                            arrow_default = "backward"
-                        elif t in (
-                            "Flow",
-                            "Generalize",
-                            "Generalization",
-                            "Include",
-                            "Extend",
-                            "Propagate",
-                            "Propagate by Review",
-                            "Propagate by Approval",
-                        ):
-                            arrow_default = "forward"
-                        else:
-                            arrow_default = "none"
-                        conn_stereo = (
-                            "control action"
-                            if t == "Control Action"
-                            else "feedback" if t == "Feedback" else t.lower()
-                        )
-                        conn = DiagramConnection(
-                            self.start.obj_id,
-                            obj.obj_id,
-                            t,
-                            arrow=arrow_default,
-                            stereotype=conn_stereo,
-                        )
-                        self.connections.append(conn)
-                        src_id = self.start.element_id
-                        dst_id = obj.element_id
-                        if src_id and dst_id:
-                            rel_stereo = (
-                                "control action" if t == "Control Action" else "feedback" if t == "Feedback" else None
-                            )
-                            rel = self.repo.create_relationship(
-                                t, src_id, dst_id, stereotype=rel_stereo
-                            )
-                            self.repo.add_relationship_to_diagram(
-                                self.diagram_id, rel.rel_id
-                            )
-                        self._sync_to_repository()
-                        ConnectionDialog(self, conn)
+                if valid:
+                    if t == "Control Action":
+                        arrow_default = "forward"
+                    elif t == "Feedback":
+                        arrow_default = "backward"
+                    elif t in (
+                        "Flow",
+                        "Generalize",
+                        "Generalization",
+                        "Include",
+                        "Extend",
+                        "Propagate",
+                        "Propagate by Review",
+                        "Propagate by Approval",
+                        "Re-use",
+                    ):
+                        arrow_default = "forward"
                     else:
-                        messagebox.showwarning("Invalid Connection", msg)
+                        arrow_default = "none"
+                    conn_stereo = (
+                        "control action"
+                        if t == "Control Action"
+                        else "feedback" if t == "Feedback" else t.lower()
+                    )
+                    conn = DiagramConnection(
+                        self.start.obj_id,
+                        obj.obj_id,
+                        t,
+                        arrow=arrow_default,
+                        stereotype=conn_stereo,
+                    )
+                    self.connections.append(conn)
+                    src_id = self.start.element_id
+                    dst_id = obj.element_id
+                    if src_id and dst_id:
+                        rel_stereo = (
+                            "control action" if t == "Control Action" else "feedback" if t == "Feedback" else None
+                        )
+                        rel = self.repo.create_relationship(
+                            t, src_id, dst_id, stereotype=rel_stereo
+                        )
+                        self.repo.add_relationship_to_diagram(
+                            self.diagram_id, rel.rel_id
+                        )
+                    self._sync_to_repository()
+                    ConnectionDialog(self, conn)
+                else:
+                    messagebox.showwarning("Invalid Connection", msg)
                 self.start = None
                 self.temp_line_end = None
                 self.selected_obj = None
@@ -3440,6 +3452,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3643,6 +3656,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3675,6 +3689,7 @@ class SysMLDiagramWindow(tk.Frame):
                         "Propagate",
                         "Propagate by Review",
                         "Propagate by Approval",
+                        "Re-use",
                     ):
                         arrow_default = "forward"
                     else:
@@ -3942,6 +3957,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3965,6 +3981,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalization",
             "Generalize",
@@ -8178,6 +8195,7 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
         ):
             ttk.Button(
                 bpmn_panel,

--- a/tests/test_bpmn_reuse_visibility.py
+++ b/tests/test_bpmn_reuse_visibility.py
@@ -1,0 +1,62 @@
+from dataclasses import asdict
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import SysMLObject, DiagramConnection
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+
+
+def _setup_repo():
+    SysMLRepository._instance = None
+    return SysMLRepository.get_instance()
+
+
+def test_work_product_reuse_visibility():
+    repo = _setup_repo()
+    diag = repo.create_diagram("BPMN Diagram", name="Gov")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"]), GovernanceModule(name="P2")]
+    toolbox.diagrams = {"Gov": diag.diag_id}
+
+    wp = SysMLObject(1, "Work Product", 0.0, 0.0, properties={"name": "HAZOP"})
+    phase = SysMLObject(2, "Lifecycle Phase", 0.0, 0.0, properties={"name": "P2"})
+    diag.objects.extend([asdict(wp), asdict(phase)])
+    conn = DiagramConnection(wp.obj_id, phase.obj_id, "Re-use")
+    diag.connections.append(asdict(conn))
+
+    toolbox.add_work_product("Gov", "HAZOP", "")
+    toolbox.set_active_module("P1")
+    toolbox.register_created_work_product("HAZOP", "Doc1")
+
+    toolbox.set_active_module("P2")
+    assert toolbox.document_visible("HAZOP", "Doc1")
+    assert "HAZOP" not in toolbox.enabled_products()
+
+
+def test_phase_reuse_visibility():
+    repo = _setup_repo()
+    diag = repo.create_diagram("BPMN Diagram", name="Gov1")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov1"]), GovernanceModule(name="P2")]
+    toolbox.diagrams = {"Gov1": diag.diag_id}
+
+    src = SysMLObject(1, "Lifecycle Phase", 0.0, 0.0, properties={"name": "P1"})
+    dst = SysMLObject(2, "Lifecycle Phase", 0.0, 0.0, properties={"name": "P2"})
+    diag.objects.extend([asdict(src), asdict(dst)])
+    conn = DiagramConnection(src.obj_id, dst.obj_id, "Re-use")
+    diag.connections.append(asdict(conn))
+
+    toolbox.add_work_product("Gov1", "Risk Assessment", "")
+    toolbox.set_active_module("P1")
+    toolbox.register_created_work_product("Risk Assessment", "RA1")
+
+    toolbox.set_active_module("P2")
+    assert toolbox.document_visible("Risk Assessment", "RA1")
+    assert "Risk Assessment" not in toolbox.enabled_products()
+


### PR DESCRIPTION
## Summary
- add "Re-use" connection button to BPMN toolbox and support linking work products or phases to phases
- show reused work products as read-only in target lifecycle phases
- cover BPMN re-use visibility with unit tests

## Testing
- `pytest` *(fails: 96 errors during collection)*
- `pytest tests/test_bpmn_reuse_visibility.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689d4138c92083258de0d224d24c0721