### PR TITLE
Add bidirectional trace links to governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2713,6 +2713,7 @@ class SysMLDiagramWindow(tk.Frame):
                     "Propagate by Review",
                     "Propagate by Approval",
                     "Re-use",
+                    "Trace",
                     "Connector",
                     "Generalize",
                     "Generalization",
@@ -2746,6 +2747,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalize",
             "Generalization",
@@ -2938,6 +2940,9 @@ class SysMLDiagramWindow(tk.Frame):
             elif conn_type == "Re-use":
                 if src.obj_type not in ("Work Product", "Lifecycle Phase") or dst.obj_type != "Lifecycle Phase":
                     return False, "Re-use links must originate from a Work Product or Lifecycle Phase and target a Lifecycle Phase"
+            elif conn_type == "Trace":
+                if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
+                    return False, "Trace links must connect Work Products"
             else:
                 allowed = {
                     "Initial": {
@@ -3031,6 +3036,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3152,6 +3158,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3177,6 +3184,8 @@ class SysMLDiagramWindow(tk.Frame):
                             arrow_default = "forward"
                         elif t == "Feedback":
                             arrow_default = "backward"
+                        elif t == "Trace":
+                            arrow_default = "both"
                         elif t in (
                             "Flow",
                             "Generalize",
@@ -3187,7 +3196,7 @@ class SysMLDiagramWindow(tk.Frame):
                             "Propagate by Review",
                             "Propagate by Approval",
                             "Re-use",
-                        ):
+                            ):
                             arrow_default = "forward"
                         else:
                             arrow_default = "none"
@@ -3212,14 +3221,28 @@ class SysMLDiagramWindow(tk.Frame):
                                 if t == "Control Action"
                                 else "feedback" if t == "Feedback" else None
                             )
-                            rel = self.repo.create_relationship(
-                                t, src_id, dst_id, stereotype=rel_stereo
-                            )
-                            self.repo.add_relationship_to_diagram(
-                                self.diagram_id, rel.rel_id
-                            )
-                            if t == "Generalization":
-                                inherit_block_properties(self.repo, src_id)
+                            if t == "Trace":
+                                rel1 = self.repo.create_relationship(
+                                    t, src_id, dst_id, stereotype=rel_stereo
+                                )
+                                rel2 = self.repo.create_relationship(
+                                    t, dst_id, src_id, stereotype=rel_stereo
+                                )
+                                self.repo.add_relationship_to_diagram(
+                                    self.diagram_id, rel1.rel_id
+                                )
+                                self.repo.add_relationship_to_diagram(
+                                    self.diagram_id, rel2.rel_id
+                                )
+                            else:
+                                rel = self.repo.create_relationship(
+                                    t, src_id, dst_id, stereotype=rel_stereo
+                                )
+                                self.repo.add_relationship_to_diagram(
+                                    self.diagram_id, rel.rel_id
+                                )
+                                if t == "Generalization":
+                                    inherit_block_properties(self.repo, src_id)
                         self._sync_to_repository()
                         ConnectionDialog(self, conn)
                     else:
@@ -3456,6 +3479,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3660,6 +3684,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3683,6 +3708,8 @@ class SysMLDiagramWindow(tk.Frame):
                         arrow_default = "forward"
                     elif self.current_tool == "Feedback":
                         arrow_default = "backward"
+                    elif self.current_tool == "Trace":
+                        arrow_default = "both"
                     elif self.current_tool in (
                         "Flow",
                         "Generalize",
@@ -3753,17 +3780,39 @@ class SysMLDiagramWindow(tk.Frame):
                             if self.current_tool == "Feedback"
                             else None
                         )
-                        rel = self.repo.create_relationship(
-                            self.current_tool,
-                            self.start.element_id,
-                            obj.element_id,
-                            stereotype=rel_stereo,
-                        )
-                        self.repo.add_relationship_to_diagram(
-                            self.diagram_id, rel.rel_id
-                        )
-                        if self.current_tool == "Generalization":
-                            inherit_block_properties(self.repo, self.start.element_id)
+                        if self.current_tool == "Trace":
+                            rel1 = self.repo.create_relationship(
+                                self.current_tool,
+                                self.start.element_id,
+                                obj.element_id,
+                                stereotype=rel_stereo,
+                            )
+                            rel2 = self.repo.create_relationship(
+                                self.current_tool,
+                                obj.element_id,
+                                self.start.element_id,
+                                stereotype=rel_stereo,
+                            )
+                            self.repo.add_relationship_to_diagram(
+                                self.diagram_id, rel1.rel_id
+                            )
+                            self.repo.add_relationship_to_diagram(
+                                self.diagram_id, rel2.rel_id
+                            )
+                        else:
+                            rel = self.repo.create_relationship(
+                                self.current_tool,
+                                self.start.element_id,
+                                obj.element_id,
+                                stereotype=rel_stereo,
+                            )
+                            self.repo.add_relationship_to_diagram(
+                                self.diagram_id, rel.rel_id
+                            )
+                            if self.current_tool == "Generalization":
+                                inherit_block_properties(
+                                    self.repo, self.start.element_id
+                                )
                     self._sync_to_repository()
                     ConnectionDialog(self, conn)
                 else:
@@ -3961,6 +4010,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3985,6 +4035,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
             "Connector",
             "Generalization",
             "Generalize",
@@ -8225,6 +8276,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "Propagate by Review",
             "Propagate by Approval",
             "Re-use",
+            "Trace",
         ):
             ttk.Button(
                 governance_panel,

--- a/tests/test_governance_trace_relationship.py
+++ b/tests/test_governance_trace_relationship.py
@@ -1,0 +1,94 @@
+import types
+import unittest
+
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+class DummyCanvas:
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+    def configure(self, **kwargs):
+        pass
+
+
+class GovernanceTraceRelationshipTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+        from gui import architecture
+
+        self._orig_conn_dialog = architecture.ConnectionDialog
+
+    def tearDown(self):
+        from gui import architecture
+
+        architecture.ConnectionDialog = self._orig_conn_dialog
+
+    def _create_window(self, src, dst, diag):
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = self.repo
+        win.diagram_id = diag.diag_id
+        win.zoom = 1
+        win.canvas = DummyCanvas()
+        win.find_object = lambda x, y, prefer_port=False: src if win.start is None else dst
+        win.validate_connection = GovernanceDiagramWindow.validate_connection.__get__(
+            win, GovernanceDiagramWindow
+        )
+        win.update_property_view = lambda: None
+        win.redraw = lambda: None
+        win.current_tool = "Trace"
+        win.start = None
+        win.temp_line_end = None
+        win.selected_obj = None
+        win.connections = []
+        win._sync_to_repository = lambda: None
+        from gui import architecture
+
+        architecture.ConnectionDialog = lambda *args, **kwargs: None
+        return win
+
+    def test_trace_relationship_creates_bidirectional_link(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "WP1"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "WP2"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window(o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        conn = win.connections[0]
+        self.assertEqual(conn.conn_type, "Trace")
+        self.assertEqual(conn.arrow, "both")
+        rel_types = {r.rel_type for r in repo.relationships}
+        self.assertEqual(rel_types, {"Trace"})
+        self.assertEqual(len(repo.relationships), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add Trace button to governance diagram toolbox
- enable Trace connections between work products with arrows on both ends
- create repo relationships in both directions for Trace links
- test Trace relationship creation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689d621e49a08325b6b4f45ab34e839f