### PR TITLE
Enforce governance-defined trace links

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -46,7 +46,9 @@ class SafetyWorkProduct:
 
     diagram: str
     analysis: str
-    rationale: str
+    rationale: str = ""
+    # Names of work products this item may trace to according to governance.
+    traceable: List[str] = field(default_factory=list)
 
     # ------------------------------------------------------------------
     def to_dict(self) -> dict:
@@ -60,6 +62,7 @@ class SafetyWorkProduct:
             data.get("diagram", ""),
             data.get("analysis", ""),
             data.get("rationale", ""),
+            list(data.get("traceable", [])),
         )
 
 
@@ -501,6 +504,43 @@ class SafetyManagementToolbox:
             return joint_review
         return False
 
+    # ------------------------------------------------------------------
+    def _trace_mapping(self) -> Dict[str, set[str]]:
+        """Return mapping of work product name to traceable targets."""
+        repo = SysMLRepository.get_instance()
+        diag_ids = self.diagrams.values()
+        if self.active_module:
+            names = self.diagrams_in_module(self.active_module)
+            diag_ids = [self.diagrams.get(n) for n in names if self.diagrams.get(n)]
+        mapping: Dict[str, set[str]] = {}
+        for diag_id in diag_ids:
+            if not repo.diagram_visible(diag_id):
+                continue
+            diag = repo.diagrams.get(diag_id)
+            if not diag:
+                continue
+            id_to_name: Dict[int, str] = {}
+            for obj in getattr(diag, "objects", []):
+                if obj.get("obj_type") == "Work Product":
+                    name = obj.get("properties", {}).get("name")
+                    if name:
+                        id_to_name[obj.get("obj_id")] = name
+            for conn in getattr(diag, "connections", []):
+                stereo = (conn.get("stereotype") or conn.get("conn_type") or "").lower()
+                if stereo == "trace":
+                    sname = id_to_name.get(conn.get("src"))
+                    tname = id_to_name.get(conn.get("dst"))
+                    if sname and tname:
+                        mapping.setdefault(sname, set()).add(tname)
+                        mapping.setdefault(tname, set()).add(sname)
+        return mapping
+
+    # ------------------------------------------------------------------
+    def can_trace(self, source: str, target: str) -> bool:
+        """Return ``True`` if ``source`` may trace to ``target``."""
+        traces = self._trace_mapping()
+        return target in traces.get(source, set())
+
     def build_lifecycle(self, stages: List[str]) -> None:
         """Define the project lifecycle stages."""
         self.lifecycle = stages
@@ -510,8 +550,19 @@ class SafetyManagementToolbox:
         self.workflows[name] = steps
 
     def get_work_products(self) -> List[SafetyWorkProduct]:
-        """Return all registered work products."""
-        return list(self.work_products)
+        """Return all registered work products including traceability info."""
+        traces = self._trace_mapping()
+        repo = SysMLRepository.get_instance()
+        for diag in repo.diagrams.values():
+            key = diag.diag_type
+            targets = traces.get(key) or traces.get(key.replace(" Diagram", ""))
+            diag.traceable = sorted(targets) if targets else []
+
+        products: List[SafetyWorkProduct] = []
+        for wp in self.work_products:
+            wp.traceable = sorted(traces.get(wp.analysis, set()))
+            products.append(wp)
+        return products
 
     def get_workflow(self, name: str) -> List[str]:
         """Return the steps for the requested workflow."""

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6790,6 +6790,16 @@ class SysMLDiagramWindow(tk.Frame):
                     self.repo.elements[obj.element_id].properties.setdefault(
                         "asil", asil
                     )
+            if obj.element_id:
+                targets = [
+                    self.repo.elements[r.target].name
+                    for r in self.repo.relationships
+                    if r.rel_type == "Trace"
+                    and r.source == obj.element_id
+                    and r.target in self.repo.elements
+                ]
+                if targets:
+                    obj.properties["trace_to"] = ", ".join(sorted(targets))
             self.objects.append(obj)
         self.sort_objects()
         self.connections = []
