### PR TITLE
Restrict safety analysis inputs to governed relations

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -776,7 +776,8 @@ class SafetyManagementToolbox:
         product which in turn is "Used By" an analysis then that analysis is
         considered a valid target for ``source`` as well.  "Used after Review"
         and "Used after Approval" relations only become visible when the
-        corresponding state flag is provided.
+        corresponding state flag is provided. Only analysis types listed in
+        :data:`SAFETY_ANALYSIS_WORK_PRODUCTS` are returned.
         """
         analyses = self._analysis_mapping()
         traces = self._trace_mapping()
@@ -801,7 +802,7 @@ class SafetyManagementToolbox:
                 targets |= rels.get("used after review", set())
             if approved:
                 targets |= rels.get("used after approval", set())
-        return targets
+        return {t for t in targets if t in SAFETY_ANALYSIS_WORK_PRODUCTS}
 
     # ------------------------------------------------------------------
     def analysis_inputs(
@@ -809,13 +810,16 @@ class SafetyManagementToolbox:
     ) -> set[str]:
         """Return work products that may serve as input to ``target`` analysis.
 
-        Any work product that traces to another work product with a direct
-        relationship to ``target`` is also considered an input.  Visibility of
-        "Used after Review" and "Used after Approval" relations depends on the
+        Only analyses defined in :data:`SAFETY_ANALYSIS_WORK_PRODUCTS` are
+        considered. Any work product that traces to another work product with a
+        direct relationship to ``target`` is also considered an input.  Visibility
+        of "Used after Review" and "Used after Approval" relations depends on the
         provided state flags.
         """
         analyses = self._analysis_mapping()
         traces = self._trace_mapping()
+        if target not in SAFETY_ANALYSIS_WORK_PRODUCTS:
+            return set()
 
         direct: set[str] = set()
         for src, rels in analyses.items():


### PR DESCRIPTION
## Summary
- Filter analysis targets and inputs to only show safety analyses defined in governance
- Add tests ensuring analysis inputs stay hidden until a governance relationship exists

## Testing
- `PYTHONPATH=. pytest tests/test_governance_relationship_stereotype.py`

------
https://chatgpt.com/codex/tasks/task_b_689e1a7ca3e88325be351d12cc8d58ec