### PR TITLE
Add requirements generator for governance diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ These diagrams provide a single reference for planning work products,
 coordinating reviews and communicating how safety, cybersecurity and AI
 assurance fit together across the item’s lifecycle.
 
+Governance diagrams can also produce **derived requirements**.  Each task,
+flow and relationship—including any optional conditions—is converted into a
+natural language statement so governance models can be exported as concise
+requirements lists.
+
 ## Workflow Overview
 
 The diagram below illustrates how information flows through the major work products. Each box lists the main inputs and outputs so you can see how analyses feed into one another and where the review workflow fits. Approved reviews update the ASIL and CAL values propagated throughout the model.

--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -16,24 +16,95 @@ class GovernanceDiagram:
     """
 
     graph: nx.DiGraph = field(default_factory=nx.DiGraph)
+    # Explicit mapping of edges to their metadata so the diagram works even
+    # when :mod:`networkx` is not fully featured.
+    edge_data: dict[tuple[str, str], dict[str, str | None]] = field(
+        default_factory=dict
+    )
 
     def add_task(self, name: str) -> None:
         """Add a task node to the diagram."""
         self.graph.add_node(name)
 
-    def add_flow(self, src: str, dst: str) -> None:
-        """Add a directed flow between two existing tasks."""
+    def add_flow(self, src: str, dst: str, condition: str | None = None) -> None:
+        """Add a directed flow between two existing tasks.
+
+        Parameters
+        ----------
+        src, dst:
+            Names of the existing source and destination tasks.
+        condition:
+            Optional textual condition that must hold for the flow to occur.
+        """
+
         if not self.graph.has_node(src) or not self.graph.has_node(dst):
             raise ValueError("Both tasks must exist before creating a flow")
         self.graph.add_edge(src, dst)
+        self.edge_data[(src, dst)] = {"kind": "flow", "condition": condition}
+
+    def add_relationship(
+        self, src: str, dst: str, condition: str | None = None
+    ) -> None:
+        """Add a non-flow relationship between two existing tasks."""
+        if not self.graph.has_node(src) or not self.graph.has_node(dst):
+            raise ValueError("Both tasks must exist before creating a relationship")
+        self.graph.add_edge(src, dst)
+        self.edge_data[(src, dst)] = {
+            "kind": "relationship",
+            "condition": condition,
+        }
 
     def tasks(self) -> List[str]:
         """Return all task node names in the diagram."""
         return list(self.graph.nodes())
 
     def flows(self) -> List[Tuple[str, str]]:
-        """Return all directed flows (edges) in the diagram."""
-        return list(self.graph.edges())
+        """Return all directed flow edges in the diagram."""
+        edges: List[Tuple[str, str]] = []
+        for u, v in self.graph.edges():
+            data = self.edge_data.get((u, v))
+            if data is None or data.get("kind") == "flow":
+                edges.append((u, v))
+        return edges
+
+    def relationships(self) -> List[Tuple[str, str]]:
+        """Return all non-flow relationships in the diagram."""
+        return [
+            (u, v)
+            for (u, v), data in self.edge_data.items()
+            if data.get("kind") == "relationship"
+        ]
+
+    def generate_requirements(self) -> List[str]:
+        """Generate textual requirements from the diagram.
+
+        Tasks, flows, relationships and any optional conditions are converted
+        into simple natural language statements for downstream processing or
+        documentation.
+        """
+
+        requirements: List[str] = []
+
+        for task in self.tasks():
+            requirements.append(f"The system shall perform task '{task}'.")
+
+        for src, dst in self.graph.edges():
+            data = self.edge_data.get((src, dst), {"kind": "flow", "condition": None})
+            cond = data.get("condition")
+            kind = data.get("kind")
+            if kind == "flow":
+                if cond:
+                    req = f"When {cond}, task '{src}' shall precede task '{dst}'."
+                else:
+                    req = f"Task '{src}' shall precede task '{dst}'."
+            else:  # relationship
+                if cond:
+                    req = f"Task '{src}' shall be related to task '{dst}' when {cond}."
+                else:
+                    req = f"Task '{src}' shall be related to task '{dst}'."
+            requirements.append(req)
+
+        return requirements
 
     @classmethod
     def default_from_work_products(cls, names: List[str]) -> "GovernanceDiagram":

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram
+
+
+def test_generate_requirements_from_governance_diagram():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Start")
+    diagram.add_task("Approve")
+    diagram.add_task("Finish")
+    diagram.add_flow("Start", "Approve")
+    diagram.add_flow("Approve", "Finish", condition="approval granted")
+    diagram.add_relationship("Start", "Finish", condition="risk identified")
+
+    reqs = diagram.generate_requirements()
+
+    assert "The system shall perform task 'Start'." in reqs
+    assert "Task 'Start' shall precede task 'Approve'." in reqs
+    assert "When approval granted, task 'Approve' shall precede task 'Finish'." in reqs
+    assert (
+        "Task 'Start' shall be related to task 'Finish' when risk identified." in reqs
+    )


### PR DESCRIPTION
## Summary
- extend GovernanceDiagram with relationship/condition support
- generate textual requirements from tasks, flows, and relationships
- document derived requirements from governance diagrams

## Testing
- `pytest tests/test_governance_requirements_generator.py -q`
- `pytest tests/test_governance_phase_toggle.py::test_open_governance_diagram_activates_phase -q`


------
https://chatgpt.com/codex/tasks/task_b_689e9ede9004832781ce449367279eb8