### PR TITLE
Show phase in object names and freeze governance diagrams

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -130,6 +130,9 @@ class SafetyManagementToolbox:
     doc_phases: Dict[str, Dict[str, str]] = field(default_factory=dict)
     # Optional callback invoked whenever the enabled work product set changes.
     on_change: Optional[Callable[[], None]] = field(default=None, repr=False)
+    # Phases and diagrams that have been frozen due to created work products
+    frozen_modules: set[str] = field(default_factory=set)
+    frozen_diagrams: set[str] = field(default_factory=set)
 
     # ------------------------------------------------------------------
     def add_work_product(self, diagram: str, analysis: str, rationale: str) -> None:
@@ -174,6 +177,7 @@ class SafetyManagementToolbox:
         self.work_product_counts[analysis] = self.work_product_counts.get(analysis, 0) + 1
         if self.active_module:
             self.doc_phases.setdefault(analysis, {})[name] = self.active_module
+            self._freeze_active_phase()
 
     # ------------------------------------------------------------------
     def register_loaded_work_product(self, analysis: str, name: str) -> None:
@@ -187,6 +191,21 @@ class SafetyManagementToolbox:
             self.work_product_counts[analysis] -= 1
         if name:
             self.doc_phases.get(analysis, {}).pop(name, None)
+
+    # ------------------------------------------------------------------
+    def _freeze_active_phase(self) -> None:
+        """Freeze the currently active phase and its governance diagrams."""
+        if not self.active_module:
+            return
+        if self.active_module in self.frozen_modules:
+            return
+        repo = SysMLRepository.get_instance()
+        self.frozen_modules.add(self.active_module)
+        for diag_name in self.diagrams_in_module(self.active_module):
+            self.frozen_diagrams.add(diag_name)
+            diag_id = self.diagrams.get(diag_name)
+            if diag_id:
+                repo.freeze_diagram(diag_id)
 
     # ------------------------------------------------------------------
     def rename_document(self, analysis: str, old: str, new: str) -> None:
@@ -408,7 +427,7 @@ class SafetyManagementToolbox:
         when it references the renamed module.
         """
 
-        if not new or old == new:
+        if not new or old == new or old in self.frozen_modules:
             return
 
         existing = set(self.list_modules())
@@ -431,6 +450,15 @@ class SafetyManagementToolbox:
             return False
 
         _rename(self.modules)
+
+        # Update document phase mappings
+        for mapping in self.doc_phases.values():
+            for doc, phase in list(mapping.items()):
+                if phase == old:
+                    mapping[doc] = new
+
+        # Propagate to repository objects
+        SysMLRepository.get_instance().rename_phase(old, new)
 
     # ------------------------------------------------------------------
     def propagation_type(self, source: str, target: str) -> Optional[str]:
@@ -541,6 +569,8 @@ class SafetyManagementToolbox:
 
     def delete_diagram(self, name: str) -> None:
         """Remove a diagram from the toolbox and repository."""
+        if name in self.frozen_diagrams:
+            return
         diag_id = self.diagrams.get(name)
         if not diag_id:
             return
@@ -560,6 +590,8 @@ class SafetyManagementToolbox:
         new: str
             Desired new name for the diagram.
         """
+        if old in self.frozen_diagrams:
+            return
         diag_id = self.diagrams.get(old)
         if not diag_id or not new:
             return
@@ -613,6 +645,8 @@ class SafetyManagementToolbox:
             "modules": [m.to_dict() for m in self.modules],
             "active_module": self.active_module,
             "doc_phases": {k: dict(v) for k, v in self.doc_phases.items()},
+            "frozen_modules": list(self.frozen_modules),
+            "frozen_diagrams": list(self.frozen_diagrams),
         }
 
     # ------------------------------------------------------------------
@@ -640,6 +674,13 @@ class SafetyManagementToolbox:
         toolbox.doc_phases = {
             k: dict(v) for k, v in data.get("doc_phases", {}).items()
         }
+        toolbox.frozen_modules = set(data.get("frozen_modules", []))
+        toolbox.frozen_diagrams = set(data.get("frozen_diagrams", []))
+        repo = SysMLRepository.get_instance()
+        for name in toolbox.frozen_diagrams:
+            diag_id = toolbox.diagrams.get(name)
+            if diag_id:
+                repo.freeze_diagram(diag_id)
         return toolbox
 
     # ------------------------------------------------------------------

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1834,6 +1834,12 @@ class SysMLObject:
     collapsed: Dict[str, bool] = field(default_factory=dict)
     phase: str | None = field(default_factory=lambda: SysMLRepository.get_instance().active_phase)
 
+    # ------------------------------------------------------------
+    def display_name(self) -> str:
+        """Return the object's name annotated with its creation phase."""
+        name = self.properties.get("name", "")
+        return f"{name} ({self.phase})" if name and self.phase else name
+
 
 @dataclass
 class OperationParameter:

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -24,6 +24,11 @@ class SysMLElement:
     modified_by_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
     phase: Optional[str] = None
 
