### PR TITLE
Enable GSN governance group activation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2023,6 +2023,11 @@ class FaultTreeApp:
             "GSN Explorer",
             "manage_gsn",
         ),
+        "GSN": (
+            "Safety Analysis",
+            "GSN Explorer",
+            "manage_gsn",
+        ),
         "Requirement Specification": (
             "System Design (Item Definition)",
             "Requirements Editor",
@@ -2108,6 +2113,11 @@ class FaultTreeApp:
             "Scenario Libraries",
             "manage_scenario_libraries",
         ),
+        "ODD": (
+            "Scenario",
+            "ODD Libraries",
+            "manage_odd_libraries",
+        ),
     }
 
     for _wp in REQUIREMENT_WORK_PRODUCTS:
@@ -2136,6 +2146,7 @@ class FaultTreeApp:
         "Reliability Analysis": "Quantitative Analysis",
         "Safety & Security Case": "GSN",
         "GSN Argumentation": "GSN",
+        "ODD": "Scenario",
     }
 
     def __init__(self, root):
@@ -2504,7 +2515,7 @@ class FaultTreeApp:
             command=self.manage_odd_libraries,
             state=tk.DISABLED,
         )
-        self.work_product_menus.setdefault("Scenario", []).append(
+        self.work_product_menus.setdefault("ODD", []).append(
             (libs_menu, libs_menu.index("end"))
         )
 
@@ -2532,6 +2543,7 @@ class FaultTreeApp:
         menubar.add_cascade(label="Scenario", menu=libs_menu)
         idx = menubar.index("end")
         self.work_product_menus.setdefault("Scenario", []).append((menubar, idx))
+        self.work_product_menus.setdefault("ODD", []).append((menubar, idx))
         menubar.entryconfig(idx, state=tk.DISABLED)
         menubar.add_cascade(label="Qualitative Analysis", menu=qualitative_menu)
         idx = menubar.index("end")
@@ -9088,6 +9100,7 @@ class FaultTreeApp:
             "FTA": "top_events",
             "Architecture Diagram": "arch_diagrams",
             "Scenario": "scenario_libraries",
+            "ODD": "odd_libraries",
             "Qualitative Analysis": (
                 "hazop_docs",
                 "stpa_docs",

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -9177,6 +9177,8 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "FTA",
             "FMEA",
             "FMEDA",
+            "Scenario",
+            "ODD",
         ]
         options = list(dict.fromkeys(options))
         area_map = {
@@ -9197,6 +9199,8 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "FTA": "Safety Analysis",
             "FMEA": "Safety Analysis",
             "FMEDA": "Safety Analysis",
+            "Scenario": "Scenario",
+            "ODD": "Scenario",
         }
         areas = {
             o.properties.get("name")

--- a/tests/test_governance_phase_toggle.py
+++ b/tests/test_governance_phase_toggle.py
@@ -2,6 +2,7 @@ import types
 import tkinter as tk
 import sys
 from pathlib import Path
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -331,6 +332,168 @@ def test_work_product_disables_when_leaving_phase(monkeypatch):
 
     win.add_work_product()
     assert menu.state == tk.NORMAL
+
+
+@pytest.mark.parametrize(
+    "analysis,parent",
+    [
+        ("FTA", None),
+        ("Threat Analysis", "Qualitative Analysis"),
+        ("FI2TC", "Qualitative Analysis"),
+        ("TC2FI", "Qualitative Analysis"),
+        ("FMEA", "Qualitative Analysis"),
+        ("FMEDA", "Quantitative Analysis"),
+        ("Scenario", None),
+        ("ODD", "Scenario"),
+        ("Safety & Security Case", "GSN"),
+        ("GSN Argumentation", "GSN"),
+    ],
+)
+def test_work_product_group_activation(analysis, parent, monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="GovX")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [
+        GovernanceModule(name="P1"),
+        GovernanceModule(name="P2", diagrams=["GovX"]),
+    ]
+    toolbox.diagrams = {"GovX": diag.diag_id}
+
+    from AutoML import FaultTreeApp
+
+    class DummyListbox:
+        def __init__(self):
+            self.items = []
+            self.item_colors = {}
+
+        def get(self, *_):
+            return self.items
+
+        def insert(self, index, item):
+            self.items.insert(index if isinstance(index, int) else len(self.items), item)
+
+        def itemconfig(self, index, foreground="black"):
+            try:
+                item = self.items[index]
+            except IndexError:
+                return
+            self.item_colors[item] = foreground
+
+    class DummyMenu:
+        def __init__(self):
+            self.state = None
+
+        def entryconfig(self, _idx, state=tk.DISABLED):
+            self.state = state
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    lb = DummyListbox()
+    menu = DummyMenu()
+    area = FaultTreeApp.WORK_PRODUCT_INFO[analysis][0]
+    app.tool_listboxes = {area: lb}
+    app.tool_categories = {area: []}
+    app.tool_actions = {}
+    app.work_product_menus = {analysis: [(menu, 0)]}
+    parent_menu = None
+    if parent:
+        parent_menu = DummyMenu()
+        app.work_product_menus[parent] = [(parent_menu, 0)]
+        pinfo = FaultTreeApp.WORK_PRODUCT_INFO[parent]
+        setattr(app, pinfo[2], lambda: None)
+
+    info = FaultTreeApp.WORK_PRODUCT_INFO[analysis]
+    setattr(app, info[2], lambda: None)
+
+    app.enabled_work_products = set()
+    app.enable_process_area = lambda area: None
+    app.tool_to_work_product = {
+        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+    }
+    app.update_views = lambda: None
+    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
+        app, FaultTreeApp
+    )
+    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
+        app, FaultTreeApp
+    )
+    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
+        app, FaultTreeApp
+    )
+    app.lifecycle_var = DummyVar("P1")
+    app.safety_mgmt_toolbox = toolbox
+    toolbox.on_change = app.refresh_tool_enablement
+
+    app.on_lifecycle_selected()
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = [
+        SysMLObject(
+            1,
+            "System Boundary",
+            0.0,
+            0.0,
+            width=200.0,
+            height=150.0,
+            properties={"name": "Safety Analysis"},
+        ),
+        SysMLObject(
+            2,
+            "System Boundary",
+            0.0,
+            0.0,
+            width=200.0,
+            height=150.0,
+            properties={"name": "Hazard & Threat Analysis"},
+        ),
+        SysMLObject(
+            3,
+            "System Boundary",
+            0.0,
+            0.0,
+            width=200.0,
+            height=150.0,
+            properties={"name": "Scenario"},
+        ),
+    ]
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.app = app
+
+    class FakeDialog:
+        def __init__(self, *args, **kwargs):
+            self.selection = analysis
+
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", FakeDialog)
+
+    win.add_work_product()
+
+    tool_name = FaultTreeApp.WORK_PRODUCT_INFO[analysis][1]
+    assert menu.state == tk.DISABLED
+    assert lb.item_colors.get(tool_name) == "gray"
+    if parent_menu:
+        assert parent_menu.state == tk.DISABLED
+
+    app.lifecycle_var.set("P2")
+    app.on_lifecycle_selected()
+    assert menu.state == tk.NORMAL
+    assert lb.item_colors.get(tool_name) == "black"
+    if parent_menu:
+        assert parent_menu.state == tk.NORMAL
 
 
 def test_open_diagram_updates_phase_combobox():


### PR DESCRIPTION
## Summary
- ensure GSN parent menu can be toggled by declaring work product in governance diagrams
- add separate ODD and Scenario work products with menu activation and removal guards
- test activation/deactivation of threat analysis, FI2TC, TC2FI, FMEA, FMEDA, safety case, GSN, scenario and ODD across phases

## Testing
- `pytest tests/test_governance_phase_toggle.py::test_work_product_group_activation -q`
- `pytest -q` *(fails: GovernanceRelationshipStereotypeTests::test_used_relations_reject_non_analysis_targets, GovernanceTraceRelationshipTests::test_trace_between_safety_analyses_disallowed, GovernanceTraceRelationshipTests::test_used_by_between_safety_analyses_disallowed)*

------
https://chatgpt.com/codex/tasks/task_b_689e46458e588325bc2b3742616e8768