### PR TITLE
Compute parent combination probabilities for CBN tables

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -257,7 +257,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
         """Draw a node as a filled circle with a text label."""
         r = self.NODE_RADIUS
         if kind == "trigger":
-            color = "lightgreen"
+            color = "lightblue"
         elif kind == "insufficiency":
             color = "lightyellow"
         else:
@@ -297,7 +297,11 @@ class CausalBayesianNetworkWindow(tk.Frame):
             return
         parents = doc.network.parents.get(name, [])
         prob_col = f"P({name}=T)"
-        cols = list(parents) + [prob_col]
+        if parents:
+            combo_col = "P(parents)"
+            cols = list(parents) + [combo_col, prob_col]
+        else:
+            cols = [prob_col]
         frame = ttk.Frame(self.canvas)
         label_text = (
             f"Prior probability of {name}" if not parents else f"Conditional probabilities for {name}"
@@ -314,7 +318,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
         else:
             info = (
                 "Each row shows a combination of parent values; "
-                f"{prob_col} is the probability that {name} is True for that combination"
+                f"{prob_col} is the probability that {name} is True for that combination "
+                f"and {combo_col} is the probability of the parent combination"
             )
         ToolTip(tree, info)
         tree.bind("<Double-1>", lambda e, n=name: self.edit_cpd_row(n))
@@ -339,8 +344,9 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if not parents:
             tree.insert("", "end", values=[f"{rows[0][1]:.3f}"])
         else:
-            for combo, prob in rows:
+            for combo, prob, combo_prob in rows:
                 row = ["T" if val else "F" for val in combo]
+                row.append(f"{combo_prob:.3f}")
                 row.append(f"{prob:.3f}")
                 tree.insert("", "end", values=row)
         tree.configure(height=len(rows))

--- a/tests/test_causal_bayesian_network_analysis.py
+++ b/tests/test_causal_bayesian_network_analysis.py
@@ -56,6 +56,9 @@ def test_truth_table_auto_fill():
     assert len(rows) == 2
     assert rows[0][0] == (False,)
     assert rows[0][1] == pytest.approx(0.0)
+    # probability of parent combination P(A=False) = 0.6
+    assert rows[0][2] == pytest.approx(0.6, rel=1e-3)
+    assert rows[1][2] == pytest.approx(0.4, rel=1e-3)
 
 def test_marginal_probability_propagation():
     cbn = CausalBayesianNetwork()

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -130,11 +130,11 @@ def _setup_window():
             parents = self.parents.get(name, [])
             if not parents:
                 prob = float(self.cpds.get(name, 0.0))
-                return [((), prob)]
+                return [((), prob, 1.0)]
             cpds = self.cpds.get(name, {})
             rows = []
             for combo in product([False, True], repeat=len(parents)):
-                rows.append((combo, float(cpds.get(combo, 0.0))))
+                rows.append((combo, float(cpds.get(combo, 0.0)), 0.0))
             return rows
 
     doc = types.SimpleNamespace(network=Net(), positions={})
@@ -203,5 +203,5 @@ def test_node_colors_by_type():
     win.drawing_helper._fill_gradient_circle = capture
     win._draw_node("T", 0, 0, "trigger")
     win._draw_node("I", 0, 0, "insufficiency")
-    assert colors[0] == "lightgreen"
+    assert colors[0] == "lightblue"
     assert colors[1] == "lightyellow"


### PR DESCRIPTION
## Summary
- compute marginal probability of each parent combination in `cpd_rows`
- show parent combination probabilities in the CBN GUI
- color triggering condition nodes light blue

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ec950cd5c83278878c360cda97c68