### PR TITLE
Disallow analysis-to-analysis links in governance

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3202,6 +3202,13 @@ class SysMLDiagramWindow(tk.Frame):
                     return False, (
                         "Requirement work products must use 'Satisfied by' or 'Derived from'"
                     )
+                if (
+                    sname in SAFETY_ANALYSIS_WORK_PRODUCTS
+                    and dname in SAFETY_ANALYSIS_WORK_PRODUCTS
+                ):
+                    return False, (
+                        "Safety analysis work products cannot trace to other safety analyses"
+                    )
             elif conn_type in (
                 "Used By",
                 "Used after Review",
@@ -3209,10 +3216,15 @@ class SysMLDiagramWindow(tk.Frame):
             ):
                 if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
                     return False, f"{conn_type} links must connect Work Products"
+                sname = src.properties.get("name")
                 dname = dst.properties.get("name")
                 if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS:
                     return False, (
                         f"{conn_type} links must target a safety analysis work product",
+                    )
+                if sname in SAFETY_ANALYSIS_WORK_PRODUCTS:
+                    return False, (
+                        f"{conn_type} links cannot originate from a safety analysis work product",
                     )
             else:
                 allowed = {

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -228,7 +228,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
                 0,
                 0,
                 element_id=e1.elem_id,
-                properties={"name": "Mission Profile"},
+                properties={"name": "Architecture Diagram"},
             )
             o2 = SysMLObject(
                 2,
@@ -250,6 +250,34 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             )
             valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, rel)
             self.assertTrue(valid)
+
+    def test_used_relationships_disallow_analysis_sources(self):
+        repo = self.repo
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "FMEA"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        for rel in ["Used By", "Used after Review", "Used after Approval"]:
+            valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, rel)
+            self.assertFalse(valid)
 
     def test_analysis_targets_used_after_review_visibility(self):
         repo = self.repo

--- a/tests/test_governance_trace_relationship.py
+++ b/tests/test_governance_trace_relationship.py
@@ -119,6 +119,34 @@ class GovernanceTraceRelationshipTests(unittest.TestCase):
         self.assertFalse(valid)
         self.assertIn("Requirement work products", msg)
 
+    def test_trace_between_safety_analyses_disallowed(self):
+        repo = self.repo
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "FMEA"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        valid, msg = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Trace")
+        self.assertFalse(valid)
+        self.assertIn("Safety analysis", msg)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- prevent trace relationships between safety analyses
- block used-by links from originating from safety analyses
- add regression tests for governance link validation

## Testing
- `PYTHONPATH=$PWD pytest tests/test_governance_relationship_stereotype.py tests/test_governance_trace_relationship.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e1e5265948325b13f88917fe5b1a2