### PR TITLE
Add requirements generator for governance diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,40 @@ These diagrams provide a single reference for planning work products,
 coordinating reviews and communicating how safety, cybersecurity and AI
 assurance fit together across the item’s lifecycle.
 
+Governance diagrams can also produce **derived requirements**.  Each task,
+flow and relationship—including any optional conditions—is converted into a
+natural language statement so governance models can be exported as concise
+requirements lists.
+
+When editing a governance diagram in the Safety & Security Management tool,
+use the **Requirements** button to generate these statements and view them in
+a new tab within the working area.
+
+For example, the snippet below creates a tiny governance diagram and prints
+its derived requirements:
+
+```python
+from analysis.governance import GovernanceDiagram
+
+diagram = GovernanceDiagram()
+diagram.add_task("Draft Plan")
+diagram.add_task("Review Plan")
+diagram.add_flow("Draft Plan", "Review Plan", condition="plan complete")
+diagram.add_relationship("Review Plan", "Draft Plan", "changes requested")
+
+for req in diagram.generate_requirements():
+    print(req)
+```
+
+Running this script produces:
+
+```
+The system shall perform task 'Draft Plan'.
+The system shall perform task 'Review Plan'.
+When plan complete, task 'Draft Plan' shall precede task 'Review Plan'.
+Task 'Review Plan' shall be related to task 'Draft Plan' when changes requested.
+```
+
 ## Workflow Overview
 
 The diagram below illustrates how information flows through the major work products. Each box lists the main inputs and outputs so you can see how analyses feed into one another and where the review workflow fits. Approved reviews update the ASIL and CAL values propagated throughout the model.

--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -1,7 +1,7 @@
 """Basic governance diagram support for safety workflows."""
 
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import networkx as nx
 
