### PR TITLE
Center process area boundary titles

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5588,12 +5588,13 @@ class SysMLDiagramWindow(tk.Frame):
                     fill=outline,
                 )
 
-                lx = x - w + 8 * self.zoom
+                lx = x - w + label_w / 2
+                ly = y + 4 * self.zoom
                 self.canvas.create_text(
                     lx,
-                    y,
+                    ly,
                     text=wrapped,
-                    anchor="w",
+                    anchor="center",
                     angle=90,
                     font=font or self.font,
                     justify="center",

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -108,18 +108,21 @@ def test_activity_boundary_label_rotated_left_inside():
     assert win.canvas.text_calls, "label not drawn"
     x, y, kwargs = win.canvas.text_calls[0]
     assert kwargs.get("angle") == 90
-    assert kwargs.get("anchor") == "w"
+    assert kwargs.get("anchor") == "center"
     assert "\n" in kwargs.get("text", ""), "label not wrapped inside boundary"
-    assert x == obj.x - obj.width / 2 + 8
-    assert y == obj.y
     # compartment line drawn to separate title
     assert win.canvas.line_calls, "compartment not drawn"
     (line_args, _line_kwargs) = win.canvas.line_calls[0]
     x1, y1, x2, y2 = line_args
     assert x1 == x2
     lines = kwargs.get("text", "").count("\n") + 1
-    expected_x = x + lines * 16 + 8
-    assert x1 == expected_x
+    x_left = obj.x - obj.width / 2
+    expected_line_x = x_left + lines * 16 + 16
+    assert x1 == expected_line_x
+    expected_x = x_left + (x1 - x_left) / 2
+    assert x == expected_x
+    expected_y = obj.y + 4
+    assert y == expected_y
 
 
 def test_process_area_boundary_title_clipped_inside():


### PR DESCRIPTION
## Summary
- Center process area boundary labels within their compartments and drop them slightly for better layout
- Update tests to match new label positioning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689dc25cbe2483258befc5207221323c