### PR TITLE
Enforce governance-defined trace links

### DIFF
--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -25,7 +25,12 @@ from analysis.safety_management import (
     GovernanceModule,
     SafetyWorkProduct,
 )
-from gui.architecture import GovernanceDiagramWindow, SysMLObject, ArchitectureManagerDialog
+from gui.architecture import (
+    GovernanceDiagramWindow,
+    SysMLObject,
+    ArchitectureManagerDialog,
+    SysMLObjectDialog,
+)
 from gui.safety_management_explorer import SafetyManagementExplorer
 from gui.safety_management_toolbox import SafetyManagementWindow
 from gui.review_toolbox import ReviewData
@@ -1942,6 +1947,111 @@ def test_propagation_type_uses_stereotype_when_conn_type_missing():
     ]
     diag.connections = [{"src": 1, "dst": 2, "stereotype": "propagate by review"}]
     assert toolbox.propagation_type("Risk Assessment", "FTA") == "Propagate by Review"
+
+
+def test_can_trace_filters_by_phase():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    diag1 = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag1.phase = "Phase1"
+    toolbox.diagrams["Gov1"] = diag1.diag_id
+    diag1.objects = [
+        {"obj_id": 1, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Risk Assessment"}},
+        {"obj_id": 2, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "FTA"}},
+    ]
+    diag1.connections = [{"src": 1, "dst": 2, "conn_type": "Trace"}]
+
+    diag2 = repo.create_diagram("Governance Diagram", name="Gov2")
+    diag2.phase = "Phase2"
+    toolbox.diagrams["Gov2"] = diag2.diag_id
+    diag2.objects = [
+        {"obj_id": 1, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Risk Assessment"}},
+        {"obj_id": 2, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "STPA"}},
+    ]
+    diag2.connections = [{"src": 1, "dst": 2, "conn_type": "Trace"}]
+
+    repo.active_phase = "Phase1"
+    toolbox.add_work_product("Gov1", "Risk Assessment", "")
+    toolbox.add_work_product("Gov1", "FTA", "")
+    toolbox.add_work_product("Gov2", "STPA", "")
+
+    wps = {wp.analysis: wp for wp in toolbox.get_work_products()}
+    assert "FTA" in wps["Risk Assessment"].traceable
+    assert "STPA" not in wps["Risk Assessment"].traceable
+    assert toolbox.can_trace("Risk Assessment", "FTA")
+    assert not toolbox.can_trace("Risk Assessment", "STPA")
+
+
+def test_object_dialog_creates_trace_relationship():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams["Gov"] = diag.diag_id
+    diag.objects = [
+        {
+            "obj_id": 1,
+            "obj_type": "Work Product",
+            "x": 0.0,
+            "y": 0.0,
+            "properties": {"name": "Architecture Diagram"},
+        },
+        {
+            "obj_id": 2,
+            "obj_type": "Work Product",
+            "x": 0.0,
+            "y": 0.0,
+            "properties": {"name": "Safety & Security Concept"},
+        },
+    ]
+    diag.connections = [{"src": 1, "dst": 2, "conn_type": "Trace"}]
+
+    toolbox.add_work_product("Gov", "Architecture Diagram", "")
+    toolbox.add_work_product("Gov", "Safety & Security Concept", "")
+
+    src_elem = repo.create_element("Block", name="Architecture Diagram")
+    dst_elem = repo.create_element("Block", name="Safety & Security Concept")
+    obj = SysMLObject(
+        1,
+        "Work Product",
+        0.0,
+        0.0,
+        element_id=src_elem.elem_id,
+        properties={"name": "Architecture Diagram"},
+    )
+
+    dlg = SysMLObjectDialog.__new__(SysMLObjectDialog)
+    dlg.obj = obj
+    dlg.entries = {}
+    dlg.listboxes = {}
+    dlg._operations = []
+    dlg._behaviors = []
+    dlg.master = types.SimpleNamespace()
+    dlg.name_var = types.SimpleNamespace(get=lambda: "Architecture Diagram")
+    dlg.width_var = types.SimpleNamespace(get=lambda: "60")
+    dlg.height_var = types.SimpleNamespace(get=lambda: "80")
+
+    class DummyList:
+        def __init__(self, items):
+            self.items = items
+
+        def get(self, i):
+            return self.items[i]
+
+        def curselection(self):
+            return (0,)
+
+    dlg.trace_list = DummyList(["Safety & Security Concept"])
+
+    SysMLObjectDialog.apply(dlg)
+
+    assert obj.properties.get("trace_to") == "Safety & Security Concept"
+    rels = {(r.source, r.target, r.rel_type) for r in repo.relationships}
+    assert (src_elem.elem_id, dst_elem.elem_id, "Trace") in rels
+    assert (dst_elem.elem_id, src_elem.elem_id, "Trace") in rels
 
 
 def test_list_modules_includes_submodules():


### PR DESCRIPTION
## Summary
- expose trace targets for any diagram element based on governance-defined work product relationships
- persist selected trace links as bidirectional repository relationships
- test dialog trace application

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689dbd91330883259af12f63e57eccf6