### PR TITLE
feat: add repository requirement lookup

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -1400,6 +1400,16 @@ class EditNodeDialog(simpledialog.Dialog):
     def get_requirement_allocation_names(self, req_id):
         """Return a list of node or FMEA entry names where the requirement appears."""
         names = []
+        repo = SysMLRepository.get_instance()
+        for diag_id, obj_id in repo.find_requirements(req_id):
+            diag = repo.diagrams.get(diag_id)
+            obj = next((o for o in getattr(diag, "objects", []) if o.get("obj_id") == obj_id), None)
+            dname = diag.name if diag else ""
+            oname = obj.get("properties", {}).get("name", "") if obj else ""
+            if dname and oname:
+                names.append(f"{dname}:{oname}")
+            elif dname or oname:
+                names.append(dname or oname)
         for n in self.app.get_all_nodes(self.app.root_node):
             reqs = getattr(n, "safety_requirements", [])
             if any((r.get("id") if isinstance(r, dict) else getattr(r, "id", None)) == req_id for r in reqs):
@@ -2698,6 +2708,16 @@ class FaultTreeApp:
     def get_requirement_allocation_names(self, req_id):
         """Return a list of node or FMEA entry names where the requirement appears."""
         names = []
+        repo = SysMLRepository.get_instance()
+        for diag_id, obj_id in repo.find_requirements(req_id):
+            diag = repo.diagrams.get(diag_id)
+            obj = next((o for o in getattr(diag, "objects", []) if o.get("obj_id") == obj_id), None)
+            dname = diag.name if diag else ""
+            oname = obj.get("properties", {}).get("name", "") if obj else ""
+            if dname and oname:
+                names.append(f"{dname}:{oname}")
+            elif dname or oname:
+                names.append(dname or oname)
         for n in self.get_all_nodes(self.root_node):
             reqs = getattr(n, "safety_requirements", [])
             if any((r.get("id") if isinstance(r, dict) else getattr(r, "id", None)) == req_id for r in reqs):
@@ -2931,6 +2951,16 @@ class FaultTreeApp:
     def get_requirement_allocation_names(self, req_id):
         """Return a list of node or FMEA entry names where the requirement appears."""
         names = []
+        repo = SysMLRepository.get_instance()
+        for diag_id, obj_id in repo.find_requirements(req_id):
+            diag = repo.diagrams.get(diag_id)
+            obj = next((o for o in getattr(diag, "objects", []) if o.get("obj_id") == obj_id), None)
+            dname = diag.name if diag else ""
+            oname = obj.get("properties", {}).get("name", "") if obj else ""
+            if dname and oname:
+                names.append(f"{dname}:{oname}")
+            elif dname or oname:
+                names.append(dname or oname)
         for n in self.get_all_nodes(self.root_node):
             reqs = getattr(n, "safety_requirements", [])
             if any((r.get("id") if isinstance(r, dict) else getattr(r, "id", None)) == req_id for r in reqs):
@@ -3080,6 +3110,16 @@ class FaultTreeApp:
     def get_requirement_allocation_names(self, req_id):
         """Return a list of node or FMEA entry names where the requirement appears."""
         names = []
+        repo = SysMLRepository.get_instance()
+        for diag_id, obj_id in repo.find_requirements(req_id):
+            diag = repo.diagrams.get(diag_id)
+            obj = next((o for o in getattr(diag, "objects", []) if o.get("obj_id") == obj_id), None)
+            dname = diag.name if diag else ""
+            oname = obj.get("properties", {}).get("name", "") if obj else ""
+            if dname and oname:
+                names.append(f"{dname}:{oname}")
+            elif dname or oname:
+                names.append(dname or oname)
         for n in self.get_all_nodes(self.root_node):
             reqs = getattr(n, "safety_requirements", [])
             if any((r.get("id") if isinstance(r, dict) else getattr(r, "id", None)) == req_id for r in reqs):
@@ -3262,6 +3302,16 @@ class FaultTreeApp:
     def get_requirement_allocation_names(self, req_id):
         """Return a list of node or FMEA entry names where the requirement appears."""
         names = []
+        repo = SysMLRepository.get_instance()
+        for diag_id, obj_id in repo.find_requirements(req_id):
+            diag = repo.diagrams.get(diag_id)
+            obj = next((o for o in getattr(diag, "objects", []) if o.get("obj_id") == obj_id), None)
+            dname = diag.name if diag else ""
+            oname = obj.get("properties", {}).get("name", "") if obj else ""
+            if dname and oname:
+                names.append(f"{dname}:{oname}")
+            elif dname or oname:
+                names.append(dname or oname)
         for n in self.get_all_nodes(self.root_node):
             reqs = getattr(n, "safety_requirements", [])
             if any((r.get("id") if isinstance(r, dict) else getattr(r, "id", None)) == req_id for r in reqs):

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -2,7 +2,7 @@
 import json
 import uuid
 from dataclasses import dataclass, field, asdict
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 import os
 import datetime
 import analysis.user_config as user_config
@@ -695,6 +695,18 @@ class SysMLRepository:
                     mapped = name_map.get(def_val)
                     if mapped:
                         obj.setdefault("properties", {})["definition"] = mapped
+
+    def find_requirements(self, req_id: str) -> List[Tuple[str, int]]:
+        """Return list of (diagram_id, obj_id) where ``req_id`` is allocated."""
+        matches: List[Tuple[str, int]] = []
+        for diag_id, diag in self.diagrams.items():
+            for obj in getattr(diag, "objects", []):
+                for req in obj.get("requirements", []):
+                    rid = req.get("id") if isinstance(req, dict) else req
+                    if rid == req_id:
+                        matches.append((diag_id, obj.get("obj_id")))
+                        break
+        return matches
 
     def get_activity_actions(self) -> list[str]:
         """Return all action names and activity diagram names."""

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -180,6 +180,27 @@ class RepositoryTests(unittest.TestCase):
         obj = new_repo.diagrams[diag.diag_id].objects[0]
         self.assertEqual(obj.get("requirements")[0]["id"], "REQ1")
 
+    def test_find_requirements(self):
+        diag = self.repo.create_diagram("Use Case Diagram", name="UC")
+        actor = self.repo.create_element("Actor", name="User")
+        self.repo.add_element_to_diagram(diag.diag_id, actor.elem_id)
+        diag.objects = [
+            {
+                "obj_id": 1,
+                "obj_type": "Actor",
+                "x": 0,
+                "y": 0,
+                "element_id": actor.elem_id,
+                "width": 80.0,
+                "height": 40.0,
+                "properties": {"name": "User"},
+                "requirements": [{"id": "R1"}],
+            }
+        ]
+        matches = self.repo.find_requirements("R1")
+        self.assertEqual(matches, [(diag.diag_id, 1)])
+        self.assertEqual(self.repo.find_requirements("R2"), [])
+
     def test_connection_persistence(self):
         diag = self.repo.create_diagram("Block Diagram", name="BD")
         a = self.repo.create_element("Block", name="A")


### PR DESCRIPTION
## Summary
- add `find_requirements` to SysMLRepository to locate requirement allocations
- expose requirement trace info in Requirements Explorer window
- reuse repository lookup when computing requirement allocations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689dd1f61fcc8325b6284ec32184d44a