+    # ------------------------------------------------------------
+    def display_name(self) -> str:
+        """Return element name annotated with its creation phase."""
+        return f"{self.name} ({self.phase})" if self.phase else self.name
+
 @dataclass
 class SysMLRelationship:
     rel_id: str
@@ -62,6 +67,11 @@ class SysMLDiagram:
     modified_by_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
     phase: Optional[str] = None
 
+    # ------------------------------------------------------------
+    def display_name(self) -> str:
+        """Return diagram name annotated with its creation phase."""
+        return f"{self.name} ({self.phase})" if self.phase else self.name
+
 class SysMLRepository:
     """Singleton repository for all AutoML elements and relationships."""
     _instance = None
@@ -83,6 +93,8 @@ class SysMLRepository:
         # Work product types reused by the active phase. Any diagrams of these
         # types originating from other phases are visible but read-only.
         self.reuse_products: set[str] = set()
+        # Diagrams made immutable after phase freeze
+        self.frozen_diagrams: set[str] = set()
         self.root_package = self.create_element("Package", name="Root")
 
     def touch_element(self, elem_id: str) -> None:
@@ -456,7 +468,9 @@ class SysMLRepository:
         return False
 
     def diagram_read_only(self, diag_id: str) -> bool:
-        """Return ``True`` if ``diag_id`` originates from a reused phase or work product."""
+        """Return ``True`` if ``diag_id`` is frozen or originates from reuse."""
+        if diag_id in self.frozen_diagrams:
+            return True
         diag = self.diagrams.get(diag_id)
         if not diag:
             return False
@@ -465,6 +479,37 @@ class SysMLRepository:
         if diag.phase != self.active_phase and diag.phase in getattr(self, "reuse_phases", set()):
             return True
         return diag.phase != self.active_phase and diag.diag_type in getattr(self, "reuse_products", set())
+
+    # ------------------------------------------------------------
+    def freeze_diagram(self, diag_id: str) -> None:
+        """Mark a diagram as immutable."""
+        self.frozen_diagrams.add(diag_id)
+
+    # ------------------------------------------------------------
+    def rename_phase(self, old: str, new: str) -> None:
+        """Rename lifecycle phase ``old`` to ``new`` across repository data."""
+        if old == new:
+            return
+        if self.active_phase == old:
+            self.active_phase = new
+        if old in self.reuse_phases:
+            self.reuse_phases.remove(old)
+            self.reuse_phases.add(new)
+        for elem in self.elements.values():
+            if elem.phase == old:
+                elem.phase = new
+        for rel in self.relationships:
+            if rel.phase == old:
+                rel.phase = new
+        for diag in self.diagrams.values():
+            if diag.phase == old:
+                diag.phase = new
+            for obj in diag.objects:
+                if obj.get("phase") == old:
+                    obj["phase"] = new
+            for conn in diag.connections:
+                if conn.get("phase") == old:
+                    conn["phase"] = new
 
     def element_read_only(self, elem_id: str) -> bool:
         """Return ``True`` if ``elem_id`` originates from a reused phase or work product."""

--- a/tests/test_phase_display_and_freeze.py
+++ b/tests/test_phase_display_and_freeze.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sysml.sysml_repository import SysMLRepository
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+
+
+def test_display_name_and_phase_rename_propagation():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    tb = SafetyManagementToolbox()
+    tb.modules = [GovernanceModule(name="P1")]
+    tb.set_active_module("P1")
+    elem = repo.create_element("Block", name="E1")
+    diag = repo.create_diagram("Use Case Diagram", name="D1")
+    tb.doc_phases = {"HAZOP": {"HZ1": "P1"}}
+    assert elem.display_name() == "E1 (P1)"
+    assert diag.display_name() == "D1 (P1)"
+    tb.rename_module("P1", "NP")
+    assert elem.phase == "NP"
+    assert diag.phase == "NP"
+    assert elem.display_name() == "E1 (NP)"
+    assert tb.doc_phases["HAZOP"]["HZ1"] == "NP"
+
+
+def test_phase_freezes_after_work_product():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    tb = SafetyManagementToolbox()
+    diag_id = tb.create_diagram("Gov")
+    tb.modules = [GovernanceModule(name="P1", diagrams=["Gov"])]
+    tb.set_active_module("P1")
+    tb.register_created_work_product("HAZOP", "HZ1")
+    assert "P1" in tb.frozen_modules
+    assert "Gov" in tb.frozen_diagrams
+    assert repo.diagram_read_only(diag_id)
+    tb.rename_module("P1", "New")
+    assert tb.list_modules() == ["P1"]
+    tb.rename_diagram("Gov", "Other")
+    assert "Gov" in tb.diagrams


### PR DESCRIPTION
## Summary
- Display the creating phase alongside element, diagram, and object names
- Rename phases cascades to repository elements and work product mappings
- Freeze lifecycle phases and governance diagrams once work products exist
- Persist frozen state and mark frozen diagrams read-only
- Add tests for phase annotations, renaming propagation, and freeze behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dc0348c5c8325a01cad46e6b5244e