### PR TITLE
Add parent combination probabilities to CBN and tweak trigger node color

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -257,7 +257,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
         """Draw a node as a filled circle with a text label."""
         r = self.NODE_RADIUS
         if kind == "trigger":
-            color = "lightgreen"
+            color = "lightblue"
         elif kind == "insufficiency":
             color = "lightyellow"
         else:
@@ -297,7 +297,10 @@ class CausalBayesianNetworkWindow(tk.Frame):
             return
         parents = doc.network.parents.get(name, [])
         prob_col = f"P({name}=T)"
+        combo_col = "P(Parents)" if parents else None
         cols = list(parents) + [prob_col]
+        if combo_col:
+            cols.append(combo_col)
         frame = ttk.Frame(self.canvas)
         label_text = (
             f"Prior probability of {name}" if not parents else f"Conditional probabilities for {name}"
@@ -315,6 +318,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
             info = (
                 "Each row shows a combination of parent values; "
                 f"{prob_col} is the probability that {name} is True for that combination"
+                f" and {combo_col} is the probability of that parent combination"
             )
         ToolTip(tree, info)
         tree.bind("<Double-1>", lambda e, n=name: self.edit_cpd_row(n))
@@ -339,9 +343,10 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if not parents:
             tree.insert("", "end", values=[f"{rows[0][1]:.3f}"])
         else:
-            for combo, prob in rows:
+            for combo, prob, combo_prob in rows:
                 row = ["T" if val else "F" for val in combo]
                 row.append(f"{prob:.3f}")
+                row.append(f"{combo_prob:.3f}")
                 tree.insert("", "end", values=row)
         tree.configure(height=len(rows))
         frame.update_idletasks()

--- a/tests/test_causal_bayesian_network_analysis.py
+++ b/tests/test_causal_bayesian_network_analysis.py
@@ -57,6 +57,15 @@ def test_truth_table_auto_fill():
     assert rows[0][0] == (False,)
     assert rows[0][1] == pytest.approx(0.0)
 
+
+def test_cpd_rows_include_parent_probabilities():
+    cbn = CausalBayesianNetwork()
+    cbn.add_node("Rain", cpd=0.3)
+    cbn.add_node("WetGround", parents=["Rain"], cpd={(True,): 0.9, (False,): 0.1})
+    rows = cbn.cpd_rows("WetGround")
+    assert rows[0][2] == pytest.approx(0.7, rel=1e-3)
+    assert rows[1][2] == pytest.approx(0.3, rel=1e-3)
+
 def test_marginal_probability_propagation():
     cbn = CausalBayesianNetwork()
     cbn.add_node("Rain", cpd=0.3)

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -130,11 +130,11 @@ def _setup_window():
             parents = self.parents.get(name, [])
             if not parents:
                 prob = float(self.cpds.get(name, 0.0))
-                return [((), prob)]
+                return [((), prob, 1.0)]
             cpds = self.cpds.get(name, {})
             rows = []
             for combo in product([False, True], repeat=len(parents)):
-                rows.append((combo, float(cpds.get(combo, 0.0))))
+                rows.append((combo, float(cpds.get(combo, 0.0)), 0.0))
             return rows
 
     doc = types.SimpleNamespace(network=Net(), positions={})
@@ -203,5 +203,5 @@ def test_node_colors_by_type():
     win.drawing_helper._fill_gradient_circle = capture
     win._draw_node("T", 0, 0, "trigger")
     win._draw_node("I", 0, 0, "insufficiency")
-    assert colors[0] == "lightgreen"
+    assert colors[0] == "lightblue"
     assert colors[1] == "lightyellow"


### PR DESCRIPTION
## Summary
- compute probability of each parent combination in CBN truth tables
- display parent combination probabilities and color trigger nodes light blue

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ec950cd5c83278878c360cda97c68