### PR TITLE
Enforce governance on analysis inputs

### DIFF
--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -20,6 +20,7 @@ from gui.architecture import (
     format_control_flow_label,
     format_diagram_name,
 )
+from analysis.safety_management import SAFETY_ANALYSIS_WORK_PRODUCTS
 
 
 class StpaWindow(tk.Frame):
@@ -157,13 +158,25 @@ class StpaWindow(tk.Frame):
             )
             repo = SysMLRepository.get_instance()
             self.diag_map = {}
-            diags = []
-            for d in repo.diagrams.values():
-                if d.diag_type != "Control Flow Diagram":
-                    continue
-                disp = format_diagram_name(d)
-                self.diag_map[disp] = d.diag_id
-                diags.append(disp)
+            diags: list[str] = []
+            toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+            review = getattr(self.app, "current_review", None)
+            reviewed = getattr(review, "reviewed", False)
+            approved = getattr(review, "approved", False)
+            allowed = (
+                toolbox.analysis_inputs("STPA", reviewed=reviewed, approved=approved)
+                if toolbox
+                else SAFETY_ANALYSIS_WORK_PRODUCTS
+            )
+            if "Architecture Diagram" in allowed:
+                for d in repo.diagrams.values():
+                    if d.diag_type != "Control Flow Diagram":
+                        continue
+                    if toolbox and not toolbox.document_visible("Architecture Diagram", d.name):
+                        continue
+                    disp = format_diagram_name(d)
+                    self.diag_map[disp] = d.diag_id
+                    diags.append(disp)
             self.diag_var = tk.StringVar()
             ttk.Combobox(
                 master, textvariable=self.diag_var, values=diags, state="readonly"
@@ -185,13 +198,25 @@ class StpaWindow(tk.Frame):
             )
             repo = SysMLRepository.get_instance()
             self.diag_map = {}
-            diags = []
-            for d in repo.diagrams.values():
-                if d.diag_type != "Control Flow Diagram":
-                    continue
-                disp = format_diagram_name(d)
-                self.diag_map[disp] = d.diag_id
-                diags.append(disp)
+            diags: list[str] = []
+            toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+            review = getattr(self.app, "current_review", None)
+            reviewed = getattr(review, "reviewed", False)
+            approved = getattr(review, "approved", False)
+            allowed = (
+                toolbox.analysis_inputs("STPA", reviewed=reviewed, approved=approved)
+                if toolbox
+                else SAFETY_ANALYSIS_WORK_PRODUCTS
+            )
+            if "Architecture Diagram" in allowed:
+                for d in repo.diagrams.values():
+                    if d.diag_type != "Control Flow Diagram":
+                        continue
+                    if toolbox and not toolbox.document_visible("Architecture Diagram", d.name):
+                        continue
+                    disp = format_diagram_name(d)
+                    self.diag_map[disp] = d.diag_id
+                    diags.append(disp)
             self.diag_var = tk.StringVar()
             current = ""
             if self.app.active_stpa:

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -7,6 +7,7 @@ from gui.toolboxes import ToolTip, configure_table_style
 from analysis.models import ThreatDoc, ThreatEntry
 from sysml.sysml_repository import SysMLRepository
 from gui.architecture import format_diagram_name
+from analysis.safety_management import SAFETY_ANALYSIS_WORK_PRODUCTS
 from .threat_dialog import ThreatDialog
 
 
@@ -142,13 +143,25 @@ class ThreatWindow(tk.Frame):
             )
             repo = SysMLRepository.get_instance()
             self.diag_map = {}
-            diags = []
-            for d in repo.diagrams.values():
-                if d.diag_type != "Internal Block Diagram":
-                    continue
-                disp = format_diagram_name(d)
-                self.diag_map[disp] = d.diag_id
-                diags.append(disp)
+            diags: list[str] = []
+            toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+            review = getattr(self.app, "current_review", None)
+            reviewed = getattr(review, "reviewed", False)
+            approved = getattr(review, "approved", False)
+            allowed = (
+                toolbox.analysis_inputs("Threat Analysis", reviewed=reviewed, approved=approved)
+                if toolbox
+                else SAFETY_ANALYSIS_WORK_PRODUCTS
+            )
+            if "Architecture Diagram" in allowed:
+                for d in repo.diagrams.values():
+                    if d.diag_type != "Internal Block Diagram":
+                        continue
+                    if toolbox and not toolbox.document_visible("Architecture Diagram", d.name):
+                        continue
+                    disp = format_diagram_name(d)
+                    self.diag_map[disp] = d.diag_id
+                    diags.append(disp)
             self.diag_var = tk.StringVar()
             ttk.Combobox(
                 master, textvariable=self.diag_var, values=diags, state="readonly"
@@ -172,13 +185,25 @@ class ThreatWindow(tk.Frame):
             )
             repo = SysMLRepository.get_instance()
             self.diag_map = {}