@@ -7259,7 +7269,16 @@ class SysMLObjectDialog(simpledialog.Dialog):
 
         repo = SysMLRepository.get_instance()
         current_diagram = repo.diagrams.get(getattr(self.master, "diagram_id", ""))
+        toolbox = getattr(app, "safety_mgmt_toolbox", None)
+        wp_map = {}
+        if toolbox:
+            wps = toolbox.get_work_products()
+            wp_map = {wp.analysis: wp for wp in wps}
+        diag_trace_opts = (
+            sorted(getattr(current_diagram, "traceable", [])) if current_diagram else []
+        )
         link_row = 0
+        trace_shown = False
         if self.obj.obj_type == "Block":
             diags = [d for d in repo.diagrams.values() if d.diag_type == "Internal Block Diagram"]
             ids = {d.name or d.diag_id: d.diag_id for d in diags}
@@ -7274,6 +7293,29 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 row=link_row, column=1, padx=4, pady=2
             )
             link_row += 1
+        elif self.obj.obj_type == "Work Product":
+            name = self.obj.properties.get("name", "")
+            targets = wp_map.get(name)
+            trace_opts = sorted(getattr(targets, "traceable", [])) if targets else []
+            if trace_opts:
+                ttk.Label(link_frame, text="Trace To:").grid(
+                    row=link_row, column=0, sticky="e", padx=4, pady=2
+                )
+                lb = tk.Listbox(link_frame, height=4, selectmode=tk.MULTIPLE)
+                for opt in trace_opts:
+                    lb.insert(tk.END, opt)
+                current = [
+                    s.strip()
+                    for s in self.obj.properties.get("trace_to", "").split(",")
+                    if s.strip()
+                ]
+                for idx, opt in enumerate(trace_opts):
+                    if opt in current:
+                        lb.selection_set(idx)
+                lb.grid(row=link_row, column=1, padx=4, pady=2, sticky="we")
+                self.trace_list = lb
+                link_row += 1
+                trace_shown = True
         elif self.obj.obj_type == "Use Case":
             diagrams = [d for d in repo.diagrams.values() if d.diag_type == "Governance Diagram"]
             self.behavior_map = {d.name or d.diag_id: d.diag_id for d in diagrams}
@@ -7287,6 +7329,25 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 link_frame, textvariable=self.behavior_var, values=list(self.behavior_map.keys())
             ).grid(row=link_row, column=1, padx=4, pady=2)
             link_row += 1
