### PR TITLE
Highlight and drag-connect nodes in CBN diagrams

### DIFF
--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -13,31 +13,52 @@ class DummyCanvas:
         self.moves = []
         self.last_configure = {}
 
-    def create_line(self, x1, y1, x2, y2, fill=None, tags=None):
+    def create_line(self, x1, y1, x2, y2, **kw):
         i = self.next_id
         self.next_id += 1
-        self.items[i] = {"type": "line", "tags": set([tags]) if tags else set()}
+        self.items[i] = {"type": "line", "coords": [x1, y1, x2, y2]}
+        self.items[i].update(kw)
         return i
 
     def create_oval(self, x1, y1, x2, y2, **kw):
         i = self.next_id
         self.next_id += 1
-        self.items[i] = {"type": "oval"}
+        self.items[i] = {"type": "oval", "coords": [x1, y1, x2, y2]}
+        self.items[i].update(kw)
         return i
 
     def create_text(self, x, y, **kw):
         i = self.next_id
         self.next_id += 1
-        self.items[i] = {"type": "text"}
+        self.items[i] = {"type": "text", "coords": [x, y]}
+        self.items[i].update(kw)
         return i
 
-    def coords(self, *args, **kwargs):
-        pass
+    def create_rectangle(self, x1, y1, x2, y2, **kw):
+        i = self.next_id
+        self.next_id += 1
+        self.items[i] = {"type": "rectangle", "coords": [x1, y1, x2, y2]}
+        self.items[i].update(kw)
+        return i
+
+    def delete(self, item):
+        if item == "all":
+            self.items.clear()
+        else:
+            self.items.pop(item, None)
+
+    def coords(self, item, x1, y1, x2=None, y2=None):
+        if item in self.items:
+            if x2 is None and y2 is None:
+                self.items[item]["coords"] = [x1, y1]
+            else:
+                self.items[item]["coords"] = [x1, y1, x2, y2]
 
     def move(self, tag, dx, dy):
         self.moves.append((tag, dx, dy))
 
     def itemconfigure(self, item, **kw):
+        self.items.setdefault(item, {}).update(kw)
         self.last_configure.update(kw)
 
     def update_idletasks(self):
@@ -119,6 +140,13 @@ def _setup_window():
     win.current_tool = "Select"
     win._place_table = lambda *a, **k: None
     win._position_table = lambda *a, **k: None
+    win.after = lambda *a, **k: None
+    win.after_cancel = lambda *a, **k: None
+    win.selected_node = None
+    win.selection_rect = None
+    win.temp_edge_line = None
+    win.temp_edge_anim = None
+    win.temp_edge_offset = 0
     app = DummyApp()
     class Net:
         def __init__(self):
@@ -140,6 +168,10 @@ def _setup_window():
     doc = types.SimpleNamespace(network=Net(), positions={})
     app.active_cbn = doc
     win.app = app
+    win._find_node = lambda x, y: next(
+        (n for n, (nx, ny) in doc.positions.items() if abs(nx - x) <= win.NODE_RADIUS and abs(ny - y) <= win.NODE_RADIUS),
+        None,
+    )
     return win, doc
 
 
@@ -205,3 +237,28 @@ def test_node_colors_by_type():
     win._draw_node("I", 0, 0, "insufficiency")
     assert colors[0] == "lightblue"
     assert colors[1] == "lightyellow"
+
+
+def test_select_highlights_node():
+    win, doc = _setup_window()
+    doc.network.nodes.add("A")
+    doc.positions["A"] = (0, 0)
+    win._draw_node("A", 0, 0)
+    win.on_click(types.SimpleNamespace(x=0, y=0))
+    assert win.selected_node == "A"
+    assert win.selection_rect in win.canvas.items
+
+
+def test_drag_relationship_creates_edge():
+    win, doc = _setup_window()
+    doc.network.nodes.update({"A", "B"})
+    doc.positions["A"] = (0, 0)
+    doc.positions["B"] = (100, 0)
+    win._draw_node("A", 0, 0)
+    win._draw_node("B", 100, 0)
+    win.current_tool = "Relationship"
+    win.on_click(types.SimpleNamespace(x=0, y=0))
+    win.on_drag(types.SimpleNamespace(x=100, y=0))
+    win.on_release(types.SimpleNamespace(x=100, y=0))
+    assert len(win.edges) == 1
+    assert "A" in doc.network.parents.get("B", [])


### PR DESCRIPTION
## Summary
- highlight selected nodes in causal Bayesian diagrams similar to SysML
- require drag-and-drop for relationships with animated dotted preview
- add tests for highlighting and drag connection

## Testing
- `PYTHONPATH=. pytest tests/test_causal_bayesian_ui.py tests/test_causal_bayesian_network_analysis.py tests/test_causal_bayesian_network_governance.py`

------
https://chatgpt.com/codex/tasks/task_b_689ecb864e508327940e09f2dbd334a2