### PR TITLE
Show lifecycle phase in UI listings, hide in diagrams

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,11 @@
+# Shared GUI helpers
+
+from __future__ import annotations
+
+
+def format_name_with_phase(name: str, phase: str | None) -> str:
+    """Return ``name`` with ``" (phase)"`` appended when ``phase`` is set."""
+
+    if phase:
+        return f"{name} ({phase})" if name else f"({phase})"
+    return name

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3,7 +3,7 @@ import tkinter as tk
 import tkinter.font as tkFont
 import textwrap
 from tkinter import ttk, simpledialog
-from gui import messagebox
+from gui import messagebox, format_name_with_phase
 import json
 import math
 import re
@@ -41,6 +41,11 @@ def _get_next_id() -> int:
     val = _next_obj_id
     _next_obj_id += 1
     return val
+
+
+def _format_label(_win, name: str, _phase: str | None) -> str:
+    """Return ``name`` unchanged for diagram labels."""
+    return name or ""
 
 
 def _parse_float(val: str | None, default: float) -> float:
@@ -4695,7 +4700,8 @@ class SysMLDiagramWindow(tk.Frame):
 
     def _min_block_size(self, obj: SysMLObject) -> tuple[float, float]:
         """Return minimum width and height to display all Block text."""
-        header = f"<<block>> {obj.properties.get('name', '')}".strip()
+        name = _format_label(self, obj.properties.get('name', ''), obj.phase)
+        header = f"<<block>> {name}".strip()
         width_px = self.font.measure(header) + 8 * self.zoom
         compartments = self._block_compartments(obj)
         total_lines = 1
@@ -4784,7 +4790,7 @@ class SysMLDiagramWindow(tk.Frame):
     def _object_label_lines(self, obj: SysMLObject) -> list[str]:
         """Return the lines of text displayed inside *obj*."""
         if obj.obj_type == "System Boundary" or obj.obj_type == "Block Boundary":
-            name = obj.properties.get("name", "")
+            name = _format_label(self, obj.properties.get("name", ""), obj.phase)
             return [name] if name else []
 
         if obj.obj_type in ("Block", "Port"):
@@ -4870,11 +4876,12 @@ class SysMLDiagramWindow(tk.Frame):
                 elif not name:
                     name = f" : {def_part}"
 
+        name = _format_label(self, name, obj.phase)
         lines: list[str] = []
         diag_id = self.repo.get_linked_diagram(obj.element_id)
         if diag_id and diag_id in self.repo.diagrams:
             diag = self.repo.diagrams[diag_id]
-            diag_name = diag.name or diag_id
+            diag_name = _format_label(self, diag.name or diag_id, diag.phase)
             lines.append(diag_name)
 
         if obj.obj_type in ("Action", "CallBehaviorAction") and name:
@@ -4969,7 +4976,6 @@ class SysMLDiagramWindow(tk.Frame):
             "Merge",
         ) and min_h > obj.height:
             obj.height = min_h
-
     def sort_objects(self) -> None:
         """Order objects so boundaries render behind and their ports above."""
 
@@ -5529,7 +5535,7 @@ class SysMLDiagramWindow(tk.Frame):
                 outline=outline,
                 fill="",
             )
-            label = obj.properties.get("name", "")
+            label = _format_label(self, obj.properties.get("name", ""), obj.phase)
             if label:
                 # Wrap and scale the label so it always fits within the boundary box
                 avail_w = max(obj.width * self.zoom - 16 * self.zoom, 1)
@@ -5603,7 +5609,7 @@ class SysMLDiagramWindow(tk.Frame):
                 outline=outline,
                 fill="",
             )
-            label = obj.properties.get("name", "")
+            label = _format_label(self, obj.properties.get("name", ""), obj.phase)
             if label:
                 lx = x
                 ly = y - h - 4 * self.zoom