+            if diag_trace_opts:
+                ttk.Label(link_frame, text="Trace To:").grid(
+                    row=link_row, column=0, sticky="e", padx=4, pady=2
+                )
+                lb = tk.Listbox(link_frame, height=4, selectmode=tk.MULTIPLE)
+                for opt in diag_trace_opts:
+                    lb.insert(tk.END, opt)
+                current = [
+                    s.strip()
+                    for s in self.obj.properties.get("trace_to", "").split(",")
+                    if s.strip()
+                ]
+                for idx, opt in enumerate(diag_trace_opts):
+                    if opt in current:
+                        lb.selection_set(idx)
+                lb.grid(row=link_row, column=1, padx=4, pady=2, sticky="we")
+                self.trace_list = lb
+                link_row += 1
+                trace_shown = True
         elif self.obj.obj_type in ("Action Usage", "Action"):
             if (
                 self.obj.obj_type == "Action"
@@ -7359,6 +7420,26 @@ class SysMLObjectDialog(simpledialog.Dialog):
             self.def_cb.bind("<<ComboboxSelected>>", self._on_def_selected)
             self._current_def_id = cur_id
             link_row += 1
+
+        if diag_trace_opts and not trace_shown:
+            ttk.Label(link_frame, text="Trace To:").grid(
+                row=link_row, column=0, sticky="e", padx=4, pady=2
+            )
+            lb = tk.Listbox(link_frame, height=4, selectmode=tk.MULTIPLE)
+            for opt in diag_trace_opts:
+                lb.insert(tk.END, opt)
+            current = [
+                s.strip()
+                for s in self.obj.properties.get("trace_to", "").split(",")
+                if s.strip()
+            ]
+            for idx, opt in enumerate(diag_trace_opts):
+                if opt in current:
+                    lb.selection_set(idx)
+            lb.grid(row=link_row, column=1, padx=4, pady=2, sticky="we")
+            self.trace_list = lb
+            link_row += 1
+            trace_shown = True
 
         # Requirement allocation section
         req_row = 0
@@ -7709,6 +7790,39 @@ class SysMLObjectDialog(simpledialog.Dialog):
                     prev_keys = {_part_prop_key(p) for p in prev_parts}
                     new_keys = {_part_prop_key(i) for i in items}
                     removed_parts = [p for p in prev_parts if _part_prop_key(p) not in new_keys]
+
+        trace_lb = getattr(self, "trace_list", None)
+        if trace_lb:
+            selected = [trace_lb.get(i) for i in trace_lb.curselection()]
+            joined = ", ".join(selected)
+            if joined:
+                self.obj.properties["trace_to"] = joined
+            else:
+                self.obj.properties.pop("trace_to", None)
+            if self.obj.element_id and self.obj.element_id in repo.elements:
+                elem_props = repo.elements[self.obj.element_id].properties
+                if joined:
+                    elem_props["trace_to"] = joined
+                else:
+                    elem_props.pop("trace_to", None)
+            removed = {
+                r.rel_id
+                for r in repo.relationships
+                if r.rel_type == "Trace"
+                and (r.source == self.obj.element_id or r.target == self.obj.element_id)
+            }
+            if removed:
+                repo.relationships = [r for r in repo.relationships if r.rel_id not in removed]
+                for diag in repo.diagrams.values():
+                    diag.relationships = [rid for rid in diag.relationships if rid not in removed]
+            for name in selected:
+                target_elem = next(
+                    (e for e in repo.elements.values() if e.name == name),
+                    None,
+                )
+                if target_elem and self.obj.element_id:
+                    repo.create_relationship("Trace", self.obj.element_id, target_elem.elem_id)
+                    repo.create_relationship("Trace", target_elem.elem_id, self.obj.element_id)
 
         if self.obj.element_id and self.obj.element_id in repo.elements:
             elem_type = repo.elements[self.obj.element_id].elem_type

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -54,6 +54,7 @@ class SysMLDiagram:
     relationships: List[str] = field(default_factory=list)
     objects: List[dict] = field(default_factory=list)
     connections: List[dict] = field(default_factory=list)
+    traceable: List[str] = field(default_factory=list)
     created: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
     author: str = field(default_factory=lambda: user_config.CURRENT_USER_NAME)
     author_email: str = field(default_factory=lambda: user_config.CURRENT_USER_EMAIL)

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -25,7 +25,12 @@ from analysis.safety_management import (
     GovernanceModule,
     SafetyWorkProduct,
 )
-from gui.architecture import GovernanceDiagramWindow, SysMLObject, ArchitectureManagerDialog
+from gui.architecture import (
+    GovernanceDiagramWindow,
+    SysMLObject,
+    ArchitectureManagerDialog,
+    SysMLObjectDialog,
+)
 from gui.safety_management_explorer import SafetyManagementExplorer
 from gui.safety_management_toolbox import SafetyManagementWindow
 from gui.review_toolbox import ReviewData
@@ -1942,6 +1947,221 @@ def test_propagation_type_uses_stereotype_when_conn_type_missing():
     ]
     diag.connections = [{"src": 1, "dst": 2, "stereotype": "propagate by review"}]
     assert toolbox.propagation_type("Risk Assessment", "FTA") == "Propagate by Review"