-            diags = []
-            for d in repo.diagrams.values():
-                if d.diag_type != "Internal Block Diagram":
-                    continue
-                disp = format_diagram_name(d)
-                self.diag_map[disp] = d.diag_id
-                diags.append(disp)
+            diags: list[str] = []
+            toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+            review = getattr(self.app, "current_review", None)
+            reviewed = getattr(review, "reviewed", False)
+            approved = getattr(review, "approved", False)
+            allowed = (
+                toolbox.analysis_inputs("Threat Analysis", reviewed=reviewed, approved=approved)
+                if toolbox
+                else SAFETY_ANALYSIS_WORK_PRODUCTS
+            )
+            if "Architecture Diagram" in allowed:
+                for d in repo.diagrams.values():
+                    if d.diag_type != "Internal Block Diagram":
+                        continue
+                    if toolbox and not toolbox.document_visible("Architecture Diagram", d.name):
+                        continue
+                    disp = format_diagram_name(d)
+                    self.diag_map[disp] = d.diag_id
+                    diags.append(disp)
             self.diag_var = tk.StringVar()
             ttk.Combobox(
                 master, textvariable=self.diag_var, values=diags, state="readonly"

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -2616,7 +2616,7 @@ class RiskAssessmentWindow(tk.Frame):
             inputs = (
                 toolbox.analysis_inputs("Risk Assessment", reviewed=reviewed, approved=approved)
                 if toolbox
-                else set()
+                else SAFETY_ANALYSIS_WORK_PRODUCTS
             )
             if "HAZOP" not in inputs:
                 hazop_names = []

--- a/tests/test_analysis_input_diagram_filters.py
+++ b/tests/test_analysis_input_diagram_filters.py
@@ -1,0 +1,136 @@
+import types
+
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from sysml.sysml_repository import SysMLRepository
+from gui.stpa_window import StpaWindow
+from gui.threat_window import ThreatWindow
+
+
+class DummyWidget:
+    def __init__(self, *a, textvariable=None, values=None, state=None, **k):
+        self.textvariable = textvariable
+        self.configured = {"values": values}
+
+    def grid(self, *a, **k):
+        pass
+
+    def pack(self, *a, **k):
+        pass
+
+    def configure(self, **k):
+        self.configured.update(k)
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, v):
+        self._value = v
+
+
+# ---------------------------------------------------------------------------
+# STPA dialog
+# ---------------------------------------------------------------------------
+
+def test_stpa_dialog_respects_governance(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    repo.create_diagram("Control Flow Diagram", name="CFD1")
+    repo.create_diagram("Control Flow Diagram", name="CFD2")
+
+    combo_calls = []
+
+    def combo_stub(*a, **k):
+        cb = DummyWidget(*a, **k)
+        combo_calls.append(cb)
+        return cb
+
+    monkeypatch.setattr("gui.stpa_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.stpa_window.ttk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.ttk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.stpa_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    class Toolbox:
+        def __init__(self, allowed, visible):
+            self.allowed = allowed
+            self.visible = visible
+
+        def analysis_inputs(self, target, **kwargs):
+            return self.allowed
+
+        def document_visible(self, analysis, name):
+            return name in self.visible
+
+    app = types.SimpleNamespace(safety_mgmt_toolbox=Toolbox(set(), set()))
+
+    dlg = StpaWindow.NewStpaDialog.__new__(StpaWindow.NewStpaDialog)
+    dlg.app = app
+    dlg.body(master=DummyWidget())
+    assert combo_calls[0].configured["values"] == []
+
+    combo_calls.clear()
+    app.safety_mgmt_toolbox.allowed = {"Architecture Diagram"}
+    app.safety_mgmt_toolbox.visible = {"CFD1"}
+
+    dlg = StpaWindow.NewStpaDialog.__new__(StpaWindow.NewStpaDialog)
+    dlg.app = app
+    dlg.body(master=DummyWidget())
+    assert combo_calls[0].configured["values"] == ["CFD1 : CFD"]
+
+
+# ---------------------------------------------------------------------------
+# Threat Analysis dialog
+# ---------------------------------------------------------------------------
+
+def test_threat_dialog_respects_governance(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    repo.create_diagram("Internal Block Diagram", name="IBD1")
+    repo.create_diagram("Internal Block Diagram", name="IBD2")
+
+    combo_calls = []
+
+    def combo_stub(*a, **k):
+        cb = DummyWidget(*a, **k)
+        combo_calls.append(cb)
+        return cb
+
+    monkeypatch.setattr("gui.threat_window.ttk.Combobox", combo_stub)
+    monkeypatch.setattr("gui.threat_window.ttk.Label", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.threat_window.ttk.Entry", lambda *a, **k: DummyWidget())
+    monkeypatch.setattr("gui.threat_window.tk.StringVar", lambda value="": DummyVar(value))
+
+    class Toolbox:
+        def __init__(self, allowed, visible):
+            self.allowed = allowed
+            self.visible = visible
+
+        def analysis_inputs(self, target, **kwargs):
+            return self.allowed
+
+        def document_visible(self, analysis, name):
+            return name in self.visible
+
+    app = types.SimpleNamespace(safety_mgmt_toolbox=Toolbox(set(), set()))
+
+    dlg = ThreatWindow.NewThreatDialog.__new__(ThreatWindow.NewThreatDialog)
+    dlg.app = app
+    dlg.body(master=DummyWidget())
+    assert combo_calls[0].configured["values"] == []
+
+    combo_calls.clear()
+    app.safety_mgmt_toolbox.allowed = {"Architecture Diagram"}
+    app.safety_mgmt_toolbox.visible = {"IBD1"}
+
+    dlg = ThreatWindow.NewThreatDialog.__new__(ThreatWindow.NewThreatDialog)
+    dlg.app = app
+    dlg.body(master=DummyWidget())
+    assert combo_calls[0].configured["values"] == ["IBD1 : IBD"]


### PR DESCRIPTION
## Summary
- hide architecture diagrams from STPA and Threat Analysis dialogs unless governance declares them
- respect lifecycle visibility when listing diagrams
- default risk assessment row dialog to allow all analyses when no governance is configured
- cover governance filtering for STPA and Threat Analysis with tests

## Testing
- `pytest tests/test_analysis_input_diagram_filters.py tests/test_risk_assessment_filters.py tests/test_analysis_input_visibility.py`

------
https://chatgpt.com/codex/tasks/task_b_689e316d85f08325bb7c6b5cfaf6fd7d