### PR TITLE
Rotate process area labels vertically inside boundaries

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5479,28 +5479,48 @@ class SysMLDiagramWindow(tk.Frame):
             )
             label = obj.properties.get("name", "")
             if label:
-                diag = self.repo.diagrams.get(self.diagram_id)
-                if diag and diag.diag_type in ("Activity Diagram", "BPMN Diagram"):
-                    lx = x - w - 4 * self.zoom
-                    ly = y
-                    self.canvas.create_text(
-                        lx,
-                        ly,
-                        text=label,
-                        angle=90,
-                        anchor="e",
-                        font=self.font,
-                    )
-                else:
-                    lx = x
-                    ly = y - h - 4 * self.zoom
-                    self.canvas.create_text(
-                        lx,
-                        ly,
-                        text=label,
-                        anchor="s",
-                        font=self.font,
-                    )
+                # Wrap and scale the label so it always fits within the boundary box
+                avail_w = max(obj.width * self.zoom - 16 * self.zoom, 1)
+                avail_h = max(obj.height * self.zoom - 16 * self.zoom, 1)
+
+                try:
+                    font = tkFont.Font(font=self.font)
+                    char_w = max(font.measure("M"), 1)
+                    line_h = max(font.metrics("linespace"), 1)
+                except Exception:
+                    font = None
+                    char_w = 8
+                    line_h = 16
+
+                max_chars = max(int(avail_h / char_w), 1)
+                max_lines = max(int(avail_w / line_h), 1)
+
+                wrap_width = max_chars
+                wrapped = textwrap.fill(label, width=wrap_width)
+                lines = wrapped.count("\n") + 1
+
+                # Reduce font size until the wrapped text fits horizontally
+                if font is not None:
+                    while lines > max_lines and font.cget("size") > 6:
+                        font.configure(size=font.cget("size") - 1)
+                        char_w = max(font.measure("M"), 1)
+                        line_h = max(font.metrics("linespace"), 1)
+                        max_chars = max(int(avail_h / char_w), 1)
+                        max_lines = max(int(avail_w / line_h), 1)
+                        wrap_width = max_chars
+                        wrapped = textwrap.fill(label, width=wrap_width)
+                        lines = wrapped.count("\n") + 1
+
+                lx = x - w + 8 * self.zoom
+                self.canvas.create_text(
+                    lx,
+                    y,
+                    text=wrapped,
+                    anchor="w",
+                    angle=90,
+                    font=font or self.font,
+                    justify="center",
+                )
         elif obj.obj_type == "Block Boundary":
             self._create_round_rect(
                 x - w,

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -80,7 +80,7 @@ class DummyCanvas:
         return y
 
 
-def test_activity_boundary_label_rotated_left():
+def test_activity_boundary_label_rotated_left_inside():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     diag = repo.create_diagram("BPMN Diagram")
@@ -92,13 +92,25 @@ def test_activity_boundary_label_rotated_left():
     win.font = None
     win._draw_gradient_rect = lambda *args, **kwargs: None
     win.selected_objs = []
-    obj = SysMLObject(1, "System Boundary", 0.0, 0.0, width=100.0, height=80.0, properties={"name": "Lane"})
+    long_name = "Very Long Process Area Name"
+    obj = SysMLObject(
+        1,
+        "System Boundary",
+        0.0,
+        0.0,
+        width=100.0,
+        height=80.0,
+        properties={"name": long_name},
+    )
     win.draw_object(obj)
 
     assert win.canvas.text_calls, "label not drawn"
-    x, _, kwargs = win.canvas.text_calls[0]
+    x, y, kwargs = win.canvas.text_calls[0]
     assert kwargs.get("angle") == 90
-    assert x < obj.x - obj.width / 2
+    assert kwargs.get("anchor") == "w"
+    assert "\n" in kwargs.get("text", ""), "label not wrapped inside boundary"
+    assert x == obj.x - obj.width / 2 + 8
+    assert y == obj.y
 
 
 def test_toolbox_manages_diagram_lifecycle():


### PR DESCRIPTION
## Summary
- Wrap and scale process area labels so they always stay within their boundary shapes
- Update safety management test to verify long labels wrap inside boundaries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689d59152cd4832586acbf045bc11fbc