@@ -5615,7 +5621,7 @@ class SysMLDiagramWindow(tk.Frame):
                     font=self.font,
                 )
         elif obj.obj_type == "Work Product":
-            label = obj.properties.get("name", "")
+            label = _format_label(self, obj.properties.get("name", ""), obj.phase)
             diagram_products = {
                 "Architecture Diagram",
                 "Safety & Security Concept",
@@ -5698,7 +5704,7 @@ class SysMLDiagramWindow(tk.Frame):
                 outline=outline,
                 fill=color,
             )
-            label = obj.properties.get("name", "")
+            label = _format_label(self, obj.properties.get("name", ""), obj.phase)
             if label:
                 self.canvas.create_text(
                     x,
@@ -5726,7 +5732,7 @@ class SysMLDiagramWindow(tk.Frame):
             )
             diag = self.repo.diagrams.get(self.diagram_id)
             if not diag or diag.diag_type != "Control Flow Diagram":
-                label = obj.properties.get("name", "")
+                label = _format_label(self, obj.properties.get("name", ""), obj.phase)
                 if label:
                     lx = x
                     ly = y - h - 4 * self.zoom
@@ -5836,10 +5842,13 @@ class SysMLDiagramWindow(tk.Frame):
                 ly_off = _parse_float(obj.properties.get("labelY"), -8.0)
                 lx = x + lx_off * self.zoom
                 ly = y + ly_off * self.zoom
+                port_label = _format_label(
+                    self, obj.properties.get("name", ""), obj.phase
+                )
                 self.canvas.create_text(
                     lx,
                     ly,
-                    text=obj.properties.get("name", ""),
+                    text=port_label,
                     anchor="center",
                     font=self.font,
                 )
@@ -5880,7 +5889,8 @@ class SysMLDiagramWindow(tk.Frame):
                 fill="",
                 outline=outline,
             )
-            header = f"<<block>> {obj.properties.get('name', '')}".strip()
+            name = _format_label(self, obj.properties.get('name', ''), obj.phase)
+            header = f"<<block>> {name}".strip()
             self.canvas.create_line(left, top + 20 * self.zoom, right, top + 20 * self.zoom)
             self.canvas.create_text(
                 left + 4 * self.zoom,
@@ -5980,50 +5990,10 @@ class SysMLDiagramWindow(tk.Frame):
             "Port",
             "Work Product",
         ):
-            name = obj.properties.get("name", obj.obj_type)
-            label = name
-            if obj.obj_type == "Part":
-                def_id = obj.properties.get("definition")
-                if def_id and def_id in self.repo.elements:
-                    def_name = self.repo.elements[def_id].name or def_id
-                    label = f"{name} : {def_name}" if name else def_name
-            diag_id = self.repo.get_linked_diagram(obj.element_id)
-            label_lines = []
-            if diag_id and diag_id in self.repo.diagrams:
-                diag = self.repo.diagrams[diag_id]
-                diag_name = diag.name or diag_id
-                label_lines.append(diag_name)
-            label_lines.append(label)
-            key = obj.obj_type.replace(" ", "")
-            if not key.endswith("Usage"):
-                key += "Usage"
-            for prop in SYSML_PROPERTIES.get(key, []):
-                if obj.obj_type == "Part" and prop in (
-                    "fit",
-                    "qualification",
-                    "failureModes",
-                    "asil",
-                ):
-                    continue
-                val = obj.properties.get(prop)
-                if val:
-                    label_lines.append(f"{prop}: {val}")
-            if obj.obj_type == "Part":
-                rel_items = []
-                for lbl, key in (
-                    ("ASIL", "asil"),
-                    ("FIT", "fit"),
-                    ("Qual", "qualification"),
-                    ("FM", "failureModes"),
-                ):
-                    val = obj.properties.get(key)
-                    if val:
-                        rel_items.append(f"{lbl}: {val}")
-                if rel_items:
-                    label_lines.extend(rel_items)
-                reqs = "; ".join(r.get("id") for r in obj.requirements)
-                if reqs:
-                    label_lines.append(f"Reqs: {reqs}")
+            if hasattr(self, "_object_label_lines"):
+                label_lines = self._object_label_lines(obj)
+            else:
+                label_lines = SysMLDiagramWindow._object_label_lines(self, obj)
             if obj.obj_type == "Actor":
                 sy = obj.height / 40.0 * self.zoom
                 label_x = x