+
+
+def test_can_trace_filters_by_phase():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    diag1 = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag1.phase = "Phase1"
+    toolbox.diagrams["Gov1"] = diag1.diag_id
+    diag1.objects = [
+        {"obj_id": 1, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Risk Assessment"}},
+        {"obj_id": 2, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "FTA"}},
+    ]
+    diag1.connections = [{"src": 1, "dst": 2, "conn_type": "Trace"}]
+
+    diag2 = repo.create_diagram("Governance Diagram", name="Gov2")
+    diag2.phase = "Phase2"
+    toolbox.diagrams["Gov2"] = diag2.diag_id
+    diag2.objects = [
+        {"obj_id": 1, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "Risk Assessment"}},
+        {"obj_id": 2, "obj_type": "Work Product", "x": 0.0, "y": 0.0, "properties": {"name": "STPA"}},
+    ]
+    diag2.connections = [{"src": 1, "dst": 2, "conn_type": "Trace"}]
+
+    repo.active_phase = "Phase1"
+    toolbox.add_work_product("Gov1", "Risk Assessment", "")
+    toolbox.add_work_product("Gov1", "FTA", "")
+    toolbox.add_work_product("Gov2", "STPA", "")
+
+    wps = {wp.analysis: wp for wp in toolbox.get_work_products()}
+    assert "FTA" in wps["Risk Assessment"].traceable
+    assert "STPA" not in wps["Risk Assessment"].traceable
+    assert toolbox.can_trace("Risk Assessment", "FTA")
+    assert not toolbox.can_trace("Risk Assessment", "STPA")
+
+
+def test_object_dialog_creates_trace_relationship():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams["Gov"] = diag.diag_id
+    diag.objects = [
+        {
+            "obj_id": 1,
+            "obj_type": "Work Product",
+            "x": 0.0,
+            "y": 0.0,
+            "properties": {"name": "Architecture Diagram"},
+        },
+        {
+            "obj_id": 2,
+            "obj_type": "Work Product",
+            "x": 0.0,
+            "y": 0.0,
+            "properties": {"name": "Safety & Security Concept"},
+        },
+    ]
+    diag.connections = [{"src": 1, "dst": 2, "conn_type": "Trace"}]
+
+    toolbox.add_work_product("Gov", "Architecture Diagram", "")
+    toolbox.add_work_product("Gov", "Safety & Security Concept", "")
+
+    src_elem = repo.create_element("Block", name="Architecture Diagram")
+    dst_elem = repo.create_element("Block", name="Safety & Security Concept")
+    obj = SysMLObject(
+        1,
+        "Work Product",
+        0.0,
+        0.0,
+        element_id=src_elem.elem_id,
+        properties={"name": "Architecture Diagram"},
+    )
+
+    dlg = SysMLObjectDialog.__new__(SysMLObjectDialog)
+    dlg.obj = obj
+    dlg.entries = {}
+    dlg.listboxes = {}
+    dlg._operations = []
+    dlg._behaviors = []
+    dlg.master = types.SimpleNamespace()
+    dlg.name_var = types.SimpleNamespace(get=lambda: "Architecture Diagram")
+    dlg.width_var = types.SimpleNamespace(get=lambda: "60")
+    dlg.height_var = types.SimpleNamespace(get=lambda: "80")
+
+    class DummyList:
+        def __init__(self, items):
+            self.items = items
+
+        def get(self, i):
+            return self.items[i]
+
+        def curselection(self):
+            return (0,)
+
+    dlg.trace_list = DummyList(["Safety & Security Concept"])
+
+    SysMLObjectDialog.apply(dlg)
+
+    assert obj.properties.get("trace_to") == "Safety & Security Concept"
+    rels = {(r.source, r.target, r.rel_type) for r in repo.relationships}
+    assert (src_elem.elem_id, dst_elem.elem_id, "Trace") in rels
+    assert (dst_elem.elem_id, src_elem.elem_id, "Trace") in rels
+
+
+def test_use_case_dialog_creates_trace_relationship():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams["Gov"] = gov.diag_id
+    gov.objects = [
+        {
+            "obj_id": 1,
+            "obj_type": "Work Product",
+            "x": 0.0,
+            "y": 0.0,
+            "properties": {"name": "Use Case"},
+        },
+        {
+            "obj_id": 2,
+            "obj_type": "Work Product",
+            "x": 0.0,
+            "y": 0.0,
+            "properties": {"name": "Safety & Security Concept"},
+        },
+    ]
+    gov.connections = [{"src": 1, "dst": 2, "conn_type": "Trace"}]
+
+    toolbox.add_work_product("Gov", "Use Case", "")
+    toolbox.add_work_product("Gov", "Safety & Security Concept", "")
+
+    assert toolbox.can_trace("Use Case", "Safety & Security Concept")
+
+    uc_diag = repo.create_diagram("Use Case Diagram", name="UC")
+    uc_elem = repo.create_element("Use Case", name="Scenario")
+    target_elem = repo.create_element("Block", name="Safety & Security Concept")
+    obj = SysMLObject(
+        1,
+        "Use Case",
+        0.0,
+        0.0,
+        element_id=uc_elem.elem_id,
+        properties={"name": "Scenario"},
+    )
+
+    dlg = SysMLObjectDialog.__new__(SysMLObjectDialog)
+    dlg.obj = obj
+    dlg.entries = {}
+    dlg.listboxes = {}
+    dlg._operations = []
+    dlg._behaviors = []
+    dlg.master = types.SimpleNamespace()
+    dlg.name_var = types.SimpleNamespace(get=lambda: "Scenario")
+    dlg.width_var = types.SimpleNamespace(get=lambda: "60")
+    dlg.height_var = types.SimpleNamespace(get=lambda: "40")
+
+    class DummyList:
+        def __init__(self, items):
+            self.items = items
+
+        def get(self, i):
+            return self.items[i]
+
+        def curselection(self):
+            return (0,)
+
+    dlg.trace_list = DummyList(["Safety & Security Concept"])
+
+    SysMLObjectDialog.apply(dlg)
+
+    assert obj.properties.get("trace_to") == "Safety & Security Concept"
+    rels = {(r.source, r.target, r.rel_type) for r in repo.relationships}
+    assert (uc_elem.elem_id, target_elem.elem_id, "Trace") in rels
+    assert (target_elem.elem_id, uc_elem.elem_id, "Trace") in rels
+
+
+def test_diagram_traceable_targets_populated():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams["Gov"] = gov.diag_id
+    gov.objects = [
+        {
+            "obj_id": 1,
+            "obj_type": "Work Product",
+            "x": 0.0,
+            "y": 0.0,
+            "properties": {"name": "Use Case"},
+        },
+        {
+            "obj_id": 2,
+            "obj_type": "Work Product",
+            "x": 0.0,
+            "y": 0.0,
+            "properties": {"name": "Activity"},
+        },
+    ]
+    gov.connections = [{"src": 1, "dst": 2, "conn_type": "Trace"}]
+
+    toolbox.add_work_product("Gov", "Use Case", "")
+    toolbox.add_work_product("Gov", "Activity", "")
+
+    uc = repo.create_diagram("Use Case Diagram", name="UC")
+    act = repo.create_diagram("Activity Diagram", name="AD")
+
+    toolbox.get_work_products()
+
+    assert uc.traceable == ["Activity"]
+    assert act.traceable == ["Use Case"]
 
 
 def test_list_modules_includes_submodules():


### PR DESCRIPTION
## Summary
- surface governance-approved trace targets in work product dialogs
- persist selected traces as bidirectional repository relationships
- test dialog trace application
- expose trace options for all analysis diagram elements
- propagate governance traceability to diagrams

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689dbd91330883259af12f63e57eccf6