### PR TITLE
Filter risk assessment inputs by governance

### DIFF
--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -35,7 +35,7 @@ from analysis.models import (
     CAL_TABLE,
     REQUIREMENT_WORK_PRODUCTS,
 )
-from analysis.safety_management import ACTIVE_TOOLBOX
+from analysis.safety_management import ACTIVE_TOOLBOX, SAFETY_ANALYSIS_WORK_PRODUCTS
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.constants import CHECK_MARK, CROSS_MARK
 from gui.architecture import (
@@ -2424,19 +2424,25 @@ class RiskAssessmentWindow(tk.Frame):
             self.name_var = tk.StringVar()
             ttk.Entry(master, textvariable=self.name_var).grid(row=0, column=1)
             ttk.Label(master, text="HAZOPs").grid(row=1, column=0, sticky="e")
-            names = [d.name for d in self.app.hazop_docs]
+            toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+            allowed = (
+                toolbox.analysis_inputs("Risk Assessment")
+                if toolbox
+                else SAFETY_ANALYSIS_WORK_PRODUCTS
+            )
+            names = [d.name for d in self.app.hazop_docs] if "HAZOP" in allowed else []
             self.hazop_var = tk.StringVar()
             ttk.Combobox(
                 master, textvariable=self.hazop_var, values=names, state="readonly"
             ).grid(row=1, column=1)
             ttk.Label(master, text="STPA").grid(row=2, column=0, sticky="e")
-            stpas = [d.name for d in self.app.stpa_docs]
+            stpas = [d.name for d in self.app.stpa_docs] if "STPA" in allowed else []
             self.stpa_var = tk.StringVar()
             ttk.Combobox(
                 master, textvariable=self.stpa_var, values=stpas, state="readonly"
             ).grid(row=2, column=1)
             ttk.Label(master, text="Threat Analysis").grid(row=3, column=0, sticky="e")
-            threats = [d.name for d in self.app.threat_docs]
+            threats = [d.name for d in self.app.threat_docs] if "Threat Analysis" in allowed else []
             self.threat_var = tk.StringVar()
             ttk.Combobox(
                 master, textvariable=self.threat_var, values=threats, state="readonly"
@@ -2460,20 +2466,26 @@ class RiskAssessmentWindow(tk.Frame):
 
         def body(self, master):
             ttk.Label(master, text="HAZOPs").grid(row=0, column=0, sticky="e")
-            names = [d.name for d in self.app.hazop_docs]
+            toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+            allowed = (
+                toolbox.analysis_inputs("Risk Assessment")
+                if toolbox
+                else SAFETY_ANALYSIS_WORK_PRODUCTS
+            )
+            names = [d.name for d in self.app.hazop_docs] if "HAZOP" in allowed else []
             current = self.doc.hazops[0] if self.doc.hazops else ""
             self.hazop_var = tk.StringVar(value=current)
             ttk.Combobox(
                 master, textvariable=self.hazop_var, values=names, state="readonly"
             ).grid(row=0, column=1)
             ttk.Label(master, text="STPA").grid(row=1, column=0, sticky="e")
-            stpas = [d.name for d in self.app.stpa_docs]
+            stpas = [d.name for d in self.app.stpa_docs] if "STPA" in allowed else []
             self.stpa_var = tk.StringVar(value=getattr(self.doc, "stpa", ""))
             ttk.Combobox(
                 master, textvariable=self.stpa_var, values=stpas, state="readonly"
             ).grid(row=1, column=1)
             ttk.Label(master, text="Threat Analysis").grid(row=2, column=0, sticky="e")
-            threats = [d.name for d in self.app.threat_docs]
+            threats = [d.name for d in self.app.threat_docs] if "Threat Analysis" in allowed else []
             self.threat_var = tk.StringVar(value=getattr(self.doc, "threat", ""))
             ttk.Combobox(
                 master, textvariable=self.threat_var, values=threats, state="readonly"

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -192,7 +192,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             0,
             0,
             element_id=e1.elem_id,
-            properties={"name": "Architecture Diagram"},
+            properties={"name": "Risk Assessment"},
         )
         o2 = SysMLObject(
             2,
@@ -200,7 +200,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             0,
             100,
             element_id=e2.elem_id,
-            properties={"name": "FTA"},
+            properties={"name": "Architecture Diagram"},
         )
         diag.objects = [o1.__dict__, o2.__dict__]
         for rel in ["Used By", "Used after Review", "Used after Approval"]:

--- a/tests/test_risk_assessment_governance.py
+++ b/tests/test_risk_assessment_governance.py
@@ -1,0 +1,66 @@
+import types
+from gui.toolboxes import RiskAssessmentWindow
+
+
+def test_risk_assessment_dialog_hides_unrelated_inputs(monkeypatch):
+    """Only work products allowed by governance appear in risk assessment dialogs."""
+
+    # Allow only HAZOP as input to risk assessments
+    toolbox = types.SimpleNamespace(analysis_inputs=lambda target: {"HAZOP"})
+    app = types.SimpleNamespace(
+        hazop_docs=[types.SimpleNamespace(name="HZ1")],
+        stpa_docs=[types.SimpleNamespace(name="STPA1")],
+        threat_docs=[types.SimpleNamespace(name="TA1")],
+        safety_mgmt_toolbox=toolbox,
+    )
+
+    class DummyWidget:
+        def grid(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+    combos = []
+
+    class DummyCombobox(DummyWidget):
+        def __init__(self, *a, textvariable=None, values=None, state=None, **k):
+            self.textvariable = textvariable
+            self.configured = {"values": values}
+            combos.append(self)
+
+        def configure(self, **k):
+            self.configured.update(k)
+
+    monkeypatch.setattr("gui.toolboxes.ttk.Combobox", DummyCombobox)
+    monkeypatch.setattr("gui.toolboxes.ttk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.toolboxes.ttk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr(
+        "gui.toolboxes.tk.StringVar",
+        lambda value="": types.SimpleNamespace(get=lambda: value, set=lambda v: None),
+    )
+
+    # New assessment dialog filtering
+    dlg = RiskAssessmentWindow.NewAssessmentDialog.__new__(
+        RiskAssessmentWindow.NewAssessmentDialog
+    )
+    dlg.app = app
+    dlg.body(master=DummyWidget())
+    hazop_vals, stpa_vals, threat_vals = [cb.configured["values"] for cb in combos]
+    assert hazop_vals == ["HZ1"]
+    assert stpa_vals == []
+    assert threat_vals == []
+
+    # Edit assessment dialog filtering
+    combos.clear()
+    doc = types.SimpleNamespace(hazops=["HZ1"], stpa="", threat="")
+    dlg2 = RiskAssessmentWindow.EditAssessmentDialog.__new__(
+        RiskAssessmentWindow.EditAssessmentDialog
+    )
+    dlg2.app = app
+    dlg2.doc = doc
+    dlg2.body(master=DummyWidget())
+    hazop_vals, stpa_vals, threat_vals = [cb.configured["values"] for cb in combos]
+    assert hazop_vals == ["HZ1"]
+    assert stpa_vals == []
+    assert threat_vals == []


### PR DESCRIPTION
## Summary
- hide ungoverned HAZOP, STPA and threat analysis options in risk assessment dialogs
- fix used-by relationship test to target non-analysis work products
- add test ensuring risk assessment dialogs respect governance inputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e1a7ca3e88325be351d12cc8d58ec