### PR TITLE
Update CBN truth tables to show joint probabilities and auto-refresh

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -293,7 +293,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
             )
             if prob is not None:
                 doc.network.cpds[name] = prob
-                self._update_table(name)
+                self._update_all_tables()
             return
         cpds = {}
         for combo in product([True, False], repeat=len(parents)):
@@ -311,7 +311,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
                 return
             cpds[combo] = prob
         doc.network.cpds[name] = cpds
-        self._update_table(name)
+        self._update_all_tables()
 
     # ------------------------------------------------------------------
     def _draw_node(self, name: str, x: float, y: float, kind: str | None = None) -> None:
@@ -359,8 +359,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
         parents = doc.network.parents.get(name, [])
         prob_col = f"P({name}=T)"
         if parents:
-            combo_col = "P(parents)"
-            cols = list(parents) + [combo_col, prob_col]
+            joint_col = f"P({name}=T, parents)"
+            cols = list(parents) + [joint_col]
         else:
             cols = [prob_col]
         frame = ttk.Frame(self.canvas)
@@ -372,15 +372,16 @@ class CausalBayesianNetworkWindow(tk.Frame):
         tree = ttk.Treeview(frame, columns=cols, show="headings", height=0)
         for c in cols:
             tree.heading(c, text=c)
-            tree.column(c, width=80 if c == prob_col else 60, anchor=tk.CENTER)
+            is_prob = c == prob_col or (parents and c == joint_col)
+            tree.column(c, width=80 if is_prob else 60, anchor=tk.CENTER)
         tree.pack(side=tk.TOP, fill=tk.X)
         if not parents:
             info = f"Prior probability that {name} is True"
         else:
             info = (
                 "Each row shows a combination of parent values; "
-                f"{prob_col} is the probability that {name} is True for that combination "
-                f"and {combo_col} is the probability of the parent combination"
+                f"{joint_col} is the joint probability that the parents take that combination "
+                f"and {name} is True"
             )
         ToolTip(tree, info)
         tree.bind("<Double-1>", lambda e, n=name: self.edit_cpd_row(n))
@@ -403,9 +404,9 @@ class CausalBayesianNetworkWindow(tk.Frame):
             tree.insert("", "end", values=[f"{rows[0][1]:.3f}"])
         else:
             for combo, prob, combo_prob in rows:
+                joint = combo_prob * prob
                 row = ["T" if val else "F" for val in combo]
-                row.append(f"{combo_prob:.3f}")
-                row.append(f"{prob:.3f}")
+                row.append(f"{joint:.3f}")
                 tree.insert("", "end", values=row)
         tree.configure(height=len(rows))
         frame.update_idletasks()
@@ -425,6 +426,14 @@ class CausalBayesianNetworkWindow(tk.Frame):
         r = self.NODE_RADIUS
         self.canvas.itemconfigure(win, width=w, height=h)
         self.canvas.coords(win, x + r + 10, y - h / 2)
+
+    # ------------------------------------------------------------------
+    def _update_all_tables(self) -> None:
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc:
+            return
+        for node in doc.network.nodes:
+            self._update_table(node)
 
     # ------------------------------------------------------------------
     def _rebuild_table(self, name: str) -> None:
@@ -451,7 +460,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
             )
             if prob is not None:
                 doc.network.cpds[name] = prob
-                self._update_table(name)
+                self._update_all_tables()
             return
         current = tuple(v == "T" for v in values[:-1])
         prob = simpledialog.askfloat(
@@ -460,7 +469,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if prob is None:
             return
         doc.network.cpds[name][current] = prob
-        self._update_table(name)
+        self._update_all_tables()
 
     # ------------------------------------------------------------------
     def _find_node(self, x: float, y: float) -> str | None:

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -1,5 +1,7 @@
 import types
 from itertools import product
+
+from analysis import CausalBayesianNetwork
 from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
 from gui.drawing_helper import FTADrawingHelper
 
@@ -175,6 +177,32 @@ def _setup_window():
     return win, doc
 
 
+def _setup_window_real():
+    win = object.__new__(CausalBayesianNetworkWindow)
+    win.NODE_RADIUS = CausalBayesianNetworkWindow.NODE_RADIUS
+    win.canvas = DummyCanvas()
+    win.drawing_helper = FTADrawingHelper()
+    win.nodes = {}
+    win.tables = {}
+    win.id_to_node = {}
+    win.edges = []
+    win.current_tool = "Select"
+    win._place_table = lambda *a, **k: None
+    win._position_table = lambda *a, **k: None
+    win.after = lambda *a, **k: None
+    win.after_cancel = lambda *a, **k: None
+    win.selected_node = None
+    win.selection_rect = None
+    win.temp_edge_line = None
+    win.temp_edge_anim = None
+    win.temp_edge_offset = 0
+    app = DummyApp()
+    doc = types.SimpleNamespace(network=CausalBayesianNetwork(), positions={})
+    app.active_cbn = doc
+    win.app = app
+    return win, doc
+
+
 def test_fill_moves_with_node():
     win, doc = _setup_window()
     doc.network.nodes.add("A")
@@ -262,3 +290,23 @@ def test_drag_relationship_creates_edge():
     win.on_release(types.SimpleNamespace(x=100, y=0))
     assert len(win.edges) == 1
     assert "A" in doc.network.parents.get("B", [])
+
+
+def test_joint_probabilities_refresh_on_parent_change():
+    win, doc = _setup_window_real()
+    cbn = doc.network
+    cbn.add_node("A", cpd=0.2)
+    cbn.add_node("B", parents=["A"], cpd={(True,): 0.5, (False,): 0.1})
+    tree_a = DummyTree(); frame_a = DummyFrame(tree_a); win.tables["A"] = (1, frame_a, tree_a)
+    tree_b = DummyTree(); frame_b = DummyFrame(tree_b); win.tables["B"] = (2, frame_b, tree_b)
+    doc.positions["A"] = (0, 0)
+    doc.positions["B"] = (0, 0)
+
+    win._update_all_tables()
+    assert tree_b.rows[0][-1] == f"{0.8 * 0.1:.3f}"
+    assert tree_b.rows[1][-1] == f"{0.2 * 0.5:.3f}"
+
+    cbn.cpds["A"] = 0.7
+    win._update_all_tables()
+    assert tree_b.rows[0][-1] == f"{0.3 * 0.1:.3f}"
+    assert tree_b.rows[1][-1] == f"{0.7 * 0.5:.3f}"


### PR DESCRIPTION
## Summary
- combine parent and node probabilities into a single joint column in causal Bayesian network tables
- refresh all tables whenever probabilities change
- test joint probability refresh behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ece33600483279d87e9a98f0b56cf