### PR TITLE
Avoid overlapping stereotype tags on vertical relations

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6543,8 +6543,8 @@ class SysMLDiagramWindow(tk.Frame):
                     else 0
                 )
                 self.canvas.create_text(
-                    x,
-                    (y1 + y2) / 2 - 10 * self.zoom - offset,
+                    x + offset,
+                    (y1 + y2) / 2 - 10 * self.zoom,
                     text=label,
                     font=self.font,
                     tags="connection",
@@ -6823,13 +6823,22 @@ class SysMLDiagramWindow(tk.Frame):
                 if hasattr(self, "_label_offset")
                 else 0
             )
-            self.canvas.create_text(
-                mx,
-                my - 10 * self.zoom - offset,
-                text=label,
-                font=self.font,
-                tags="connection",
-            )
+            if math.isclose(ax, bx):
+                self.canvas.create_text(
+                    mx + offset,
+                    my - 10 * self.zoom,
+                    text=label,
+                    font=self.font,
+                    tags="connection",
+                )
+            else:
+                self.canvas.create_text(
+                    mx,
+                    my - 10 * self.zoom - offset,
+                    text=label,
+                    font=self.font,
+                    tags="connection",
+                )
 
     def get_object(self, oid: int) -> SysMLObject | None:
         for o in self.objects:

--- a/tests/test_connection_label_offset.py
+++ b/tests/test_connection_label_offset.py
@@ -1,4 +1,9 @@
 import unittest
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from sysml.sysml_repository import SysMLRepository, SysMLDiagram
 from gui.architecture import SysMLDiagramWindow, DiagramConnection, SysMLObject
 
@@ -57,6 +62,21 @@ class ConnectionLabelOffsetTests(unittest.TestCase):
         y1 = win.canvas.texts[1][0][1]
         self.assertNotEqual(y0, y1)
         self.assertEqual(abs(y0 - y1), 15)
+
+    def test_offset_vertical_labels(self):
+        win = DummyWindow()
+        a = SysMLObject(1, "Existing Element", 0, 0)
+        b = SysMLObject(2, "Existing Element", 0, 100)
+        conn1 = DiagramConnection(1, 2, "Association")
+        conn2 = DiagramConnection(1, 2, "Association")
+        win.connections = [conn1, conn2]
+        SysMLDiagramWindow.draw_connection(win, a, b, conn1)
+        SysMLDiagramWindow.draw_connection(win, a, b, conn2)
+        self.assertEqual(len(win.canvas.texts), 2)
+        x0 = win.canvas.texts[0][0][0]
+        x1 = win.canvas.texts[1][0][0]
+        self.assertNotEqual(x0, x1)
+        self.assertEqual(abs(x0 - x1), 15)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- offset stereotype labels horizontally when drawing vertical connections
- account for vertical connections when offsetting labels on multi-segment edges
- test label offsets for both horizontal and vertical connections

## Testing
- `pytest tests/test_connection_label_offset.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e469e8b50832582f0665f268f80f8