### PR TITLE
Allow reused work products to remain visible

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -276,9 +276,12 @@ class SafetyManagementToolbox:
         if not self.active_module:
             return set()
         diagrams = self.diagrams_in_module(self.active_module)
-        if not diagrams:
-            return set()
-        return {wp.analysis for wp in self.work_products if wp.diagram in diagrams}
+        reuse = self._reuse_map().get(self.active_module, {})
+        for phase in reuse.get("phases", set()):
+            diagrams.update(self.diagrams_in_module(phase))
+        enabled = {wp.analysis for wp in self.work_products if wp.diagram in diagrams}
+        enabled.update(reuse.get("work_products", set()))
+        return enabled
 
     # ------------------------------------------------------------------
     def is_enabled(self, analysis: str) -> bool:

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3193,16 +3193,34 @@ class SysMLDiagramWindow(tk.Frame):
                             if t == "Control Action"
                             else "feedback" if t == "Feedback" else t.lower()
                         )
-                        rel = self.repo.create_relationship(
-                            t, src_id, dst_id, stereotype=rel_stereo
+                        conn = DiagramConnection(
+                            self.start.obj_id,
+                            obj.obj_id,
+                            t,
+                            arrow=arrow_default,
+                            stereotype=conn_stereo,
                         )
-                        self.repo.add_relationship_to_diagram(
-                            self.diagram_id, rel.rel_id
-                        )
-                    self._sync_to_repository()
-                    ConnectionDialog(self, conn)
-                else:
-                    messagebox.showwarning("Invalid Connection", msg)
+                        self.connections.append(conn)
+                        src_id = self.start.element_id
+                        dst_id = obj.element_id
+                        if src_id and dst_id:
+                            rel_stereo = (
+                                "control action"
+                                if t == "Control Action"
+                                else "feedback" if t == "Feedback" else None
+                            )
+                            rel = self.repo.create_relationship(
+                                t, src_id, dst_id, stereotype=rel_stereo
+                            )
+                            self.repo.add_relationship_to_diagram(
+                                self.diagram_id, rel.rel_id
+                            )
+                            if t == "Generalization":
+                                inherit_block_properties(self.repo, src_id)
+                        self._sync_to_repository()
+                        ConnectionDialog(self, conn)
+                    else:
+                        messagebox.showwarning("Invalid Connection", msg)
                 self.start = None
                 self.temp_line_end = None
                 self.selected_obj = None

--- a/tests/test_bpmn_reuse_visibility.py
+++ b/tests/test_bpmn_reuse_visibility.py
@@ -35,7 +35,7 @@ def test_work_product_reuse_visibility():
 
     toolbox.set_active_module("P2")
     assert toolbox.document_visible("HAZOP", "Doc1")
-    assert "HAZOP" not in toolbox.enabled_products()
+    assert "HAZOP" in toolbox.enabled_products()
 
 
 def test_phase_reuse_visibility():
@@ -58,5 +58,5 @@ def test_phase_reuse_visibility():
 
     toolbox.set_active_module("P2")
     assert toolbox.document_visible("Risk Assessment", "RA1")
-    assert "Risk Assessment" not in toolbox.enabled_products()
+    assert "Risk Assessment" in toolbox.enabled_products()
 


### PR DESCRIPTION
## Summary
- Expand phase filtering to show work products reused by phase or directly
- Restore connection creation logic to build relationships on second click
- Adjust BPMN reuse visibility tests for enabled work products

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d4ec285808325bd7ad5ae9f80f384