### PR TITLE
Add Re-use relationship to BPMN toolbox

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -11663,12 +11663,16 @@ class FaultTreeApp:
         tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
         item_map = {}
+        toolbox = getattr(self, "safety_mgmt_toolbox", None)
         for fmea in self.fmeas:
+            name = fmea.get("name", "")
+            if toolbox and not toolbox.document_visible("FMEA", name):
+                continue
             iid = tree.insert(
                 "",
                 "end",
                 values=(
-                    fmea.get("name", ""),
+                    name,
                     fmea.get("created", ""),
                     fmea.get("author", ""),
                     fmea.get("modified", ""),
@@ -11716,9 +11720,12 @@ class FaultTreeApp:
             doc = item_map.get(iid)
             if not doc:
                 return
+            if toolbox and toolbox.document_read_only("FMEA", doc["name"]):
+                messagebox.showinfo("Read-only", "Re-used FMEAs cannot be deleted")
+                return
             self.fmeas.remove(doc)
-            if hasattr(self, "safety_mgmt_toolbox"):
-                self.safety_mgmt_toolbox.register_deleted_work_product("FMEA", doc["name"])
+            if toolbox:
+                toolbox.register_deleted_work_product("FMEA", doc["name"])
             tree.delete(iid)
             item_map.pop(iid, None)
             self.update_views()
@@ -11728,14 +11735,17 @@ class FaultTreeApp:
             doc = item_map.get(iid)
             if not doc:
                 return
+            if toolbox and toolbox.document_read_only("FMEA", doc["name"]):
+                messagebox.showinfo("Read-only", "Re-used FMEAs cannot be renamed")
+                return
             current = doc.get("name", "")
             name = simpledialog.askstring("Rename FMEA", "Enter new name:", initialvalue=current)
             if not name:
                 return
             old = doc["name"]
             doc["name"] = name
-            if hasattr(self, "safety_mgmt_toolbox"):
-                self.safety_mgmt_toolbox.rename_document("FMEA", old, name)
+            if toolbox:
+                toolbox.rename_document("FMEA", old, name)
             self.touch_doc(doc)
             tree.item(iid, values=(name, doc["created"], doc["author"], doc["modified"], doc["modified_by"]))
             self.update_views()
@@ -12908,6 +12918,10 @@ class FaultTreeApp:
         del_btn.pack(side=tk.LEFT, padx=2)
         comment_btn = ttk.Button(btn_frame, text="Comment")
         comment_btn.pack(side=tk.LEFT, padx=2)
+        toolbox = getattr(self, "safety_mgmt_toolbox", None)
+        if fmea and toolbox and toolbox.document_read_only("FMEA", fmea["name"]):
+            for b in (add_btn, remove_btn, del_btn, comment_btn):
+                b.state(["disabled"])
         if fmeda:
             def calculate_fmeda():
                 if bom_var.get():

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2709,6 +2709,7 @@ class SysMLDiagramWindow(tk.Frame):
                     "Propagate",
                     "Propagate by Review",
                     "Propagate by Approval",
+                    "Re-use",
                     "Connector",
                     "Generalize",
                     "Generalization",
@@ -2741,6 +2742,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalize",
             "Generalization",
@@ -2930,6 +2932,9 @@ class SysMLDiagramWindow(tk.Frame):
                 dst_name = dst.properties.get("name")
                 if (src_name, dst_name) not in ALLOWED_PROPAGATIONS:
                     return False, f"Propagation from {src_name} to {dst_name} is not allowed"
+            elif conn_type == "Re-use":
+                if src.obj_type not in ("Work Product", "Lifecycle Phase") or dst.obj_type != "Lifecycle Phase":
+                    return False, "Re-use links must originate from a Work Product or Lifecycle Phase and target a Lifecycle Phase"
             else:
                 allowed = {
                     "Initial": {
@@ -3022,6 +3027,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3142,6 +3148,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3176,6 +3183,7 @@ class SysMLDiagramWindow(tk.Frame):
                             "Propagate",
                             "Propagate by Review",
                             "Propagate by Approval",
+                            "Re-use",
                         ):
                             arrow_default = "forward"
                         else:
@@ -3440,6 +3448,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3643,6 +3652,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3675,6 +3685,7 @@ class SysMLDiagramWindow(tk.Frame):
                         "Propagate",
                         "Propagate by Review",
                         "Propagate by Approval",
+                        "Re-use",
                     ):
                         arrow_default = "forward"
                     else:
@@ -3942,6 +3953,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3965,6 +3977,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
             "Connector",
             "Generalization",
             "Generalize",
@@ -8178,6 +8191,7 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
+            "Re-use",
         ):
             ttk.Button(
                 bpmn_panel,

--- a/tests/test_bpmn_reuse.py
+++ b/tests/test_bpmn_reuse.py
@@ -1,0 +1,55 @@
+from sysml.sysml_repository import SysMLRepository
+from analysis.safety_management import SafetyManagementToolbox
+
+
+def _obj(obj_id: int, obj_type: str, name: str) -> dict:
+    return {
+        "obj_id": obj_id,
+        "obj_type": obj_type,
+        "x": 0.0,
+        "y": 0.0,
+        "width": 60.0,
+        "height": 80.0,
+        "properties": {"name": name},
+    }
+
+
+def test_work_product_reuse_visible():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("BPMN Diagram", name="GovWP")
+    diag.objects.extend([
+        _obj(1, "Work Product", "HAZOP"),
+        _obj(2, "Lifecycle Phase", "P2"),
+    ])
+    diag.connections.append({"src": 1, "dst": 2, "conn_type": "Re-use"})
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams = {"GovWP": diag.diag_id}
+    toolbox.set_active_module("P1")
+    toolbox.register_created_work_product("HAZOP", "HazDoc")
+    toolbox.set_active_module("P2")
+    assert toolbox.document_visible("HAZOP", "HazDoc")
+    assert toolbox.document_read_only("HAZOP", "HazDoc")
+    toolbox.set_active_module("P3")
+    assert not toolbox.document_visible("HAZOP", "HazDoc")
+
+
+def test_phase_reuse_shows_all_docs():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("BPMN Diagram", name="GovPhase")
+    diag.objects.extend([
+        _obj(1, "Lifecycle Phase", "P1"),
+        _obj(2, "Lifecycle Phase", "P2"),
+    ])
+    diag.connections.append({"src": 1, "dst": 2, "conn_type": "Re-use"})
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams = {"GovPhase": diag.diag_id}
+    toolbox.set_active_module("P1")
+    toolbox.register_created_work_product("FMEA", "FmeaDoc")
+    toolbox.set_active_module("P2")
+    assert toolbox.document_visible("FMEA", "FmeaDoc")
+    assert toolbox.document_read_only("FMEA", "FmeaDoc")
+    toolbox.set_active_module("P3")
+    assert not toolbox.document_visible("FMEA", "FmeaDoc")
+


### PR DESCRIPTION
## Summary
- add `Re-use` tool in BPMN diagrams and validate connections to lifecycle phases
- show work products from reused phases or explicitly reused items in other phases
- prevent edits to reused work products by marking them read-only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d4138c92083258de0d224d24c0721