### PR TITLE
Fix activation of quantitative governance work products

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2463,7 +2463,11 @@ class FaultTreeApp:
         )
         # --- Quantitative Analysis Menu ---
         quantitative_menu = tk.Menu(menubar, tearoff=0)
-        quantitative_menu.add_command(label="Mission Profiles", command=self.manage_mission_profiles)
+        quantitative_menu.add_command(
+            label="Mission Profiles",
+            command=self.manage_mission_profiles,
+            state=tk.DISABLED,
+        )
         self.work_product_menus.setdefault("Mission Profile", []).append(
             (quantitative_menu, quantitative_menu.index("end"))
         )
@@ -2471,7 +2475,9 @@ class FaultTreeApp:
             label="Mechanism Libraries", command=self.manage_mechanism_libraries
         )
         quantitative_menu.add_command(
-            label="Reliability Analysis", command=self.open_reliability_window
+            label="Reliability Analysis",
+            command=self.open_reliability_window,
+            state=tk.DISABLED,
         )
         self.work_product_menus.setdefault("Reliability Analysis", []).append(
             (quantitative_menu, quantitative_menu.index("end"))

--- a/tests/test_governance_work_product_enablement.py
+++ b/tests/test_governance_work_product_enablement.py
@@ -9,8 +9,17 @@ from sysml.sysml_repository import SysMLRepository
 import pytest
 
 
-@pytest.mark.parametrize("analysis", ["FI2TC", "TC2FI"])
-def test_governance_work_product_enablement(analysis, monkeypatch):
+@pytest.mark.parametrize(
+    "analysis, area_name",
+    [
+        ("FI2TC", "Hazard & Threat Analysis"),
+        ("TC2FI", "Hazard & Threat Analysis"),
+        ("Mission Profile", "Safety Analysis"),
+        ("Reliability Analysis", "Safety Analysis"),
+        ("Risk Assessment", "Risk Assessment"),
+    ],
+)
+def test_governance_work_product_enablement(analysis, area_name, monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     diag = repo.create_diagram("Governance Diagram", name="Gov1")
@@ -20,8 +29,8 @@ def test_governance_work_product_enablement(analysis, monkeypatch):
     prev_tb = _sm.ACTIVE_TOOLBOX
     toolbox = SafetyManagementToolbox()
 
-    # Required process area for FI2TC/TC2FI
-    area = SysMLObject(1, "System Boundary", 0, 0, properties={"name": "Hazard & Threat Analysis"})
+    # Required process area for the selected analysis
+    area = SysMLObject(1, "System Boundary", 0, 0, properties={"name": area_name})
 
     win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo


### PR DESCRIPTION
## Summary
- ensure Mission Profile and Reliability Analysis menu items start disabled so governance can enable or disable them
- broaden governance enablement tests to cover Mission Profile, Reliability Analysis, and Risk Assessment

## Testing
- `pytest tests/test_governance_work_product_enablement.py`

------
https://chatgpt.com/codex/tasks/task_b_689e458268f48325b546c41be4c9f577