@@ -9231,7 +9201,7 @@ class ArchitectureManagerDialog(tk.Frame):
                     parent,
                     "end",
                     iid=elem_id,
-                    text=elem.name or elem_id,
+                    text=format_name_with_phase(elem.name or elem_id, elem.phase),
                     values=(elem.elem_type,),
                     image=icon,
                 )
@@ -9262,7 +9232,7 @@ class ArchitectureManagerDialog(tk.Frame):
                     parent,
                     "end",
                     iid=pkg_id,
-                    text=pkg.name or pkg_id,
+                    text=format_name_with_phase(pkg.name or pkg_id, pkg.phase),
                     open=True,
                     image=self.pkg_icon,
                 )
@@ -9279,7 +9249,7 @@ class ArchitectureManagerDialog(tk.Frame):
                     add_elem(e.elem_id, node)
             for d in self.repo.diagrams.values():
                 if d.package == pkg_id and "safety-management" not in getattr(d, "tags", []):
-                    label = d.name or d.diag_id
+                    label = format_name_with_phase(d.name or d.diag_id, d.phase)
                     icon = self.diagram_icons.get(d.diag_type, self.default_diag_icon)
                     diag_iid = f"diag_{d.diag_id}"
                     if self.tree.exists(diag_iid):
@@ -9301,7 +9271,10 @@ class ArchitectureManagerDialog(tk.Frame):
                     )
                     for obj in objs:
                         props = getattr(obj, "properties", obj.get("properties", {}))
-                        name = props.get("name", getattr(obj, "obj_type", obj.get("obj_type")))
+                        name = format_name_with_phase(
+                            props.get("name", getattr(obj, "obj_type", obj.get("obj_type"))),
+                            getattr(obj, "phase", obj.get("phase")),
+                        )
                         oid = getattr(obj, "obj_id", obj.get("obj_id"))
                         otype = getattr(obj, "obj_type", obj.get("obj_type"))
                         icon = self.elem_icons.get(otype, self.default_elem_icon)

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -5,6 +5,7 @@ import tkinter as tk
 from tkinter import ttk, simpledialog
 
 from gsn import GSNNode, GSNDiagram, GSNModule
+from gui import format_name_with_phase
 
 
 class GSNExplorer(tk.Frame):
@@ -77,16 +78,31 @@ class GSNExplorer(tk.Frame):
         # common parent.  This mirrors the behaviour of other explorer
         # widgets and allows dropping items onto the "GSN" root to move
         # them to the top level.
-        root_id = self.tree.insert("", "end", text="GSN", image=self.module_icon)
+        root_id = self.tree.insert(
+            "",
+            "end",
+            text=format_name_with_phase("GSN", None),
+            image=self.module_icon,
+        )
         self.item_map[root_id] = ("root", None)
         # modules at root
         for mod in getattr(self.app, "gsn_modules", []):
-            mod_id = self.tree.insert(root_id, "end", text=mod.name, image=self.module_icon)
+            mod_id = self.tree.insert(
+                root_id,
+                "end",
+                text=format_name_with_phase(mod.name, getattr(mod, "phase", None)),
+                image=self.module_icon,
+            )
             self.item_map[mod_id] = ("module", mod)
             self._add_module_children(mod_id, mod)
         # diagrams not in any module
         for diag in getattr(self.app, "gsn_diagrams", []):
