### PR TITLE
Enable GSN governance group activation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2023,6 +2023,11 @@ class FaultTreeApp:
             "GSN Explorer",
             "manage_gsn",
         ),
+        "GSN": (
+            "Safety Analysis",
+            "GSN Explorer",
+            "manage_gsn",
+        ),
         "Requirement Specification": (
             "System Design (Item Definition)",
             "Requirements Editor",
@@ -2103,10 +2108,15 @@ class FaultTreeApp:
             "Reliability Analysis",
             "open_reliability_window",
         ),
-        "Scenario": (
+        "Scenario Library": (
             "Scenario",
             "Scenario Libraries",
             "manage_scenario_libraries",
+        ),
+        "ODD": (
+            "Scenario",
+            "ODD Libraries",
+            "manage_odd_libraries",
         ),
     }
 
@@ -2136,6 +2146,7 @@ class FaultTreeApp:
         "Reliability Analysis": "Quantitative Analysis",
         "Safety & Security Case": "GSN",
         "GSN Argumentation": "GSN",
+        "ODD": "Scenario Library",
     }
 
     def __init__(self, root):
@@ -2496,7 +2507,7 @@ class FaultTreeApp:
             command=self.manage_scenario_libraries,
             state=tk.DISABLED,
         )
-        self.work_product_menus.setdefault("Scenario", []).append(
+        self.work_product_menus.setdefault("Scenario Library", []).append(
             (libs_menu, libs_menu.index("end"))
         )
         libs_menu.add_command(
@@ -2504,7 +2515,7 @@ class FaultTreeApp:
             command=self.manage_odd_libraries,
             state=tk.DISABLED,
         )
-        self.work_product_menus.setdefault("Scenario", []).append(
+        self.work_product_menus.setdefault("ODD", []).append(
             (libs_menu, libs_menu.index("end"))
         )
 
@@ -2531,7 +2542,8 @@ class FaultTreeApp:
         menubar.entryconfig(idx, state=tk.DISABLED)
         menubar.add_cascade(label="Scenario", menu=libs_menu)
         idx = menubar.index("end")
-        self.work_product_menus.setdefault("Scenario", []).append((menubar, idx))
+        self.work_product_menus.setdefault("Scenario Library", []).append((menubar, idx))
+        self.work_product_menus.setdefault("ODD", []).append((menubar, idx))
         menubar.entryconfig(idx, state=tk.DISABLED)
         menubar.add_cascade(label="Qualitative Analysis", menu=qualitative_menu)
         idx = menubar.index("end")
@@ -9087,7 +9099,8 @@ class FaultTreeApp:
             "FMEDA": "fmeda_components",
             "FTA": "top_events",
             "Architecture Diagram": "arch_diagrams",
-            "Scenario": "scenario_libraries",
+            "Scenario Library": "scenario_libraries",
+            "ODD": "odd_libraries",
             "Qualitative Analysis": (
                 "hazop_docs",
                 "stpa_docs",

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -9177,6 +9177,8 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "FTA",
             "FMEA",
             "FMEDA",
+            "Scenario Library",
+            "ODD",
         ]
         options = list(dict.fromkeys(options))
         area_map = {
@@ -9197,6 +9199,8 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "FTA": "Safety Analysis",
             "FMEA": "Safety Analysis",
             "FMEDA": "Safety Analysis",
+            "Scenario Library": "Scenario",
+            "ODD": "Scenario",
         }
         areas = {
             o.properties.get("name")
@@ -9232,6 +9236,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "Hazard & Threat Analysis",
             "Risk Assessment",
             "Safety Analysis",
+            "Scenario",
         ]
         dlg = self._SelectDialog(self, "Add Process Area", options)
         name = getattr(dlg, "selection", "")

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -734,7 +734,7 @@ def test_menu_work_products_toggle_and_guard_existing_docs():
         ("Reliability Analysis", "reliability_analyses"),
         ("Qualitative Analysis", "hazop_docs"),
         ("Architecture Diagram", "arch_diagrams"),
-        ("Scenario", "scenario_libraries"),
+        ("Scenario Library", "scenario_libraries"),
         ("FTA", "top_events"),
     ]
 


### PR DESCRIPTION
## Summary
- ensure GSN parent menu can be toggled by declaring work product in governance diagrams
- add separate ODD and Scenario work products with menu activation and removal guards
- allow adding Scenario process area so ODD/Scenario work products can be attached
- test activation/deactivation of threat analysis, FI2TC, TC2FI, FMEA, FMEDA, safety case, GSN, scenario library and ODD across phases
- recognize Scenario Library as a distinct work product so adding it to governance diagrams enables the Scenario menu

## Testing
- `pytest tests/test_governance_phase_toggle.py::test_add_process_area_lists_scenario -q`
- `pytest tests/test_governance_phase_toggle.py::test_work_product_group_activation -q`
- `pytest tests/test_safety_management.py::test_menu_work_products_toggle_and_guard_existing_docs -q`
- `pytest -q` *(fails: GovernanceRelationshipStereotypeTests::test_used_relations_reject_non_analysis_targets, GovernanceTraceRelationshipTests::test_trace_between_safety_analyses_disallowed, GovernanceTraceRelationshipTests::test_used_by_between_safety_analyses_disallowed)*

------
https://chatgpt.com/codex/tasks/task_b_689e46458e588325bc2b3742616e8768