### PR TITLE
Add Safety & AI Lifecycle toolbox to governance diagrams

### DIFF
--- a/styles/pastel.xml
+++ b/styles/pastel.xml
@@ -12,4 +12,7 @@
   <object type="Block" color="#B0C4DE" />
   <object type="Decision" color="#FFFFFF" />
   <object type="Merge" color="#FFFFFF" />
+  <object type="Database" color="#cfe2f3" />
+  <object type="ANN" color="#d5e8d4" />
+  <object type="Data acquisition" color="#ffe6cc" />
 </style>

--- a/sysml/sysml_spec.py
+++ b/sysml/sysml_spec.py
@@ -84,3 +84,16 @@ for prop in (
 # Keep BlockBoundaryUsage in sync with BlockUsage properties, including
 # reliability annotations.
 SYSML_PROPERTIES['BlockBoundaryUsage'] = list(SYSML_PROPERTIES['BlockUsage'])
+
+# ----------------------------------------------------------------------
+# Additional elements for Safety & AI Lifecycle toolbox
+# ----------------------------------------------------------------------
+for key in (
+    'DatabaseUsage',
+    'ANNUsage',
+    'DataacquisitionUsage',
+):
+    SYSML_PROPERTIES.setdefault(key, [])
+
+# Data acquisition nodes allow custom compartments
+SYSML_PROPERTIES['DataacquisitionUsage'] = ['compartments']


### PR DESCRIPTION
## Summary
- color Safety & AI nodes with white-to-color gradients and fix Database cylinder top
- add default pastel colors for Database, ANN, and Data acquisition
- ensure Safety & AI relationships only connect Safety & AI elements

## Testing
- `PYTHONPATH=. pytest tests/test_governance_diagram_refresh.py::test_open_governance_diagram_refreshes_after_phase_activation -q`
- `PYTHONPATH=. pytest tests/test_governance_relationship_stereotype.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e9a398024832798135f36e9d2f939