### PR TITLE
Add Scenario and ODD libraries as governance work products

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -9177,6 +9177,8 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "FTA",
             "FMEA",
             "FMEDA",
+            "Scenario Library",
+            "ODD Library",
         ]
         options = list(dict.fromkeys(options))
         area_map = {
@@ -9197,6 +9199,8 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "FTA": "Safety Analysis",
             "FMEA": "Safety Analysis",
             "FMEDA": "Safety Analysis",
+            "Scenario Library": "Scenario",
+            "ODD Library": "Scenario",
         }
         areas = {
             o.properties.get("name")

--- a/tests/test_governance_work_product_enablement.py
+++ b/tests/test_governance_work_product_enablement.py
@@ -9,8 +9,16 @@ from sysml.sysml_repository import SysMLRepository
 import pytest
 
 
-@pytest.mark.parametrize("analysis", ["FI2TC", "TC2FI"])
-def test_governance_work_product_enablement(analysis, monkeypatch):
+@pytest.mark.parametrize(
+    "analysis, area_name",
+    [
+        ("FI2TC", "Hazard & Threat Analysis"),
+        ("TC2FI", "Hazard & Threat Analysis"),
+        ("Scenario Library", "Scenario"),
+        ("ODD Library", "Scenario"),
+    ],
+)
+def test_governance_work_product_enablement(analysis, area_name, monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     diag = repo.create_diagram("Governance Diagram", name="Gov1")
@@ -20,8 +28,8 @@ def test_governance_work_product_enablement(analysis, monkeypatch):
     prev_tb = _sm.ACTIVE_TOOLBOX
     toolbox = SafetyManagementToolbox()
 
-    # Required process area for FI2TC/TC2FI
-    area = SysMLObject(1, "System Boundary", 0, 0, properties={"name": "Hazard & Threat Analysis"})
+    # Required process area for the selected work product
+    area = SysMLObject(1, "System Boundary", 0, 0, properties={"name": area_name})
 
     win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
     win.repo = repo

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -734,7 +734,8 @@ def test_menu_work_products_toggle_and_guard_existing_docs():
         ("Reliability Analysis", "reliability_analyses"),
         ("Qualitative Analysis", "hazop_docs"),
         ("Architecture Diagram", "arch_diagrams"),
-        ("Scenario", "scenario_libraries"),
+        ("Scenario Library", "scenario_libraries"),
+        ("ODD Library", "odd_libraries"),
         ("FTA", "top_events"),
     ]
 


### PR DESCRIPTION
## Summary
- add Scenario and ODD libraries as discrete governance work products
- enable/disable Scenario and ODD menus and tools per active governance diagram
- expose Scenario and ODD libraries in governance diagram work product dialog

## Testing
- `pytest tests/test_governance_work_product_enablement.py tests/test_safety_management.py::test_menu_work_products_toggle_and_guard_existing_docs -q`
- `pytest tests/test_safety_management.py::test_governance_enables_tools_per_phase -q`


------
https://chatgpt.com/codex/tasks/task_b_689e45ec4e2883258f4dc6425c27072a