### PR TITLE
Rename Analyze relation to Used By in governance diagrams

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -650,7 +650,7 @@ class SafetyManagementToolbox:
                         id_to_name[obj.get("obj_id")] = name
             for conn in getattr(diag, "connections", []):
                 stereo = (conn.get("stereotype") or conn.get("conn_type") or "").lower()
-                if stereo == "analyze":
+                if stereo == "used by":
                     sname = id_to_name.get(conn.get("src"))
                     tname = id_to_name.get(conn.get("dst"))
                     if sname and tname:

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2944,7 +2944,7 @@ class SysMLDiagramWindow(tk.Frame):
                     "Propagate",
                     "Propagate by Review",
                     "Propagate by Approval",
-                    "Analyze",
+                    "Used By",
                     "Re-use",
                     "Trace",
                     "Satisfied by",
@@ -2981,7 +2981,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -3198,14 +3198,13 @@ class SysMLDiagramWindow(tk.Frame):
                     return False, (
                         "Requirement work products must use 'Satisfied by' or 'Derived from'"
                     )
-            elif conn_type == "Analyze":
+            elif conn_type == "Used By":
                 if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
-                    return False, "Analyze links must connect Work Products"
-                sname = src.properties.get("name")
+                    return False, "Used By links must connect Work Products"
                 dname = dst.properties.get("name")
-                if sname != "Architecture Diagram" or dname not in SAFETY_ANALYSIS_WORK_PRODUCTS:
+                if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS:
                     return False, (
-                        "Analyze links must connect an Architecture Diagram to a safety analysis work product"
+                        "Used By links must target a safety analysis work product"
                     )
             else:
                 allowed = {
@@ -3299,7 +3298,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -3452,7 +3451,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -3493,7 +3492,7 @@ class SysMLDiagramWindow(tk.Frame):
                             "Propagate",
                             "Propagate by Review",
                             "Propagate by Approval",
-                            "Analyze",
+                            "Used By",
                             "Re-use",
                             "Satisfied by",
                             "Derived from",
@@ -3779,7 +3778,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -4009,7 +4008,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -4048,7 +4047,7 @@ class SysMLDiagramWindow(tk.Frame):
                         "Propagate",
                         "Propagate by Review",
                         "Propagate by Approval",
-                        "Analyze",
+                        "Used By",
                         "Re-use",
                         "Satisfied by",
                         "Derived from",
@@ -4345,7 +4344,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
             "Re-use",
             "Trace",
             "Connector",
@@ -4371,7 +4370,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
             "Re-use",
             "Trace",
             "Connector",
@@ -8996,7 +8995,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
             "Re-use",
             "Trace",
             "Satisfied by",

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -81,7 +81,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
         GovernanceDiagramWindow.on_left_press(win, event2)
         self.assertEqual(repo.relationships[0].stereotype, "propagate")
 
-    def test_analyze_relationship_stereotype(self):
+    def test_used_by_relationship_stereotype(self):
         repo = self.repo
         e1 = repo.create_element("Block", name="E1")
         e2 = repo.create_element("Block", name="E2")
@@ -105,25 +105,46 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             properties={"name": "FTA"},
         )
         diag.objects = [o1.__dict__, o2.__dict__]
-        win = self._create_window("Analyze", o1, o2, diag)
+        win = self._create_window("Used By", o1, o2, diag)
         event1 = types.SimpleNamespace(x=0, y=0, state=0)
         GovernanceDiagramWindow.on_left_press(win, event1)
         event2 = types.SimpleNamespace(x=0, y=100, state=0)
         GovernanceDiagramWindow.on_left_press(win, event2)
-        self.assertEqual(repo.relationships[0].stereotype, "analyze")
+        self.assertEqual(repo.relationships[0].stereotype, "used by")
 
-    def test_analyze_relationship_validation(self):
+    def test_used_by_relationship_validation(self):
         repo = self.repo
         diag = repo.create_diagram("Governance Diagram", name="Gov")
         e1 = repo.create_element("Block", name="E1")
         e2 = repo.create_element("Block", name="E2")
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
         o1 = SysMLObject(
             1,
             "Work Product",
             0,
             0,
             element_id=e1.elem_id,
-            properties={"name": "HAZOP"},
+            properties={"name": "Mission Profile"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "Architecture Diagram"},
+        )
+        valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Used By")
+        self.assertFalse(valid)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Mission Profile"},
         )
         o2 = SysMLObject(
             2,
@@ -133,29 +154,8 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             element_id=e2.elem_id,
             properties={"name": "FTA"},
         )
-        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
-        win.repo = repo
-        win.diagram_id = diag.diag_id
-        valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Analyze")
-        self.assertFalse(valid)
-        o1 = SysMLObject(
-            1,
-            "Work Product",
-            0,
-            0,
-            element_id=e1.elem_id,
-            properties={"name": "Architecture Diagram"},
-        )
-        o2 = SysMLObject(
-            2,
-            "Work Product",
-            0,
-            100,
-            element_id=e2.elem_id,
-            properties={"name": "Requirement Specification"},
-        )
-        valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Analyze")
-        self.assertFalse(valid)
+        valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Used By")
+        self.assertTrue(valid)
 
     def test_analysis_targets_mapping(self):
         repo = self.repo
@@ -183,7 +183,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             properties={"name": "FTA"},
         )
         diag.objects = [o1.__dict__, o2.__dict__]
-        win = self._create_window("Analyze", o1, o2, diag)
+        win = self._create_window("Used By", o1, o2, diag)
         event1 = types.SimpleNamespace(x=0, y=0, state=0)
         GovernanceDiagramWindow.on_left_press(win, event1)
         event2 = types.SimpleNamespace(x=0, y=100, state=0)


### PR DESCRIPTION
## Summary
- Rename Analyze relationship to Used By for governance diagrams
- Allow any work product to be marked as input to safety analyses via Used By links
- Update governance tests to cover new Used By relationship

## Testing
- `PYTHONPATH=. pytest tests/test_governance_relationship_stereotype.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689dfe5897cc832598299830aec2807d