### PR TITLE
Freeze lifecycle phases after work products exist

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -23,6 +23,8 @@ from typing import Dict, List, Callable, Optional
 
 from sysml.sysml_repository import SysMLRepository
 
+ACTIVE_TOOLBOX: Optional["SafetyManagementToolbox"] = None
+
 # Relationships that allow propagation of results between work products. Each
 # entry is a directed edge from source to target analysis name.
 ALLOWED_PROPAGATIONS: set[tuple[str, str]] = {
@@ -88,6 +90,7 @@ class GovernanceModule:
     name: str
     modules: List["GovernanceModule"] = field(default_factory=list)
     diagrams: List[str] = field(default_factory=list)
+    frozen: bool = False
 
     # ------------------------------------------------------------------
     def to_dict(self) -> dict:
@@ -96,6 +99,7 @@ class GovernanceModule:
             "name": self.name,
             "modules": [m.to_dict() for m in self.modules],
             "diagrams": list(self.diagrams),
+            "frozen": self.frozen,
         }
 
     # ------------------------------------------------------------------
@@ -105,6 +109,7 @@ class GovernanceModule:
         mod = cls(data.get("name", ""))
         mod.modules = [cls.from_dict(m) for m in data.get("modules", [])]
         mod.diagrams = list(data.get("diagrams", []))
+        mod.frozen = data.get("frozen", False)
         return mod
 
 
@@ -134,9 +139,41 @@ class SafetyManagementToolbox:
     # Optional callback invoked whenever the enabled work product set changes.
     on_change: Optional[Callable[[], None]] = field(default=None, repr=False)
 
+    def __post_init__(self) -> None:
+        global ACTIVE_TOOLBOX
+        ACTIVE_TOOLBOX = self
+
+    # ------------------------------------------------------------------
+    def module_frozen(self, name: Optional[str]) -> bool:
+        if not name:
+            return False
+        mod = self._find_module(name, self.modules)
+        return bool(mod and getattr(mod, "frozen", False))
+
+    # ------------------------------------------------------------------
+    def freeze_active_phase(self) -> None:
+        """Mark the currently active module as frozen and lock its diagrams."""
+        if not self.active_module or self.module_frozen(self.active_module):
+            return
+        mod = self._find_module(self.active_module, self.modules)
+        if not mod:
+            return
+        mod.frozen = True
+        repo = SysMLRepository.get_instance()
+        for name in self.diagrams_in_module(self.active_module):
+            diag_id = self.diagrams.get(name)
+            if not diag_id:
+                continue
+            diag = repo.diagrams.get(diag_id)
+            if diag:
+                diag.locked = True
+
     # ------------------------------------------------------------------
     def add_work_product(self, diagram: str, analysis: str, rationale: str) -> None:
         """Add a work product linking a diagram to an analysis with rationale."""
+        mod = self.module_for_diagram(diagram)
+        if self.module_frozen(mod):
+            return
         self.work_products.append(SafetyWorkProduct(diagram, analysis, rationale))
         if self.on_change:
             self.on_change()
@@ -160,6 +197,9 @@ class SafetyManagementToolbox:
             type or the declaration was not found.
         """
 
+        mod = self.module_for_diagram(diagram)
+        if self.module_frozen(mod):
+            return False
         if self.work_product_counts.get(analysis, 0) > 0:
             return False
 
@@ -177,6 +217,7 @@ class SafetyManagementToolbox:
         self.work_product_counts[analysis] = self.work_product_counts.get(analysis, 0) + 1
         if self.active_module:
             self.doc_phases.setdefault(analysis, {})[name] = self.active_module
+            self.freeze_active_phase()
 
     # ------------------------------------------------------------------
     def register_loaded_work_product(self, analysis: str, name: str) -> None:
@@ -412,6 +453,10 @@ class SafetyManagementToolbox:
         """
 
         if not new or old == new:
+            return
+
+        mod = self._find_module(old, self.modules)
+        if mod and getattr(mod, "frozen", False):
             return
 
         existing = set(self.list_modules())

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -61,6 +61,7 @@ class SysMLDiagram:
     modified_by: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
     modified_by_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)
     phase: Optional[str] = None
+    locked: bool = False
 
 class SysMLRepository:
     """Singleton repository for all AutoML elements and relationships."""
@@ -203,6 +204,13 @@ class SysMLRepository:
             phase=self.active_phase,
         )
         self.elements[elem_id] = elem