-            diag_id = self.tree.insert(root_id, "end", text=diag.root.user_name, image=self.diagram_icon)
+            diag_id = self.tree.insert(
+                root_id,
+                "end",
+                text=format_name_with_phase(diag.root.user_name, getattr(diag, "phase", None)),
+                image=self.diagram_icon,
+            )
             self.item_map[diag_id] = ("diagram", diag)
             self._add_diagram_children(diag_id, diag)
 
@@ -105,11 +121,21 @@ class GSNExplorer(tk.Frame):
     # ------------------------------------------------------------------
     def _add_module_children(self, parent_id: str, module: GSNModule):
         for sub in module.modules:
-            sub_id = self.tree.insert(parent_id, "end", text=sub.name, image=self.module_icon)
+            sub_id = self.tree.insert(
+                parent_id,
+                "end",
+                text=format_name_with_phase(sub.name, getattr(sub, "phase", None)),
+                image=self.module_icon,
+            )
             self.item_map[sub_id] = ("module", sub)
             self._add_module_children(sub_id, sub)
         for diag in module.diagrams:
-            diag_id = self.tree.insert(parent_id, "end", text=diag.root.user_name, image=self.diagram_icon)
+            diag_id = self.tree.insert(
+                parent_id,
+                "end",
+                text=format_name_with_phase(diag.root.user_name, getattr(diag, "phase", None)),
+                image=self.diagram_icon,
+            )
             self.item_map[diag_id] = ("diagram", diag)
             self._add_diagram_children(diag_id, diag)
 
@@ -129,7 +155,12 @@ class GSNExplorer(tk.Frame):
             visited_ids.add(id(node))
             for child in node.children:
                 icon = self.node_icons.get(child.node_type, self.default_node_icon)
-                child_id = self.tree.insert(parent_id, "end", text=child.user_name, image=icon)
+                child_id = self.tree.insert(
+                    parent_id,
+                    "end",
+                    text=format_name_with_phase(child.user_name, getattr(child, "phase", None)),
+                    image=icon,
+                )
                 self.item_map[child_id] = ("node", child)
                 _add_node(child_id, child)
 
@@ -138,7 +169,12 @@ class GSNExplorer(tk.Frame):
         for node in diagram.nodes:
             if id(node) not in visited_ids:
                 icon = self.node_icons.get(node.node_type, self.default_node_icon)
-                node_id = self.tree.insert(diag_id, "end", text=node.user_name, image=icon)
+                node_id = self.tree.insert(
+                    diag_id,
+                    "end",
+                    text=format_name_with_phase(node.user_name, getattr(node, "phase", None)),
+                    image=icon,
+                )
                 self.item_map[node_id] = ("node", node)
                 _add_node(node_id, node)
 

--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -33,7 +33,7 @@ class DiagramSelectDialog(simpledialog.Dialog):  # pragma: no cover - requires t
         self.selection = self.var.get()
 
 from analysis.safety_case import SafetyCaseLibrary, SafetyCase
-from gui import messagebox
+from gui import messagebox, format_name_with_phase
 from gui.safety_case_table import SafetyCaseTable
 
 
@@ -86,10 +86,21 @@ class SafetyCaseExplorer(tk.Frame):
         self.item_map.clear()
         self.tree.delete(*self.tree.get_children(""))
         for case in self.library.list_cases():
-            iid = self.tree.insert("", "end", text=case.name, image=self.case_icon)
+            phase = getattr(case, "phase", None)
+            iid = self.tree.insert(
+                "",
+                "end",
+                text=format_name_with_phase(case.name, phase),
+                image=self.case_icon,
+            )
             self.item_map[iid] = ("case", case)
             for sol in case.solutions:
-                sid = self.tree.insert(iid, "end", text=sol.user_name, image=self.solution_icon)
+                sid = self.tree.insert(
+                    iid,
+                    "end",
+                    text=format_name_with_phase(sol.user_name, getattr(sol, "phase", None)),
+                    image=self.solution_icon,
+                )
                 self.item_map[sid] = ("solution", sol)
 
     # ------------------------------------------------------------------

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -6,8 +6,16 @@ from tkinter import ttk, simpledialog
 from gui import messagebox
 from dataclasses import dataclass, field
 from typing import List, Dict
