### PR TITLE
Update Bayesian network tables with dynamic probabilities

### DIFF
--- a/analysis/causal_bayesian_network.py
+++ b/analysis/causal_bayesian_network.py
@@ -232,32 +232,33 @@ class CausalBayesianNetwork:
             rows.append((combo, float(cpds.get(combo, 0.0))))
         return rows
 
-    def cpd_rows(self, var: str) -> List[Tuple[Tuple[bool, ...], float, float]]:
-        """Return parent combinations, ``P(var=True)`` and their probabilities.
+    def cpd_rows(self, var: str) -> List[Tuple[Tuple[bool, ...], float, float, float]]:
+        """Return rows of the conditional probability table for ``var``.
 
-        The returned list represents the rows of the node's conditional
-        probability table.  All ``2^n`` combinations of parent values are
-        included.  The third element of each tuple is the probability of that
-        parent combination occurring based on the current marginal
-        probabilities of the parent nodes.  Probabilities not explicitly
-        provided when the node was added default to ``0.0`` so that the table is
-        always complete.
+        Each returned tuple has four elements:
+
+        ``(parent_values, P(var=True | parents), P(parents), P(all))``
+
+        where ``P(all)`` is the joint probability of the entire row, i.e. the
+        probability that the parents take ``parent_values`` *and* ``var`` is
+        ``True``.  Missing entries in the conditional probability table default
+        to ``0.0`` so that the table is always complete.
         """
 
         rows = self._cpd_rows_only(var)
         parents = self.parents.get(var, [])
         if not parents:
             combo, prob = rows[0]
-            return [(combo, prob, 1.0)]
+            return [(combo, prob, 1.0, prob)]
 
         parent_probs = self.marginal_probabilities()
-        result: List[Tuple[Tuple[bool, ...], float, float]] = []
+        result: List[Tuple[Tuple[bool, ...], float, float, float]] = []
         for combo, p_true in rows:
             weight = 1.0
             for parent, val in zip(parents, combo):
                 parent_prob = parent_probs.get(parent, 0.0)
                 weight *= parent_prob if val else 1.0 - parent_prob
-            result.append((combo, p_true, weight))
+            result.append((combo, p_true, weight, weight * p_true))
         return result
 
 

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -299,7 +299,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
         prob_col = f"P({name}=T)"
         if parents:
             combo_col = "P(parents)"
-            cols = list(parents) + [combo_col, prob_col]
+            total_col = "P(total)"
+            cols = list(parents) + [combo_col, prob_col, total_col]
         else:
             cols = [prob_col]
         frame = ttk.Frame(self.canvas)
@@ -311,15 +312,17 @@ class CausalBayesianNetworkWindow(tk.Frame):
         tree = ttk.Treeview(frame, columns=cols, show="headings", height=0)
         for c in cols:
             tree.heading(c, text=c)
-            tree.column(c, width=80 if c == prob_col else 60, anchor=tk.CENTER)
+            width = 80 if c in (prob_col, total_col if parents else None) else 60
+            tree.column(c, width=width, anchor=tk.CENTER)
         tree.pack(side=tk.TOP, fill=tk.X)
         if not parents:
             info = f"Prior probability that {name} is True"
         else:
             info = (
                 "Each row shows a combination of parent values; "
-                f"{prob_col} is the probability that {name} is True for that combination "
-                f"and {combo_col} is the probability of the parent combination"
+                f"{prob_col} is the probability that {name} is True for that combination, "
+                f"{combo_col} is the probability of the parent combination and {total_col} is the "
+                "joint probability of the entire row"
             )
         ToolTip(tree, info)
         tree.bind("<Double-1>", lambda e, n=name: self.edit_cpd_row(n))
@@ -344,10 +347,11 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if not parents:
             tree.insert("", "end", values=[f"{rows[0][1]:.3f}"])
         else:
-            for combo, prob, combo_prob in rows:
+            for combo, prob, combo_prob, total_prob in rows:
                 row = ["T" if val else "F" for val in combo]
                 row.append(f"{combo_prob:.3f}")
                 row.append(f"{prob:.3f}")
+                row.append(f"{total_prob:.3f}")
                 tree.insert("", "end", values=row)
         tree.configure(height=len(rows))
         frame.update_idletasks()
@@ -377,6 +381,16 @@ class CausalBayesianNetworkWindow(tk.Frame):
         self._place_table(name)
 
     # ------------------------------------------------------------------
+    def _update_all_tables(self) -> None:
+        """Update probability tables for all nodes in the active document."""
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc:
+            return
+        for node in doc.network.nodes:
+            if node in self.tables:
+                self._update_table(node)
+
+    # ------------------------------------------------------------------
     def add_cpd_row(self, name: str) -> None:
         doc = getattr(self.app, "active_cbn", None)
         if not doc:
@@ -388,7 +402,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
             )
             if prob is not None:
                 doc.network.cpds[name] = prob
-                self._update_table(name)
+                self._update_all_tables()
             return
         values = []
         for p in parents:
@@ -402,7 +416,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if prob is None:
             return
         doc.network.cpds.setdefault(name, {})[tuple(values)] = prob
-        self._update_table(name)
+        self._update_all_tables()
 
     # ------------------------------------------------------------------
     def edit_cpd_row(self, name: str) -> None:
@@ -421,7 +435,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
             )
             if prob is not None:
                 doc.network.cpds[name] = prob
-                self._update_table(name)
+                self._update_all_tables()
             return
         current = tuple(v == "T" for v in values[:-1])
         prob = simpledialog.askfloat(
@@ -430,7 +444,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if prob is None:
             return
         doc.network.cpds[name][current] = prob
-        self._update_table(name)
+        self._update_all_tables()
 
     # ------------------------------------------------------------------
     def _find_node(self, x: float, y: float) -> str | None:

--- a/tests/test_causal_bayesian_network_analysis.py
+++ b/tests/test_causal_bayesian_network_analysis.py
@@ -59,6 +59,8 @@ def test_truth_table_auto_fill():
     # probability of parent combination P(A=False) = 0.6
     assert rows[0][2] == pytest.approx(0.6, rel=1e-3)
     assert rows[1][2] == pytest.approx(0.4, rel=1e-3)
+    # total probability for row A=True is 0.4 * 0.7
+    assert rows[1][3] == pytest.approx(0.28, rel=1e-3)
 
 def test_marginal_probability_propagation():
     cbn = CausalBayesianNetwork()
@@ -77,3 +79,18 @@ def test_marginal_probability_propagation():
     probs = cbn.marginal_probabilities()
     assert probs["WetGround"] == pytest.approx(0.58, rel=1e-3)
     assert probs["SlipperyRoad"] == pytest.approx(0.485, rel=1e-3)
+
+
+def test_cpd_rows_updates_with_parent_change():
+    cbn = CausalBayesianNetwork()
+    cbn.add_node("Rain", cpd=0.3)
+    cbn.add_node("WetGround", parents=["Rain"], cpd={(True,): 0.9, (False,): 0.1})
+    rows = cbn.cpd_rows("WetGround")
+    # row for Rain=True is second row
+    assert rows[1][2] == pytest.approx(0.3, rel=1e-3)
+    assert rows[1][3] == pytest.approx(0.27, rel=1e-3)
+    # change parent probability
+    cbn.cpds["Rain"] = 0.6
+    rows = cbn.cpd_rows("WetGround")
+    assert rows[1][2] == pytest.approx(0.6, rel=1e-3)
+    assert rows[1][3] == pytest.approx(0.54, rel=1e-3)


### PR DESCRIPTION
## Summary
- compute and return joint probabilities for each CPT row
- refresh all child truth tables when editing probabilities
- display P(total) column in Bayesian network editor and test for updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ecc77f54083279abbbf823af5462d