+        try:
+            from analysis import safety_management as sm
+            toolbox = getattr(sm, "ACTIVE_TOOLBOX", None)
+            if toolbox:
+                toolbox.freeze_active_phase()
+        except Exception:
+            pass
         return elem
 
     # ------------------------------------------------------------------
@@ -287,17 +295,28 @@ class SysMLRepository:
             phase=self.active_phase,
         )
         self.diagrams[diag_id] = diagram
+        try:
+            from analysis import safety_management as sm
+            toolbox = getattr(sm, "ACTIVE_TOOLBOX", None)
+            if toolbox:
+                toolbox.freeze_active_phase()
+        except Exception:
+            pass
         return diagram
 
     def add_element_to_diagram(self, diag_id: str, elem_id: str) -> None:
         diag = self.diagrams.get(diag_id)
         if diag and elem_id not in diag.elements:
+            if self.diagram_read_only(diag_id):
+                return
             self.push_undo_state()
             diag.elements.append(elem_id)
 
     def add_relationship_to_diagram(self, diag_id: str, rel_id: str) -> None:
         diag = self.diagrams.get(diag_id)
         if diag and rel_id not in diag.relationships:
+            if self.diagram_read_only(diag_id):
+                return
             self.push_undo_state()
             diag.relationships.append(rel_id)
 
@@ -456,10 +475,12 @@ class SysMLRepository:
         return False
 
     def diagram_read_only(self, diag_id: str) -> bool:
-        """Return ``True`` if ``diag_id`` originates from a reused phase or work product."""
+        """Return ``True`` if ``diag_id`` is locked or originates from a reused phase/work product."""
         diag = self.diagrams.get(diag_id)
         if not diag:
             return False
+        if getattr(diag, "locked", False):
+            return True
         if self.active_phase is None or diag.phase is None:
             return False
         if diag.phase != self.active_phase and diag.phase in getattr(self, "reuse_phases", set()):

--- a/tests/test_phase_freezing.py
+++ b/tests/test_phase_freezing.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+
+
+def _setup():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    diag_id = toolbox.create_diagram("Gov1")
+    toolbox.modules = [GovernanceModule("P1", diagrams=["Gov1"])]
+    toolbox.diagrams["Gov1"] = diag_id
+    toolbox.add_work_product("Gov1", "FMEA", "")
+    toolbox.add_work_product("Gov1", "FTA", "")
+    return repo, toolbox, diag_id
+
+
+def test_freeze_after_work_product_blocks_changes():
+    repo, toolbox, diag_id = _setup()
+    toolbox.set_active_module("P1")
+    toolbox.register_created_work_product("FMEA", "Doc1")
+    mod = toolbox._find_module("P1", toolbox.modules)
+    assert mod.frozen
+    assert repo.diagrams[diag_id].locked
+    toolbox.rename_module("P1", "P1_new")
+    assert toolbox.modules[0].name == "P1"
+    toolbox.add_work_product("Gov1", "FMEDA", "")
+    assert all(wp.analysis != "FMEDA" for wp in toolbox.work_products)
+    assert not toolbox.remove_work_product("Gov1", "FTA")
+    toolbox.rename_diagram("Gov1", "GovX")
+    assert repo.diagrams[diag_id].name == "Gov1"
+
+
+def test_freeze_on_element_creation_blocks_changes():
+    repo, toolbox, diag_id = _setup()
+    toolbox.set_active_module("P1")
+    repo.create_element("Block", "B1")
+    mod = toolbox._find_module("P1", toolbox.modules)
+    assert mod.frozen
+    toolbox.rename_module("P1", "P1_new")
+    assert toolbox.modules[0].name == "P1"
+    toolbox.add_work_product("Gov1", "FMEDA", "")
+    assert all(wp.analysis != "FMEDA" for wp in toolbox.work_products)
+    assert not toolbox.remove_work_product("Gov1", "FTA")
+    toolbox.rename_diagram("Gov1", "GovX")
+    assert repo.diagrams[diag_id].name == "Gov1"


### PR DESCRIPTION
## Summary
- Track frozen lifecycle phases via a new `frozen` flag on `GovernanceModule`
- Lock governance diagrams and block module/work-product edits once a phase is frozen
- Respect diagram locks in repository element/diagram creation and editing

## Testing
- `pytest tests/test_phase_freezing.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dc1b08d6083258369cd8ec6696fea