### PR TITLE
Enable governance-based element tracing

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4,7 +4,14 @@ import tkinter.font as tkFont
 import textwrap
 from tkinter import ttk, simpledialog
 from gui import messagebox, format_name_with_phase
-from gui.tooltip import ToolTip
+try:  # pragma: no cover - GUI helper may be absent in headless tests
+    from gui.tooltip import ToolTip
+except Exception:  # pragma: no cover
+    class ToolTip:  # type: ignore
+        """Fallback no-op tooltip used when GUI toolkit is unavailable."""
+
+        def __init__(self, *args, **kwargs):
+            pass
 import json
 import math
 import re
@@ -35,6 +42,26 @@ OBJECT_COLORS = StyleManager.get_instance().styles
 _next_obj_id = 1
 # Pixel distance used when detecting clicks on connection lines
 CONNECTION_SELECT_RADIUS = 15
+
+# Diagram types that belong to the generic "Architecture Diagram" work product
+ARCH_DIAGRAM_TYPES = {
+    "Use Case Diagram",
+    "Activity Diagram",
+    "Block Diagram",
+    "Internal Block Diagram",
+}
+
+
+def _work_product_name(diag_type: str) -> str:
+    """Return work product name for a given diagram type."""
+    return "Architecture Diagram" if diag_type in ARCH_DIAGRAM_TYPES else diag_type
+
+
+def _diag_matches_wp(diag_type: str, work_product: str) -> bool:
+    """Return True if *diag_type* is part of *work_product*."""
+    if work_product == "Architecture Diagram":
+        return diag_type in ARCH_DIAGRAM_TYPES
+    return diag_type == work_product
 
 
 def _get_next_id() -> int:
@@ -6953,6 +6980,46 @@ class SysMLObjectDialog(simpledialog.Dialog):
         def apply(self):
             self.result = [c for c, var in self.selected.items() if var.get()]
 
+    class SelectTraceDialog(simpledialog.Dialog):
+        """Dialog to choose target elements for trace links."""
+
+        def __init__(
+            self,
+            parent,
+            repo: SysMLRepository,
+            work_products: list[str],
+            source_id: int | None,
+            source_diag: str | None,
+        ):
+            self.repo = repo
+            self.work_products = work_products
+            self.source_id = source_id
+            self.source_diag = source_diag
+            self.selection: list[str] = []
+            super().__init__(parent, title="Select Trace Targets")
+
+        def body(self, master):  # pragma: no cover - requires tkinter
+            ttk.Label(master, text="Select targets:").pack(anchor="w", padx=5, pady=5)
+            self.lb = tk.Listbox(master, selectmode=tk.MULTIPLE, width=40)
+            self._tokens: list[str] = []
+            for diag in self.repo.diagrams.values():
+                if not any(_diag_matches_wp(diag.diag_type, wp) for wp in self.work_products):
+                    continue
+                dname = diag.name or diag.diag_id
+                for obj in getattr(diag, "objects", []):
+                    if diag.diag_id == self.source_diag and obj.get("obj_id") == self.source_id:
+                        continue
+                    name = obj.get("properties", {}).get("name") or obj.get("obj_type", "")
+                    token = f"{diag.diag_id}:{obj.get('obj_id')}"
+                    self._tokens.append(token)
+                    self.lb.insert(tk.END, f"{dname}:{name}")
+            self.lb.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+            return self.lb
+
+        def apply(self):  # pragma: no cover - requires tkinter
+            sels = self.lb.curselection()
+            self.selection = [self._tokens[i] for i in sels]
+
     class SelectNamesDialog(simpledialog.Dialog):
         """Dialog to choose which part names should be added."""
 
@@ -7335,14 +7402,14 @@ class SysMLObjectDialog(simpledialog.Dialog):
         self.current_diagram = current_diagram
         toolbox = getattr(app, "safety_mgmt_toolbox", None)
         wp_map = {wp.analysis: wp for wp in toolbox.get_work_products()} if toolbox else {}
