### PR TITLE
Refresh menu enablement after phase change

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -95,7 +95,7 @@ class SafetyManagementWindow(tk.Frame):
                     app.on_lifecycle_selected()
                 except Exception:
                     pass
-            elif hasattr(app, "refresh_tool_enablement"):
+            if hasattr(app, "refresh_tool_enablement"):
                 try:
                     app.refresh_tool_enablement()
                 except Exception:

--- a/tests/test_requirement_work_products.py
+++ b/tests/test_requirement_work_products.py
@@ -40,7 +40,7 @@ def test_add_requirement_work_product(monkeypatch):
     win._sync_to_repository = lambda: None
     win.redraw = lambda: None
     added = []
-    win.app = types.SimpleNamespace(enable_work_product=lambda name: added.append(name))
+    win.app = types.SimpleNamespace(enable_work_product=lambda name, *, refresh=True: added.append(name))
 
     name = f"{_fmt(REQUIREMENT_TYPE_OPTIONS[2])} Requirement Specification"
 

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1014,6 +1014,97 @@ def test_phase_selection_updates_app(monkeypatch):
     assert app.called
 
 
+def test_phase_selection_refreshes_menus():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("BPMN Diagram", name="Gov1")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov1"])]
+    toolbox.diagrams = {"Gov1": diag.diag_id}
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    class DummyMenu:
+        def __init__(self):
+            self.state = tk.DISABLED
+
+        def entryconfig(self, _idx, state=tk.DISABLED):
+            self.state = state
+
+    menu = DummyMenu()
+    app = types.SimpleNamespace(
+        lifecycle_var=DummyVar(),
+        work_product_menus={"HAZOP": [(menu, 0)]},
+        enabled_work_products=set(),
+        tool_listboxes={},
+        safety_mgmt_toolbox=toolbox,
+    )
+
+    def refresh_tool_enablement():
+        for m, idx in app.work_product_menus["HAZOP"]:
+            m.entryconfig(idx, state=tk.NORMAL)
+
+    app.refresh_tool_enablement = refresh_tool_enablement
+
+    def on_lifecycle_selected(_event=None):
+        pass
+
+    app.on_lifecycle_selected = on_lifecycle_selected
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = app
+    win.phase_var = DummyVar("P1")
+    win.refresh_diagrams = lambda: None
+
+    SafetyManagementWindow.select_phase(win)
+
+    assert menu.state == tk.NORMAL
+
+
+def test_child_work_product_enables_parent_menu():
+    """Enabling a work product should also activate its parent menu."""
+
+    class DummyMenu:
+        def __init__(self):
+            self.state = tk.DISABLED
+
+        def entryconfig(self, _idx, state=tk.DISABLED):
+            self.state = state
+
+    parent_menu = DummyMenu()
+    child_menu = DummyMenu()
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.tool_listboxes = {}
+    app.tool_actions = {}
+    app.tool_categories = {}
+    app._add_tool_category = lambda area, names: None
+    app.work_product_menus = {
+        "HAZOP": [(child_menu, 0)],
+        "Qualitative Analysis": [(parent_menu, 0)],
+    }
+    app.enabled_work_products = set()
+    app.update_views = lambda: None
+
+    FaultTreeApp.enable_work_product(app, "HAZOP")
+
+    assert child_menu.state == tk.NORMAL
+    assert parent_menu.state == tk.NORMAL
+
+    FaultTreeApp.disable_work_product(app, "HAZOP", force=True)
+    assert parent_menu.state == tk.DISABLED
+
+
 def test_phase_without_diagrams_disables_tools():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
@@ -1616,7 +1707,7 @@ def test_add_work_product_uses_half_width(monkeypatch):
     win.sort_objects = lambda: None
     win._sync_to_repository = lambda: None
     win.redraw = lambda: None
-    win.app = types.SimpleNamespace(enable_work_product=lambda name: None)
+    win.app = types.SimpleNamespace(enable_work_product=lambda name, *, refresh=True: None)
 
     class FakeDialog:
         def __init__(self, *args, **kwargs):

--- a/tests/test_safety_management_persistence.py
+++ b/tests/test_safety_management_persistence.py
@@ -96,7 +96,7 @@ def test_safety_management_roundtrip_serialisation():
 def test_apply_model_enables_governed_work_products(monkeypatch):
     app = _minimal_app()
     enabled = []
-    def record_enable(self, name):
+    def record_enable(self, name, *, refresh: bool = True):
         enabled.append(name)
         self.enabled_work_products.add(name)
 
@@ -106,7 +106,7 @@ def test_apply_model_enables_governed_work_products(monkeypatch):
     toolbox.add_work_product("Gov", "HAZOP", "Rationale")
     data = {"safety_mgmt_toolbox": toolbox.to_dict()}
     app.apply_model_data(data, ensure_root=False)
-    assert enabled == ["HAZOP"]
+    assert set(enabled) == {"HAZOP", "Qualitative Analysis"}
 
 
 def test_apply_model_without_governance_disables_work_products(monkeypatch):
@@ -170,10 +170,10 @@ def test_only_active_phase_work_products_enabled_on_load(monkeypatch):
         new_app, FaultTreeApp
     )
 
-    def enable_wp(self, name):
+    def enable_wp(self, name, *, refresh: bool = True):
         self.enabled_work_products.add(name)
 
-    def disable_wp(self, name, *, force: bool = False):
+    def disable_wp(self, name, *, force: bool = False, refresh: bool = True):
         self.enabled_work_products.discard(name)
         return True
 
@@ -185,4 +185,4 @@ def test_only_active_phase_work_products_enabled_on_load(monkeypatch):
 
     new_app.safety_mgmt_toolbox.set_active_module("Phase2")
     new_app.refresh_tool_enablement()
-    assert new_app.enabled_work_products == {"HAZOP"}
+    assert new_app.enabled_work_products == {"HAZOP", "Qualitative Analysis"}


### PR DESCRIPTION
## Summary
- Allow enabling of parent menu categories when child work products are activated
- Propagate work product enable/disable logic to parent menus and update persistence tests
- Add regression test ensuring HAZOP activates the Qualitative Analysis menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d4038e014832595aaa23d154ecb8e