### PR TITLE
Prevent dragging items into descendants

### DIFF
--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -238,6 +238,9 @@ class SafetyManagementExplorer(tk.Frame):
         else:
             parent_mod = None
             new_parent = self.root_iid
+        if SafetyManagementExplorer._is_descendant(self, new_parent, self._drag_item):
+            self._drag_item = None
+            return
 
         self.tree.move(self._drag_item, new_parent, "end")
 
@@ -253,6 +256,15 @@ class SafetyManagementExplorer(tk.Frame):
                 self.toolbox.modules.append(item_obj)
 
         self._drag_item = None
+
+    # ------------------------------------------------------------------
+    def _is_descendant(self, item: str, ancestor: str) -> bool:
+        """Return ``True`` if *item* is a descendant of *ancestor*."""
+        while item:
+            if item == ancestor:
+                return True
+            item = self.tree.parent(item)
+        return False
 
     # ------------------------------------------------------------------
     def _in_any_module(self, name: str, mods: List[GovernanceModule]) -> bool:


### PR DESCRIPTION
## Summary
- prevent moving a tree item into one of its descendants in Safety Management Explorer
- add helper to detect descendant relationships before performing move

## Testing
- `pytest` *(fails: test_governance_phase_toggle.py::test_open_governance_diagram_refreshes_tools, test_governance_relationship_stereotype.py::GovernanceRelationshipStereotypeTests::test_used_relations_reject_non_analysis_targets, test_governance_trace_relationship.py::GovernanceTraceRelationshipTests::test_trace_between_safety_analyses_disallowed, test_governance_trace_relationship.py::GovernanceTraceRelationshipTests::test_used_by_between_safety_analyses_disallowed, test_risk_assessment_filters.py::test_row_dialog_filters_stpa_and_threat)*

------
https://chatgpt.com/codex/tasks/task_b_689e3186d2388325aa8bcafffdbb9227