### PR TITLE
Add Analyze relationship for governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -25,7 +25,11 @@ from analysis.models import (
     REQUIREMENT_WORK_PRODUCTS,
     REQUIREMENT_TYPE_OPTIONS,
 )
-from analysis.safety_management import ALLOWED_PROPAGATIONS, ACTIVE_TOOLBOX
+from analysis.safety_management import (
+    ALLOWED_PROPAGATIONS,
+    ACTIVE_TOOLBOX,
+    SAFETY_ANALYSIS_WORK_PRODUCTS,
+)
 
 # ---------------------------------------------------------------------------
 # Appearance customization
@@ -2920,6 +2924,7 @@ class SysMLDiagramWindow(tk.Frame):
                     "Trace",
                     "Satisfied by",
                     "Derived from",
+                    "Analyze",
                     "Connector",
                     "Generalize",
                     "Generalization",
@@ -2956,6 +2961,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Trace",
             "Satisfied by",
             "Derived from",
+            "Analyze",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3168,6 +3174,14 @@ class SysMLDiagramWindow(tk.Frame):
                     return False, (
                         "Requirement work products must use 'Satisfied by' or 'Derived from'"
                     )
+            elif conn_type == "Analyze":
+                if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
+                    return False, "Analyze links must connect Work Products"
+                if src.properties.get("name") != "Architecture Diagram":
+                    return False, "Analyze links must originate from Architecture Diagram"
+                dname = dst.properties.get("name")
+                if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS:
+                    return False, f"{dname} is not a safety analysis work product"
             else:
                 allowed = {
                     "Initial": {
@@ -3386,6 +3400,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Approval",
             "Re-use",
             "Trace",
+            "Analyze",
             "Connector",
             "Generalize",
             "Generalization",
@@ -3425,6 +3440,7 @@ class SysMLDiagramWindow(tk.Frame):
                           "Re-use",
                           "Satisfied by",
                           "Derived from",
+                          "Analyze",
                           ):
                               arrow_default = "forward"
                         else:
@@ -3711,6 +3727,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Trace",
             "Satisfied by",
             "Derived from",
+            "Analyze",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3918,6 +3935,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Trace",
             "Satisfied by",
             "Derived from",
+            "Analyze",
             "Connector",
             "Generalization",
             "Generalize",
@@ -3955,6 +3973,7 @@ class SysMLDiagramWindow(tk.Frame):
                         "Re-use",
                         "Satisfied by",
                         "Derived from",
+                        "Analyze",
                     ):
                         arrow_default = "forward"
                     else:
@@ -4246,6 +4265,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Approval",
             "Re-use",
             "Trace",
+            "Analyze",
             "Connector",
             "Generalization",
             "Generalize",
@@ -4271,6 +4291,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate by Approval",
             "Re-use",
             "Trace",
+            "Analyze",
             "Connector",
             "Generalization",
             "Generalize",
@@ -8792,6 +8813,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "Trace",
             "Satisfied by",
             "Derived from",
+            "Analyze",
         ):
             ttk.Button(
                 governance_panel,

--- a/tests/test_governance_analyze_relationship.py
+++ b/tests/test_governance_analyze_relationship.py
@@ -1,0 +1,98 @@
+import types
+import unittest
+
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+from analysis.safety_management import SafetyManagementToolbox
+
+
+class DummyCanvas:
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+    def configure(self, **kwargs):
+        pass
+
+
+class GovernanceAnalyzeRelationshipTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+        from gui import architecture
+        self._orig_conn_dialog = architecture.ConnectionDialog
+
+    def tearDown(self):
+        from gui import architecture
+        architecture.ConnectionDialog = self._orig_conn_dialog
+
+    def _create_window(self, tool, src, dst, diag):
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = self.repo
+        win.diagram_id = diag.diag_id
+        win.zoom = 1
+        win.canvas = DummyCanvas()
+        win.find_object = lambda x, y, prefer_port=False: src if win.start is None else dst
+        win.validate_connection = GovernanceDiagramWindow.validate_connection.__get__(win, GovernanceDiagramWindow)
+        win.update_property_view = lambda: None
+        win.redraw = lambda: None
+        win.current_tool = tool
+        win.start = None
+        win.temp_line_end = None
+        win.selected_obj = None
+        win.connections = []
+        win._sync_to_repository = lambda: None
+        from gui import architecture
+        architecture.ConnectionDialog = lambda *args, **kwargs: None
+        return win
+
+    def test_analyze_relationship_stereotype(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Architecture Diagram"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FMEA"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Analyze", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        self.assertEqual(self.repo.relationships[0].stereotype, "analyze")
+
+    def test_toolbox_can_analyze(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams["Gov"] = diag.diag_id
+        o1 = {"obj_id": 1, "obj_type": "Work Product", "x": 0, "y": 0, "properties": {"name": "Architecture Diagram"}}
+        o2 = {"obj_id": 2, "obj_type": "Work Product", "x": 0, "y": 100, "properties": {"name": "FMEA"}}
+        diag.objects = [o1, o2]
+        diag.connections = [{"src": 1, "dst": 2, "conn_type": "Analyze"}]
+        toolbox.add_work_product("Gov", "Architecture Diagram", "")
+        toolbox.add_work_product("Gov", "FMEA", "")
+        self.assertTrue(toolbox.can_analyze("Architecture Diagram", "FMEA"))
+        self.assertIn("Architecture Diagram", toolbox.analysis_inputs("FMEA"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Analyze relationship in governance diagrams allowing architectural diagrams to link to safety analyses
- support Analyze links in safety management toolbox to validate analysis inputs
- test Analyze relationship creation and toolbox behavior

## Testing
- `PYTHONPATH=. pytest tests/test_governance_analyze_relationship.py tests/test_governance_relationship_stereotype.py::GovernanceRelationshipStereotypeTests::test_propagate_relationship_stereotype tests/test_architecture_requirement_traceability.py::test_requirement_traces_to_architecture_elements -q`


------
https://chatgpt.com/codex/tasks/task_b_689df1f1fe3483258437681d89e078ab