+import re
 
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+
+
+def _strip_phase_suffix(name: str) -> str:
+    """Return *name* without any trailing ``" (...)"`` phase text."""
+    if not name:
+        return ""
+    return re.sub(r" \([^()]+\)$", "", name)
 
 
 class SafetyManagementExplorer(tk.Frame):
@@ -71,26 +79,30 @@ class SafetyManagementExplorer(tk.Frame):
 
         def _add_module(parent: str, mod: GovernanceModule) -> None:
             for sub in mod.modules:
-                sub_id = self.tree.insert(parent, "end", text=sub.name, image=self.folder_icon)
+                label = _strip_phase_suffix(sub.name)
+                sub_id = self.tree.insert(parent, "end", text=label, image=self.folder_icon)
                 self.item_map[sub_id] = ("module", sub)
                 _add_module(sub_id, sub)
             for name in mod.diagrams:
-                diag_id = self.tree.insert(parent, "end", text=name, image=self.diagram_icon)
-                self.item_map[diag_id] = ("diagram", name)
+                plain = _strip_phase_suffix(name)
+                diag_id = self.tree.insert(parent, "end", text=plain, image=self.diagram_icon)
+                self.item_map[diag_id] = ("diagram", plain)
 
         for mod in self.toolbox.modules:
+            label = _strip_phase_suffix(mod.name)
             mod_id = self.tree.insert(
-                self.root_iid, "end", text=mod.name, image=self.folder_icon
+                self.root_iid, "end", text=label, image=self.folder_icon
             )
             self.item_map[mod_id] = ("module", mod)
             _add_module(mod_id, mod)
 
         for name in sorted(self.toolbox.diagrams.keys()):
             if not self._in_any_module(name, self.toolbox.modules):
+                label = _strip_phase_suffix(name)
                 iid = self.tree.insert(
-                    self.root_iid, "end", text=name, image=self.diagram_icon
+                    self.root_iid, "end", text=label, image=self.diagram_icon
                 )
-                self.item_map[iid] = ("diagram", name)
+                self.item_map[iid] = ("diagram", label)
 
     # ------------------------------------------------------------------
     def new_folder(self):
@@ -240,20 +252,23 @@ class SafetyManagementExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def _in_any_module(self, name: str, mods: List[GovernanceModule]) -> bool:
+        target = _strip_phase_suffix(name)
         for mod in mods:
-            if name in mod.diagrams or self._in_any_module(name, mod.modules):
+            if any(_strip_phase_suffix(d) == target for d in mod.diagrams) or self._in_any_module(name, mod.modules):
                 return True
         return False
 
     def _replace_name_in_modules(self, old: str, new: str, mods: List[GovernanceModule]) -> None:
+        old_plain = _strip_phase_suffix(old)
+        new_plain = _strip_phase_suffix(new)
         for mod in mods:
-            mod.diagrams = [new if d == old else d for d in mod.diagrams]
-            self._replace_name_in_modules(old, new, mod.modules)
+            mod.diagrams = [new_plain if _strip_phase_suffix(d) == old_plain else d for d in mod.diagrams]
+            self._replace_name_in_modules(old_plain, new_plain, mod.modules)
 
     def _remove_name(self, name: str, mods: List[GovernanceModule]) -> None:
+        target = _strip_phase_suffix(name)
         for mod in mods:
-            if name in mod.diagrams:
-                mod.diagrams.remove(name)
+            mod.diagrams = [d for d in mod.diagrams if _strip_phase_suffix(d) != target]
             self._remove_name(name, mod.modules)
 
     def _remove_module(self, target: GovernanceModule, mods: List[GovernanceModule]) -> bool:

