### PR TITLE
Enable Process menu for FTA governance

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2144,6 +2144,7 @@ class FaultTreeApp:
         "FMEDA": "Quantitative Analysis",
         "Mission Profile": "Quantitative Analysis",
         "Reliability Analysis": "Quantitative Analysis",
+        "FTA": "Process",
         "Safety & Security Case": "GSN",
         "GSN Argumentation": "GSN",
         "ODD": "Scenario Library",

--- a/tests/test_governance_group_activation.py
+++ b/tests/test_governance_group_activation.py
@@ -42,7 +42,7 @@ class DummyMenu:
 @pytest.mark.parametrize(
     "work_product,parent",
     [
-        ("FTA", "FTA"),
+        ("FTA", "Process"),
         ("Safety & Security Case", "GSN"),
         ("GSN Argumentation", "GSN"),
         ("FMEA", "Qualitative Analysis"),

--- a/tests/test_governance_phase_toggle.py
+++ b/tests/test_governance_phase_toggle.py
@@ -351,7 +351,7 @@ def test_work_product_disables_when_leaving_phase(monkeypatch):
 @pytest.mark.parametrize(
     "analysis,parent",
     [
-        ("FTA", None),
+        ("FTA", "Process"),
         ("Threat Analysis", "Qualitative Analysis"),
         ("FI2TC", "Qualitative Analysis"),
         ("TC2FI", "Qualitative Analysis"),


### PR DESCRIPTION
## Summary
- Activate the Process menu automatically whenever FTA governance is enabled
- Adjust governance activation tests to expect Process menu enablement when FTA is declared

## Testing
- `pytest tests/test_governance_group_activation.py -q`
- `pytest tests/test_governance_phase_toggle.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e535e179483259f9c1b8b5a190343