### PR TITLE
Restrict unsupported "Used" relationships

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -63,6 +63,24 @@ SAFETY_ANALYSIS_WORK_PRODUCTS: set[str] = {
     "ODD",
 }
 
+# Work products that may be used as inputs for any analysis without
+# additional dependency checks
+UNRESTRICTED_USAGE_SOURCES: set[str] = {"Architecture Diagram"}
+
+# Explicit work product dependencies allowed for "Used" style relationships.
+# Each tuple maps a source work product to a target analysis that genuinely
+# depends on it.  Relationships outside this set are rejected to prevent
+# meaningless connections between unrelated work products.
+ALLOWED_USAGE: set[tuple[str, str]] = set(ALLOWED_PROPAGATIONS)
+ALLOWED_USAGE.update(
+    {
+        ("Mission Profile", "Reliability Analysis"),
+        ("Mission Profile", "FTA"),
+        ("Requirement Specification", "HAZOP"),
+        ("ODD", "Scenario Library"),
+    }
+)
+
 @dataclass
 class SafetyWorkProduct:
     """Describe a work product generated from a diagram or analysis."""

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -29,6 +29,8 @@ from analysis.safety_management import (
     ALLOWED_PROPAGATIONS,
     ACTIVE_TOOLBOX,
     SAFETY_ANALYSIS_WORK_PRODUCTS,
+    ALLOWED_USAGE,
+    UNRESTRICTED_USAGE_SOURCES,
 )
 
 # ---------------------------------------------------------------------------
@@ -3210,10 +3212,16 @@ class SysMLDiagramWindow(tk.Frame):
                 if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
                     return False, f"{conn_type} links must connect Work Products"
                 dname = dst.properties.get("name")
+                sname = src.properties.get("name")
                 if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS:
                     return False, (
                         f"{conn_type} links must target a safety analysis work product",
                     )
+                if (
+                    sname not in UNRESTRICTED_USAGE_SOURCES
+                    and (sname, dname) not in ALLOWED_USAGE
+                ):
+                    return False, f"{dname} has no dependency on {sname}"
                 # Prevent multiple 'Used' relationships between the same
                 # work products within the active lifecycle phase. Only one
                 # of "Used By", "Used after Review" or "Used after Approval"

--- a/tests/test_governance_relationship_stereotype.py
+++ b/tests/test_governance_relationship_stereotype.py
@@ -289,6 +289,35 @@ class GovernanceRelationshipStereotypeTests(unittest.TestCase):
             valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, rel)
             self.assertTrue(valid)
 
+    def test_used_relationship_requires_dependency(self):
+        repo = self.repo
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        rels = ["Used By", "Used after Review", "Used after Approval"]
+        for rel in rels:
+            o1 = SysMLObject(
+                1,
+                "Work Product",
+                0,
+                0,
+                element_id=e1.elem_id,
+                properties={"name": "Mission Profile"},
+            )
+            o2 = SysMLObject(
+                2,
+                "Work Product",
+                0,
+                100,
+                element_id=e2.elem_id,
+                properties={"name": "STPA"},
+            )
+            valid, _ = GovernanceDiagramWindow.validate_connection(win, o1, o2, rel)
+            self.assertFalse(valid)
+
     def test_analysis_inputs_used_after_approval_visibility(self):
         repo = self.repo
         toolbox = SafetyManagementToolbox()


### PR DESCRIPTION
## Summary
- prevent "Used" relationships without a true dependency
- document allowable work product inputs
- test that unsupported "Used" relations are rejected

## Testing
- `PYTHONPATH=. pytest tests/test_governance_relationship_stereotype.py -q`
- `PYTHONPATH=. pytest tests/test_analysis_input_visibility.py -q`
- `PYTHONPATH=. pytest tests/test_safety_management.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e57b467a4832597d91edbdc4e752e