### PR TITLE
Enable governed requirement relations and bidirectional allocations

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -609,6 +609,41 @@ class SafetyManagementToolbox:
         return mapping
 
     # ------------------------------------------------------------------
+    def _req_relation_mapping(self) -> Dict[str, Dict[str, set[str]]]:
+        """Return mapping of requirement work products to relation targets.
+
+        The returned dictionary is structured as ``source -> relation ->
+        {targets}`` where *relation* is the connection stereotype used between
+        work products such as ``"satisfied by"`` or ``"derived from"``.
+        """
+        repo = SysMLRepository.get_instance()
+        diag_ids = self.diagrams.values()
+        if self.active_module:
+            names = self.diagrams_in_module(self.active_module)
+            diag_ids = [self.diagrams.get(n) for n in names if self.diagrams.get(n)]
+        mapping: Dict[str, Dict[str, set[str]]] = {}
+        for diag_id in diag_ids:
+            if not repo.diagram_visible(diag_id):
+                continue
+            diag = repo.diagrams.get(diag_id)
+            if not diag:
+                continue
+            id_to_name: Dict[int, str] = {}
+            for obj in getattr(diag, "objects", []):
+                if obj.get("obj_type") == "Work Product":
+                    name = obj.get("properties", {}).get("name")
+                    if name:
+                        id_to_name[obj.get("obj_id")] = name
+            for conn in getattr(diag, "connections", []):
+                stereo = (conn.get("stereotype") or conn.get("conn_type") or "").lower()
+                if stereo in {"satisfied by", "derived from"}:
+                    sname = id_to_name.get(conn.get("src"))
+                    tname = id_to_name.get(conn.get("dst"))
+                    if sname and tname:
+                        mapping.setdefault(sname, {}).setdefault(stereo, set()).add(tname)
+        return mapping
+
+    # ------------------------------------------------------------------
     def _normalize_work_product(self, name: str) -> str:
         """Translate requirement types to their work product names."""
         from analysis.models import REQUIREMENT_TYPE_OPTIONS, REQUIREMENT_WORK_PRODUCTS
@@ -622,10 +657,44 @@ class SafetyManagementToolbox:
     # ------------------------------------------------------------------
     def can_trace(self, source: str, target: str) -> bool:
         """Return ``True`` if ``source`` may trace to ``target``."""
+        from analysis.models import REQUIREMENT_WORK_PRODUCTS
+
         source = self._normalize_work_product(source)
         target = self._normalize_work_product(target)
+        if source in REQUIREMENT_WORK_PRODUCTS and target in REQUIREMENT_WORK_PRODUCTS:
+            return False
         traces = self._trace_mapping()
-        return target in traces.get(source, set())
+        if target in traces.get(source, set()):
+            return True
+        general = REQUIREMENT_WORK_PRODUCTS[0]
+        specific_wps = set(REQUIREMENT_WORK_PRODUCTS[1:])
+        if source in specific_wps and target in traces.get(general, set()):
+            return True
+        if target in specific_wps and source in traces.get(general, set()):
+            return True
+        return False
+
+    # ------------------------------------------------------------------
+    def can_link_requirements(self, src_type: str, dst_type: str, relation: str) -> bool:
+        """Return ``True`` if requirements of ``src_type`` may relate to
+        ``dst_type`` using ``relation`` (e.g., ``"satisfied by"``)."""
+
+        from analysis.models import REQUIREMENT_WORK_PRODUCTS
+
+        src_wp = self._normalize_work_product(src_type)
+        dst_wp = self._normalize_work_product(dst_type)
+        rels = self._req_relation_mapping()
+        rel = relation.lower()
+        if dst_wp in rels.get(src_wp, {}).get(rel, set()):
+            return True
+        general = REQUIREMENT_WORK_PRODUCTS[0]
+        specific = set(REQUIREMENT_WORK_PRODUCTS[1:])
+        gen_targets = rels.get(general, {}).get(rel, set())
+        if src_wp in specific and (dst_wp in gen_targets or general in gen_targets):
+            return True
+        if dst_wp in specific and (src_wp in gen_targets or general in gen_targets):
+            return True
+        return False
 
     # ------------------------------------------------------------------
     def requirement_work_product(self, req_type: str) -> str:

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4,7 +4,10 @@ import tkinter.font as tkFont
 import textwrap
 from tkinter import ttk, simpledialog
 from gui import messagebox, format_name_with_phase
