### PR TITLE
Disallow cross-links between safety analyses

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3202,6 +3202,13 @@ class SysMLDiagramWindow(tk.Frame):
                     return False, (
                         "Requirement work products must use 'Satisfied by' or 'Derived from'"
                     )
+                if (
+                    sname in SAFETY_ANALYSIS_WORK_PRODUCTS
+                    and dname in SAFETY_ANALYSIS_WORK_PRODUCTS
+                ):
+                    return False, (
+                        "Trace links cannot connect two safety analysis work products"
+                    )
             elif conn_type in (
                 "Used By",
                 "Used after Review",
@@ -3209,10 +3216,15 @@ class SysMLDiagramWindow(tk.Frame):
             ):
                 if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
                     return False, f"{conn_type} links must connect Work Products"
+                sname = src.properties.get("name")
                 dname = dst.properties.get("name")
                 if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS:
                     return False, (
                         f"{conn_type} links must target a safety analysis work product",
+                    )
+                if sname in SAFETY_ANALYSIS_WORK_PRODUCTS:
+                    return False, (
+                        f"{conn_type} links cannot connect two safety analysis work products"
                     )
             else:
                 allowed = {

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -32,6 +32,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
     def tearDown(self):
         from gui import architecture
         architecture.ConnectionDialog = self._orig_conn_dialog
+        SysMLRepository.reset_instance()
 
     def _create_window(self, tool, src, dst, diag):
         win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
@@ -248,8 +249,9 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
                 element_id=e2.elem_id,
                 properties={"name": "FTA"},
             )
-            valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, rel)
-            self.assertTrue(valid)
+            valid, msg = GovernanceDiagramWindow.validate_connection(win, o1, o2, rel)
+            self.assertFalse(valid)
+            self.assertIn("safety analysis", msg)
 
     def test_analysis_targets_used_after_review_visibility(self):
         repo = self.repo

--- a/tests/test_governance_trace_relationship.py
+++ b/tests/test_governance_trace_relationship.py
@@ -28,6 +28,7 @@ class GovernanceTraceRelationshipTests(unittest.TestCase):
         from gui import architecture
 
         architecture.ConnectionDialog = self._orig_conn_dialog
+        SysMLRepository.reset_instance()
 
     def _create_window(self, src, dst, diag):
         win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
@@ -118,6 +119,62 @@ class GovernanceTraceRelationshipTests(unittest.TestCase):
         valid, msg = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Trace")
         self.assertFalse(valid)
         self.assertIn("Requirement work products", msg)
+
+    def test_trace_between_safety_analyses_disallowed(self):
+        repo = self.repo
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "FMEA"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        valid, msg = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Trace")
+        self.assertFalse(valid)
+        self.assertIn("safety analysis", msg)
+
+    def test_used_by_between_safety_analyses_disallowed(self):
+        repo = self.repo
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "FMEA"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        valid, msg = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Used By")
+        self.assertFalse(valid)
+        self.assertIn("safety analysis", msg)
 
 
 if __name__ == "__main__":

--- a/tests/test_gsn_solution_work_product_clone.py
+++ b/tests/test_gsn_solution_work_product_clone.py
@@ -3,6 +3,7 @@ import math
 from gsn import GSNNode, GSNDiagram
 from gui.gsn_config_window import GSNElementConfig, _collect_work_products
 from analysis import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
 
 
 class DummyVar:
@@ -144,6 +145,7 @@ def test_collect_work_products_returns_unique_sorted():
 
 
 def test_collect_work_products_includes_toolbox_entries():
+    SysMLRepository.reset_instance()
     root = GSNNode("Root", "Goal")
     diag = GSNDiagram(root)
     toolbox = SafetyManagementToolbox()
@@ -406,7 +408,7 @@ def test_config_dialog_lists_project_spis(monkeypatch):
 
 def test_config_dialog_lists_toolbox_work_products(monkeypatch):
     """Work product combo should list toolbox entries."""
-
+    SysMLRepository.reset_instance()
     root = GSNNode("Root", "Goal")
     diag = GSNDiagram(root)
     node = GSNNode("New", "Solution")


### PR DESCRIPTION
## Summary
- prevent Trace and Used By links from connecting two safety analysis work products
- add tests covering invalid safety analysis relationships and clean up repository state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e1e5265948325b13f88917fe5b1a2