@@ -16,24 +16,95 @@ class GovernanceDiagram:
     """
 
     graph: nx.DiGraph = field(default_factory=nx.DiGraph)
+    # Explicit mapping of edges to their metadata so the diagram works even
+    # when :mod:`networkx` is not fully featured.
+    edge_data: dict[tuple[str, str], dict[str, str | None]] = field(
+        default_factory=dict
+    )
 
     def add_task(self, name: str) -> None:
         """Add a task node to the diagram."""
         self.graph.add_node(name)
 
-    def add_flow(self, src: str, dst: str) -> None:
-        """Add a directed flow between two existing tasks."""
+    def add_flow(self, src: str, dst: str, condition: str | None = None) -> None:
+        """Add a directed flow between two existing tasks.
+
+        Parameters
+        ----------
+        src, dst:
+            Names of the existing source and destination tasks.
+        condition:
+            Optional textual condition that must hold for the flow to occur.
+        """
+
         if not self.graph.has_node(src) or not self.graph.has_node(dst):
             raise ValueError("Both tasks must exist before creating a flow")
         self.graph.add_edge(src, dst)
+        self.edge_data[(src, dst)] = {"kind": "flow", "condition": condition}
+
+    def add_relationship(
+        self, src: str, dst: str, condition: str | None = None
+    ) -> None:
+        """Add a non-flow relationship between two existing tasks."""
+        if not self.graph.has_node(src) or not self.graph.has_node(dst):
+            raise ValueError("Both tasks must exist before creating a relationship")
+        self.graph.add_edge(src, dst)
+        self.edge_data[(src, dst)] = {
+            "kind": "relationship",
+            "condition": condition,
+        }
 
     def tasks(self) -> List[str]:
         """Return all task node names in the diagram."""
         return list(self.graph.nodes())
 
     def flows(self) -> List[Tuple[str, str]]:
-        """Return all directed flows (edges) in the diagram."""
-        return list(self.graph.edges())
+        """Return all directed flow edges in the diagram."""
+        edges: List[Tuple[str, str]] = []
+        for u, v in self.graph.edges():
+            data = self.edge_data.get((u, v))
+            if data is None or data.get("kind") == "flow":
+                edges.append((u, v))
+        return edges
+
+    def relationships(self) -> List[Tuple[str, str]]:
+        """Return all non-flow relationships in the diagram."""
+        return [
+            (u, v)
+            for (u, v), data in self.edge_data.items()
+            if data.get("kind") == "relationship"
+        ]
+
+    def generate_requirements(self) -> List[str]:
+        """Generate textual requirements from the diagram.
+
+        Tasks, flows, relationships and any optional conditions are converted
+        into simple natural language statements for downstream processing or
+        documentation.
+        """
+
+        requirements: List[str] = []
+
+        for task in self.tasks():
+            requirements.append(f"The system shall perform task '{task}'.")
+
+        for src, dst in self.graph.edges():
+            data = self.edge_data.get((src, dst), {"kind": "flow", "condition": None})
+            cond = data.get("condition")
+            kind = data.get("kind")
+            if kind == "flow":
+                if cond:
+                    req = f"When {cond}, task '{src}' shall precede task '{dst}'."
+                else:
+                    req = f"Task '{src}' shall precede task '{dst}'."
+            else:  # relationship
+                if cond:
+                    req = f"Task '{src}' shall be related to task '{dst}' when {cond}."
+                else:
+                    req = f"Task '{src}' shall be related to task '{dst}'."
+            requirements.append(req)
+
+        return requirements
 
     @classmethod
     def default_from_work_products(cls, names: List[str]) -> "GovernanceDiagram":
@@ -45,3 +116,60 @@ class GovernanceDiagram:
         for src, dst in zip(tasks, tasks[1:]):
             diagram.add_flow(src, dst)
         return diagram
+
+    @classmethod
+    def from_repository(cls, repo: Any, diag_id: str) -> "GovernanceDiagram":
+        """Build a :class:`GovernanceDiagram` from a repository diagram.
+
+        Parameters
+        ----------
+        repo:
+            Repository instance providing ``diagrams`` and ``elements`` maps.
+        diag_id:
+            Identifier of the governance diagram to convert.
+        """
+
+        diagram = cls()
+        src_diagram = repo.diagrams.get(diag_id)
+        if not src_diagram:
+            return diagram
+
+        id_to_name: dict[int, str] = {}
+        for obj in getattr(src_diagram, "objects", []):
+            odict = obj if isinstance(obj, dict) else obj.__dict__
+            if odict.get("obj_type") != "Action":
+                continue
+            elem_id = odict.get("element_id")
+            name = ""
+            if elem_id and elem_id in repo.elements:
+                name = repo.elements[elem_id].name
+            if not name:
+                name = odict.get("properties", {}).get("name", "")
+            if not name:
+                continue
+            diagram.add_task(name)
+            id_to_name[odict.get("obj_id")] = name
+
+        for conn in getattr(src_diagram, "connections", []):
+            cdict = conn if isinstance(conn, dict) else conn.__dict__
+            src = id_to_name.get(cdict.get("src"))
+            dst = id_to_name.get(cdict.get("dst"))
+            if not src or not dst:
+                continue
+            cond = cdict.get("name") or cdict.get("properties", {}).get("condition")
+            if cdict.get("conn_type") == "Flow":
+                diagram.add_flow(src, dst, cond)
+            else:
+                diagram.add_relationship(src, dst, cond)
+
+        return diagram
+
+
+if __name__ == "__main__":  # pragma: no cover - example usage for docs
+    demo = GovernanceDiagram()
+    demo.add_task("Draft Plan")
+    demo.add_task("Review Plan")
+    demo.add_flow("Draft Plan", "Review Plan")
+    demo.add_relationship("Review Plan", "Draft Plan", "changes requested")
+    for requirement in demo.generate_requirements():
+        print(requirement)

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -2,8 +2,10 @@ import tkinter as tk
 from tkinter import ttk, simpledialog
 
 from analysis import SafetyManagementToolbox
+from analysis.governance import GovernanceDiagram
 from gui.architecture import GovernanceDiagramWindow
 from gui import messagebox
+from sysml.sysml_repository import SysMLRepository
 
 
 class SafetyManagementWindow(tk.Frame):
@@ -43,6 +45,9 @@ class SafetyManagementWindow(tk.Frame):
         ttk.Button(top, text="New", command=self.new_diagram).pack(side=tk.LEFT)
         ttk.Button(top, text="Rename", command=self.rename_diagram).pack(side=tk.LEFT)
         ttk.Button(top, text="Delete", command=self.delete_diagram).pack(side=tk.LEFT)
+        ttk.Button(top, text="Requirements", command=self.generate_requirements).pack(
+            side=tk.LEFT
+        )
 
         self.diagram_frame = ttk.Frame(self)
         self.diagram_frame.pack(fill=tk.BOTH, expand=True)
@@ -147,3 +152,23 @@ class SafetyManagementWindow(tk.Frame):
             return
         self.current_window = GovernanceDiagramWindow(self.diagram_frame, self.app, diagram_id=diag_id)
         self.current_window.pack(fill=tk.BOTH, expand=True)
+
+    def generate_requirements(self) -> None:
+        """Generate requirements for the selected governance diagram."""
+        name = self.diag_var.get()
+        if not name:
+            return
+        diag_id = self.toolbox.diagrams.get(name)
+        if not diag_id:
+            return
+        repo = SysMLRepository.get_instance()
+        gov = GovernanceDiagram.from_repository(repo, diag_id)
+        reqs = gov.generate_requirements()
+        if not reqs:
+            messagebox.showinfo("Requirements", "No requirements were generated.")
+            return
+        frame = self.app._new_tab(f"{name} Requirements")
+        txt = tk.Text(frame, wrap="word")
+        txt.insert("1.0", "\n".join(reqs))
+        txt.configure(state="disabled")
+        txt.pack(fill=tk.BOTH, expand=True)

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -1,0 +1,67 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow, SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+from gui import safety_management_toolbox as smt
+
+
+def test_requirements_button_opens_tab(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    t1 = repo.create_element("Action", name="Start")
+    t2 = repo.create_element("Action", name="Finish")
+    diag.objects = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t1.elem_id, "properties": {"name": "Start"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t2.elem_id, "properties": {"name": "Finish"}},
+    ]
+    diag.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams["Gov"] = diag.diag_id
+
+    class DummyTab:
+        pass
+
+    tabs: list[tuple[str, DummyTab]] = []
+
+    def _new_tab(title):
+        tab = DummyTab()
+        tabs.append((title, tab))
+        return tab
+
+    created_texts = []
+
+    class DummyText:
+        def __init__(self, master, wrap="word"):
+            self.content = ""
+            created_texts.append(self)
+
+        def insert(self, index, text):
+            self.content += text
+
+        def configure(self, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.tk, "Text", DummyText)
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace(_new_tab=_new_tab)
+    win.diag_var = types.SimpleNamespace(get=lambda: "Gov")
+
+    win.generate_requirements()
+
+    assert tabs
+    title, _tab = tabs[0]
+    assert "Gov Requirements" in title
+    assert created_texts
+    assert "Task 'Start' shall precede task 'Finish'." in created_texts[0].content

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram
+
+
+def test_generate_requirements_from_governance_diagram():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Start")
+    diagram.add_task("Approve")
+    diagram.add_task("Finish")
+    diagram.add_flow("Start", "Approve")
+    diagram.add_flow("Approve", "Finish", condition="approval granted")
+    diagram.add_relationship("Start", "Finish", condition="risk identified")
+
+    reqs = diagram.generate_requirements()
+
+    assert "The system shall perform task 'Start'." in reqs
+    assert "Task 'Start' shall precede task 'Approve'." in reqs
+    assert "When approval granted, task 'Approve' shall precede task 'Finish'." in reqs
+    assert (
+        "Task 'Start' shall be related to task 'Finish' when risk identified." in reqs
+    )


### PR DESCRIPTION
## Summary
- extend GovernanceDiagram with repository conversion helper
- add GUI button to export governance diagram requirements to a new tab
- document how to view derived requirements in the Safety & Security Management tool

## Testing
- `pytest tests/test_governance_requirements_generator.py -q`
- `pytest tests/test_governance_requirements_button.py -q`
- `pytest tests/test_governance_phase_toggle.py::test_open_governance_diagram_activates_phase -q`


------
https://chatgpt.com/codex/tasks/task_b_689e9ede9004832781ce449367279eb8