### PR TITLE
Group relationship tools in diagram toolboxes

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2735,7 +2735,16 @@ def format_diagram_name(diagram: "SysMLDiagram | None") -> str:
 class SysMLDiagramWindow(tk.Frame):
     """Base frame for AutoML diagrams with zoom and pan support."""
 
-    def __init__(self, master, title, tools, diagram_id: str | None = None, app=None, history=None):
+    def __init__(
+        self,
+        master,
+        title,
+        tools,
+        diagram_id: str | None = None,
+        app=None,
+        history=None,
+        relation_tools: list[str] | None = None,
+    ):
         super().__init__(master)
         self.app = app
         self.diagram_history: list[str] = list(history) if history else []
@@ -2804,10 +2813,24 @@ class SysMLDiagramWindow(tk.Frame):
 
         # Always provide a select tool
         tools = ["Select"] + tools
+        self.tools_frame = ttk.Frame(self.toolbox)
+        self.tools_frame.pack(fill=tk.X, padx=2, pady=2)
         for tool in tools:
-            ttk.Button(self.toolbox, text=tool, command=lambda t=tool: self.select_tool(t)).pack(
-                fill=tk.X, padx=2, pady=2
-            )
+            ttk.Button(
+                self.tools_frame,
+                text=tool,
+                command=lambda t=tool: self.select_tool(t),
+            ).pack(fill=tk.X, padx=2, pady=2)
+
+        if relation_tools:
+            self.rel_frame = ttk.LabelFrame(self.toolbox, text="Relationships")
+            self.rel_frame.pack(fill=tk.X, padx=2, pady=2)
+            for tool in relation_tools:
+                ttk.Button(
+                    self.rel_frame,
+                    text=tool,
+                    command=lambda t=tool: self.select_tool(t),
+                ).pack(fill=tk.X, padx=2, pady=2)
 
         self.prop_frame = ttk.LabelFrame(self.toolbox, text="Properties")
         self.prop_frame.pack(fill=tk.BOTH, expand=True, padx=2, pady=2)
@@ -8654,17 +8677,35 @@ class ConnectionDialog(simpledialog.Dialog):
 
 class UseCaseDiagramWindow(SysMLDiagramWindow):
     def __init__(self, master, app, diagram_id: str | None = None, history=None):
-        tools = [
-            "Actor",
-            "Use Case",
-            "System Boundary",
+        tools = ["Actor", "Use Case", "System Boundary"]
+        rel_tools = [
             "Association",
             "Communication Path",
             "Generalize",
             "Include",
             "Extend",
         ]
-        super().__init__(master, "Use Case Diagram", tools, diagram_id, app=app, history=history)
+        try:
+            super().__init__(
+                master,
+                "Use Case Diagram",
+                tools,
+                diagram_id,
+                app=app,
+                history=history,
+                relation_tools=rel_tools,
+            )
+        except TypeError:
+            super().__init__(
+                master,
+                "Use Case Diagram",
+                tools + rel_tools,
+                diagram_id,
+                app=app,
+                history=history,
+            )
+        if not hasattr(self, "tools_frame"):
+            self.tools_frame = self.toolbox
 
 
 class ActivityDiagramWindow(SysMLDiagramWindow):
@@ -8678,10 +8719,30 @@ class ActivityDiagramWindow(SysMLDiagramWindow):
             "Merge",
             "Fork",
             "Join",
-            "Flow",
             "System Boundary",
         ]
