### PR TITLE
Allow ODD to use Scenario Library work products

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -50,6 +50,7 @@ ALLOWED_ANALYSIS_USAGE: set[tuple[str, str]] = {
     # in connection validation so it is omitted here.
     ("Reliability Analysis", "FMEA"),
     ("Reliability Analysis", "FMEDA"),
+    ("ODD", "Scenario Library"),
 }
 
 # Work products that support governed inputs from other work products


### PR DESCRIPTION
## Summary
- Allow "Used" relationships from ODD to Scenario Library in governance diagrams
- Add tests ensuring ODD can use Scenario Library while reverse links remain blocked
- Exercise SafetyManagementToolbox to expose ODD→Scenario Library linkage

## Testing
- `PYTHONPATH=$PWD pytest tests/test_governance_relationship_stereotype.py -q`
- `PYTHONPATH=$PWD pytest tests/test_governance_phase_toggle.py::test_work_product_group_activation -q`


------
https://chatgpt.com/codex/tasks/task_b_689e8805ed9c8327bc66982277da5871