-        diagram_wp = wp_map.get(getattr(current_diagram, "diag_type", ""))
-        diag_trace_opts = (
-            sorted(getattr(diagram_wp, "traceable", [])) if diagram_wp else []
-        )
+        diag_type = getattr(current_diagram, "diag_type", "")
+        analysis_name = _work_product_name(diag_type)
+        diagram_wp = wp_map.get(analysis_name)
+        diag_trace_opts = sorted(getattr(diagram_wp, "traceable", [])) if diagram_wp else []
         self._target_work_product = (
             self.obj.properties.get("name", "")
             if self.obj.obj_type == "Work Product"
-            else getattr(diagram_wp, "analysis", getattr(current_diagram, "diag_type", ""))
+            else getattr(diagram_wp, "analysis", analysis_name)
         )
         link_row = 0
         trace_shown = False
@@ -7492,19 +7559,16 @@ class SysMLObjectDialog(simpledialog.Dialog):
             ttk.Label(link_frame, text="Trace To:").grid(
                 row=link_row, column=0, sticky="e", padx=4, pady=2
             )
-            lb = tk.Listbox(link_frame, height=4, selectmode=tk.MULTIPLE)
-            for opt in diag_trace_opts:
-                lb.insert(tk.END, opt)
-            current = [
-                s.strip()
-                for s in self.obj.properties.get("trace_to", "").split(",")
-                if s.strip()
-            ]
-            for idx, opt in enumerate(diag_trace_opts):
-                if opt in current:
-                    lb.selection_set(idx)
-            lb.grid(row=link_row, column=1, padx=4, pady=2, sticky="we")
-            self.trace_list = lb
+            self.trace_list = tk.Listbox(link_frame, height=4)
+            self.trace_list.grid(row=link_row, column=1, padx=4, pady=2, sticky="we")
+            btnf = ttk.Frame(link_frame)
+            btnf.grid(row=link_row, column=2, padx=2)
+            ttk.Button(btnf, text="Add", command=lambda: self.add_trace(diag_trace_opts)).pack(side=tk.TOP)
+            ttk.Button(btnf, text="Remove", command=self.remove_trace).pack(side=tk.TOP)
+            self._trace_targets = []
+            for token in [t.strip() for t in self.obj.properties.get("trace_to", "").split(",") if t.strip()]:
+                self._trace_targets.append(token)
+                self.trace_list.insert(tk.END, self._format_trace_label(token))
             link_row += 1
             trace_shown = True
 
@@ -7581,6 +7645,47 @@ class SysMLObjectDialog(simpledialog.Dialog):
         if val:
             lb.delete(idx)
             lb.insert(idx, val)
+
+    def add_trace(self, trace_wps):
+        repo = SysMLRepository.get_instance()
+        dlg = self.SelectTraceDialog(
+            self,
+            repo,
+            trace_wps,
+            getattr(self.obj, "obj_id", None),
+            getattr(self.master, "diagram_id", None),
+        )
+        for token in getattr(dlg, "selection", []):
+            if token not in self._trace_targets:
+                self._trace_targets.append(token)
+                self.trace_list.insert(tk.END, self._format_trace_label(token))
+
+    def remove_trace(self):
+        sel = list(self.trace_list.curselection())
+        for idx in reversed(sel):
+            self.trace_list.delete(idx)
+            del self._trace_targets[idx]
+
+    def _format_trace_label(self, token: str) -> str:
+        repo = SysMLRepository.get_instance()
+        parts = token.split(":", 1)
+        if len(parts) != 2:
+            return token
+        diag_id, obj_id = parts
+        diag = repo.diagrams.get(diag_id)
+        dname = getattr(diag, "name", diag_id) if diag else diag_id
+        obj = None
+        if diag:
+            obj = next(
+                (o for o in getattr(diag, "objects", []) if str(o.get("obj_id")) == obj_id),
+                None,
+            )
+        oname = (
+            obj.get("properties", {}).get("name") or obj.get("obj_type")
+            if obj
+            else obj_id
+        )
+        return f"{dname}:{oname}"
 
     class OperationDialog(simpledialog.Dialog):
         def __init__(self, parent, operation=None):
