### PR TITLE
Handle governance group activation for safety analyses

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9033,25 +9033,25 @@ class FaultTreeApp:
 
     def enable_work_product(self, name: str, *, refresh: bool = True) -> None:
         info = self.WORK_PRODUCT_INFO.get(name)
-        if not info:
-            return
-        area, tool_name, method_name = info
-        self.enable_process_area(area)
-        if tool_name not in self.tool_actions:
-            action = getattr(self, method_name, None)
-            if action:
-                self.tool_actions[tool_name] = action
-                lb = self.tool_listboxes.get(area)
-                if lb:
-                    lb.insert(tk.END, tool_name)
-        mapping = getattr(self, "tool_to_work_product", {})
-        existing = mapping.get(tool_name)
-        if isinstance(existing, set):
-            existing.add(name)
-        elif existing:
-            mapping[tool_name] = {existing, name}
-        else:
-            mapping.setdefault(tool_name, set()).add(name)
+        area = tool_name = method_name = None
+        if info:
+            area, tool_name, method_name = info
+            self.enable_process_area(area)
+            if tool_name not in self.tool_actions:
+                action = getattr(self, method_name, None)
+                if action:
+                    self.tool_actions[tool_name] = action
+                    lb = self.tool_listboxes.get(area)
+                    if lb:
+                        lb.insert(tk.END, tool_name)
+            mapping = getattr(self, "tool_to_work_product", {})
+            existing = mapping.get(tool_name)
+            if isinstance(existing, set):
+                existing.add(name)
+            elif existing:
+                mapping[tool_name] = {existing, name}
+            else:
+                mapping.setdefault(tool_name, set()).add(name)
         # Enable corresponding menu entry if one was registered
         for menu, idx in self.work_product_menus.get(name, []):
             try:

--- a/tests/test_governance_group_activation.py
+++ b/tests/test_governance_group_activation.py
@@ -1,0 +1,98 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+from AutoML import FaultTreeApp
+
+
+class DummyListbox:
+    def __init__(self):
+        self.items = []
+        self.colors = []
+
+    def get(self, *_):
+        return self.items
+
+    def insert(self, index, item):
+        self.items.insert(index if isinstance(index, int) else len(self.items), item)
+
+    def itemconfig(self, index, foreground="black"):
+        self.colors.append((index, foreground))
+
+    def size(self):
+        return len(self.items)
+
+    def delete(self, i):
+        del self.items[i]
+
+
+class DummyMenu:
+    def __init__(self):
+        self.state = None
+
+    def entryconfig(self, _idx, state=tk.DISABLED):
+        self.state = state
+
+
+@pytest.mark.parametrize(
+    "work_product,parent",
+    [
+        ("FTA", "FTA"),
+        ("Safety & Security Case", "GSN"),
+        ("GSN Argumentation", "GSN"),
+        ("FMEA", "Qualitative Analysis"),
+        ("FMEDA", "Quantitative Analysis"),
+    ],
+)
+def test_work_product_groups_follow_phase(work_product, parent):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"]), GovernanceModule(name="P2")]
+    toolbox.diagrams = {"Gov": diag.diag_id}
+    toolbox.set_active_module("P1")
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    lb = DummyListbox()
+    app.tool_listboxes = {"Safety Analysis": lb}
+    app.tool_categories = {"Safety Analysis": []}
+    app.tool_actions = {}
+    wp_menu = DummyMenu()
+    parent_menu = wp_menu if work_product == parent else DummyMenu()
+    app.work_product_menus = {work_product: [(wp_menu, 0)]}
+    if parent not in app.work_product_menus:
+        app.work_product_menus[parent] = [(parent_menu, 0)]
+    app.enabled_work_products = set()
+    app.enable_process_area = lambda area: None
+    app.tool_to_work_product = {info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()}
+    app.update_views = lambda: None
+    app.safety_mgmt_toolbox = toolbox
+    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(app, FaultTreeApp)
+    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(app, FaultTreeApp)
+    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(app, FaultTreeApp)
+
+    toolbox.add_work_product("Gov", work_product, "")
+    toolbox.on_change = app.refresh_tool_enablement
+    app.refresh_tool_enablement()
+
+    assert work_product in app.enabled_work_products
+    assert parent in app.enabled_work_products
+    assert wp_menu.state == tk.NORMAL
+    assert parent_menu.state == tk.NORMAL
+
+    toolbox.set_active_module("P2")
+    app.refresh_tool_enablement()
+    assert work_product not in app.enabled_work_products
+    assert parent not in app.enabled_work_products
+    assert wp_menu.state == tk.DISABLED
+    assert parent_menu.state == tk.DISABLED
+    # Reset global toolbox to avoid side effects on other tests
+    from analysis import safety_management as _sm
+    _sm.ACTIVE_TOOLBOX = None
+


### PR DESCRIPTION
## Summary
- ensure enabling work product groups without metadata activates parent menus
- add regression tests for lifecycle phase group activation

## Testing
- `pytest -q`
  - 3 failed, 512 passed, 3 skipped


------
https://chatgpt.com/codex/tasks/task_b_689e46458e588325bc2b3742616e8768