### PR TITLE
Filter governance work products by process area

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -9172,10 +9172,6 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "FMEDA",
         ]
         options = list(dict.fromkeys(options))
-        dlg = self._SelectDialog(self, "Add Work Product", options)
-        name = getattr(dlg, "selection", "")
-        if not name:
-            return
         area_map = {
             "Architecture Diagram": "System Design (Item Definition)",
             "Safety & Security Concept": "System Design (Item Definition)",
@@ -9195,11 +9191,20 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "FMEA": "Safety Analysis",
             "FMEDA": "Safety Analysis",
         }
-        required = area_map.get(name)
-        if required and not any(
-            o.obj_type == "System Boundary" and o.properties.get("name") == required
+        areas = {
+            o.properties.get("name")
             for o in self.objects
-        ):
+            if o.obj_type == "System Boundary"
+        }
+        options = [
+            opt for opt in options if not area_map.get(opt) or area_map[opt] in areas
+        ]
+        dlg = self._SelectDialog(self, "Add Work Product", options)
+        name = getattr(dlg, "selection", "")
+        if not name:
+            return
+        required = area_map.get(name)
+        if required and required not in areas:
             messagebox.showerror(
                 "Missing Process Area",
                 f"Add process area '{required}' before adding this work product.",

--- a/tests/test_governance_process_area_filter.py
+++ b/tests/test_governance_process_area_filter.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_work_product_combo_filters_process_area(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+
+    captured = []
+
+    class DummyDialog:
+        def __init__(self, parent, title, options):
+            captured.append(options)
+            self.selection = ""
+
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", DummyDialog)
+
+    # Without process area, FI2TC should not be listed
+    win.add_work_product()
+    assert "FI2TC" not in captured[-1]
+
+    # Add required process area and try again
+    area = SysMLObject(1, "System Boundary", 0, 0, properties={"name": "Hazard & Threat Analysis"})
+    win.objects.append(area)
+    win.add_work_product()
+    assert "FI2TC" in captured[-1]

--- a/tests/test_governance_work_product_enablement.py
+++ b/tests/test_governance_work_product_enablement.py
@@ -1,3 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from gui.architecture import GovernanceDiagramWindow, SysMLObject
 from analysis import SafetyManagementToolbox
 from sysml.sysml_repository import SysMLRepository
@@ -5,6 +10,7 @@ import pytest
 
 
 @pytest.mark.parametrize("analysis", ["FI2TC", "TC2FI"])
+def test_governance_work_product_enablement(analysis, monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     diag = repo.create_diagram("Governance Diagram", name="Gov1")
@@ -26,6 +32,7 @@ import pytest
     win.redraw = lambda: None
 
     enable_calls = []
+    captured = {}
 
     class DummyApp:
         safety_mgmt_toolbox = toolbox
@@ -36,14 +43,15 @@ import pytest
 
     win.app = DummyApp()
 
-    # Pretend user selected analysis in dialog
-    monkeypatch.setattr(
-        GovernanceDiagramWindow,
-        "_SelectDialog",
-        lambda *a, **k: type("D", (), {"selection": analysis})(),
-    )
+    class DummyDialog:
+        def __init__(self, parent, title, options):
+            captured["options"] = options
+            self.selection = analysis
+
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", DummyDialog)
 
     win.add_work_product()
 
+    assert analysis in captured["options"]
     assert enable_calls == [analysis]
     assert any(wp.analysis == analysis for wp in toolbox.work_products)


### PR DESCRIPTION
## Summary
- show only work products whose required process area exists on a governance diagram
- ensure FI2TC/TC2FI remain enabled when their process area is present
- test governance work product option filtering

## Testing
- `pytest tests/test_governance_process_area_filter.py tests/test_governance_work_product_enablement.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689e25bbb0548325b010efc0d346f898