### PR TITLE
Restrict nonsensical work product usage links

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -63,6 +63,17 @@ SAFETY_ANALYSIS_WORK_PRODUCTS: set[str] = {
     "ODD",
 }
 
+# Pairs of safety analysis work products where "Used" relationships are permitted.
+# These are directed edges from the source work product to the analysis that uses
+# it. Any other combination of safety analyses is considered invalid.
+ALLOWED_ANALYSIS_USED_RELATIONS: set[tuple[str, str]] = {
+    ("Scenario Library", "ODD"),
+}
+
+# Safety analysis work products that may serve as inputs to other analyses
+# without additional restrictions.
+UNRESTRICTED_ANALYSIS_INPUTS: set[str] = {"Mission Profile"}
+
 @dataclass
 class SafetyWorkProduct:
     """Describe a work product generated from a diagram or analysis."""

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -29,6 +29,8 @@ from analysis.safety_management import (
     ALLOWED_PROPAGATIONS,
     ACTIVE_TOOLBOX,
     SAFETY_ANALYSIS_WORK_PRODUCTS,
+    ALLOWED_ANALYSIS_USED_RELATIONS,
+    UNRESTRICTED_ANALYSIS_INPUTS,
 )
 
 # ---------------------------------------------------------------------------
@@ -3202,6 +3204,11 @@ class SysMLDiagramWindow(tk.Frame):
                     return False, (
                         "Requirement work products must use 'Satisfied by' or 'Derived from'"
                     )
+                if (
+                    sname in SAFETY_ANALYSIS_WORK_PRODUCTS
+                    and dname in SAFETY_ANALYSIS_WORK_PRODUCTS
+                ):
+                    return False, "Trace links between safety analysis work products are not allowed"
             elif conn_type in (
                 "Used By",
                 "Used after Review",
@@ -3209,11 +3216,16 @@ class SysMLDiagramWindow(tk.Frame):
             ):
                 if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
                     return False, f"{conn_type} links must connect Work Products"
+                sname = src.properties.get("name")
                 dname = dst.properties.get("name")
                 if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS:
-                    return False, (
-                        f"{conn_type} links must target a safety analysis work product",
-                    )
+                    return False, f"{conn_type} links must target a safety analysis work product"
+                if (
+                    sname in SAFETY_ANALYSIS_WORK_PRODUCTS
+                    and sname not in UNRESTRICTED_ANALYSIS_INPUTS
+                    and (sname, dname) not in ALLOWED_ANALYSIS_USED_RELATIONS
+                ):
+                    return False, f"{conn_type} links between safety analysis work products are not allowed"
                 # Prevent multiple 'Used' relationships between the same
                 # work products within the active lifecycle phase. Only one
                 # of "Used By", "Used after Review" or "Used after Approval"
@@ -3233,7 +3245,7 @@ class SysMLDiagramWindow(tk.Frame):
                     ):
                         return False, (
                             "A 'Used' relationship between these work products "
-                            "already exists in this phase",
+                            "already exists in this phase"
                         )
             else:
                 allowed = {

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -276,7 +276,7 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
                 0,
                 0,
                 element_id=e1.elem_id,
-                properties={"name": "ODD"},
+                properties={"name": "Scenario Library"},
             )
             o2 = SysMLObject(
                 2,
@@ -284,10 +284,12 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
                 0,
                 100,
                 element_id=e2.elem_id,
-                properties={"name": "Scenario Library"},
+                properties={"name": "ODD"},
             )
             valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, rel)
             self.assertTrue(valid)
+            valid, _ = GovernanceDiagramWindow.validate_connection(win, o2, o1, rel)
+            self.assertFalse(valid)
 
     def test_analysis_inputs_used_after_approval_visibility(self):
         repo = self.repo


### PR DESCRIPTION
## Summary
- prevent "Used" relationships between safety analyses unless explicitly allowed
- allow Scenario Library to supply ODD while rejecting the reverse
- disallow trace links between safety analyses and cover with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689e5600966483259f4c58d0b3f6d506