-from gui.tooltip import ToolTip
+try:  # Guard against environments where the tooltip module is unavailable
+    from gui.tooltip import ToolTip
+except Exception:  # pragma: no cover - fallback for minimal installs
+    ToolTip = None  # type: ignore
 import json
 import math
 import re
@@ -35,6 +38,26 @@ OBJECT_COLORS = StyleManager.get_instance().styles
 _next_obj_id = 1
 # Pixel distance used when detecting clicks on connection lines
 CONNECTION_SELECT_RADIUS = 15
+
+# Diagram types that belong to the generic "Architecture Diagram" work product
+ARCH_DIAGRAM_TYPES = {
+    "Use Case Diagram",
+    "Activity Diagram",
+    "Block Diagram",
+    "Internal Block Diagram",
+}
+
+
+def _work_product_name(diag_type: str) -> str:
+    """Return work product name for a given diagram type."""
+    return "Architecture Diagram" if diag_type in ARCH_DIAGRAM_TYPES else diag_type
+
+
+def _diag_matches_wp(diag_type: str, work_product: str) -> bool:
+    """Return True if *diag_type* is part of *work_product*."""
+    if work_product == "Architecture Diagram":
+        return diag_type in ARCH_DIAGRAM_TYPES
+    return diag_type == work_product
 
 
 def _get_next_id() -> int:
