### PR TITLE
Center process area labels inside boundaries

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5479,28 +5479,14 @@ class SysMLDiagramWindow(tk.Frame):
             )
             label = obj.properties.get("name", "")
             if label:
-                diag = self.repo.diagrams.get(self.diagram_id)
-                if diag and diag.diag_type in ("Activity Diagram", "BPMN Diagram"):
-                    lx = x - w - 4 * self.zoom
-                    ly = y
-                    self.canvas.create_text(
-                        lx,
-                        ly,
-                        text=label,
-                        angle=90,
-                        anchor="e",
-                        font=self.font,
-                    )
-                else:
-                    lx = x
-                    ly = y - h - 4 * self.zoom
-                    self.canvas.create_text(
-                        lx,
-                        ly,
-                        text=label,
-                        anchor="s",
-                        font=self.font,
-                    )
+                self.canvas.create_text(
+                    x,
+                    y,
+                    text=label,
+                    anchor="center",
+                    font=self.font,
+                    width=obj.width * self.zoom,
+                )
         elif obj.obj_type == "Block Boundary":
             self._create_round_rect(
                 x - w,

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -80,7 +80,7 @@ class DummyCanvas:
         return y
 
 
-def test_activity_boundary_label_rotated_left():
+def test_activity_boundary_label_centered():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     diag = repo.create_diagram("BPMN Diagram")
@@ -92,13 +92,22 @@ def test_activity_boundary_label_rotated_left():
     win.font = None
     win._draw_gradient_rect = lambda *args, **kwargs: None
     win.selected_objs = []
-    obj = SysMLObject(1, "System Boundary", 0.0, 0.0, width=100.0, height=80.0, properties={"name": "Lane"})
+    obj = SysMLObject(
+        1,
+        "System Boundary",
+        0.0,
+        0.0,
+        width=100.0,
+        height=80.0,
+        properties={"name": "Lane"},
+    )
     win.draw_object(obj)
 
     assert win.canvas.text_calls, "label not drawn"
-    x, _, kwargs = win.canvas.text_calls[0]
-    assert kwargs.get("angle") == 90
-    assert x < obj.x - obj.width / 2
+    x, y, kwargs = win.canvas.text_calls[0]
+    assert kwargs.get("anchor") == "center"
+    assert kwargs.get("width") == obj.width
+    assert (x, y) == (obj.x, obj.y)
 
 
 def test_toolbox_manages_diagram_lifecycle():


### PR DESCRIPTION
## Summary
- Render System Boundary names centered inside their shapes
- Adjust tests to match new label placement behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d59152cd4832586acbf045bc11fbc