### PR TITLE
Add bidirectional trace relationship to governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2713,6 +2713,7 @@ class SysMLDiagramWindow(tk.Frame):
                     "Propagate by Review",
                     "Propagate by Approval",
                     "Re-use",
+                    "Trace",
                     "Connector",
                     "Generalize",
                     "Generalization",
@@ -2746,6 +2747,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalize",
             "Generalization",
@@ -2935,6 +2937,9 @@ class SysMLDiagramWindow(tk.Frame):
                 dst_name = dst.properties.get("name")
                 if (src_name, dst_name) not in ALLOWED_PROPAGATIONS:
                     return False, f"Propagation from {src_name} to {dst_name} is not allowed"
+            elif conn_type == "Trace":
+                if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
+                    return False, "Trace links must connect Work Products"
             elif conn_type == "Re-use":
                 if src.obj_type not in ("Work Product", "Lifecycle Phase") or dst.obj_type != "Lifecycle Phase":
                     return False, "Re-use links must originate from a Work Product or Lifecycle Phase and target a Lifecycle Phase"
@@ -3031,6 +3036,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3152,6 +3158,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3177,6 +3184,8 @@ class SysMLDiagramWindow(tk.Frame):
                             arrow_default = "forward"
                         elif t == "Feedback":
                             arrow_default = "backward"
+                        elif t == "Trace":
+                            arrow_default = "both"
                         elif t in (
                             "Flow",
                             "Generalize",
@@ -3456,6 +3465,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3660,6 +3670,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3683,6 +3694,8 @@ class SysMLDiagramWindow(tk.Frame):
                         arrow_default = "forward"
                     elif self.current_tool == "Feedback":
                         arrow_default = "backward"
+                    elif self.current_tool == "Trace":
+                        arrow_default = "both"
                     elif self.current_tool in (
                         "Flow",
                         "Generalize",
@@ -3961,6 +3974,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3985,6 +3999,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalization",
             "Generalize",
@@ -8225,6 +8240,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
         ):
             ttk.Button(
                 governance_panel,

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -80,6 +80,38 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
         GovernanceDiagramWindow.on_left_press(win, event2)
         self.assertEqual(repo.relationships[0].stereotype, "propagate")
 
+    def test_trace_relationship_bidirectional(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="A")
+        e2 = repo.create_element("Block", name="B")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "WP1"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "WP2"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Trace", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        self.assertEqual(repo.relationships[0].stereotype, "trace")
+        self.assertEqual(win.connections[0].arrow, "both")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `Trace` tool to governance diagrams to link any two work products
- support bidirectional trace connections with black arrows on both ends
- test trace relationships for correct stereotype and arrow style

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d621e49a08325b6b4f45ab34e839f