### PR TITLE
Propagate Bayesian probabilities and auto-complete CPT tables

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -259,7 +259,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if kind == "trigger":
             color = "lightgreen"
         elif kind == "insufficiency":
-            color = "lightcoral"
+            color = "lightyellow"
         else:
             color = "lightyellow"
         fill_tag = f"fill_{name}"
@@ -335,17 +335,15 @@ class CausalBayesianNetworkWindow(tk.Frame):
         win, frame, tree = self.tables[name]
         tree.delete(*tree.get_children())
         parents = doc.network.parents.get(name, [])
+        rows = doc.network.cpd_rows(name)
         if not parents:
-            prob = doc.network.cpds.get(name, 0.0)
-            tree.insert("", "end", values=[f"{prob:.3f}"])
-            tree.configure(height=1)
+            tree.insert("", "end", values=[f"{rows[0][1]:.3f}"])
         else:
-            cpds = doc.network.cpds.get(name, {})
-            for combo, prob in cpds.items():
+            for combo, prob in rows:
                 row = ["T" if val else "F" for val in combo]
                 row.append(f"{prob:.3f}")
                 tree.insert("", "end", values=row)
-            tree.configure(height=len(cpds))
+        tree.configure(height=len(rows))
         frame.update_idletasks()
         self.canvas.itemconfigure(
             win, width=frame.winfo_reqwidth(), height=frame.winfo_reqheight()


### PR DESCRIPTION
## Summary
- Add `marginal_probabilities` helper that propagates True/False probabilities from parent nodes to compute each node's marginal probability.
- Color triggering conditions light green and functional insufficiency nodes light yellow in the Bayesian network editor.
- Expand tests to cover probability propagation and new node colors.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ec581aadc8327a15d0f1dba289868