### PR TITLE
Rename BPMN references to Governance

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -323,7 +323,7 @@ from gui.architecture import (
     BlockDiagramWindow,
     InternalBlockDiagramWindow,
     ControlFlowDiagramWindow,
-    BPMNDiagramWindow,
+    GovernanceDiagramWindow,
     ArchitectureManagerDialog,
     parse_behaviors,
 )
@@ -2131,7 +2131,7 @@ class FaultTreeApp:
         self.diagram_icons = {
             "Use Case Diagram": self._create_icon("circle", "blue"),
             "Activity Diagram": self._create_icon("arrow", "green"),
-            "BPMN Diagram": self._create_icon("arrow", "green"),
+            "Governance Diagram": self._create_icon("arrow", "green"),
             "Block Diagram": self._create_icon("rect", "orange"),
             "Internal Block Diagram": self._create_icon("nested", "purple"),
             "Control Flow Diagram": self._create_icon("arrow", "red"),
@@ -4224,8 +4224,8 @@ class FaultTreeApp:
             win = InternalBlockDiagramWindow(temp, self, diagram_id=diagram.diag_id)
         elif diagram.diag_type == "Control Flow Diagram":
             win = ControlFlowDiagramWindow(temp, self, diagram_id=diagram.diag_id)
-        elif diagram.diag_type == "BPMN Diagram":
-            win = BPMNDiagramWindow(temp, self, diagram_id=diagram.diag_id)
+        elif diagram.diag_type == "Governance Diagram":
+            win = GovernanceDiagramWindow(temp, self, diagram_id=diagram.diag_id)
         else:
             temp.destroy()
             return None
@@ -16558,7 +16558,7 @@ class FaultTreeApp:
                 if widget == tab:
                     repo = SysMLRepository.get_instance()
                     diag = repo.diagrams.get(diag_id)
-                    if diag and diag.diag_type == "BPMN Diagram":
+                    if diag and diag.diag_type == "Governance Diagram":
                         toolbox.list_diagrams()
                         name = next(
                             (n for n, did in toolbox.diagrams.items() if did == diag_id),
@@ -16810,8 +16810,8 @@ class FaultTreeApp:
             UseCaseDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Activity Diagram":
             ActivityDiagramWindow(tab, self, diagram_id=diag.diag_id)
-        elif diag.diag_type == "BPMN Diagram":
-            BPMNDiagramWindow(tab, self, diagram_id=diag.diag_id)
+        elif diag.diag_type == "Governance Diagram":
+            GovernanceDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Block Diagram":
             BlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Internal Block Diagram":
@@ -16839,8 +16839,8 @@ class FaultTreeApp:
             UseCaseDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Activity Diagram":
             ActivityDiagramWindow(tab, self, diagram_id=diag.diag_id)
-        elif diag.diag_type == "BPMN Diagram":
-            BPMNDiagramWindow(tab, self, diagram_id=diag.diag_id)
+        elif diag.diag_type == "Governance Diagram":
+            GovernanceDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Block Diagram":
             BlockDiagramWindow(tab, self, diagram_id=diag.diag_id)
         elif diag.diag_type == "Internal Block Diagram":

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -521,7 +521,7 @@ class SafetyManagementToolbox:
     # Diagram management helpers
     # ------------------------------------------------------------------
     def create_diagram(self, name: str) -> str:
-        """Create a new BPMN Diagram tracked by this toolbox.
+        """Create a new Governance Diagram tracked by this toolbox.
 
         Parameters
         ----------
@@ -534,7 +534,7 @@ class SafetyManagementToolbox:
             The repository identifier of the created diagram.
         """
         repo = SysMLRepository.get_instance()
-        diag = repo.create_diagram("BPMN Diagram", name=name)
+        diag = repo.create_diagram("Governance Diagram", name=name)
         diag.tags.append("safety-management")
         self.diagrams[name] = diag.diag_id
         return diag.diag_id
@@ -586,7 +586,7 @@ class SafetyManagementToolbox:
     def list_diagrams(self) -> List[str]:
         """Return the names of all managed diagrams.
 
-        Any BPMN Diagram in the repository tagged with
+        Any Governance Diagram in the repository tagged with
         ``"safety-management"`` should appear in the toolbox even if it
         was created outside of :meth:`create_diagram`. To ensure the list is
         complete we rescan the repository on each call and synchronize the

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2923,7 +2923,7 @@ class SysMLDiagramWindow(tk.Frame):
                     False,
                     f"Flow from {src.obj_type} to {dst.obj_type} is not allowed",
                 )
-        elif diag_type == "BPMN Diagram":
+        elif diag_type == "Governance Diagram":
             if conn_type in (
                 "Propagate",
                 "Propagate by Review",
@@ -4120,8 +4120,8 @@ class SysMLDiagramWindow(tk.Frame):
             UseCaseDiagramWindow(self.master, self.app, diagram_id=chosen, history=history)
         elif diag.diag_type == "Activity Diagram":
             ActivityDiagramWindow(self.master, self.app, diagram_id=chosen, history=history)
-        elif diag.diag_type == "BPMN Diagram":
-            BPMNDiagramWindow(self.master, self.app, diagram_id=chosen, history=history)
+        elif diag.diag_type == "Governance Diagram":
+            GovernanceDiagramWindow(self.master, self.app, diagram_id=chosen, history=history)
         elif diag.diag_type == "Block Diagram":
             BlockDiagramWindow(self.master, self.app, diagram_id=chosen, history=history)
         elif diag.diag_type == "Internal Block Diagram":
@@ -4157,8 +4157,8 @@ class SysMLDiagramWindow(tk.Frame):
             ActivityDiagramWindow(
                 self.master, self.app, diagram_id=prev_id, history=self.diagram_history
             )
-        elif diag.diag_type == "BPMN Diagram":
-            BPMNDiagramWindow(
+        elif diag.diag_type == "Governance Diagram":
+            GovernanceDiagramWindow(
                 self.master, self.app, diagram_id=prev_id, history=self.diagram_history
             )
         elif diag.diag_type == "Block Diagram":
@@ -7171,7 +7171,7 @@ class SysMLObjectDialog(simpledialog.Dialog):
             )
             link_row += 1
         elif self.obj.obj_type == "Use Case":
-            diagrams = [d for d in repo.diagrams.values() if d.diag_type == "BPMN Diagram"]
+            diagrams = [d for d in repo.diagrams.values() if d.diag_type == "Governance Diagram"]
             self.behavior_map = {d.name or d.diag_id: d.diag_id for d in diagrams}
             ttk.Label(link_frame, text="Behavior Diagram:").grid(
                 row=link_row, column=0, sticky="e", padx=4, pady=2
@@ -7187,16 +7187,16 @@ class SysMLObjectDialog(simpledialog.Dialog):
             if (
                 self.obj.obj_type == "Action"
                 and current_diagram
-                and current_diagram.diag_type == "BPMN Diagram"
+                and current_diagram.diag_type == "Governance Diagram"
             ):
                 diagrams = [
-                    d for d in repo.diagrams.values() if d.diag_type == "BPMN Diagram"
+                    d for d in repo.diagrams.values() if d.diag_type == "Governance Diagram"
                 ]
             else:
                 diagrams = [
                     d
                     for d in repo.diagrams.values()
-                    if d.diag_type in ("Activity Diagram", "BPMN Diagram")
+                    if d.diag_type in ("Activity Diagram", "Governance Diagram")
                 ]
             self.behavior_map = {d.name or d.diag_id: d.diag_id for d in diagrams}
             ttk.Label(link_frame, text="Behavior Diagram:").grid(
@@ -7213,7 +7213,7 @@ class SysMLObjectDialog(simpledialog.Dialog):
             bdiags = [
                 d
                 for d in repo.diagrams.values()
-                if d.diag_type in ("Activity Diagram", "BPMN Diagram")
+                if d.diag_type in ("Activity Diagram", "Governance Diagram")
             ]
             self.behavior_map = {d.name or d.diag_id: d.diag_id for d in bdiags}
             ttk.Label(link_frame, text="Behavior Diagram:").grid(
@@ -7412,7 +7412,7 @@ class SysMLObjectDialog(simpledialog.Dialog):
         diagrams = [
             d
             for d in repo.diagrams.values()
-            if d.diag_type in ("Activity Diagram", "BPMN Diagram")
+            if d.diag_type in ("Activity Diagram", "Governance Diagram")
         ]
         diag_map = {d.name or d.diag_id: d.diag_id for d in diagrams}
         ops = [op.name for op in self._operations]
@@ -7433,7 +7433,7 @@ class SysMLObjectDialog(simpledialog.Dialog):
         diagrams = [
             d
             for d in repo.diagrams.values()
-            if d.diag_type in ("Activity Diagram", "BPMN Diagram")
+            if d.diag_type in ("Activity Diagram", "Governance Diagram")
         ]
         diag_map = {d.name or d.diag_id: d.diag_id for d in diagrams}
         ops = [op.name for op in self._operations]
@@ -8164,7 +8164,7 @@ class ActivityDiagramWindow(SysMLDiagramWindow):
         self._sync_to_repository()
 
 
-class BPMNDiagramWindow(SysMLDiagramWindow):
+class GovernanceDiagramWindow(SysMLDiagramWindow):
     def __init__(self, master, app, diagram_id: str | None = None, history=None):
         tools = [
             "Action",
@@ -8175,7 +8175,7 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             "Flow",
             "System Boundary",
         ]
-        super().__init__(master, "BPMN Diagram", tools, diagram_id, app=app, history=history)
+        super().__init__(master, "Governance Diagram", tools, diagram_id, app=app, history=history)
         for child in self.toolbox.winfo_children():
             if isinstance(child, ttk.Button) and child.cget("text") == "Action":
                 child.configure(text="Task")
@@ -8183,8 +8183,8 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
         canvas_frame = self.canvas.master
         canvas_frame.pack_forget()
 
-        bpmn_panel = ttk.LabelFrame(self, text="BPMN")
-        bpmn_panel.pack(side=tk.RIGHT, fill=tk.Y, padx=2, pady=2)
+        governance_panel = ttk.LabelFrame(self, text="Governance")
+        governance_panel.pack(side=tk.RIGHT, fill=tk.Y, padx=2, pady=2)
 
         for name in (
             "Propagate",
@@ -8193,23 +8193,23 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
             "Re-use",
         ):
             ttk.Button(
-                bpmn_panel,
+                governance_panel,
                 text=name,
                 command=lambda t=name: self.select_tool(t),
             ).pack(fill=tk.X, padx=2, pady=2)
 
         ttk.Button(
-            bpmn_panel,
+            governance_panel,
             text="Add Work Product",
             command=self.add_work_product,
         ).pack(fill=tk.X, padx=2, pady=2)
         ttk.Button(
-            bpmn_panel,
+            governance_panel,
             text="Add Process Area",
             command=self.add_process_area,
         ).pack(fill=tk.X, padx=2, pady=2)
         ttk.Button(
-            bpmn_panel,
+            governance_panel,
             text="Add Lifecycle Phase",
             command=self.add_lifecycle_phase,
         ).pack(fill=tk.X, padx=2, pady=2)
@@ -8221,7 +8221,7 @@ class BPMNDiagramWindow(SysMLDiagramWindow):
     def _activate_parent_phase(self) -> None:
         """Activate the lifecycle phase containing this diagram.
 
-        When a BPMN diagram window is opened, switch the application's active
+        When a Governance diagram window is opened, switch the application's active
         lifecycle phase to the module that owns the diagram. Any tooling not
         enabled for that phase is hidden via ``on_lifecycle_selected`` or
         ``refresh_tool_enablement``.
@@ -8910,7 +8910,7 @@ class NewDiagramDialog(simpledialog.Dialog):
                 values=[
                     "Use Case Diagram",
                     "Activity Diagram",
-                    "BPMN Diagram",
+                    "Governance Diagram",
                     "Block Diagram",
                     "Internal Block Diagram",
                     "Control Flow Diagram",
@@ -9054,7 +9054,7 @@ class ArchitectureManagerDialog(tk.Frame):
         self.diagram_icons = {
             "Use Case Diagram": self._create_icon("circle", "blue"),
             "Activity Diagram": self._create_icon("arrow", "green"),
-            "BPMN Diagram": self._create_icon("arrow", "green"),
+            "Governance Diagram": self._create_icon("arrow", "green"),
             "Block Diagram": self._create_icon("rect", "orange"),
             "Internal Block Diagram": self._create_icon("nested", "purple"),
         }
@@ -9282,8 +9282,8 @@ class ArchitectureManagerDialog(tk.Frame):
             win = UseCaseDiagramWindow(master, self.app, diagram_id=diag_id)
         elif diag.diag_type == "Activity Diagram":
             win = ActivityDiagramWindow(master, self.app, diagram_id=diag_id)
-        elif diag.diag_type == "BPMN Diagram":
-            win = BPMNDiagramWindow(master, self.app, diagram_id=diag_id)
+        elif diag.diag_type == "Governance Diagram":
+            win = GovernanceDiagramWindow(master, self.app, diagram_id=diag_id)
         elif diag.diag_type == "Block Diagram":
             win = BlockDiagramWindow(master, self.app, diagram_id=diag_id)
         elif diag.diag_type == "Internal Block Diagram":
@@ -9473,15 +9473,15 @@ class ArchitectureManagerDialog(tk.Frame):
         if elem_id.startswith("obj_"):
             messagebox.showerror("Drop Error", "Objects cannot be dropped on a diagram.")
             return
-        # Dropping a diagram onto an Activity or BPMN Diagram creates a behavior reference
+        # Dropping a diagram onto an Activity or Governance Diagram creates a behavior reference
         if elem_id.startswith("diag_"):
             src_diag = repo.diagrams.get(elem_id[5:])
             if src_diag and diagram.diag_type == "Activity Diagram" and src_diag.diag_type in (
                 "Activity Diagram",
                 "Internal Block Diagram",
-                "BPMN Diagram",
+                "Governance Diagram",
             ):
-                elem_type = "Action" if diagram.diag_type == "BPMN Diagram" else "CallBehaviorAction"
+                elem_type = "Action" if diagram.diag_type == "Governance Diagram" else "CallBehaviorAction"
                 act = repo.create_element(
                     elem_type, name=src_diag.name, owner=diagram.package
                 )
@@ -9504,8 +9504,8 @@ class ArchitectureManagerDialog(tk.Frame):
                 return
             if (
                 src_diag
-                and diagram.diag_type == "BPMN Diagram"
-                and src_diag.diag_type == "BPMN Diagram"
+                and diagram.diag_type == "Governance Diagram"
+                and src_diag.diag_type == "Governance Diagram"
             ):
                 act = repo.create_element("Action", name=src_diag.name, owner=diagram.package)
                 repo.add_element_to_diagram(diagram.diag_id, act.elem_id)

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -2,14 +2,14 @@ import tkinter as tk
 from tkinter import ttk, simpledialog
 
 from analysis import SafetyManagementToolbox
-from gui.architecture import BPMNDiagramWindow
+from gui.architecture import GovernanceDiagramWindow
 from gui import messagebox
 
 
 class SafetyManagementWindow(tk.Frame):
     """Editor and browser for Safety & Security Management diagrams.
 
-    Users can create, rename, and delete BPMN Diagrams that model the
+    Users can create, rename, and delete Governance Diagrams that model the
     project's safety governance. Only diagrams registered in the provided
     :class:`SafetyManagementToolbox` are listed.
     """
@@ -141,5 +141,5 @@ class SafetyManagementWindow(tk.Frame):
         diag_id = self.toolbox.diagrams.get(name)
         if diag_id is None:
             return
-        self.current_window = BPMNDiagramWindow(self.diagram_frame, self.app, diagram_id=diag_id)
+        self.current_window = GovernanceDiagramWindow(self.diagram_frame, self.app, diagram_id=diag_id)
         self.current_window.pack(fill=tk.BOTH, expand=True)

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -467,22 +467,20 @@ class SysMLRepository:
         return diag.phase != self.active_phase and diag.diag_type in getattr(self, "reuse_products", set())
 
     def element_read_only(self, elem_id: str) -> bool:
-        """Return ``True`` if ``elem_id`` originates from a reused phase."""
+        """Return ``True`` if ``elem_id`` originates from a reused phase or work product."""
         elem = self.elements.get(elem_id)
         if not elem:
             return False
         if self.active_phase is None or elem.phase is None:
             return False
-        return elem.phase != self.active_phase and elem.phase in getattr(self, "reuse_phases", set())
-
-    def diagram_read_only(self, diag_id: str) -> bool:
-        """Return ``True`` if ``diag_id`` originates from a reused phase."""
-        diag = self.diagrams.get(diag_id)
-        if not diag:
-            return False
-        if self.active_phase is None or diag.phase is None:
-            return False
-        return diag.phase != self.active_phase and diag.phase in getattr(self, "reuse_phases", set())
+        if elem.phase != self.active_phase and elem.phase in getattr(self, "reuse_phases", set()):
+            return True
+        linked = self.get_linked_diagram(elem_id)
+        if linked:
+            diag = self.diagrams.get(linked)
+            if diag and diag.diag_type in getattr(self, "reuse_products", set()):
+                return True
+        return False
 
     def visible_elements(self) -> dict[str, SysMLElement]:
         """Return mapping of element IDs to elements visible in the active phase."""

--- a/tests/test_connection_stereotype_label.py
+++ b/tests/test_connection_stereotype_label.py
@@ -20,7 +20,7 @@ class ConnectionStereotypeLabelTests(unittest.TestCase):
 
     def test_propagate_label_stereotype(self):
         conn = DiagramConnection(1, 2, "Propagate")
-        label = format_control_flow_label(conn, self.repo, "BPMN Diagram")
+        label = format_control_flow_label(conn, self.repo, "Governance Diagram")
         self.assertEqual(label, "<<propagate>>")
 
 

--- a/tests/test_governance_action_drop.py
+++ b/tests/test_governance_action_drop.py
@@ -3,11 +3,11 @@ from gui.architecture import ArchitectureManagerDialog
 from sysml.sysml_repository import SysMLRepository
 
 
-def test_drop_bpmn_diagram_creates_action(monkeypatch):
+def test_drop_governance_diagram_creates_action(monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    src = repo.create_diagram("BPMN Diagram", name="Src")
-    target = repo.create_diagram("BPMN Diagram", name="Target")
+    src = repo.create_diagram("Governance Diagram", name="Src")
+    target = repo.create_diagram("Governance Diagram", name="Target")
 
     mgr = ArchitectureManagerDialog.__new__(ArchitectureManagerDialog)
     mgr.repo = repo
@@ -24,11 +24,11 @@ def test_drop_bpmn_diagram_creates_action(monkeypatch):
     assert repo.get_linked_diagram(elem_id) == src.diag_id
 
 
-def test_drop_non_bpmn_diagram_on_bpmn_fails(monkeypatch):
+def test_drop_non_governance_diagram_on_governance_fails(monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     src = repo.create_diagram("Activity Diagram", name="Act")
-    target = repo.create_diagram("BPMN Diagram", name="Target")
+    target = repo.create_diagram("Governance Diagram", name="Target")
 
     mgr = ArchitectureManagerDialog.__new__(ArchitectureManagerDialog)
     mgr.repo = repo

--- a/tests/test_governance_actions.py
+++ b/tests/test_governance_actions.py
@@ -3,17 +3,17 @@ import unittest
 from unittest import mock
 
 from sysml.sysml_repository import SysMLRepository
-from gui.architecture import ArchitectureManagerDialog, BPMNDiagramWindow
+from gui.architecture import ArchitectureManagerDialog, GovernanceDiagramWindow
 
 
-class BPMNActionsTests(unittest.TestCase):
+class GovernanceActionsTests(unittest.TestCase):
     def setUp(self):
         SysMLRepository._instance = None
         self.repo = SysMLRepository.get_instance()
 
     def test_drop_creates_action(self):
-        src = self.repo.create_diagram("BPMN Diagram", name="Src")
-        target = self.repo.create_diagram("BPMN Diagram", name="Tgt")
+        src = self.repo.create_diagram("Governance Diagram", name="Src")
+        target = self.repo.create_diagram("Governance Diagram", name="Tgt")
         explorer = ArchitectureManagerDialog.__new__(ArchitectureManagerDialog)
         explorer.repo = self.repo
         with mock.patch("gui.messagebox.showerror"):
@@ -25,8 +25,8 @@ class BPMNActionsTests(unittest.TestCase):
         self.assertEqual(self.repo.get_linked_diagram(elem.elem_id), src.diag_id)
 
     def test_toolbox_creates_action(self):
-        diag = self.repo.create_diagram("BPMN Diagram")
-        win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+        diag = self.repo.create_diagram("Governance Diagram")
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
         win.repo = self.repo
         win.diagram_id = diag.diag_id
         win.zoom = 1.0
@@ -50,7 +50,7 @@ class BPMNActionsTests(unittest.TestCase):
             canvasx=lambda v: v, canvasy=lambda v: v, configure=lambda **kw: None
         )
         event = types.SimpleNamespace(x=10, y=10)
-        BPMNDiagramWindow.on_left_press(win, event)
+        GovernanceDiagramWindow.on_left_press(win, event)
         obj = win.objects[0]
         elem = self.repo.elements[obj.element_id]
         self.assertEqual(obj.obj_type, "Action")

--- a/tests/test_governance_diagram_refresh.py
+++ b/tests/test_governance_diagram_refresh.py
@@ -3,14 +3,14 @@ from dataclasses import asdict
 
 from sysml.sysml_repository import SysMLRepository
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
-from gui.architecture import BPMNDiagramWindow, SysMLDiagramWindow, SysMLObject
+from gui.architecture import GovernanceDiagramWindow, SysMLDiagramWindow, SysMLObject
 import gui.architecture as arch
 
 
-def test_open_bpmn_diagram_refreshes_after_phase_activation(monkeypatch):
+def test_open_governance_diagram_refreshes_after_phase_activation(monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov2")
+    diag = repo.create_diagram("Governance Diagram", name="Gov2")
     obj = SysMLObject(1, "Work Product", 0.0, 0.0)
     diag.objects.append(asdict(obj))
 
@@ -75,7 +75,7 @@ def test_open_bpmn_diagram_refreshes_after_phase_activation(monkeypatch):
     monkeypatch.setattr(arch.ttk, "LabelFrame", DummyWidget)
     monkeypatch.setattr(arch.ttk, "Button", DummyWidget)
 
-    win = BPMNDiagramWindow(None, app, diagram_id=diag.diag_id)
+    win = GovernanceDiagramWindow(None, app, diagram_id=diag.diag_id)
 
     assert toolbox.active_module == "Phase2"
     assert len(win.objects) == 1

--- a/tests/test_governance_diagram_visibility.py
+++ b/tests/test_governance_diagram_visibility.py
@@ -15,7 +15,7 @@ def test_governance_elements_visible_all_phases():
     toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
     toolbox.set_active_module("P1")
 
-    diag = repo.create_diagram("BPMN Diagram", name="Gov")
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
     diag.tags.append("safety-management")
 
     obj1 = SysMLObject(1, "Work Product", 0.0, 0.0)

--- a/tests/test_governance_phase_toggle.py
+++ b/tests/test_governance_phase_toggle.py
@@ -7,7 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from sysml.sysml_repository import SysMLRepository
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
-from gui.architecture import BPMNDiagramWindow, SysMLObject
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
 
 
 class DummyVar:
@@ -21,10 +21,10 @@ class DummyVar:
         return self.value
 
 
-def test_open_bpmn_diagram_activates_phase():
+def test_open_governance_diagram_activates_phase():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov1")
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule(name="Phase1", diagrams=["Gov1"])]
@@ -42,12 +42,12 @@ def test_open_bpmn_diagram_activates_phase():
 
     app.on_lifecycle_selected = on_lifecycle_selected
 
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.app = app
 
-    BPMNDiagramWindow._activate_parent_phase(win)
+    GovernanceDiagramWindow._activate_parent_phase(win)
 
     assert toolbox.active_module == "Phase1"
     assert app.lifecycle_var.get() == "Phase1"
@@ -70,7 +70,7 @@ def test_added_work_product_respects_phase(monkeypatch):
     from AutoML import FaultTreeApp
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov2")
+    diag = repo.create_diagram("Governance Diagram", name="Gov2")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [
@@ -139,7 +139,7 @@ def test_added_work_product_respects_phase(monkeypatch):
 
     app.on_lifecycle_selected()
 
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.objects = [
@@ -162,7 +162,7 @@ def test_added_work_product_respects_phase(monkeypatch):
         def __init__(self, *args, **kwargs):
             self.selection = "HAZOP"
 
-    monkeypatch.setattr(BPMNDiagramWindow, "_SelectDialog", FakeDialog)
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", FakeDialog)
 
     win.add_work_product()
     assert menu.state == tk.DISABLED
@@ -188,7 +188,7 @@ def test_work_product_disables_when_leaving_phase(monkeypatch):
     from AutoML import FaultTreeApp
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov3")
+    diag = repo.create_diagram("Governance Diagram", name="Gov3")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [
@@ -257,7 +257,7 @@ def test_work_product_disables_when_leaving_phase(monkeypatch):
 
     app.on_lifecycle_selected()
 
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.objects = [
@@ -280,7 +280,7 @@ def test_work_product_disables_when_leaving_phase(monkeypatch):
         def __init__(self, *args, **kwargs):
             self.selection = "HAZOP"
 
-    monkeypatch.setattr(BPMNDiagramWindow, "_SelectDialog", FakeDialog)
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", FakeDialog)
 
     win.add_work_product()
     assert menu.state == tk.NORMAL

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -1,7 +1,7 @@
 import types
 import unittest
 
-from gui.architecture import BPMNDiagramWindow, SysMLObject
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
 from sysml.sysml_repository import SysMLRepository
 
 
@@ -28,14 +28,14 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
         architecture.ConnectionDialog = self._orig_conn_dialog
 
     def _create_window(self, tool, src, dst, diag):
-        win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
         win.repo = self.repo
         win.diagram_id = diag.diag_id
         win.zoom = 1
         win.canvas = DummyCanvas()
         win.find_object = lambda x, y, prefer_port=False: src if win.start is None else dst
-        win.validate_connection = BPMNDiagramWindow.validate_connection.__get__(
-            win, BPMNDiagramWindow
+        win.validate_connection = GovernanceDiagramWindow.validate_connection.__get__(
+            win, GovernanceDiagramWindow
         )
         win.update_property_view = lambda: None
         win.redraw = lambda: None
@@ -53,7 +53,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
         repo = self.repo
         e1 = repo.create_element("Block", name="E1")
         e2 = repo.create_element("Block", name="E2")
-        diag = repo.create_diagram("BPMN Diagram", name="Gov")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
         repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
         repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
         o1 = SysMLObject(
@@ -75,9 +75,9 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
         diag.objects = [o1.__dict__, o2.__dict__]
         win = self._create_window("Propagate", o1, o2, diag)
         event1 = types.SimpleNamespace(x=0, y=0, state=0)
-        BPMNDiagramWindow.on_left_press(win, event1)
+        GovernanceDiagramWindow.on_left_press(win, event1)
         event2 = types.SimpleNamespace(x=0, y=100, state=0)
-        BPMNDiagramWindow.on_left_press(win, event2)
+        GovernanceDiagramWindow.on_left_press(win, event2)
         self.assertEqual(repo.relationships[0].stereotype, "propagate")
 
 

--- a/tests/test_governance_reuse.py
+++ b/tests/test_governance_reuse.py
@@ -17,7 +17,7 @@ def _obj(obj_id: int, obj_type: str, name: str) -> dict:
 def test_work_product_reuse_visible():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="GovWP")
+    diag = repo.create_diagram("Governance Diagram", name="GovWP")
     diag.objects.extend([
         _obj(1, "Work Product", "HAZOP"),
         _obj(2, "Lifecycle Phase", "P2"),
@@ -37,7 +37,7 @@ def test_work_product_reuse_visible():
 def test_phase_reuse_shows_all_docs():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="GovPhase")
+    diag = repo.create_diagram("Governance Diagram", name="GovPhase")
     diag.objects.extend([
         _obj(1, "Lifecycle Phase", "P1"),
         _obj(2, "Lifecycle Phase", "P2"),

--- a/tests/test_governance_reuse_visibility.py
+++ b/tests/test_governance_reuse_visibility.py
@@ -17,7 +17,7 @@ def _setup_repo():
 
 def test_work_product_reuse_visibility():
     repo = _setup_repo()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov")
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"]), GovernanceModule(name="P2")]
@@ -41,7 +41,7 @@ def test_work_product_reuse_visibility():
 
 def test_phase_reuse_visibility():
     repo = _setup_repo()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov1")
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov1"]), GovernanceModule(name="P2")]
@@ -65,7 +65,7 @@ def test_phase_reuse_visibility():
 
 def test_activity_diagram_reuse_read_only():
     repo = _setup_repo()
-    gov = repo.create_diagram("BPMN Diagram", name="Gov")
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"]), GovernanceModule(name="P2")]
@@ -88,7 +88,7 @@ def test_activity_diagram_reuse_read_only():
 
 def test_phase_reuse_shows_diagrams_and_elements():
     repo = _setup_repo()
-    gov = repo.create_diagram("BPMN Diagram", name="Gov")
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [
@@ -120,7 +120,7 @@ def test_phase_reuse_shows_diagrams_and_elements():
 
 def test_activity_diagram_reuse_read_only():
     repo = _setup_repo()
-    gov = repo.create_diagram("BPMN Diagram", name="Gov")
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"]), GovernanceModule(name="P2")]

--- a/tests/test_phase_reuse_read_only.py
+++ b/tests/test_phase_reuse_read_only.py
@@ -16,7 +16,7 @@ def _setup_repo():
 
 def _prepare():
     repo = _setup_repo()
-    gov = repo.create_diagram("BPMN Diagram", name="Gov")
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"]), GovernanceModule(name="P2")]
     toolbox.diagrams = {"Gov": gov.diag_id}
@@ -69,7 +69,7 @@ def test_reused_diagram_read_only_blocks_modification():
 
 def _prepare_product_reuse():
     repo = _setup_repo()
-    gov = repo.create_diagram("BPMN Diagram", name="Gov")
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"]), GovernanceModule(name="P2")]
     toolbox.diagrams = {"Gov": gov.diag_id}

--- a/tests/test_phase_visibility.py
+++ b/tests/test_phase_visibility.py
@@ -7,7 +7,7 @@ from gui.architecture import (
     SysMLObject,
     DiagramConnection,
     SysMLDiagramWindow,
-    BPMNDiagramWindow,
+    GovernanceDiagramWindow,
 )
 
 PIL_stub = types.ModuleType("PIL")
@@ -106,21 +106,21 @@ def test_on_lifecycle_selected_refreshes_diagrams():
     assert refreshed["count"] == 1
 
 
-def test_bpmn_diagram_refreshes_on_phase_change():
+def test_governance_diagram_refreshes_on_phase_change():
     repo = SysMLRepository.reset_instance()
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule("P1"), GovernanceModule("P2")]
     toolbox.set_active_module("P1")
-    diag = repo.create_diagram("BPMN Diagram")
+    diag = repo.create_diagram("Governance Diagram")
     obj1 = SysMLObject(1, "Work Product", 0.0, 0.0, properties={"name": "Spec1"})
     diag.objects.append(asdict(obj1))
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.sort_objects = lambda: None
     win.redraw = lambda: None
     win.update_property_view = lambda: None
-    BPMNDiagramWindow.refresh_from_repository(win)
+    GovernanceDiagramWindow.refresh_from_repository(win)
     assert len(win.objects) == 1
     toolbox.set_active_module("P2")
     obj2 = SysMLObject(2, "Work Product", 0.0, 0.0, properties={"name": "Spec2"})
@@ -132,7 +132,7 @@ def test_bpmn_diagram_refreshes_on_phase_change():
     app.refresh_tool_enablement = lambda: None
 
     inner = types.SimpleNamespace(
-        refresh_from_repository=lambda: BPMNDiagramWindow.refresh_from_repository(win),
+        refresh_from_repository=lambda: GovernanceDiagramWindow.refresh_from_repository(win),
         winfo_children=lambda: [],
     )
     container = types.SimpleNamespace(winfo_children=lambda: [inner])

--- a/tests/test_requirement_work_products.py
+++ b/tests/test_requirement_work_products.py
@@ -1,7 +1,7 @@
 import types
 
 from analysis.models import REQUIREMENT_TYPE_OPTIONS
-from gui.architecture import BPMNDiagramWindow, SysMLObject
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
 from sysml.sysml_repository import SysMLRepository
 from AutoML import FaultTreeApp
 
@@ -22,7 +22,7 @@ def test_add_requirement_work_product(monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     diag = repo.create_diagram("Gov")
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.objects = [
@@ -48,7 +48,7 @@ def test_add_requirement_work_product(monkeypatch):
         def __init__(self, *args, **kwargs):
             self.selection = name
 
-    monkeypatch.setattr(BPMNDiagramWindow, "_SelectDialog", FakeDialog)
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", FakeDialog)
 
     win.add_work_product()
 

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -25,7 +25,7 @@ from analysis.safety_management import (
     GovernanceModule,
     SafetyWorkProduct,
 )
-from gui.architecture import BPMNDiagramWindow, SysMLObject, ArchitectureManagerDialog
+from gui.architecture import GovernanceDiagramWindow, SysMLObject, ArchitectureManagerDialog
 from gui.safety_management_explorer import SafetyManagementExplorer
 from gui.safety_management_toolbox import SafetyManagementWindow
 from gui.review_toolbox import ReviewData
@@ -36,11 +36,11 @@ from analysis.models import HazopDoc, StpaDoc
 
 def test_work_product_registration():
     toolbox = SafetyManagementToolbox()
-    toolbox.add_work_product("BPMN Diagram", "HAZOP", "Link action to hazard")
+    toolbox.add_work_product("Governance Diagram", "HAZOP", "Link action to hazard")
 
     products = toolbox.get_work_products()
     assert len(products) == 1
-    assert products[0].diagram == "BPMN Diagram"
+    assert products[0].diagram == "Governance Diagram"
     assert products[0].analysis == "HAZOP"
     assert products[0].rationale == "Link action to hazard"
 
@@ -83,8 +83,8 @@ class DummyCanvas:
 def test_activity_boundary_label_centered():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram")
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.zoom = 1.0
@@ -492,7 +492,7 @@ def test_external_safety_diagrams_load_in_toolbox_list():
     """Diagrams tagged for governance appear even if created elsewhere."""
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="GovX")
+    diag = repo.create_diagram("Governance Diagram", name="GovX")
     diag.tags.append("safety-management")
     toolbox = SafetyManagementToolbox()
     names = toolbox.list_diagrams()
@@ -675,11 +675,11 @@ def test_menu_work_products_toggle_and_guard_existing_docs():
         assert FaultTreeApp.disable_work_product(app, name)
         assert menu.state == tk.DISABLED
 
-def test_governance_diagram_opens_with_bpmn_toolbox(monkeypatch):
-    """Governance diagrams open as BPMN diagrams with their toolbox."""
+def test_governance_diagram_opens_with_governance_toolbox(monkeypatch):
+    """Governance diagrams open as Governance diagrams with their toolbox."""
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="GovA")
+    diag = repo.create_diagram("Governance Diagram", name="GovA")
     diag.tags.append("safety-management")
 
     app = FaultTreeApp.__new__(FaultTreeApp)
@@ -704,21 +704,21 @@ def test_governance_diagram_opens_with_bpmn_toolbox(monkeypatch):
     app._new_tab = _new_tab
     app.refresh_all = lambda: None
 
-    calls = {"bpmn": False, "activity": False}
+    calls = {"governance": False, "activity": False}
 
-    def fake_bpmn(tab, _app, diagram_id):
-        calls["bpmn"] = True
+    def fake_governance(tab, _app, diagram_id):
+        calls["governance"] = True
         assert diagram_id == diag.diag_id
 
     def fake_activity(tab, _app, diagram_id):
         calls["activity"] = True
 
-    monkeypatch.setattr(AutoML, "BPMNDiagramWindow", fake_bpmn)
+    monkeypatch.setattr(AutoML, "GovernanceDiagramWindow", fake_governance)
     monkeypatch.setattr(AutoML, "ActivityDiagramWindow", fake_activity)
 
     app.open_management_window(0)
 
-    assert calls["bpmn"]
+    assert calls["governance"]
     assert not calls["activity"]
 
 
@@ -727,9 +727,9 @@ def test_diagram_hierarchy_orders_levels():
     repo = SysMLRepository.get_instance()
     toolbox = SafetyManagementToolbox()
 
-    a = repo.create_diagram("BPMN Diagram", name="A")
-    b = repo.create_diagram("BPMN Diagram", name="B")
-    c = repo.create_diagram("BPMN Diagram", name="C")
+    a = repo.create_diagram("Governance Diagram", name="A")
+    b = repo.create_diagram("Governance Diagram", name="B")
+    c = repo.create_diagram("Governance Diagram", name="C")
     for diag in (a, b, c):
         diag.tags.append("safety-management")
 
@@ -758,8 +758,8 @@ def test_diagram_hierarchy_from_object_properties():
     repo = SysMLRepository.get_instance()
     toolbox = SafetyManagementToolbox()
 
-    parent = repo.create_diagram("BPMN Diagram", name="Parent")
-    child = repo.create_diagram("BPMN Diagram", name="Child")
+    parent = repo.create_diagram("Governance Diagram", name="Parent")
+    child = repo.create_diagram("Governance Diagram", name="Child")
     for d in (parent, child):
         d.tags.append("safety-management")
 
@@ -788,8 +788,8 @@ def test_work_products_filtered_by_phase_in_tree():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
 
-    d1 = repo.create_diagram("BPMN Diagram", name="Gov1")
-    d2 = repo.create_diagram("BPMN Diagram", name="Gov2")
+    d1 = repo.create_diagram("Governance Diagram", name="Gov1")
+    d2 = repo.create_diagram("Governance Diagram", name="Gov2")
     for d in (d1, d2):
         d.tags.append("safety-management")
 
@@ -870,8 +870,8 @@ def test_work_products_filtered_by_phase_in_tree():
 def test_governance_enables_tools_per_phase():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    d1 = repo.create_diagram("BPMN Diagram", name="Gov1")
-    d2 = repo.create_diagram("BPMN Diagram", name="Gov2")
+    d1 = repo.create_diagram("Governance Diagram", name="Gov1")
+    d2 = repo.create_diagram("Governance Diagram", name="Gov2")
     for d in (d1, d2):
         d.tags.append("safety-management")
 
@@ -987,7 +987,7 @@ def test_governance_enables_tools_per_phase():
 def test_phase_selection_updates_app(monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov1")
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov1"])]
@@ -1026,7 +1026,7 @@ def test_phase_selection_updates_app(monkeypatch):
 def test_phase_selection_refreshes_menus():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov1")
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
 
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov1"])]
@@ -1159,7 +1159,7 @@ def test_refresh_tool_enablement_enables_parent_menus():
 def test_phase_without_diagrams_disables_tools():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    d1 = repo.create_diagram("BPMN Diagram", name="Gov1")
+    d1 = repo.create_diagram("Governance Diagram", name="Gov1")
     d1.tags.append("safety-management")
 
     toolbox = SafetyManagementToolbox()
@@ -1740,8 +1740,8 @@ def test_folder_double_click_opens_safety_management_explorer():
 def test_add_work_product_uses_half_width(monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram")
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.objects = [
@@ -1764,7 +1764,7 @@ def test_add_work_product_uses_half_width(monkeypatch):
         def __init__(self, *args, **kwargs):
             self.selection = "HAZOP"
 
-    monkeypatch.setattr(BPMNDiagramWindow, "_SelectDialog", FakeDialog)
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", FakeDialog)
 
     win.add_work_product()
 
@@ -1775,8 +1775,8 @@ def test_add_work_product_uses_half_width(monkeypatch):
 def test_work_product_color_and_text_wrapping():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram")
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.zoom = 1.0
@@ -1811,8 +1811,8 @@ def test_work_product_color_and_text_wrapping():
 def test_work_product_shapes_fixed_size():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram")
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     win.zoom = 1.0
@@ -1847,18 +1847,18 @@ def test_work_product_shapes_fixed_size():
 def test_propagation_connection_validation():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram")
-    win = BPMNDiagramWindow.__new__(BPMNDiagramWindow)
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo
     win.diagram_id = diag.diag_id
     wp1 = SysMLObject(1, "Work Product", 0.0, 0.0, properties={"name": "Risk Assessment"})
     wp2 = SysMLObject(2, "Work Product", 0.0, 0.0, properties={"name": "FTA"})
     win.objects = [wp1, wp2]
-    valid, _ = BPMNDiagramWindow.validate_connection(win, wp1, wp2, "Propagate")
+    valid, _ = GovernanceDiagramWindow.validate_connection(win, wp1, wp2, "Propagate")
     assert valid
     wp3 = SysMLObject(3, "Work Product", 0.0, 0.0, properties={"name": "STPA"})
     win.objects.append(wp3)
-    valid, _ = BPMNDiagramWindow.validate_connection(win, wp1, wp3, "Propagate")
+    valid, _ = GovernanceDiagramWindow.validate_connection(win, wp1, wp3, "Propagate")
     assert not valid
 
 
@@ -1866,7 +1866,7 @@ def test_can_propagate_respects_review_states():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     toolbox = SafetyManagementToolbox()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov")
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
     toolbox.diagrams["Gov"] = diag.diag_id
     diag.objects = [
         {"obj_id": 1, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Risk Assessment"}},
@@ -1886,7 +1886,7 @@ def test_propagation_type_uses_stereotype_when_conn_type_missing():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     toolbox = SafetyManagementToolbox()
-    diag = repo.create_diagram("BPMN Diagram", name="Gov")
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
     toolbox.diagrams["Gov"] = diag.diag_id
     diag.objects = [
         {"obj_id": 1, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Risk Assessment"}},
@@ -1947,7 +1947,7 @@ def test_disable_requirement_work_product_keeps_editor():
     assert "Requirements Editor" not in app.tool_actions
 
 
-def test_focus_bpmn_diagram_sets_phase_and_hides_functions():
+def test_focus_governance_diagram_sets_phase_and_hides_functions():
     SysMLRepository._instance = None
     toolbox = SafetyManagementToolbox()
     d1 = toolbox.create_diagram("Gov1")
@@ -2010,7 +2010,7 @@ def test_focus_bpmn_diagram_sets_phase_and_hides_functions():
     app.safety_mgmt_toolbox = toolbox
     changes: list[str] = []
     toolbox.on_change = lambda: changes.append("x")
-    AutoML.BPMNDiagramWindow = lambda *args, **kwargs: None
+    AutoML.GovernanceDiagramWindow = lambda *args, **kwargs: None
 
     FaultTreeApp.open_arch_window(app, d1)
     app.doc_nb.select(app.diagram_tabs[d1])

--- a/tests/test_work_product_name_read_only.py
+++ b/tests/test_work_product_name_read_only.py
@@ -14,7 +14,7 @@ class DummyVar:
 def test_work_product_name_read_only():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("BPMN Diagram")
+    diag = repo.create_diagram("Governance Diagram")
     obj = SysMLObject(1, "Work Product", 0.0, 0.0, properties={"name": "Risk Assessment"})
     dlg = SysMLObjectDialog.__new__(SysMLObjectDialog)
     dlg.obj = obj


### PR DESCRIPTION
## Summary
- replace all BPMN terminology with Governance throughout the project
- rename diagram window and associated tests to Governance equivalents
- extend repository read-only checks to handle reused work products

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689d5d28b5d88325a7d9d72dd99ec58f