--- a/tests/test_phase_labels.py
+++ b/tests/test_phase_labels.py
@@ -1,0 +1,111 @@
+import unittest
+
+from gui import format_name_with_phase
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+class DummyFont:
+    def measure(self, text: str) -> int:
+        return len(text)
+
+    def metrics(self, name: str) -> int:
+        return 1
+
+
+class DummyWindow:
+    _object_label_lines = SysMLDiagramWindow._object_label_lines
+
+    def __init__(self, diag_id):
+        self.repo = SysMLRepository.get_instance()
+        self.zoom = 1.0
+        self.font = DummyFont()
+        self.diagram_id = diag_id
+
+
+class PhaseLabelTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository._instance = None
+
+    def test_format_helper(self):
+        self.assertEqual(format_name_with_phase("Name", "P1"), "Name (P1)")
+        self.assertEqual(format_name_with_phase("Name", None), "Name")
+
+    def test_object_label_omits_phase(self):
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Block Diagram")
+        elem = repo.create_element("Use Case", name="Do")
+        elem.phase = "PhaseX"
+        obj = SysMLObject(1, "Use Case", 0.0, 0.0, element_id=elem.elem_id, phase="PhaseX")
+        win = DummyWindow(diag.diag_id)
+        lines = win._object_label_lines(obj)
+        text = " ".join(lines)
+        self.assertIn("Do", text)
+        self.assertNotIn("PhaseX", text)
+
+    def test_governance_label_omits_phase(self):
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Governance Diagram")
+        elem = repo.create_element("Use Case", name="Check")
+        elem.phase = "PhaseZ"
+        obj = SysMLObject(
+            2,
+            "Work Product",
+            0.0,
+            0.0,
+            element_id=elem.elem_id,
+            phase="PhaseZ",
+            properties={"name": "Check"},
+        )
+        win = DummyWindow(diag.diag_id)
+        lines = win._object_label_lines(obj)
+        self.assertIn("Check", " ".join(lines))
+        self.assertNotIn("PhaseZ", " ".join(lines))
+
+    def test_safety_management_explorer_omits_phase(self):
+        from gui.safety_management_explorer import SafetyManagementExplorer
+        from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+
+        repo = SysMLRepository.get_instance()
+        toolbox = SafetyManagementToolbox()
+        diag_id = toolbox.create_diagram("GovDiag")
+        repo.diagrams[diag_id].phase = "Phase1"
+        mod = GovernanceModule("Folder")
+        mod.diagrams.append("GovDiag (Phase1)")
+        toolbox.modules.append(mod)
+
+        explorer = SafetyManagementExplorer.__new__(SafetyManagementExplorer)
+
+        class DummyTree:
+            def __init__(self):
+                self.items = {}
+                self.counter = 0
+
+            def delete(self, *items):
+                self.items = {}
+
+            def get_children(self, item=""):
+                return [iid for iid, meta in self.items.items() if meta["parent"] == item]
+
+            def insert(self, parent, index, text="", image=None, **_kwargs):
+                iid = f"i{self.counter}"
+                self.counter += 1
+                self.items[iid] = {"parent": parent, "text": text}
+                return iid
+
+        explorer.tree = DummyTree()
+        explorer.toolbox = toolbox
+        explorer.item_map = {}
+        explorer.folder_icon = None
+        explorer.diagram_icon = None
+
+        SafetyManagementExplorer.populate(explorer)
+
+        texts = [meta["text"] for meta in explorer.tree.items.values()]
+        self.assertIn("GovDiag", texts)
+        self.assertTrue(all("Phase1" not in t for t in texts))
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- ensure Safety & Security Management Explorer strips phase suffixes from governance diagram names
- handle phase-formatted names when moving, renaming, or deleting governance diagrams
- extend regression test to cover foldered diagrams with phase text

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dc156180c832590f155b9a13774ee