@@ -1958,6 +1981,49 @@ def unlink_requirement_from_object(obj, req_id: str, diagram_id: str | None = No
             obj["requirements"] = [r for r in obj.get("requirements", []) if r.get("id") != req_id]
         else:
             obj.requirements = [r for r in obj.requirements if r.get("id") != req_id]
+
+
+# ---------------------------------------------------------------------------
+def link_requirements(src_id: str, relation: str, dst_id: str) -> None:
+    """Create a requirement relationship and mirror the inverse."""
+
+    src = global_requirements.get(src_id)
+    dst = global_requirements.get(dst_id)
+    if not src or not dst:
+        return
+    rel = {"type": relation, "id": dst_id}
+    rels = src.setdefault("relations", [])
+    if rel not in rels:
+        rels.append(rel)
+    inverse = None
+    if relation == "satisfied by":
+        inverse = "satisfies"
+    elif relation == "derived from":
+        inverse = "derives"
+    if inverse:
+        inv = {"type": inverse, "id": src_id}
+        dlist = dst.setdefault("relations", [])
+        if inv not in dlist:
+            dlist.append(inv)
+
+
+def unlink_requirements(src_id: str, relation: str, dst_id: str) -> None:
+    """Remove a requirement relationship."""
+
+    src = global_requirements.get(src_id)
+    dst = global_requirements.get(dst_id)
+    if not src or not dst:
+        return
+    src_rels = src.get("relations", [])
+    src["relations"] = [r for r in src_rels if not (r.get("type") == relation and r.get("id") == dst_id)]
+    inverse = None
+    if relation == "satisfied by":
+        inverse = "satisfies"
+    elif relation == "derived from":
+        inverse = "derives"
+    if inverse:
+        dst_rels = dst.get("relations", [])
+        dst["relations"] = [r for r in dst_rels if not (r.get("type") == inverse and r.get("id") == src_id)]
 
 
 def remove_orphan_ports(objs: List[SysMLObject]) -> None:
@@ -6953,6 +7019,46 @@ class SysMLObjectDialog(simpledialog.Dialog):
         def apply(self):
             self.result = [c for c, var in self.selected.items() if var.get()]
 
+    class SelectTraceDialog(simpledialog.Dialog):
+        """Dialog to choose target elements for trace links."""
+
+        def __init__(
+            self,
+            parent,
+            repo: SysMLRepository,
+            work_products: list[str],
+            source_id: int | None,
+            source_diag: str | None,
+        ):
+            self.repo = repo
+            self.work_products = work_products
+            self.source_id = source_id
+            self.source_diag = source_diag
+            self.selection: list[str] = []
+            super().__init__(parent, title="Select Trace Targets")
+
+        def body(self, master):  # pragma: no cover - requires tkinter
+            ttk.Label(master, text="Select targets:").pack(anchor="w", padx=5, pady=5)
+            self.lb = tk.Listbox(master, selectmode=tk.MULTIPLE, width=40)
+            self._tokens: list[str] = []
+            for diag in self.repo.diagrams.values():
+                if not any(_diag_matches_wp(diag.diag_type, wp) for wp in self.work_products):
+                    continue
+                dname = diag.name or diag.diag_id
+                for obj in getattr(diag, "objects", []):
+                    if diag.diag_id == self.source_diag and obj.get("obj_id") == self.source_id:
+                        continue
+                    name = obj.get("properties", {}).get("name") or obj.get("obj_type", "")
+                    token = f"{diag.diag_id}:{obj.get('obj_id')}"
+                    self._tokens.append(token)
+                    self.lb.insert(tk.END, f"{dname}:{name}")
+            self.lb.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+            return self.lb
+
+        def apply(self):  # pragma: no cover - requires tkinter
+            sels = self.lb.curselection()
+            self.selection = [self._tokens[i] for i in sels]
+
     class SelectNamesDialog(simpledialog.Dialog):
         """Dialog to choose which part names should be added."""
 
@@ -7335,14 +7441,14 @@ class SysMLObjectDialog(simpledialog.Dialog):
         self.current_diagram = current_diagram
         toolbox = getattr(app, "safety_mgmt_toolbox", None)
         wp_map = {wp.analysis: wp for wp in toolbox.get_work_products()} if toolbox else {}
-        diagram_wp = wp_map.get(getattr(current_diagram, "diag_type", ""))
-        diag_trace_opts = (
-            sorted(getattr(diagram_wp, "traceable", [])) if diagram_wp else []
-        )
+        diag_type = getattr(current_diagram, "diag_type", "")
+        analysis_name = _work_product_name(diag_type)
+        diagram_wp = wp_map.get(analysis_name)
+        diag_trace_opts = sorted(getattr(diagram_wp, "traceable", [])) if diagram_wp else []
         self._target_work_product = (
             self.obj.properties.get("name", "")
             if self.obj.obj_type == "Work Product"
-            else getattr(diagram_wp, "analysis", getattr(current_diagram, "diag_type", ""))
+            else getattr(diagram_wp, "analysis", analysis_name)
         )
         link_row = 0
         trace_shown = False
@@ -7492,19 +7598,16 @@ class SysMLObjectDialog(simpledialog.Dialog):
             ttk.Label(link_frame, text="Trace To:").grid(
                 row=link_row, column=0, sticky="e", padx=4, pady=2
             )
-            lb = tk.Listbox(link_frame, height=4, selectmode=tk.MULTIPLE)
-            for opt in diag_trace_opts:
-                lb.insert(tk.END, opt)
-            current = [
-                s.strip()
-                for s in self.obj.properties.get("trace_to", "").split(",")
-                if s.strip()
-            ]
-            for idx, opt in enumerate(diag_trace_opts):
-                if opt in current:
-                    lb.selection_set(idx)
-            lb.grid(row=link_row, column=1, padx=4, pady=2, sticky="we")
-            self.trace_list = lb
+            self.trace_list = tk.Listbox(link_frame, height=4)
+            self.trace_list.grid(row=link_row, column=1, padx=4, pady=2, sticky="we")
+            btnf = ttk.Frame(link_frame)
+            btnf.grid(row=link_row, column=2, padx=2)
+            ttk.Button(btnf, text="Add", command=lambda: self.add_trace(diag_trace_opts)).pack(side=tk.TOP)
+            ttk.Button(btnf, text="Remove", command=self.remove_trace).pack(side=tk.TOP)
+            self._trace_targets = []
+            for token in [t.strip() for t in self.obj.properties.get("trace_to", "").split(",") if t.strip()]:
+                self._trace_targets.append(token)
+                self.trace_list.insert(tk.END, self._format_trace_label(token))
             link_row += 1
             trace_shown = True
 
@@ -7528,10 +7631,11 @@ class SysMLObjectDialog(simpledialog.Dialog):
             ttk.Button(btnf, text="Add", command=self.add_requirement).pack(side=tk.TOP)
             ttk.Button(btnf, text="Remove", command=self.remove_requirement).pack(side=tk.TOP)
         else:
-            ToolTip(
-                self.req_list,
-                "Requirement allocation is disabled for this diagram due to governance restrictions.",
-            )
+            if ToolTip:
+                ToolTip(
+                    self.req_list,
+                    "Requirement allocation is disabled for this diagram due to governance restrictions.",
+                )
         for r in self.obj.requirements:
             self.req_list.insert(tk.END, f"[{r.get('id')}] {r.get('text','')}")
         req_row += 1
@@ -7581,6 +7685,47 @@ class SysMLObjectDialog(simpledialog.Dialog):
         if val:
             lb.delete(idx)
             lb.insert(idx, val)
+
+    def add_trace(self, trace_wps):
+        repo = SysMLRepository.get_instance()
+        dlg = self.SelectTraceDialog(
+            self,
+            repo,
+            trace_wps,
+            getattr(self.obj, "obj_id", None),
+            getattr(self.master, "diagram_id", None),
+        )
+        for token in getattr(dlg, "selection", []):
+            if token not in self._trace_targets:
+                self._trace_targets.append(token)
+                self.trace_list.insert(tk.END, self._format_trace_label(token))
+
+    def remove_trace(self):
+        sel = list(self.trace_list.curselection())
+        for idx in reversed(sel):
+            self.trace_list.delete(idx)
+            del self._trace_targets[idx]
+
+    def _format_trace_label(self, token: str) -> str:
+        repo = SysMLRepository.get_instance()
+        parts = token.split(":", 1)
+        if len(parts) != 2:
+            return token
+        diag_id, obj_id = parts
+        diag = repo.diagrams.get(diag_id)
+        dname = getattr(diag, "name", diag_id) if diag else diag_id
+        obj = None
+        if diag:
+            obj = next(
+                (o for o in getattr(diag, "objects", []) if str(o.get("obj_id")) == obj_id),
+                None,
+            )
+        oname = (
+            obj.get("properties", {}).get("name") or obj.get("obj_type")
+            if obj
+            else obj_id
+        )
+        return f"{dname}:{oname}"
 
     class OperationDialog(simpledialog.Dialog):
         def __init__(self, parent, operation=None):
@@ -7903,8 +8048,10 @@ class SysMLObjectDialog(simpledialog.Dialog):
 
         trace_lb = getattr(self, "trace_list", None)
         if trace_lb:
-            selected = [trace_lb.get(i) for i in trace_lb.curselection()]
-            joined = ", ".join(selected)
+            targets = getattr(self, "_trace_targets", None)
+            if targets is None:
+                targets = [trace_lb.get(i) for i in getattr(trace_lb, "curselection", lambda: [])()]
+            joined = ", ".join(targets)
             if joined:
                 self.obj.properties["trace_to"] = joined
             else:
@@ -7925,14 +8072,31 @@ class SysMLObjectDialog(simpledialog.Dialog):
                 repo.relationships = [r for r in repo.relationships if r.rel_id not in removed]
                 for diag in repo.diagrams.values():
                     diag.relationships = [rid for rid in diag.relationships if rid not in removed]
-            for name in selected:
-                target_elem = next(
-                    (e for e in repo.elements.values() if e.name == name),
+            for token in targets:
+                parts = token.split(":", 1)
+                if len(parts) != 2:
+                    target_elem = next(
+                        (e for e in repo.elements.values() if e.name == token),
+                        None,
+                    )
+                    if target_elem and self.obj.element_id:
+                        repo.create_relationship("Trace", self.obj.element_id, target_elem.elem_id)
+                        repo.create_relationship("Trace", target_elem.elem_id, self.obj.element_id)
+                    continue
+                diag_id, obj_id = parts
+                diag = repo.diagrams.get(diag_id)
+                if not diag:
+                    continue
+                obj = next(
+                    (o for o in getattr(diag, "objects", []) if str(o.get("obj_id")) == obj_id),
                     None,
                 )
+                if not obj:
+                    continue
+                target_elem = obj.get("element_id")
                 if target_elem and self.obj.element_id:
-                    repo.create_relationship("Trace", self.obj.element_id, target_elem.elem_id)
-                    repo.create_relationship("Trace", target_elem.elem_id, self.obj.element_id)
+                    repo.create_relationship("Trace", self.obj.element_id, target_elem)
+                    repo.create_relationship("Trace", target_elem, self.obj.element_id)
 
         if self.obj.element_id and self.obj.element_id in repo.elements:
             elem_type = repo.elements[self.obj.element_id].elem_type

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -38,7 +38,27 @@ from analysis.models import (
 from analysis.safety_management import ACTIVE_TOOLBOX
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.constants import CHECK_MARK, CROSS_MARK
-from sysml.sysml_repository import SysMLRepository
+from gui.architecture import _work_product_name, link_requirements, link_requirement_to_object
+
+
+def find_requirement_traces(req_id: str) -> list[str]:
+    """Return human readable diagram/object names allocated to ``req_id``."""
+    repo = SysMLRepository.get_instance()
+    results: list[str] = []
+    for diag_id, obj_id in repo.find_requirements(req_id):
+        diag = repo.diagrams.get(diag_id)
+        dname = diag.name if diag and diag.name else diag_id
+        obj = None
+        if diag:
+            obj = next(
+                (o for o in getattr(diag, "objects", []) if o.get("obj_id") == obj_id),
+                None,
+            )
+        oname = obj.get("properties", {}).get("name") if obj else ""
+        if not oname and obj:
+            oname = obj.get("obj_type", "")
+        results.append(f"{dname}:{oname}")
+    return results
 
 
 def configure_table_style(style_name: str, rowheight: int = 60) -> None:
@@ -339,17 +359,11 @@ class _TraceLinkDialog(simpledialog.Dialog):
         self.items = []
         self.lb = tk.Listbox(master, selectmode="extended", height=10, exportselection=False)
         req_type = self.requirement.get("req_type", "")
-        req_wp = ""
-        if req_type in REQUIREMENT_TYPE_OPTIONS:
-            idx = REQUIREMENT_TYPE_OPTIONS.index(req_type)
-            req_wp = REQUIREMENT_WORK_PRODUCTS[idx]
+        req_wp = self.toolbox.requirement_work_product(req_type) if self.toolbox else ""
         for diag in repo.diagrams.values():
-            if self.toolbox and req_wp:
-                try:
-                    if not self.toolbox.can_trace(req_wp, diag.diag_type):
-                        continue
-                except Exception:
-                    continue
+            diag_wp = _work_product_name(diag.diag_type)
+            if self.toolbox and req_wp and not self.toolbox.can_trace(req_wp, diag_wp):
+                continue
             for obj in diag.objects:
                 name = obj.get("properties", {}).get("name") or obj.get("obj_type", "")
                 label = f"{diag.name}:{name}" if diag.name else name
@@ -366,6 +380,58 @@ class _TraceLinkDialog(simpledialog.Dialog):
 
     def apply(self):
         self.result = {self.lb.get(i) for i in self.lb.curselection()}
+
+
+class _RequirementRelationDialog(simpledialog.Dialog):
+    """Dialog to create requirement-to-requirement links."""
+
+    def __init__(self, parent, requirement, toolbox):
+        self.req = requirement
+        self.toolbox = toolbox
+        super().__init__(parent, title="Link Requirement")
+
+    def body(self, master):
+        tk.Label(master, text="Relation:").grid(row=0, column=0, sticky="e")
+        self.rel_var = tk.StringVar()
+        options = []
+        for rel in ("satisfied by", "derived from"):
+            for r in global_requirements.values():
+                if r.get("id") == self.req.get("id"):
+                    continue
+                if self.toolbox and not self.toolbox.can_link_requirements(
+                    self.req.get("req_type", ""), r.get("req_type", ""), rel
+                ):
+                    continue
+                options.append(rel)
+                break
+        if not options:
+            options = ["satisfied by", "derived from"]
+        ttk.Combobox(
+            master, textvariable=self.rel_var, values=options, state="readonly"
+        ).grid(row=0, column=1, padx=5, pady=5)
+        tk.Label(master, text="Target:").grid(row=1, column=0, sticky="ne")
+        self.lb = tk.Listbox(master, selectmode="extended", height=10, exportselection=False)
+        self.lb.grid(row=1, column=1, padx=5, pady=5)
+        self.rel_var.trace_add("write", lambda *_: self._populate())
+        self._populate()
+        return self.lb
+
+    def _populate(self):
+        self.lb.delete(0, tk.END)
+        rel = self.rel_var.get()
+        for rid, req in global_requirements.items():
+            if rid == self.req.get("id"):
+                continue
+            if self.toolbox and rel and not self.toolbox.can_link_requirements(
+                self.req.get("req_type", ""), req.get("req_type", ""), rel
+            ):
+                continue
+            self.lb.insert(tk.END, rid)
+
+    def apply(self):
+        rel = self.rel_var.get()
+        targets = [self.lb.get(i) for i in self.lb.curselection()]
+        self.result = (rel, targets)
 
 
 class _SelectTriggeringConditionsDialog(simpledialog.Dialog):
@@ -3783,9 +3849,9 @@ class HazardExplorerWindow(tk.Toplevel):
 class DiagramElementDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
     """Dialog presenting diagram objects for selection."""
 
-    def __init__(self, parent, repo: SysMLRepository, req_type: str, can_trace):
+    def __init__(self, parent, repo: SysMLRepository, req_wp: str, can_trace):
         self.repo = repo
-        self.req_type = req_type
+        self.req_wp = req_wp
         self.can_trace = can_trace
         self.selection: list[tuple[str, int]] = []
         super().__init__(parent, "Select Targets")
@@ -3795,16 +3861,12 @@ class DiagramElementDialog(simpledialog.Dialog):  # pragma: no cover - requires 
         self.listbox = tk.Listbox(master, selectmode=tk.MULTIPLE, width=40)
         self._options: list[tuple[str, int]] = []
         for diag in self.repo.diagrams.values():
+            diag_wp = _work_product_name(diag.diag_type)
+            if self.req_wp and self.can_trace and not self.can_trace(self.req_wp, diag_wp):
+                continue
             dname = diag.name or diag.diag_id
             for obj in getattr(diag, "objects", []):
                 name = obj.get("properties", {}).get("name", "")
-                if (
-                    self.req_type
-                    and name
-                    and self.can_trace
-                    and not self.can_trace(self.req_type, name)
-                ):
-                    continue
                 label = f"{dname}:{name or obj.get('obj_type')}"
                 self._options.append((diag.diag_id, obj.get("obj_id")))
                 self.listbox.insert(tk.END, label)
@@ -3865,7 +3927,7 @@ class RequirementsExplorerWindow(tk.Toplevel):
 
         tk.Button(filter_frame, text="Apply", command=self.refresh).grid(row=0, column=8, padx=5)
 
-        self.columns = ("ID", "ASIL", "Type", "Status", "Parent", "Trace", "Text")
+        self.columns = ("ID", "ASIL", "Type", "Status", "Parent", "Trace", "Links", "Text")
         configure_table_style("ReqExp.Treeview")
         self.tree = EditableTreeview(
             self,
@@ -3879,7 +3941,7 @@ class RequirementsExplorerWindow(tk.Toplevel):
             self.tree.heading(c, text=c)
             if c == "Text":
                 width = 300
-            elif c == "Trace":
+            elif c in ("Trace", "Links"):
                 width = 200
             else:
                 width = 100
@@ -3888,6 +3950,7 @@ class RequirementsExplorerWindow(tk.Toplevel):
         btnf = ttk.Frame(self)
         btnf.pack(pady=5)
         ttk.Button(btnf, text="Link to Diagram...", command=self.link_to_diagram).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btnf, text="Link Requirement...", command=self.link_requirement).pack(side=tk.LEFT, padx=5)
         ttk.Button(btnf, text="Export CSV", command=self.export_csv).pack(side=tk.LEFT, padx=5)
         self.refresh()
 
@@ -3897,8 +3960,7 @@ class RequirementsExplorerWindow(tk.Toplevel):
         rtype = self.type_var.get().strip()
         asil = self.asil_var.get().strip()
         status = self.status_var.get().strip()
-        repo = SysMLRepository.get_instance()
-        for req in global_requirements.values():
+        for rid, req in global_requirements.items():
             if query and query not in req.get("id", "").lower() and query not in req.get("text", "").lower():
                 continue
             if rtype and req.get("req_type") != rtype:
@@ -3907,8 +3969,10 @@ class RequirementsExplorerWindow(tk.Toplevel):
                 continue
             if status and req.get("status", "") != status:
                 continue
-            trace = ", ".join(self._get_requirement_allocations(req.get("id", "")))
-            req["trace"] = trace
+            trace = ", ".join(self._get_requirement_allocations(rid))
+            links = ", ".join(
+                f"{r.get('type')} {r.get('id')}" for r in req.get("relations", [])
+            )
             self.tree.insert(
                 "",
                 "end",
@@ -3917,11 +3981,10 @@ class RequirementsExplorerWindow(tk.Toplevel):
                     req.get("asil", ""),
                     req.get("req_type", ""),
                     req.get("status", ""),
-                    trace,
                     req.get("parent_id", ""),
                     trace,
+                    links,
                     req.get("text", ""),
-                    alloc,
                 ),
             )
 
@@ -4009,10 +4072,12 @@ class RequirementsExplorerWindow(tk.Toplevel):
         repo = SysMLRepository.get_instance()
         toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
         can_trace = toolbox.can_trace if toolbox else (lambda a, b: True)
-        dlg = DiagramElementDialog(self, repo, req.get("req_type", ""), can_trace)
+        req_wp = toolbox.requirement_work_product(req.get("req_type", "")) if toolbox else ""
+        dlg = DiagramElementDialog(self, repo, req_wp, can_trace)
         targets = getattr(dlg, "selection", [])
         if not targets:
             return
+        from gui.architecture import link_requirement_to_object
         for diag_id, obj_id in targets:
             diag = repo.diagrams.get(diag_id)
             if not diag:
@@ -4020,11 +4085,26 @@ class RequirementsExplorerWindow(tk.Toplevel):
             obj = next((o for o in getattr(diag, "objects", []) if o.get("obj_id") == obj_id), None)
             if not obj:
                 continue
-            obj.setdefault("requirements", [])
-            if not any(r.get("id") == rid for r in obj["requirements"]):
-                obj["requirements"].append(req)
+            link_requirement_to_object(obj, rid, diag_id)
             repo.touch_diagram(diag_id)
             elem_id = obj.get("element_id")
             if elem_id:
                 repo.touch_element(elem_id)
+        self.refresh()
+
+    def link_requirement(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        rid = self.tree.item(sel[0], "values")[0]
+        req = global_requirements.get(rid)
+        if not req:
+            return
+        toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+        dlg = _RequirementRelationDialog(self, req, toolbox)
+        if not dlg.result:
+            return
+        relation, targets = dlg.result
+        for tid in targets:
+            link_requirements(rid, relation, tid)
         self.refresh()

--- a/tests/test_architecture_requirement_traceability.py
+++ b/tests/test_architecture_requirement_traceability.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.safety_management import SafetyManagementToolbox
+from analysis.models import global_requirements
+from sysml.sysml_repository import SysMLRepository
+from gui.architecture import link_requirement_to_object
+
+
+def test_requirement_traces_to_architecture_elements():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams["Gov"] = gov.diag_id
+    gov.objects = [
+        {"obj_id": 1, "obj_type": "Work Product", "x": 0, "y": 0, "properties": {"name": "Architecture Diagram"}},
+        {"obj_id": 2, "obj_type": "Work Product", "x": 0, "y": 100, "properties": {"name": "Requirement Specification"}},
+    ]
+    gov.connections = [{"src": 1, "dst": 2, "conn_type": "Trace"}]
+    toolbox.add_work_product("Gov", "Architecture Diagram", "")
+    toolbox.add_work_product("Gov", "Requirement Specification", "")
+
+    global_requirements.clear()
+    global_requirements["R1"] = {"id": "R1", "req_type": "vehicle", "text": "Req"}
+
+    diag = repo.create_diagram("Activity Diagram", name="Act")
+    obj = {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "requirements": []}
+    diag.objects.append(obj)
+
+    assert toolbox.can_trace("vehicle", "Architecture Diagram")
+    link_requirement_to_object(obj, "R1", diag.diag_id)
+    assert diag.diag_id in global_requirements["R1"].get("traces", [])
+    assert any(r.get("id") == "R1" for r in obj.get("requirements", []))

--- a/tests/test_requirement_relations.py
+++ b/tests/test_requirement_relations.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from analysis.safety_management import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+from analysis.models import global_requirements
+from gui.architecture import link_requirements
+
+
+def setup_toolbox():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    gov = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox.diagrams["Gov"] = gov.diag_id
+    gov.objects = [
+        {"obj_id": 1, "obj_type": "Work Product", "x": 0, "y": 0, "properties": {"name": "Requirement Specification"}},
+        {"obj_id": 2, "obj_type": "Work Product", "x": 0, "y": 100, "properties": {"name": "Requirement Specification"}},
+    ]
+    gov.connections = [
+        {"src": 1, "dst": 2, "stereotype": "satisfied by"}
+    ]
+    toolbox.add_work_product("Gov", "Requirement Specification", "")
+    return toolbox
+
+
+def test_requirement_spec_cannot_trace():
+    tb = setup_toolbox()
+    assert not tb.can_trace("Requirement Specification", "Requirement Specification")
+
+
+def test_requirement_relation_governance():
+    tb = setup_toolbox()
+    assert tb.can_link_requirements("vehicle", "vehicle", "satisfied by")
+    assert not tb.can_link_requirements("vehicle", "vehicle", "derived from")
+
+
+def test_link_requirements_creates_bidirectional_relation():
+    setup_toolbox()
+    global_requirements.clear()
+    global_requirements["R1"] = {"id": "R1", "req_type": "vehicle"}
+    global_requirements["R2"] = {"id": "R2", "req_type": "vehicle"}
+    link_requirements("R1", "satisfied by", "R2")
+    assert {"type": "satisfied by", "id": "R2"} in global_requirements["R1"].get("relations", [])
+    assert {"type": "satisfies", "id": "R1"} in global_requirements["R2"].get("relations", [])


### PR DESCRIPTION
## Summary
- Parse governance diagrams for "satisfied by"/"derived from" requirement links and expose `can_link_requirements`
- Prevent generic requirement spec traces while allowing governed relations and bidirectional allocation helpers
- Extend requirements explorer with relation column, dialog, and linking controls; add linking utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689dd0f0a2408325a9a88d0d80aa83b3