### PR TITLE
Add causal Bayesian network analysis

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2108,6 +2108,11 @@ class FaultTreeApp:
             "Reliability Analysis",
             "open_reliability_window",
         ),
+        "Causal Bayesian Network Analysis": (
+            "Safety Analysis",
+            "Causal Bayesian Network",
+            "open_causal_bayesian_network_window",
+        ),
         "Scenario Library": (
             "Scenario",
             "Scenario Libraries",
@@ -2144,6 +2149,7 @@ class FaultTreeApp:
         "FMEDA": "Quantitative Analysis",
         "Mission Profile": "Quantitative Analysis",
         "Reliability Analysis": "Quantitative Analysis",
+        "Causal Bayesian Network Analysis": "Quantitative Analysis",
         "FTA": "Process",
         "Safety & Security Case": "GSN",
         "GSN Argumentation": "GSN",
@@ -16473,6 +16479,13 @@ class FaultTreeApp:
         else:
             self._threat_tab = self._new_tab("Threat")
             self._threat_window = ThreatWindow(self._threat_tab, self)
+        self.refresh_all()
+
+    def open_causal_bayesian_network_window(self):
+        """Open the Causal Bayesian Network analysis window.
+
+        Placeholder stub so the work product is usable even without a
+        dedicated UI implementation."""
         self.refresh_all()
 
     def open_fi2tc_window(self):

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -3,12 +3,14 @@
 from .sotif_validation import acceptance_rate, hazardous_behavior_rate, validation_time
 from .confusion_matrix import compute_metrics, compute_metrics_from_target
 from .safety_case import SafetyCase, SafetyCaseLibrary
+from .causal_bayesian_network import CausalBayesianNetwork
 
 __all__ = [
     "acceptance_rate",
     "hazardous_behavior_rate",
     "validation_time",
     "compute_metrics",
+    "CausalBayesianNetwork",
     "SafetyCase",
     "SafetyCaseLibrary",
     "SafetyManagementToolbox",

--- a/analysis/causal_bayesian_network.py
+++ b/analysis/causal_bayesian_network.py
@@ -1,0 +1,166 @@
+"""Simple Causal Bayesian Network utilities.
+
+This module provides a minimal implementation of a causal Bayesian
+network for binary variables.  Networks are specified by their directed
+acyclic graph structure together with prior and conditional probability
+values.  The implementation supports classic probability queries as well
+as ``do``-style interventions.
+
+Example
+-------
+>>> cbn = CausalBayesianNetwork()
+>>> cbn.add_node('Rain', cpd=0.3)
+>>> cbn.add_node('WetGround', parents=['Rain'],
+...               cpd={(True,): 0.9, (False,): 0.1})
+>>> cbn.add_node('SlipperyRoad', parents=['WetGround'],
+...               cpd={(True,): 0.8, (False,): 0.05})
+>>> round(cbn.query('SlipperyRoad'), 3)
+0.305
+>>> round(cbn.query('SlipperyRoad', evidence={'Rain': True}), 3)
+0.725
+
+The small network above mirrors the example discussed in the project
+README and illustrates how priors, conditional probability tables and
+queries map to the "circles and tables" intuition.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Mapping, Tuple
+
+
+@dataclass
+class CausalBayesianNetwork:
+    """Represent a causal Bayesian network with binary variables."""
+
+    nodes: List[str] = field(default_factory=list)
+    parents: Dict[str, List[str]] = field(default_factory=dict)
+    cpds: Dict[str, object] = field(default_factory=dict)
+
+    def add_node(
+        self,
+        name: str,
+        *,
+        parents: Iterable[str] | None = None,
+        cpd: Mapping[Tuple[bool, ...], float] | float,
+    ) -> None:
+        """Add ``name`` with optional ``parents`` and probability ``cpd``.
+
+        For root nodes (without parents) ``cpd`` is the prior probability
+        of the node being ``True``.  Otherwise ``cpd`` must be a mapping
+        from tuples of parent values to the probability of ``True``.
+        """
+
+        if name in self.nodes:
+            raise ValueError(f"node '{name}' already exists")
+        self.nodes.append(name)
+        self.parents[name] = list(parents or [])
+        if self.parents[name]:
+            if not isinstance(cpd, Mapping):
+                raise TypeError("cpd must be a mapping for non-root nodes")
+            self.cpds[name] = dict(cpd)
+        else:
+            self.cpds[name] = float(cpd)
+
+    # ------------------------------------------------------------------
+    def query(
+        self,
+        var: str,
+        evidence: Mapping[str, bool] | None = None,
+    ) -> float:
+        """Return ``P(var=True | evidence)`` using enumeration."""
+
+        return self._query(var, evidence=evidence or {}, interventions={})
+
+    # ------------------------------------------------------------------
+    def intervention(
+        self,
+        var: str,
+        interventions: Mapping[str, bool],
+        evidence: Mapping[str, bool] | None = None,
+    ) -> float:
+        """Return ``P(var=True | do(interventions), evidence)``."""
+
+        return self._query(var, evidence=evidence or {}, interventions=interventions)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _query(
+        self,
+        var: str,
+        *,
+        evidence: Mapping[str, bool],
+        interventions: Mapping[str, bool],
+    ) -> float:
+        vars_order = self._topological()
+        dist: Dict[bool, float] = {}
+        for value in (False, True):
+            extended = dict(evidence)
+            extended[var] = value
+            dist[value] = self._enumerate_all(vars_order, extended, interventions)
+        total = dist[False] + dist[True]
+        return dist[True] / total if total else 0.0
+
+    def _enumerate_all(
+        self,
+        vars_order: List[str],
+        evidence: Dict[str, bool],
+        interventions: Mapping[str, bool],
+    ) -> float:
+        if not vars_order:
+            return 1.0
+        Y = vars_order[0]
+        rest = vars_order[1:]
+        if Y in evidence:
+            prob = self._probability(Y, evidence[Y], evidence, interventions)
+            return prob * self._enumerate_all(rest, evidence, interventions)
+        else:
+            total = 0.0
+            evidence[Y] = True
+            prob_true = self._probability(Y, True, evidence, interventions)
+            total += prob_true * self._enumerate_all(rest, evidence, interventions)
+            evidence[Y] = False
+            prob_false = self._probability(Y, False, evidence, interventions)
+            total += prob_false * self._enumerate_all(rest, evidence, interventions)
+            del evidence[Y]
+            return total
+
+    def _probability(
+        self,
+        var: str,
+        value: bool,
+        evidence: Mapping[str, bool],
+        interventions: Mapping[str, bool],
+    ) -> float:
+        if var in interventions:
+            return 1.0 if value == interventions[var] else 0.0
+        parents = self.parents.get(var, [])
+        if not parents:
+            p_true = float(self.cpds[var])
+        else:
+            key = tuple(evidence[p] for p in parents)
+            p_true = float(self.cpds[var][key])
+        return p_true if value else 1.0 - p_true
+
+    # ------------------------------------------------------------------
+    def _topological(self) -> List[str]:
+        """Return nodes in topological order."""
+
+        order: List[str] = []
+        temp_mark: set = set()
+        perm_mark: set = set()
+
+        def visit(node: str) -> None:
+            if node in perm_mark:
+                return
+            if node in temp_mark:
+                raise ValueError("graph has cycles")
+            temp_mark.add(node)
+            for parent in self.parents.get(node, []):
+                visit(parent)
+            perm_mark.add(node)
+            order.append(node)
+
+        for node in self.nodes:
+            visit(node)
+        return order

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -68,6 +68,7 @@ SAFETY_ANALYSIS_WORK_PRODUCTS: set[str] = {
     "FMEDA",
     "FTA",
     "Reliability Analysis",
+    "Causal Bayesian Network Analysis",
     "Safety & Security Case",
     "GSN Argumentation",
     "Scenario Library",

--- a/tests/test_causal_bayesian_network_analysis.py
+++ b/tests/test_causal_bayesian_network_analysis.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from analysis import CausalBayesianNetwork
+
+
+def build_network():
+    cbn = CausalBayesianNetwork()
+    cbn.add_node("Rain", cpd=0.3)
+    cbn.add_node(
+        "WetGround",
+        parents=["Rain"],
+        cpd={(True,): 0.9, (False,): 0.1},
+    )
+    cbn.add_node(
+        "SlipperyRoad",
+        parents=["WetGround"],
+        cpd={(True,): 0.8, (False,): 0.05},
+    )
+    return cbn
+
+
+def test_slippery_road_probability():
+    cbn = build_network()
+    assert cbn.query("SlipperyRoad") == pytest.approx(0.305, rel=1e-3)
+
+
+def test_slippery_road_given_rain():
+    cbn = build_network()
+    p = cbn.query("SlipperyRoad", {"Rain": True})
+    assert p == pytest.approx(0.725, rel=1e-3)
+
+
+def test_intervention_matches_conditioning_for_root():
+    cbn = build_network()
+    p_do = cbn.intervention("SlipperyRoad", {"Rain": True})
+    p_cond = cbn.query("SlipperyRoad", {"Rain": True})
+    assert p_do == pytest.approx(p_cond, rel=1e-6)

--- a/tests/test_causal_bayesian_network_governance.py
+++ b/tests/test_causal_bayesian_network_governance.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.safety_management import (
+    SAFETY_ANALYSIS_WORK_PRODUCTS,
+    SafetyManagementToolbox,
+    SafetyWorkProduct,
+)
+from analysis.governance import GovernanceDiagram
+
+
+def test_causal_bayesian_network_work_product():
+    name = "Causal Bayesian Network Analysis"
+    assert name in SAFETY_ANALYSIS_WORK_PRODUCTS
+    toolbox = SafetyManagementToolbox()
+    toolbox.work_products.append(SafetyWorkProduct("Gov", name, ""))
+    diagram = GovernanceDiagram.default_from_work_products([name])
+    assert diagram.tasks() == [name]

--- a/tests/test_governance_group_activation.py
+++ b/tests/test_governance_group_activation.py
@@ -47,6 +47,7 @@ class DummyMenu:
         ("GSN Argumentation", "GSN"),
         ("FMEA", "Qualitative Analysis"),
         ("FMEDA", "Quantitative Analysis"),
+        ("Causal Bayesian Network Analysis", "Quantitative Analysis"),
     ],
 )
 def test_work_product_groups_follow_phase(work_product, parent):

--- a/tests/test_governance_phase_toggle.py
+++ b/tests/test_governance_phase_toggle.py
@@ -357,6 +357,7 @@ def test_work_product_disables_when_leaving_phase(monkeypatch):
         ("TC2FI", "Qualitative Analysis"),
         ("FMEA", "Qualitative Analysis"),
         ("FMEDA", "Quantitative Analysis"),
+        ("Causal Bayesian Network Analysis", "Quantitative Analysis"),
         ("Scenario Library", None),
         ("ODD", "Scenario Library"),
         ("Safety & Security Case", "GSN"),


### PR DESCRIPTION
## Summary
- expose Causal Bayesian Network Analysis as a governed safety work product
- wire the new analysis into the GUI's work product registry with a stub window handler
- test governance integration and group activation for the causal Bayesian network work product

## Testing
- `pytest tests/test_causal_bayesian_network_analysis.py -q`
- `pytest tests/test_causal_bayesian_network_governance.py -q`
- `pytest tests/test_confusion_matrix.py -q`
- `pytest tests/test_governance_group_activation.py::test_work_product_groups_follow_phase -q`
- `pytest tests/test_governance_phase_toggle.py::test_work_product_group_activation -q`
- `PYTHONPATH=. pytest tests/test_governance_relationship_stereotype.py::GovernanceRelationshipStereotypeTests::test_analysis_inputs_all_safety_analyses -q`

------
https://chatgpt.com/codex/tasks/task_b_689eaad7c28c83278c67c3e66d7c96da