### PR TITLE
Mark reused elements as read-only

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -319,8 +319,10 @@ class SafetyManagementToolbox:
         if name:
             reuse = self._reuse_map().get(name, {})
             repo.reuse_phases = set(reuse.get("phases", set()))
+            repo.reuse_products = set(reuse.get("work_products", set()))
         else:
             repo.reuse_phases = set()
+            repo.reuse_products = set()
         if self.on_change:
             self.on_change()
 
@@ -539,11 +541,14 @@ class SafetyManagementToolbox:
 
     def delete_diagram(self, name: str) -> None:
         """Remove a diagram from the toolbox and repository."""
-        diag_id = self.diagrams.pop(name, None)
+        diag_id = self.diagrams.get(name)
         if not diag_id:
             return
         repo = SysMLRepository.get_instance()
+        if repo.diagram_read_only(diag_id):
+            return
         repo.delete_diagram(diag_id)
+        del self.diagrams[name]
 
     def rename_diagram(self, old: str, new: str) -> None:
         """Rename a managed diagram ensuring the name remains unique.
@@ -559,6 +564,8 @@ class SafetyManagementToolbox:
         if not diag_id or not new:
             return
         repo = SysMLRepository.get_instance()
+        if repo.diagram_read_only(diag_id):
+            return
         diag = repo.diagrams.get(diag_id)
         if not diag:
             return

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -449,6 +449,8 @@ def _shared_generalization_parent(
 
 def rename_block(repo: SysMLRepository, block_id: str, new_name: str) -> None:
     """Rename ``block_id`` and propagate changes to related blocks."""
+    if repo.element_read_only(block_id):
+        return
     repo.push_undo_state()
     block = repo.elements.get(block_id)
     if not block or block.elem_type != "Block":
@@ -1878,7 +1880,8 @@ def rename_port(
     repo: SysMLRepository, port: SysMLObject, objs: List[SysMLObject], new_name: str
 ) -> None:
     """Rename *port* and update its parent's port list."""
-
+    if port.element_id and repo.element_read_only(port.element_id):
+        return
     old_name = port.properties.get("name", "")
     if old_name == new_name:
         return

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -80,6 +80,9 @@ class SysMLRepository:
         # diagrams belonging to any of these phases should remain visible even
         # though they were not created in ``active_phase``.
         self.reuse_phases: set[str] = set()
+        # Work product types reused by the active phase. Any diagrams of these
+        # types originating from other phases are visible but read-only.
+        self.reuse_products: set[str] = set()
         self.root_package = self.create_element("Package", name="Root")
 
     def touch_element(self, elem_id: str) -> None:
@@ -300,6 +303,8 @@ class SysMLRepository:
 
     def delete_element(self, elem_id: str) -> None:
         """Remove an element and any relationships referencing it."""
+        if self.element_read_only(elem_id):
+            return
         self.push_undo_state()
         if elem_id in self.elements:
             del self.elements[elem_id]
@@ -321,6 +326,8 @@ class SysMLRepository:
         self.delete_element(pkg_id)
 
     def delete_diagram(self, diag_id: str) -> None:
+        if self.diagram_read_only(diag_id):
+            return
         self.push_undo_state()
         if diag_id in self.diagrams:
             del self.diagrams[diag_id]
@@ -410,7 +417,14 @@ class SysMLRepository:
             return False
         if self.active_phase is None or elem.phase is None:
             return True
-        return elem.phase == self.active_phase or elem.phase in getattr(self, "reuse_phases", set())
+        if elem.phase == self.active_phase or elem.phase in getattr(self, "reuse_phases", set()):
+            return True
+        diag_id = self.element_diagrams.get(elem_id)
+        if diag_id:
+            diag = self.diagrams.get(diag_id)
+            if diag and diag.diag_type in getattr(self, "reuse_products", set()):
+                return True
+        return False
 
     def diagram_visible(self, diag_id: str) -> bool:
         """Return True if ``diag_id`` should be visible in the active phase."""
@@ -421,7 +435,36 @@ class SysMLRepository:
             return True
         if self.active_phase is None or diag.phase is None:
             return True
-        return diag.phase == self.active_phase or diag.phase in getattr(self, "reuse_phases", set())
+        if diag.phase == self.active_phase or diag.phase in getattr(self, "reuse_phases", set()):
+            return True
+        return diag.diag_type in getattr(self, "reuse_products", set())
+
+    def element_read_only(self, elem_id: str) -> bool:
+        """Return ``True`` if ``elem_id`` originates from a reused phase or work product."""
+        elem = self.elements.get(elem_id)
+        if not elem:
+            return False
+        if self.active_phase is None or elem.phase is None:
+            return False
+        if elem.phase != self.active_phase and elem.phase in getattr(self, "reuse_phases", set()):
+            return True
+        diag_id = self.element_diagrams.get(elem_id)
+        if diag_id:
+            diag = self.diagrams.get(diag_id)
+            if diag and diag.diag_type in getattr(self, "reuse_products", set()) and diag.phase != self.active_phase:
+                return True
+        return False
+
+    def diagram_read_only(self, diag_id: str) -> bool:
+        """Return ``True`` if ``diag_id`` originates from a reused phase or work product."""
+        diag = self.diagrams.get(diag_id)
+        if not diag:
+            return False
+        if self.active_phase is None or diag.phase is None:
+            return False
+        if diag.phase != self.active_phase and diag.phase in getattr(self, "reuse_phases", set()):
+            return True
+        return diag.phase != self.active_phase and diag.diag_type in getattr(self, "reuse_products", set())
 
     def visible_elements(self) -> dict[str, SysMLElement]:
         """Return mapping of element IDs to elements visible in the active phase."""
