### PR TITLE
Ensure unique phase names

### DIFF
--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -111,16 +111,15 @@ class SafetyManagementExplorer(tk.Frame):
         name = simpledialog.askstring("New Folder", "Name:", parent=self)
         if not name:
             return
-        folder = GovernanceModule(name)
         sel = self.tree.selection()
         if sel:
             typ, obj = self.item_map.get(sel[0], (None, None))
-            if typ == "module":
-                obj.modules.append(folder)
+            if typ == "module" and obj is not None:
+                self.toolbox.add_module(name, obj)
             else:  # root or other selections add to top level
-                self.toolbox.modules.append(folder)
+                self.toolbox.add_module(name)
         else:
-            self.toolbox.modules.append(folder)
+            self.toolbox.add_module(name)
         self.populate()
 
     # ------------------------------------------------------------------

--- a/tests/test_unique_phase_names.py
+++ b/tests/test_unique_phase_names.py
@@ -1,0 +1,15 @@
+from analysis.safety_management import SafetyManagementToolbox
+from analysis import safety_management
+
+def test_add_module_enforces_unique_names():
+    prev = safety_management.ACTIVE_TOOLBOX
+    tb = SafetyManagementToolbox()
+    tb.add_module("Phase")
+    tb.add_module("Phase")
+    parent = tb.add_module("Parent")
+    child = tb.add_module("Phase", parent=parent)
+    assert [m.name for m in tb.modules] == ["Phase", "Phase_1", "Parent"]
+    assert child.name == "Phase_2"
+    assert tb.list_modules() == ["Phase", "Phase_1", "Parent", "Phase_2"]
+    assert len(set(tb.list_modules())) == 4
+    safety_management.ACTIVE_TOOLBOX = prev


### PR DESCRIPTION
## Summary
- ensure governance modules (phases) obtain unique names by adding helper and API
- hook Safety Management Explorer into new module API
- add regression test for unique phase naming

## Testing
- `pytest -q` *(fails: GovernanceRelationshipStereotypeTests::test_used_relations_reject_non_analysis_targets, GovernanceTraceRelationshipTests::test_trace_between_safety_analyses_disallowed, GovernanceTraceRelationshipTests::test_used_by_between_safety_analyses_disallowed)*

------
https://chatgpt.com/codex/tasks/task_b_689e368078748325a68818d609182c4a