-        super().__init__(master, "Activity Diagram", tools, diagram_id, app=app, history=history)
+        rel_tools = ["Flow"]
+        try:
+            super().__init__(
+                master,
+                "Activity Diagram",
+                tools,
+                diagram_id,
+                app=app,
+                history=history,
+                relation_tools=rel_tools,
+            )
+        except TypeError:
+            super().__init__(
+                master,
+                "Activity Diagram",
+                tools + rel_tools,
+                diagram_id,
+                app=app,
+                history=history,
+            )
+        if not hasattr(self, "tools_frame"):
+            self.tools_frame = self.toolbox
         ttk.Button(
             self.toolbox,
             text="Add Block Operations",
@@ -8765,17 +8826,30 @@ class ActivityDiagramWindow(SysMLDiagramWindow):
 
 class GovernanceDiagramWindow(SysMLDiagramWindow):
     def __init__(self, master, app, diagram_id: str | None = None, history=None):
-        tools = [
-            "Action",
-            "Initial",
-            "Final",
-            "Decision",
-            "Merge",
-            "Flow",
-            "System Boundary",
-        ]
-        super().__init__(master, "Governance Diagram", tools, diagram_id, app=app, history=history)
-        for child in self.toolbox.winfo_children():
+        tools = ["Action", "Initial", "Final", "Decision", "Merge", "System Boundary"]
+        rel_tools = ["Flow"]
+        try:
+            super().__init__(
+                master,
+                "Governance Diagram",
+                tools,
+                diagram_id,
+                app=app,
+                history=history,
+                relation_tools=rel_tools,
+            )
+        except TypeError:
+            super().__init__(
+                master,
+                "Governance Diagram",
+                tools + rel_tools,
+                diagram_id,
+                app=app,
+                history=history,
+            )
+        if not hasattr(self, "tools_frame"):
+            self.tools_frame = self.toolbox
+        for child in self.tools_frame.winfo_children():
             if isinstance(child, ttk.Button) and child.cget("text") == "Action":
                 child.configure(text="Task")
 
@@ -9025,14 +9099,34 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
 
 class BlockDiagramWindow(SysMLDiagramWindow):
     def __init__(self, master, app, diagram_id: str | None = None, history=None):
-        tools = [
-            "Block",
+        tools = ["Block"]
+        rel_tools = [
             "Association",
             "Generalization",
             "Aggregation",
             "Composite Aggregation",
         ]
-        super().__init__(master, "Block Diagram", tools, diagram_id, app=app, history=history)
+        try:
+            super().__init__(
+                master,
+                "Block Diagram",
+                tools,
+                diagram_id,
+                app=app,
+                history=history,
+                relation_tools=rel_tools,
+            )
+        except TypeError:
+            super().__init__(
+                master,
+                "Block Diagram",
+                tools + rel_tools,
+                diagram_id,
+                app=app,
+                history=history,
+            )
+        if not hasattr(self, "tools_frame"):
+            self.tools_frame = self.toolbox
         ttk.Button(
             self.toolbox,
             text="Add Blocks",
@@ -9146,12 +9240,29 @@ class BlockDiagramWindow(SysMLDiagramWindow):
 
 class InternalBlockDiagramWindow(SysMLDiagramWindow):
     def __init__(self, master, app, diagram_id: str | None = None, history=None):
-        tools = [
-            "Part",
-            "Port",
-            "Connector",
-        ]
-        super().__init__(master, "Internal Block Diagram", tools, diagram_id, app=app, history=history)
+        tools = ["Part", "Port"]
+        rel_tools = ["Connector"]
+        try:
+            super().__init__(
+                master,
+                "Internal Block Diagram",
+                tools,
+                diagram_id,
+                app=app,
+                history=history,
+                relation_tools=rel_tools,
+            )
+        except TypeError:
+            super().__init__(
+                master,
+                "Internal Block Diagram",
+                tools + rel_tools,
+                diagram_id,
+                app=app,
+                history=history,
+            )
+        if not hasattr(self, "tools_frame"):
+            self.tools_frame = self.toolbox
         ttk.Button(
             self.toolbox,
             text="Add Contained Parts",
@@ -9467,13 +9578,29 @@ class InternalBlockDiagramWindow(SysMLDiagramWindow):
 
 class ControlFlowDiagramWindow(SysMLDiagramWindow):
     def __init__(self, master, app, diagram_id: str | None = None, history=None):
-        tools = [
-            "Existing Element",
-            "Control Action",
-            "Feedback",
-            "STPA Analysis",
-        ]
-        super().__init__(master, "Control Flow Diagram", tools, diagram_id, app=app, history=history)
+        tools = ["Existing Element", "STPA Analysis"]
+        rel_tools = ["Control Action", "Feedback"]
+        try:
+            super().__init__(
+                master,
+                "Control Flow Diagram",
+                tools,
+                diagram_id,
+                app=app,
+                history=history,
+                relation_tools=rel_tools,
+            )
+        except TypeError:
+            super().__init__(
+                master,
+                "Control Flow Diagram",
+                tools + rel_tools,
+                diagram_id,
+                app=app,
+                history=history,
+            )
+        if not hasattr(self, "tools_frame"):
+            self.tools_frame = self.toolbox
 
     def select_tool(self, tool):
         if tool == "STPA Analysis":

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -67,7 +67,8 @@ class GSNDiagramWindow(tk.Frame):
         # toolbox with buttons to add nodes and connectors
         self.toolbox = ttk.Frame(self)
         self.toolbox.pack(side=tk.TOP, fill=tk.X)
-        btn_cmds = [
+
+        node_cmds = [
             ("Goal", self.add_goal),
             ("Strategy", self.add_strategy),
             ("Solution", self.add_solution),
@@ -75,14 +76,30 @@ class GSNDiagramWindow(tk.Frame):
             ("Justification", self.add_justification),
             ("Context", self.add_context),
             ("Module", self.add_module),
+        ]
+        node_frame = ttk.Frame(self.toolbox)
+        node_frame.pack(side=tk.TOP, fill=tk.X)
+        for name, cmd in node_cmds:
+            ttk.Button(node_frame, text=name, command=cmd).pack(side=tk.LEFT)
+
+        rel_cmds = [
             ("Solved By", self.connect_solved_by),
             ("In Context Of", self.connect_in_context),
+        ]
+        rel_frame = ttk.LabelFrame(self.toolbox, text="Relationships")
+        rel_frame.pack(side=tk.TOP, fill=tk.X)
+        for name, cmd in rel_cmds:
+            ttk.Button(rel_frame, text=name, command=cmd).pack(side=tk.LEFT)
+
+        util_cmds = [
             ("Zoom In", self.zoom_in),
             ("Zoom Out", self.zoom_out),
             ("Export CSV", self.export_csv),
         ]
-        for name, cmd in btn_cmds:
-            ttk.Button(self.toolbox, text=name, command=cmd).pack(side=tk.LEFT)
+        util_frame = ttk.Frame(self.toolbox)
+        util_frame.pack(side=tk.TOP, fill=tk.X)
+        for name, cmd in util_cmds:
+            ttk.Button(util_frame, text=name, command=cmd).pack(side=tk.LEFT)
 
         # drawing canvas with scrollbars so large diagrams remain accessible
         canvas_frame = ttk.Frame(self)


### PR DESCRIPTION
## Summary
- Add optional `relation_tools` parameter to SysML diagram window and render them in a dedicated "Relationships" toolbox section
- Separate node and relationship buttons in GSN diagram toolboxes for clearer distinction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689df3e2b4f88325a693e83f3c6a62f0