### PR TITLE
Ensure governance diagram elements visible across phases

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6643,10 +6643,16 @@ class SysMLDiagramWindow(tk.Frame):
         diag = self.repo.diagrams.get(self.diagram_id)
         if diag:
             existing_objs = getattr(diag, "objects", [])
-            hidden_objs = [o for o in existing_objs if not self.repo.object_visible(o)]
+            hidden_objs = [
+                o for o in existing_objs if not self.repo.object_visible(o, self.diagram_id)
+            ]
             diag.objects = hidden_objs + [obj.__dict__ for obj in self.objects]
             existing_conns = getattr(diag, "connections", [])
-            hidden_conns = [c for c in existing_conns if not self.repo.connection_visible(c)]
+            hidden_conns = [
+                c
+                for c in existing_conns
+                if not self.repo.connection_visible(c, self.diagram_id)
+            ]
             diag.connections = hidden_conns + [conn.__dict__ for conn in self.connections]
             update_block_parts_from_ibd(self.repo, diag)
             self.repo.touch_diagram(self.diagram_id)

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -413,6 +413,8 @@ class SysMLRepository:
         diag = self.diagrams.get(diag_id)
         if not diag:
             return False
+        if "safety-management" in getattr(diag, "tags", []):
+            return True
         if self.active_phase is None or diag.phase is None:
             return True
         return diag.phase == self.active_phase
@@ -425,14 +427,20 @@ class SysMLRepository:
         """Return mapping of diagram IDs to diagrams visible in the active phase."""
         return {did: d for did, d in self.diagrams.items() if self.diagram_visible(did)}
 
-    def object_visible(self, obj: dict) -> bool:
+    def object_visible(self, obj: dict, diag_id: Optional[str] = None) -> bool:
         """Return True if a diagram object should be visible in the active phase."""
+        diag = self.diagrams.get(diag_id) if diag_id else None
+        if diag and "safety-management" in getattr(diag, "tags", []):
+            return True
         if self.active_phase is None or obj.get("phase") is None:
             return True
         return obj.get("phase") == self.active_phase
 
-    def connection_visible(self, conn: dict) -> bool:
+    def connection_visible(self, conn: dict, diag_id: Optional[str] = None) -> bool:
         """Return True if a diagram connection should be visible in the active phase."""
+        diag = self.diagrams.get(diag_id) if diag_id else None
+        if diag and "safety-management" in getattr(diag, "tags", []):
+            return True
         if self.active_phase is None or conn.get("phase") is None:
             return True
         return conn.get("phase") == self.active_phase
@@ -442,14 +450,14 @@ class SysMLRepository:
         diag = self.diagrams.get(diag_id)
         if not diag:
             return []
-        return [o for o in getattr(diag, "objects", []) if self.object_visible(o)]
+        return [o for o in getattr(diag, "objects", []) if self.object_visible(o, diag_id)]
 
     def visible_connections(self, diag_id: str) -> list[dict]:
         """Return list of connections in diagram ``diag_id`` visible in the active phase."""
         diag = self.diagrams.get(diag_id)
         if not diag:
             return []
-        return [c for c in getattr(diag, "connections", []) if self.connection_visible(c)]
+        return [c for c in getattr(diag, "connections", []) if self.connection_visible(c, diag_id)]
 
     # ------------------------------------------------------------
     # Diagram linkage helpers

--- a/tests/test_governance_diagram_visibility.py
+++ b/tests/test_governance_diagram_visibility.py
@@ -1,0 +1,42 @@
+from dataclasses import asdict
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import SysMLObject, DiagramConnection
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_governance_elements_visible_all_phases():
+    repo = SysMLRepository.reset_instance()
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
+    toolbox.set_active_module("P1")
+
+    diag = repo.create_diagram("BPMN Diagram", name="Gov")
+    diag.tags.append("safety-management")
+
+    obj1 = SysMLObject(1, "Work Product", 0.0, 0.0)
+    diag.objects.append(asdict(obj1))
+
+    toolbox.set_active_module("P2")
+    obj2 = SysMLObject(2, "Work Product", 0.0, 0.0)
+    diag.objects.append(asdict(obj2))
+
+    conn = DiagramConnection(obj1.obj_id, obj2.obj_id, "Flow")
+    diag.connections.append(asdict(conn))
+
+    toolbox.set_active_module("P1")
+    assert repo.diagram_visible(diag.diag_id)
+    assert diag.diag_id in repo.visible_diagrams()
+    assert len(repo.visible_objects(diag.diag_id)) == 2
+    assert len(repo.visible_connections(diag.diag_id)) == 1
+
+    toolbox.set_active_module("P2")
+    assert repo.diagram_visible(diag.diag_id)
+    assert diag.diag_id in repo.visible_diagrams()
+    assert len(repo.visible_objects(diag.diag_id)) == 2
+    assert len(repo.visible_connections(diag.diag_id)) == 1
+


### PR DESCRIPTION
## Summary
- keep governance diagrams visible across phases in addition to their objects and connections
- add assertions verifying safety management diagrams remain visible regardless of phase

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d4582aef48325ab261995dac7be86