### PR TITLE
Add Safety & AI Lifecycle toolbox to governance diagrams

### DIFF
--- a/sysml/sysml_spec.py
+++ b/sysml/sysml_spec.py
@@ -84,3 +84,28 @@ for prop in (
 # Keep BlockBoundaryUsage in sync with BlockUsage properties, including
 # reliability annotations.
 SYSML_PROPERTIES['BlockBoundaryUsage'] = list(SYSML_PROPERTIES['BlockUsage'])
+
+# ----------------------------------------------------------------------
+# Additional elements for Safety & AI Lifecycle toolbox
+# ----------------------------------------------------------------------
+for key in (
+    'DatabaseUsage',
+    'ANNUsage',
+    'DataacquisitionUsage',
+    'AnnotationUsage',
+    'SynthesisUsage',
+    'AugmentationUsage',
+    'AcquisitionUsage',
+    'LabelingUsage',
+    'FieldriskevaluationUsage',
+    'FielddatacollectionUsage',
+    'AItrainingUsage',
+    'AIre-trainingUsage',
+    'CurationUsage',
+    'IngestionUsage',
+    'ModelevaluationUsage',
+):
+    SYSML_PROPERTIES.setdefault(key, [])
+
+# Data acquisition nodes allow custom compartments
+SYSML_PROPERTIES['DataacquisitionUsage'] = ['compartments']


### PR DESCRIPTION
## Summary
- add switchable "Safety & AI Lifecycle" toolbox to governance diagram window
- render database, ANN, and AI lifecycle elements with custom shapes
- register new element types in SysML spec properties

## Testing
- `PYTHONPATH=. pytest tests/test_governance_diagram_refresh.py::test_open_governance_diagram_refreshes_after_phase_activation -q`
- `PYTHONPATH=. pytest tests/test_governance_relationship_stereotype.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e9a398024832798135f36e9d2f939