@@ -434,7 +477,7 @@ class SysMLRepository:
     def object_visible(self, obj: dict, diag_id: Optional[str] = None) -> bool:
         """Return True if a diagram object should be visible in the active phase."""
         diag = self.diagrams.get(diag_id) if diag_id else None
-        if diag and "safety-management" in getattr(diag, "tags", []):
+        if diag and ("safety-management" in getattr(diag, "tags", []) or diag.diag_type in getattr(self, "reuse_products", set())):
             return True
         if self.active_phase is None or obj.get("phase") is None:
             return True
@@ -443,7 +486,7 @@ class SysMLRepository:
     def connection_visible(self, conn: dict, diag_id: Optional[str] = None) -> bool:
         """Return True if a diagram connection should be visible in the active phase."""
         diag = self.diagrams.get(diag_id) if diag_id else None
-        if diag and "safety-management" in getattr(diag, "tags", []):
+        if diag and ("safety-management" in getattr(diag, "tags", []) or diag.diag_type in getattr(self, "reuse_products", set())):
             return True
         if self.active_phase is None or conn.get("phase") is None:
             return True

--- a/tests/test_phase_reuse_read_only.py
+++ b/tests/test_phase_reuse_read_only.py
@@ -1,0 +1,99 @@
+from dataclasses import asdict
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import SysMLObject, DiagramConnection, rename_block, rename_port
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+
+
+def _setup_repo():
+    SysMLRepository._instance = None
+    return SysMLRepository.get_instance()
+
+
+def _prepare():
+    repo = _setup_repo()
+    gov = repo.create_diagram("BPMN Diagram", name="Gov")
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"]), GovernanceModule(name="P2")]
+    toolbox.diagrams = {"Gov": gov.diag_id}
+    src = SysMLObject(1, "Lifecycle Phase", 0.0, 0.0, properties={"name": "P1"})
+    dst = SysMLObject(2, "Lifecycle Phase", 0.0, 0.0, properties={"name": "P2"})
+    gov.objects.extend([asdict(src), asdict(dst)])
+    conn = DiagramConnection(dst.obj_id, src.obj_id, "Re-use")
+    gov.connections.append(asdict(conn))
+    return repo, toolbox
+
+
+def test_reused_element_read_only_blocks_modification():
+    repo, toolbox = _prepare()
+    toolbox.set_active_module("P1")
+    blk = repo.create_element("Block", name="B1")
+    port_elem = repo.create_element("Port", name="p", owner=blk.elem_id)
+    block_obj = SysMLObject(1, "Block", 0.0, 0.0, element_id=blk.elem_id, properties={"name": "B1"})
+    port_obj = SysMLObject(2, "Port", 0.0, 0.0, element_id=port_elem.elem_id, properties={"name": "p", "parent": str(block_obj.obj_id)})
+    toolbox.set_active_module("P2")
+
+    assert repo.element_read_only(blk.elem_id)
+    assert repo.element_read_only(port_elem.elem_id)
+
+    rename_block(repo, blk.elem_id, "B2")
+    rename_port(repo, port_obj, [block_obj, port_obj], "q")
+    assert repo.elements[blk.elem_id].name == "B1"
+    assert repo.elements[port_elem.elem_id].name == "p"
+
+    repo.delete_element(blk.elem_id)
+    assert blk.elem_id in repo.elements
+
+
+def test_reused_diagram_read_only_blocks_modification():
+    repo, toolbox = _prepare()
+    toolbox.set_active_module("P1")
+    diag = repo.create_diagram("Block Definition Diagram", name="D1")
+    toolbox.diagrams["D1"] = diag.diag_id
+    toolbox.set_active_module("P2")
+
+    assert repo.diagram_read_only(diag.diag_id)
+
+    toolbox.rename_diagram("D1", "D2")
+    assert repo.diagrams[diag.diag_id].name == "D1"
+    assert "D1" in toolbox.diagrams
+
+    toolbox.delete_diagram("D1")
+    assert diag.diag_id in repo.diagrams
+    assert "D1" in toolbox.diagrams
+
+
+def _prepare_product_reuse():
+    repo = _setup_repo()
+    gov = repo.create_diagram("BPMN Diagram", name="Gov")
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"]), GovernanceModule(name="P2")]
+    toolbox.diagrams = {"Gov": gov.diag_id}
+    phase = SysMLObject(1, "Lifecycle Phase", 0.0, 0.0, properties={"name": "P2"})
+    wp = SysMLObject(2, "Work Product", 0.0, 0.0, properties={"name": "FMEA"})
+    gov.objects.extend([asdict(phase), asdict(wp)])
+    conn = DiagramConnection(phase.obj_id, wp.obj_id, "Re-use")
+    gov.connections.append(asdict(conn))
+    return repo, toolbox
+
+
+def test_reused_work_product_read_only_blocks_modification():
+    repo, toolbox = _prepare_product_reuse()
+    toolbox.set_active_module("P1")
+    diag = repo.create_diagram("FMEA", name="F1")
+    toolbox.diagrams["F1"] = diag.diag_id
+    blk = repo.create_element("Block", name="B1")
+    repo.link_diagram(blk.elem_id, diag.diag_id)
+    toolbox.set_active_module("P2")
+
+    assert repo.diagram_read_only(diag.diag_id)
+    assert repo.element_read_only(blk.elem_id)
+
+    toolbox.rename_diagram("F1", "F2")
+    rename_block(repo, blk.elem_id, "B2")
+    assert repo.diagrams[diag.diag_id].name == "F1"
+    assert repo.elements[blk.elem_id].name == "B1"


### PR DESCRIPTION
## Summary
- track reused work product types in repository and block edits on their diagrams and elements
- propagate reuse information from safety management toolbox
- prevent renaming ports from reused elements and expand read-only tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d569c4dfc8325abd106e47ddfa38f