### PR TITLE
Propagate Bayesian probabilities and auto-complete CPT tables

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -335,17 +335,15 @@ class CausalBayesianNetworkWindow(tk.Frame):
         win, frame, tree = self.tables[name]
         tree.delete(*tree.get_children())
         parents = doc.network.parents.get(name, [])
+        rows = doc.network.cpd_rows(name)
         if not parents:
-            prob = doc.network.cpds.get(name, 0.0)
-            tree.insert("", "end", values=[f"{prob:.3f}"])
-            tree.configure(height=1)
+            tree.insert("", "end", values=[f"{rows[0][1]:.3f}"])
         else:
-            cpds = doc.network.cpds.get(name, {})
-            for combo, prob in cpds.items():
+            for combo, prob in rows:
                 row = ["T" if val else "F" for val in combo]
                 row.append(f"{prob:.3f}")
                 tree.insert("", "end", values=row)
-            tree.configure(height=len(cpds))
+        tree.configure(height=len(rows))
         frame.update_idletasks()
         self.canvas.itemconfigure(
             win, width=frame.winfo_reqwidth(), height=frame.winfo_reqheight()

--- a/tests/test_causal_bayesian_network_analysis.py
+++ b/tests/test_causal_bayesian_network_analysis.py
@@ -39,3 +39,20 @@ def test_intervention_matches_conditioning_for_root():
     p_do = cbn.intervention("SlipperyRoad", {"Rain": True})
     p_cond = cbn.query("SlipperyRoad", {"Rain": True})
     assert p_do == pytest.approx(p_cond, rel=1e-6)
+
+
+def test_missing_cpd_defaults_to_zero():
+    cbn = CausalBayesianNetwork()
+    cbn.add_node("Rain", cpd=0.5)
+    cbn.add_node("WetGround", parents=["Rain"], cpd={(True,): 0.9})
+    assert cbn.query("WetGround") == pytest.approx(0.45, rel=1e-3)
+
+
+def test_truth_table_auto_fill():
+    cbn = CausalBayesianNetwork()
+    cbn.add_node("A", cpd=0.4)
+    cbn.add_node("B", parents=["A"], cpd={(True,): 0.7})
+    rows = cbn.cpd_rows("B")
+    assert len(rows) == 2
+    assert rows[0][0] == (False,)
+    assert rows[0][1] == pytest.approx(0.0)

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -1,4 +1,5 @@
 import types
+from itertools import product
 from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
 from gui.drawing_helper import FTADrawingHelper
 
@@ -119,10 +120,24 @@ def _setup_window():
     win._place_table = lambda *a, **k: None
     win._position_table = lambda *a, **k: None
     app = DummyApp()
-    doc = types.SimpleNamespace(
-        network=types.SimpleNamespace(nodes=set(), parents={}, cpds={}),
-        positions={},
-    )
+    class Net:
+        def __init__(self):
+            self.nodes = set()
+            self.parents = {}
+            self.cpds = {}
+
+        def cpd_rows(self, name):
+            parents = self.parents.get(name, [])
+            if not parents:
+                prob = float(self.cpds.get(name, 0.0))
+                return [((), prob)]
+            cpds = self.cpds.get(name, {})
+            rows = []
+            for combo in product([False, True], repeat=len(parents)):
+                rows.append((combo, float(cpds.get(combo, 0.0))))
+            return rows
+
+    doc = types.SimpleNamespace(network=Net(), positions={})
     app.active_cbn = doc
     win.app = app
     return win, doc
@@ -153,10 +168,26 @@ def test_table_resizes_for_new_rows():
     first_height = win.canvas.last_configure.get("height")
     assert frame.update_idletasks_called
 
-    # add two rows and update
+    # updating CPDs should keep the same table size because all rows are
+    # present from the start
     frame.update_idletasks_called = False
     doc.network.cpds["A"] = {(True,): 0.1, (False,): 0.2}
     win._update_table("A")
     second_height = win.canvas.last_configure.get("height")
     assert frame.update_idletasks_called
-    assert second_height and second_height > first_height
+    assert second_height == first_height
+
+
+def test_table_auto_fills_missing_rows():
+    win, doc = _setup_window()
+    tree = DummyTree()
+    frame = DummyFrame(tree)
+    win.tables["A"] = (1, frame, tree)
+    doc.network.nodes.add("A")
+    doc.network.parents["A"] = ["P1", "P2"]
+    doc.positions["A"] = (0, 0)
+    # only one CPD entry; others should default to 0.0
+    doc.network.cpds["A"] = {(True, False): 0.2}
+    win._update_table("A")
+    assert tree.height == 4
+    assert len(tree.rows) == 4


### PR DESCRIPTION
## Summary
- Allow Bayesian network queries to treat unspecified CPD entries as probability 0.
- Introduce `cpd_rows` helper to generate full conditional probability tables for any node.
- Update GUI CPT rendering to auto-fill all truth table rows using the new helper.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ec581aadc8327a15d0f1dba289868