@@ -7903,8 +8008,10 @@ class SysMLObjectDialog(simpledialog.Dialog):
 
         trace_lb = getattr(self, "trace_list", None)
         if trace_lb:
-            selected = [trace_lb.get(i) for i in trace_lb.curselection()]
-            joined = ", ".join(selected)
+            targets = getattr(self, "_trace_targets", None)
+            if targets is None:
+                targets = [trace_lb.get(i) for i in getattr(trace_lb, "curselection", lambda: [])()]
+            joined = ", ".join(targets)
             if joined:
                 self.obj.properties["trace_to"] = joined
             else:
@@ -7925,14 +8032,31 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 repo.relationships = [r for r in repo.relationships if r.rel_id not in removed]
                 for diag in repo.diagrams.values():
                     diag.relationships = [rid for rid in diag.relationships if rid not in removed]
-            for name in selected:
-                target_elem = next(
-                    (e for e in repo.elements.values() if e.name == name),
+            for token in targets:
+                parts = token.split(":", 1)
+                if len(parts) != 2:
+                    target_elem = next(
+                        (e for e in repo.elements.values() if e.name == token),
+                        None,
+                    )
+                    if target_elem and self.obj.element_id:
+                        repo.create_relationship("Trace", self.obj.element_id, target_elem.elem_id)
+                        repo.create_relationship("Trace", target_elem.elem_id, self.obj.element_id)
+                    continue
+                diag_id, obj_id = parts
+                diag = repo.diagrams.get(diag_id)
+                if not diag:
+                    continue
+                obj = next(
+                    (o for o in getattr(diag, "objects", []) if str(o.get("obj_id")) == obj_id),
                     None,
                 )
+                if not obj:
+                    continue
+                target_elem = obj.get("element_id")
                 if target_elem and self.obj.element_id:
-                    repo.create_relationship("Trace", self.obj.element_id, target_elem.elem_id)
-                    repo.create_relationship("Trace", target_elem.elem_id, self.obj.element_id)
+                    repo.create_relationship("Trace", self.obj.element_id, target_elem)
+                    repo.create_relationship("Trace", target_elem, self.obj.element_id)
 
         if self.obj.element_id and self.obj.element_id in repo.elements:
             elem_type = repo.elements[self.obj.element_id].elem_type

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -38,7 +38,26 @@ from analysis.models import (
 from analysis.safety_management import ACTIVE_TOOLBOX
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.constants import CHECK_MARK, CROSS_MARK
-from sysml.sysml_repository import SysMLRepository
+
+
+def find_requirement_traces(req_id: str) -> list[str]:
+    """Return human readable diagram/object names allocated to ``req_id``."""
+    repo = SysMLRepository.get_instance()
+    results: list[str] = []
+    for diag_id, obj_id in repo.find_requirements(req_id):
+        diag = repo.diagrams.get(diag_id)
+        dname = diag.name if diag and diag.name else diag_id
+        obj = None
+        if diag:
+            obj = next(
+                (o for o in getattr(diag, "objects", []) if o.get("obj_id") == obj_id),
+                None,
+            )
+        oname = obj.get("properties", {}).get("name") if obj else ""
+        if not oname and obj:
+            oname = obj.get("obj_type", "")
+        results.append(f"{dname}:{oname}")
+    return results
 
 
 def configure_table_style(style_name: str, rowheight: int = 60) -> None:


### PR DESCRIPTION
## Summary
- Map architecture diagram types to their work product so governance rules apply
- Add dialog and helpers to trace elements to other diagram objects
- Expose `find_requirement_traces` helper for requirement trace queries
- Guard `ToolTip` import with a fallback to avoid GUI crashes

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dd0f0a2408325a9a88d0d80aa83b3