### PR TITLE
Rename Analyze relation to Used By in governance diagrams

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -42,14 +42,17 @@ ALLOWED_PROPAGATIONS: set[tuple[str, str]] = {
     ("FTA", "Product Goal Specification"),
 }
 
-# Work products considered safety analyses which may consume Architecture Diagrams
+# Work products that support governed inputs from other work products
 SAFETY_ANALYSIS_WORK_PRODUCTS: set[str] = {
     "HAZOP",
+    "HARA",
     "STPA",
     "Threat Analysis",
+    "Cyber Risk Assessment",
     "FI2TC",
     "TC2FI",
     "Risk Assessment",
+    "Mission Profile",
     "FMEA",
     "FMEDA",
     "FTA",
@@ -376,19 +379,13 @@ class SafetyManagementToolbox:
 
     # ------------------------------------------------------------------
     def enabled_products(self) -> set[str]:
-        """Return the set of analysis names enabled for the active phase."""
-        all_products = {wp.analysis for wp in self.work_products}
-        if not self.modules:
-            return all_products
-        if not self.active_module:
-            return set()
-        diagrams = self.diagrams_in_module(self.active_module)
-        reuse = self._reuse_map().get(self.active_module, {})
-        for phase in reuse.get("phases", set()):
-            diagrams.update(self.diagrams_in_module(phase))
-        enabled = {wp.analysis for wp in self.work_products if wp.diagram in diagrams}
-        enabled.update(reuse.get("work_products", set()))
-        return enabled
+        """Return the set of analysis names declared in any governance diagram."""
+        # Historically only work products from the active lifecycle phase were
+        # returned here which meant analyses defined in other phases stayed
+        # hidden from the UI.  The user request requires analyses such as
+        # FI2TC to be available regardless of the active phase so the list now
+        # aggregates all declared work products across every module.
+        return {wp.analysis for wp in self.work_products}
 
     # ------------------------------------------------------------------
     def is_enabled(self, analysis: str) -> bool:
@@ -536,10 +533,10 @@ class SafetyManagementToolbox:
         types. ``None`` is returned when no such link exists."""
 
         repo = SysMLRepository.get_instance()
-        diag_ids = self.diagrams.values()
-        if self.active_module:
-            names = self.diagrams_in_module(self.active_module)
-            diag_ids = [self.diagrams.get(n) for n in names if self.diagrams.get(n)]
+        # Consider traces across all governance diagrams regardless of the
+        # active module so relationships defined in earlier phases still
+        # propagate to later analyses.
+        diag_ids = list(self.diagrams.values())
         for diag_id in diag_ids:
             diag = repo.diagrams.get(diag_id)
             if not diag:
@@ -600,10 +597,10 @@ class SafetyManagementToolbox:
     def _trace_mapping(self) -> Dict[str, set[str]]:
         """Return mapping of work product name to traceable targets."""
         repo = SysMLRepository.get_instance()
-        diag_ids = self.diagrams.values()
-        if self.active_module:
-            names = self.diagrams_in_module(self.active_module)
-            diag_ids = [self.diagrams.get(n) for n in names if self.diagrams.get(n)]
+        # Use all known governance diagrams; restricting to the active module
+        # prevents cross-phase links (e.g. Prototype traces feeding Series
+        # Development analyses) from being honoured.
+        diag_ids = list(self.diagrams.values())
         mapping: Dict[str, set[str]] = {}
         for diag_id in diag_ids:
             if not repo.diagram_visible(diag_id):
@@ -628,14 +625,13 @@ class SafetyManagementToolbox:
         return mapping
 
     # ------------------------------------------------------------------
-    def _analysis_mapping(self) -> Dict[str, set[str]]:
-        """Return mapping of work product name to allowed analysis targets."""
+    def _analysis_mapping(self) -> Dict[str, Dict[str, set[str]]]:
+        """Return mapping of work product name to analysis targets by relation."""
         repo = SysMLRepository.get_instance()
-        diag_ids = self.diagrams.values()
-        if self.active_module:
-            names = self.diagrams_in_module(self.active_module)
-            diag_ids = [self.diagrams.get(n) for n in names if self.diagrams.get(n)]
-        mapping: Dict[str, set[str]] = {}
+        # Analyse all governance diagrams; limiting to the active module would
+        # hide relationships defined in other lifecycle phases.
+        diag_ids = list(self.diagrams.values())
+        mapping: Dict[str, Dict[str, set[str]]] = {}
         for diag_id in diag_ids:
             if not repo.diagram_visible(diag_id):
                 continue
@@ -650,11 +646,11 @@ class SafetyManagementToolbox:
                         id_to_name[obj.get("obj_id")] = name
             for conn in getattr(diag, "connections", []):
                 stereo = (conn.get("stereotype") or conn.get("conn_type") or "").lower()
-                if stereo == "analyze":
+                if stereo in {"used by", "used after review", "used after approval"}:
                     sname = id_to_name.get(conn.get("src"))
                     tname = id_to_name.get(conn.get("dst"))
                     if sname and tname:
-                        mapping.setdefault(sname, set()).add(tname)
+                        mapping.setdefault(sname, {}).setdefault(stereo, set()).add(tname)
         return mapping
 
     # ------------------------------------------------------------------
@@ -765,10 +761,123 @@ class SafetyManagementToolbox:
         return set(traces.get(wp, set()))
 
     # ------------------------------------------------------------------
-    def analysis_targets(self, source: str) -> set[str]:
-        """Return allowed analysis targets for ``source`` work product."""
+    def analysis_targets(
+        self, source: str, *, reviewed: bool = False, approved: bool = False
+    ) -> set[str]:
+        """Return allowed analysis targets for ``source`` work product.
+
+        Traces are followed transitively so if ``source`` traces to another work
+        product which in turn is "Used By" an analysis then that analysis is
+        considered a valid target for ``source`` as well.  "Used after Review"
+        and "Used after Approval" relations only become visible when the
+        corresponding state flag is provided.
+        """
         analyses = self._analysis_mapping()
-        return set(analyses.get(source, set()))
+        traces = self._trace_mapping()
+
+        # Discover all work products reachable from ``source`` via trace links
+        seen: set[str] = set()
+        queue = [source]
+        reachable: set[str] = set()
+        while queue:
+            cur = queue.pop(0)
+            if cur in seen:
+                continue
+            seen.add(cur)
+            reachable.add(cur)
+            queue.extend(traces.get(cur, set()) - seen)
+
+        targets: set[str] = set()
+        for src in reachable:
+            rels = analyses.get(src, {})
+            targets |= rels.get("used by", set())
+            if reviewed or approved:
+                targets |= rels.get("used after review", set())
+            if approved:
+                targets |= rels.get("used after approval", set())
+        return targets
+
+    # ------------------------------------------------------------------
+    def analysis_inputs(
+        self, target: str, *, reviewed: bool = False, approved: bool = False
+    ) -> set[str]:
+        """Return work products that may serve as input to ``target`` analysis.
+
+        Any work product that traces to another work product with a direct
+        relationship to ``target`` is also considered an input.  Visibility of
+        "Used after Review" and "Used after Approval" relations depends on the
+        provided state flags.
+        """
+        analyses = self._analysis_mapping()
+        traces = self._trace_mapping()
+
+        direct: set[str] = set()
+        for src, rels in analyses.items():
+            if target in rels.get("used by", set()):
+                direct.add(src)
+            if target in rels.get("used after review", set()) and (reviewed or approved):
+                direct.add(src)
+            if target in rels.get("used after approval", set()) and approved:
+                direct.add(src)
+
+        sources = set(direct)
+        queue = list(direct)
+        while queue:
+            cur = queue.pop(0)
+            for neigh in traces.get(cur, set()):
+                if neigh not in sources:
+                    sources.add(neigh)
+                    queue.append(neigh)
+        return sources
+
+    # ------------------------------------------------------------------
+    def analysis_usage_type(self, source: str, target: str) -> Optional[str]:
+        """Return the relationship type for using ``source`` as input to ``target``.
+
+        Direct connections are checked first. If none are found, trace links are
+        followed transitively to locate an intermediate work product connected to
+        ``target``.
+        """
+        analyses = self._analysis_mapping()
+        traces = self._trace_mapping()
+
+        visited: set[str] = set()
+        queue = [source]
+        mapping = {
+            "used by": "Used By",
+            "used after review": "Used after Review",
+            "used after approval": "Used after Approval",
+        }
+        while queue:
+            cur = queue.pop(0)
+            if cur in visited:
+                continue
+            visited.add(cur)
+            rels = analyses.get(cur, {})
+            for key, human in mapping.items():
+                if target in rels.get(key, set()):
+                    return human
+            queue.extend(traces.get(cur, set()) - visited)
+        return None
+
+    # ------------------------------------------------------------------
+    def can_use_as_input(
+        self,
+        source: str,
+        target: str,
+        *,
+        reviewed: bool = False,
+        approved: bool = False,
+    ) -> bool:
+        """Return ``True`` if ``source`` may be used as input to ``target``."""
+        rel = self.analysis_usage_type(source, target)
+        if rel == "Used By":
+            return True
+        if rel == "Used after Review":
+            return reviewed or approved
+        if rel == "Used after Approval":
+            return approved
+        return False
 
     # ------------------------------------------------------------------
     def requirement_diagram_targets(self, req_type: str) -> set[str]:
@@ -795,7 +904,11 @@ class SafetyManagementToolbox:
         products: List[SafetyWorkProduct] = []
         for wp in self.work_products:
             wp.traceable = sorted(traces.get(wp.analysis, set()))
-            wp.analyzable = sorted(analyses.get(wp.analysis, set()))
+            rels = analyses.get(wp.analysis, {})
+            combined: set[str] = set()
+            for vals in rels.values():
+                combined |= vals
+            wp.analyzable = sorted(combined)
             products.append(wp)
         return products
 

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2944,7 +2944,9 @@ class SysMLDiagramWindow(tk.Frame):
                     "Propagate",
                     "Propagate by Review",
                     "Propagate by Approval",
-                    "Analyze",
+                    "Used By",
+                    "Used after Review",
+                    "Used after Approval",
                     "Re-use",
                     "Trace",
                     "Satisfied by",
@@ -2981,7 +2983,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
+            "Used after Review",
+            "Used after Approval",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -3198,14 +3202,17 @@ class SysMLDiagramWindow(tk.Frame):
                     return False, (
                         "Requirement work products must use 'Satisfied by' or 'Derived from'"
                     )
-            elif conn_type == "Analyze":
+            elif conn_type in (
+                "Used By",
+                "Used after Review",
+                "Used after Approval",
+            ):
                 if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
-                    return False, "Analyze links must connect Work Products"
-                sname = src.properties.get("name")
+                    return False, f"{conn_type} links must connect Work Products"
                 dname = dst.properties.get("name")
-                if sname != "Architecture Diagram" or dname not in SAFETY_ANALYSIS_WORK_PRODUCTS:
+                if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS:
                     return False, (
-                        "Analyze links must connect an Architecture Diagram to a safety analysis work product"
+                        f"{conn_type} links must target a safety analysis work product",
                     )
             else:
                 allowed = {
@@ -3299,7 +3306,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
+            "Used after Review",
+            "Used after Approval",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -3452,7 +3461,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
+            "Used after Review",
+            "Used after Approval",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -3493,7 +3504,9 @@ class SysMLDiagramWindow(tk.Frame):
                             "Propagate",
                             "Propagate by Review",
                             "Propagate by Approval",
-                            "Analyze",
+                            "Used By",
+                            "Used after Review",
+                            "Used after Approval",
                             "Re-use",
                             "Satisfied by",
                             "Derived from",
@@ -3779,7 +3792,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
+            "Used after Review",
+            "Used after Approval",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -4009,7 +4024,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
+            "Used after Review",
+            "Used after Approval",
             "Re-use",
             "Trace",
             "Satisfied by",
@@ -4048,7 +4065,9 @@ class SysMLDiagramWindow(tk.Frame):
                         "Propagate",
                         "Propagate by Review",
                         "Propagate by Approval",
-                        "Analyze",
+                        "Used By",
+                        "Used after Review",
+                        "Used after Approval",
                         "Re-use",
                         "Satisfied by",
                         "Derived from",
@@ -4345,7 +4364,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
+            "Used after Review",
+            "Used after Approval",
             "Re-use",
             "Trace",
             "Connector",
@@ -4371,7 +4392,9 @@ class SysMLDiagramWindow(tk.Frame):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
+            "Used after Review",
+            "Used after Approval",
             "Re-use",
             "Trace",
             "Connector",
@@ -8996,7 +9019,9 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
-            "Analyze",
+            "Used By",
+            "Used after Review",
+            "Used after Approval",
             "Re-use",
             "Trace",
             "Satisfied by",

--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -299,6 +299,14 @@ class StpaWindow(tk.Frame):
         """Return labels of control action connections for the selected diagram."""
 
         repo = SysMLRepository.get_instance()
+        toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+        review = getattr(self.app, "current_review", None)
+        reviewed = getattr(review, "reviewed", False)
+        approved = getattr(review, "approved", False)
+        if toolbox and "Architecture Diagram" not in toolbox.analysis_inputs(
+            "STPA", reviewed=reviewed, approved=approved
+        ):
+            return []
         diag_id = getattr(getattr(self.app, "active_stpa", None), "diagram", "")
         diagram = repo.diagrams.get(diag_id)
         if not diagram or diagram.diag_type != "Control Flow Diagram":

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -2,8 +2,16 @@ import types
 import unittest
 
 from gui.architecture import GovernanceDiagramWindow, SysMLObject
+from gui.toolboxes import allowed_action_labels
+from gui.stpa_window import StpaWindow
+from gui.review_toolbox import ReviewData
+from analysis.models import StpaDoc
 from sysml.sysml_repository import SysMLRepository
-from analysis.safety_management import SafetyManagementToolbox, SafetyWorkProduct
+from analysis.safety_management import (
+    SafetyManagementToolbox,
+    SafetyWorkProduct,
+    SAFETY_ANALYSIS_WORK_PRODUCTS,
+)
 
 
 class DummyCanvas:
@@ -81,7 +89,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
         GovernanceDiagramWindow.on_left_press(win, event2)
         self.assertEqual(repo.relationships[0].stereotype, "propagate")
 
-    def test_analyze_relationship_stereotype(self):
+    def test_used_by_relationship_stereotype(self):
         repo = self.repo
         e1 = repo.create_element("Block", name="E1")
         e2 = repo.create_element("Block", name="E2")
@@ -105,25 +113,27 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             properties={"name": "FTA"},
         )
         diag.objects = [o1.__dict__, o2.__dict__]
-        win = self._create_window("Analyze", o1, o2, diag)
+        win = self._create_window("Used By", o1, o2, diag)
         event1 = types.SimpleNamespace(x=0, y=0, state=0)
         GovernanceDiagramWindow.on_left_press(win, event1)
         event2 = types.SimpleNamespace(x=0, y=100, state=0)
         GovernanceDiagramWindow.on_left_press(win, event2)
-        self.assertEqual(repo.relationships[0].stereotype, "analyze")
+        self.assertEqual(repo.relationships[0].stereotype, "used by")
 
-    def test_analyze_relationship_validation(self):
+    def test_used_after_review_relationship_stereotype(self):
         repo = self.repo
-        diag = repo.create_diagram("Governance Diagram", name="Gov")
         e1 = repo.create_element("Block", name="E1")
         e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
         o1 = SysMLObject(
             1,
             "Work Product",
             0,
             0,
             element_id=e1.elem_id,
-            properties={"name": "HAZOP"},
+            properties={"name": "Architecture Diagram"},
         )
         o2 = SysMLObject(
             2,
@@ -133,11 +143,52 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             element_id=e2.elem_id,
             properties={"name": "FTA"},
         )
-        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
-        win.repo = repo
-        win.diagram_id = diag.diag_id
-        valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Analyze")
-        self.assertFalse(valid)
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Used after Review", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        self.assertEqual(repo.relationships[0].stereotype, "used after review")
+
+    def test_used_after_approval_relationship_stereotype(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Architecture Diagram"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Used after Approval", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        self.assertEqual(repo.relationships[0].stereotype, "used after approval")
+
+    def test_used_relations_reject_non_analysis_targets(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
         o1 = SysMLObject(
             1,
             "Work Product",
@@ -154,8 +205,54 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             element_id=e2.elem_id,
             properties={"name": "Requirement Specification"},
         )
-        valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, "Analyze")
-        self.assertFalse(valid)
+        diag.objects = [o1.__dict__, o2.__dict__]
+        for rel in ["Used By", "Used after Review", "Used after Approval"]:
+            repo.relationships.clear()
+            win = self._create_window(rel, o1, o2, diag)
+            event1 = types.SimpleNamespace(x=0, y=0, state=0)
+            GovernanceDiagramWindow.on_left_press(win, event1)
+            event2 = types.SimpleNamespace(x=0, y=100, state=0)
+            GovernanceDiagramWindow.on_left_press(win, event2)
+            self.assertEqual(repo.relationships, [])
+
+    def test_used_relationship_validation(self):
+        repo = self.repo
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        rels = ["Used By", "Used after Review", "Used after Approval"]
+        for rel in rels:
+            o1 = SysMLObject(
+                1,
+                "Work Product",
+                0,
+                0,
+                element_id=e1.elem_id,
+                properties={"name": "Mission Profile"},
+            )
+            o2 = SysMLObject(
+                2,
+                "Work Product",
+                0,
+                100,
+                element_id=e2.elem_id,
+                properties={"name": "Architecture Diagram"},
+            )
+            valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, rel)
+            self.assertFalse(valid)
+            o2 = SysMLObject(
+                2,
+                "Work Product",
+                0,
+                100,
+                element_id=e2.elem_id,
+                properties={"name": "FTA"},
+            )
+            valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, rel)
+            self.assertTrue(valid)
 
     def test_analysis_targets_mapping(self):
         repo = self.repo
@@ -183,7 +280,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             properties={"name": "FTA"},
         )
         diag.objects = [o1.__dict__, o2.__dict__]
-        win = self._create_window("Analyze", o1, o2, diag)
+        win = self._create_window("Used By", o1, o2, diag)
         event1 = types.SimpleNamespace(x=0, y=0, state=0)
         GovernanceDiagramWindow.on_left_press(win, event1)
         event2 = types.SimpleNamespace(x=0, y=100, state=0)
@@ -195,6 +292,463 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
         ]
         targets = toolbox.analysis_targets("Architecture Diagram")
         self.assertEqual(targets, {"FTA"})
+
+    def test_analysis_targets_used_after_review_visibility(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Architecture Diagram"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Used after Review", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        diag.connections = [c.__dict__ for c in win.connections]
+        toolbox.work_products = [
+            SafetyWorkProduct("Gov", "Architecture Diagram", ""),
+            SafetyWorkProduct("Gov", "FTA", ""),
+        ]
+        self.assertEqual(toolbox.analysis_targets("Architecture Diagram"), set())
+        self.assertEqual(
+            toolbox.analysis_targets("Architecture Diagram", reviewed=True), {"FTA"}
+        )
+        self.assertEqual(
+            toolbox.analysis_targets("Architecture Diagram", approved=True), {"FTA"}
+        )
+
+    def test_analysis_targets_used_after_approval_visibility(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Architecture Diagram"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Used after Approval", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        diag.connections = [c.__dict__ for c in win.connections]
+        toolbox.work_products = [
+            SafetyWorkProduct("Gov", "Architecture Diagram", ""),
+            SafetyWorkProduct("Gov", "FTA", ""),
+        ]
+        self.assertEqual(toolbox.analysis_targets("Architecture Diagram"), set())
+        self.assertEqual(
+            toolbox.analysis_targets("Architecture Diagram", reviewed=True), set()
+        )
+        self.assertEqual(
+            toolbox.analysis_targets("Architecture Diagram", approved=True), {"FTA"}
+        )
+
+    def test_analysis_inputs_mapping(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Architecture Diagram"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Used By", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        diag.connections = [c.__dict__ for c in win.connections]
+        toolbox.work_products = [
+            SafetyWorkProduct("Gov", "Architecture Diagram", ""),
+            SafetyWorkProduct("Gov", "FTA", ""),
+        ]
+        self.assertEqual(toolbox.analysis_inputs("FTA"), {"Architecture Diagram"})
+
+    def test_analysis_inputs_trace_propagation(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        e3 = repo.create_element("Block", name="E3")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e3.elem_id)
+        o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "Architecture Diagram"})
+        o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Requirement Specification"})
+        o3 = SysMLObject(3, "Work Product", 0, 200, element_id=e3.elem_id, properties={"name": "HAZOP"})
+        diag.objects = [o1.__dict__, o2.__dict__, o3.__dict__]
+
+        # Trace from Architecture Diagram to Requirement Specification
+        win = self._create_window("Trace", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        trace_conn = win.connections[0]
+
+        # Used By from Requirement Specification to HAZOP
+        win2 = self._create_window("Used By", o2, o3, diag)
+        event3 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win2, event3)
+        event4 = types.SimpleNamespace(x=0, y=200, state=0)
+        GovernanceDiagramWindow.on_left_press(win2, event4)
+        diag.connections = [trace_conn.__dict__, *[c.__dict__ for c in win2.connections]]
+
+        toolbox.work_products = [
+            SafetyWorkProduct("Gov", "Architecture Diagram", ""),
+            SafetyWorkProduct("Gov", "Requirement Specification", ""),
+            SafetyWorkProduct("Gov", "HAZOP", ""),
+        ]
+        self.assertEqual(
+            toolbox.analysis_inputs("HAZOP"),
+            {"Architecture Diagram", "Requirement Specification"},
+        )
+
+    def test_analysis_inputs_cross_module(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        # Two diagrams in different lifecycle modules
+        diag1 = repo.create_diagram("Governance Diagram", name="Prototype")
+        diag2 = repo.create_diagram("Governance Diagram", name="Design")
+        toolbox.diagrams = {"Prototype": diag1.diag_id, "Design": diag2.diag_id}
+
+        # Architecture and Requirement in Prototype, HAZOP in Design
+        ea = repo.create_element("Block", name="A")
+        er = repo.create_element("Block", name="R")
+        eh = repo.create_element("Block", name="H")
+        repo.add_element_to_diagram(diag1.diag_id, ea.elem_id)
+        repo.add_element_to_diagram(diag1.diag_id, er.elem_id)
+        repo.add_element_to_diagram(diag2.diag_id, er.elem_id)
+        repo.add_element_to_diagram(diag2.diag_id, eh.elem_id)
+        oa = SysMLObject(1, "Work Product", 0, 0, element_id=ea.elem_id, properties={"name": "Architecture Diagram"})
+        orq = SysMLObject(2, "Work Product", 0, 100, element_id=er.elem_id, properties={"name": "Requirement Specification"})
+        oh = SysMLObject(3, "Work Product", 0, 0, element_id=eh.elem_id, properties={"name": "HAZOP"})
+        diag1.objects = [oa.__dict__, orq.__dict__]
+        diag2.objects = [orq.__dict__, oh.__dict__]
+
+        # Trace in Prototype
+        win1 = self._create_window("Trace", oa, orq, diag1)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win1, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win1, event2)
+
+        # Used By in Design
+        win2 = self._create_window("Used By", orq, oh, diag2)
+        event3 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win2, event3)
+        event4 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win2, event4)
+
+        diag1.connections = [c.__dict__ for c in win1.connections]
+        diag2.connections = [c.__dict__ for c in win2.connections]
+
+        toolbox.work_products = [
+            SafetyWorkProduct("Prototype", "Architecture Diagram", ""),
+            SafetyWorkProduct("Prototype", "Requirement Specification", ""),
+            SafetyWorkProduct("Design", "HAZOP", ""),
+        ]
+
+        self.assertEqual(
+            toolbox.analysis_inputs("HAZOP"),
+            {"Architecture Diagram", "Requirement Specification"},
+        )
+
+    def test_analysis_inputs_all_safety_analyses(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+
+        ea = repo.create_element("Block", name="EA")
+        repo.add_element_to_diagram(diag.diag_id, ea.elem_id)
+        oa = SysMLObject(1, "Work Product", 0, 0, element_id=ea.elem_id, properties={"name": "Architecture Diagram"})
+        objects = [oa.__dict__]
+        connections = []
+
+        for idx, analysis in enumerate(SAFETY_ANALYSIS_WORK_PRODUCTS, start=2):
+            e = repo.create_element("Block", name=f"E{idx}")
+            repo.add_element_to_diagram(diag.diag_id, e.elem_id)
+            o = SysMLObject(idx, "Work Product", 0, idx * 100, element_id=e.elem_id, properties={"name": analysis})
+            objects.append(o.__dict__)
+            win = self._create_window("Used By", oa, o, diag)
+            event1 = types.SimpleNamespace(x=0, y=0, state=0)
+            GovernanceDiagramWindow.on_left_press(win, event1)
+            event2 = types.SimpleNamespace(x=0, y=idx * 100, state=0)
+            GovernanceDiagramWindow.on_left_press(win, event2)
+            connections.extend(c.__dict__ for c in win.connections)
+
+        diag.objects = objects
+        diag.connections = connections
+
+        toolbox.work_products = [SafetyWorkProduct("Gov", "Architecture Diagram", "")]
+        toolbox.work_products.extend(
+            SafetyWorkProduct("Gov", a, "") for a in SAFETY_ANALYSIS_WORK_PRODUCTS
+        )
+
+        for analysis in SAFETY_ANALYSIS_WORK_PRODUCTS:
+            self.assertEqual(toolbox.analysis_inputs(analysis), {"Architecture Diagram"})
+
+    def test_hazop_functions_hidden_until_governed(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        app = types.SimpleNamespace(
+            get_all_action_labels=lambda: ["Func1"],
+            safety_mgmt_toolbox=toolbox,
+        )
+        self.assertEqual(allowed_action_labels(app, "HAZOP"), [])
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "Architecture Diagram"})
+        o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "HAZOP"})
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Used By", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        diag.connections = [c.__dict__ for c in win.connections]
+        self.assertEqual(allowed_action_labels(app, "HAZOP"), ["Func1"])
+
+    def test_hazop_functions_visible_via_traces(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        app = types.SimpleNamespace(
+            get_all_action_labels=lambda: ["Func1"],
+            safety_mgmt_toolbox=toolbox,
+        )
+        self.assertEqual(allowed_action_labels(app, "HAZOP"), [])
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        e3 = repo.create_element("Block", name="E3")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e3.elem_id)
+        o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "Architecture Diagram"})
+        o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Requirement Specification"})
+        o3 = SysMLObject(3, "Work Product", 0, 200, element_id=e3.elem_id, properties={"name": "HAZOP"})
+        diag.objects = [o1.__dict__, o2.__dict__, o3.__dict__]
+
+        win = self._create_window("Trace", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        trace_conn = win.connections[0]
+
+        win2 = self._create_window("Used By", o2, o3, diag)
+        event3 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win2, event3)
+        event4 = types.SimpleNamespace(x=0, y=200, state=0)
+        GovernanceDiagramWindow.on_left_press(win2, event4)
+        diag.connections = [trace_conn.__dict__, *[c.__dict__ for c in win2.connections]]
+
+        self.assertEqual(allowed_action_labels(app, "HAZOP"), ["Func1"])
+
+    def test_allowed_action_labels_respects_review_states(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        app = types.SimpleNamespace(
+            get_all_action_labels=lambda: ["Func1"],
+            safety_mgmt_toolbox=toolbox,
+            current_review=ReviewData(name="R1"),
+        )
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "Architecture Diagram"})
+        o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "HAZOP"})
+        diag.objects = [o1.__dict__, o2.__dict__]
+        diag.connections = [
+            {
+                "src": 1,
+                "dst": 2,
+                "conn_type": "Used after Approval",
+                "stereotype": "used after approval",
+            }
+        ]
+        self.assertEqual(allowed_action_labels(app, "HAZOP"), [])
+        app.current_review.reviewed = True
+        self.assertEqual(allowed_action_labels(app, "HAZOP"), [])
+        app.current_review.approved = True
+        self.assertEqual(allowed_action_labels(app, "HAZOP"), ["Func1"])
+
+    def test_stpa_control_actions_hidden_until_governed(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        cfd = repo.create_diagram("Control Flow Diagram", name="CFD")
+        cfd.connections = [
+            {"src": 1, "dst": 2, "conn_type": "Control Action", "name": "CA"}
+        ]
+        stpa_doc = StpaDoc("S1", cfd.diag_id, [])
+        app = types.SimpleNamespace(active_stpa=stpa_doc, safety_mgmt_toolbox=toolbox)
+        win = StpaWindow.__new__(StpaWindow)
+        win.app = app
+        self.assertEqual(win._get_control_actions(), [])
+        gov = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": gov.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        repo.add_element_to_diagram(gov.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(gov.diag_id, e2.elem_id)
+        o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "Architecture Diagram"})
+        o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "STPA"})
+        gov.objects = [o1.__dict__, o2.__dict__]
+        gov.connections = [
+            {
+                "src": 1,
+                "dst": 2,
+                "conn_type": "Used By",
+                "stereotype": "used by",
+            }
+        ]
+        self.assertEqual(win._get_control_actions(), ["<<control action>> CA"])
+
+    def test_analysis_inputs_used_after_review_visibility(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Architecture Diagram"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Used after Review", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        diag.connections = [c.__dict__ for c in win.connections]
+        toolbox.work_products = [
+            SafetyWorkProduct("Gov", "Architecture Diagram", ""),
+            SafetyWorkProduct("Gov", "FTA", ""),
+        ]
+        self.assertEqual(toolbox.analysis_inputs("FTA"), set())
+        self.assertEqual(toolbox.analysis_inputs("FTA", reviewed=True), {"Architecture Diagram"})
+        self.assertEqual(toolbox.analysis_inputs("FTA", approved=True), {"Architecture Diagram"})
+
+    def test_analysis_inputs_used_after_approval_visibility(self):
+        repo = self.repo
+        toolbox = SafetyManagementToolbox()
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        toolbox.diagrams = {"Gov": diag.diag_id}
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        o1 = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Architecture Diagram"},
+        )
+        o2 = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "FTA"},
+        )
+        diag.objects = [o1.__dict__, o2.__dict__]
+        win = self._create_window("Used after Approval", o1, o2, diag)
+        event1 = types.SimpleNamespace(x=0, y=0, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event1)
+        event2 = types.SimpleNamespace(x=0, y=100, state=0)
+        GovernanceDiagramWindow.on_left_press(win, event2)
+        diag.connections = [c.__dict__ for c in win.connections]
+        toolbox.work_products = [
+            SafetyWorkProduct("Gov", "Architecture Diagram", ""),
+            SafetyWorkProduct("Gov", "FTA", ""),
+        ]
+        self.assertEqual(toolbox.analysis_inputs("FTA"), set())
+        self.assertEqual(toolbox.analysis_inputs("FTA", reviewed=True), set())
+        self.assertEqual(toolbox.analysis_inputs("FTA", approved=True), {"Architecture Diagram"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Let safety analyses access inputs from any lifecycle phase by scanning all governance diagrams
- Ensure Architecture Diagram inputs surface for every safety and risk analysis once a Used By link exists
- Add cross-module and all-analysis regression tests for governed inputs
- Hide analysis inputs until explicit Used By/Used after Review/Used after Approval links exist
- Filter risk-assessment and STPA inputs through governance, respecting review and approval state
- Activate FI2TC menus/toolboxes by treating all governance work products as enabled regardless of phase

## Testing
- `pytest tests/test_governance_relationship_stereotype.py tests/test_safety_management.py::test_enabled_products_include_all_modules tests/test_safety_management.py::test_enabled_products_ignore_active_module tests/test_safety_management.py::test_fi2tc_enabled_across_modules tests/test_safety_management.py::test_can_use_as_input_respects_review_states tests/test_safety_management.py::test_can_use_as_input_via_traces -q`


------
https://chatgpt.com/codex/tasks/task_b_689dfe5897cc832598299830aec2807d