### PR TITLE
Sync menus with governance phases across all work products

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -9130,23 +9130,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         phase = toolbox.module_for_diagram(name)
         if not phase:
             return
-        if hasattr(app, "lifecycle_var"):
-            try:
-                app.lifecycle_var.set(phase)
-            except Exception:
-                pass
-        if hasattr(app, "on_lifecycle_selected"):
-            try:
-                app.on_lifecycle_selected()
-                return
-            except Exception:
-                pass
-        toolbox.set_active_module(phase)
-        if hasattr(app, "refresh_tool_enablement"):
-            try:
-                app.refresh_tool_enablement()
-            except Exception:
-                pass
+        toolbox.activate_phase(phase, app)
 
     class _SelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
         def __init__(self, parent, title: str, options: list[str]):

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -18,6 +18,10 @@ class SafetyManagementWindow(tk.Frame):
         super().__init__(master)
         self.app = app
         self.toolbox = toolbox or SafetyManagementToolbox()
+        try:
+            self.app.safety_mgmt_window = self
+        except Exception:
+            pass
 
         phase_bar = ttk.Frame(self)
         phase_bar.pack(fill=tk.X)

--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -136,6 +136,9 @@ class StpaWindow(tk.Frame):
                 self.app.stpa_entries = d.entries
                 diag = repo.diagrams.get(d.diagram)
                 self.diag_lbl.config(text=f"Diagram: {format_diagram_name(diag)}")
+                toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+                if toolbox:
+                    toolbox.activate_document_phase("STPA", name, self.app)
                 break
         self.refresh()
 

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -121,6 +121,9 @@ class ThreatWindow(tk.Frame):
                 self.app.threat_entries = d.entries
                 diag = repo.diagrams.get(d.diagram)
                 self.diag_lbl.config(text=f"Diagram: {format_diagram_name(diag)}")
+                toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+                if toolbox:
+                    toolbox.activate_document_phase("Threat Analysis", name, self.app)
                 break
         self.refresh()
 

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -1722,6 +1722,9 @@ class FI2TCWindow(tk.Frame):
             if d.name == name:
                 self.app.active_fi2tc = d
                 self.app.fi2tc_entries = d.entries
+                toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+                if toolbox:
+                    toolbox.activate_document_phase("FI2TC", name, self.app)
                 break
         self.refresh()
 
@@ -1886,6 +1889,9 @@ class HazopWindow(tk.Frame):
             if d.name == name:
                 self.app.active_hazop = d
                 self.app.hazop_entries = d.entries
+                toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+                if toolbox:
+                    toolbox.activate_document_phase("HAZOP", name, self.app)
                 break
         self.refresh()
 
@@ -2416,6 +2422,9 @@ class RiskAssessmentWindow(tk.Frame):
                 threat = getattr(d, "threat", "")
                 self.threat_lbl.config(text=f"Threat: {threat}" if threat else "Threat: none")
                 self.status_lbl.config(text=f"Status: {getattr(d, 'status', 'draft')}")
+                toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+                if toolbox:
+                    toolbox.activate_document_phase("Risk Assessment", name, self.app)
                 break
         self.refresh()
 
@@ -3784,6 +3793,9 @@ class TC2FIWindow(tk.Frame):
             if d.name == name:
                 self.app.active_tc2fi = d
                 self.app.tc2fi_entries = d.entries
+                toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+                if toolbox:
+                    toolbox.activate_document_phase("TC2FI", name, self.app)
                 break
         self.refresh()
 


### PR DESCRIPTION
## Summary
- centralize phase activation logic in the safety management toolbox
- sync lifecycle phase when selecting any work product document or governance diagram
- test STPA document selection updates application phase

## Testing
- `pytest -q` *(fails: test_governance_relationship_stereotype::test_used_relations_reject_non_analysis_targets, test_governance_trace_relationship::test_trace_between_safety_analyses_disallowed, test_governance_trace_relationship::test_used_by_between_safety_analyses_disallowed, test_risk_assessment_filters::test_row_dialog_filters_stpa_and_threat)*


------
https://chatgpt.com/codex/tasks/task_b_689e2ab22a288325b2c3ae31920955a6