### PR TITLE
Simplify Bayesian network conditional tables

### DIFF
--- a/tests/test_causal_bayesian_network_analysis.py
+++ b/tests/test_causal_bayesian_network_analysis.py
@@ -10,28 +10,20 @@ from analysis import CausalBayesianNetwork
 def build_network():
     cbn = CausalBayesianNetwork()
     cbn.add_node("Rain", cpd=0.3)
-    cbn.add_node(
-        "WetGround",
-        parents=["Rain"],
-        cpd={(True,): 0.9, (False,): 0.1},
-    )
-    cbn.add_node(
-        "SlipperyRoad",
-        parents=["WetGround"],
-        cpd={(True,): 0.8, (False,): 0.05},
-    )
+    cbn.add_node("WetGround", parents=["Rain"])
+    cbn.add_node("SlipperyRoad", parents=["WetGround"])
     return cbn
 
 
 def test_slippery_road_probability():
     cbn = build_network()
-    assert cbn.query("SlipperyRoad") == pytest.approx(0.305, rel=1e-3)
+    assert cbn.query("SlipperyRoad") == pytest.approx(0.3, rel=1e-3)
 
 
 def test_slippery_road_given_rain():
     cbn = build_network()
     p = cbn.query("SlipperyRoad", {"Rain": True})
-    assert p == pytest.approx(0.725, rel=1e-3)
+    assert p == pytest.approx(1.0, rel=1e-3)
 
 
 def test_intervention_matches_conditioning_for_root():
@@ -45,59 +37,51 @@ def test_missing_cpd_defaults_to_zero():
     cbn = CausalBayesianNetwork()
     cbn.add_node("Rain", cpd=0.5)
     cbn.add_node("WetGround", parents=["Rain"], cpd={(True,): 0.9})
-    assert cbn.query("WetGround") == pytest.approx(0.45, rel=1e-3)
+    # Conditional probabilities are ignored; probability matches parent
+    assert cbn.query("WetGround") == pytest.approx(0.5, rel=1e-3)
 
 
 def test_truth_table_auto_fill():
     cbn = CausalBayesianNetwork()
     cbn.add_node("A", cpd=0.4)
-    cbn.add_node("B", parents=["A"], cpd={(True,): 0.7})
+    cbn.add_node("B", parents=["A"])
     rows = cbn.cpd_rows("B")
     assert len(rows) == 2
     assert rows[0][0] == (False,)
     assert rows[0][1] == pytest.approx(0.0)
     # probability of parent combination P(A=False) = 0.6
     assert rows[0][2] == pytest.approx(0.6, rel=1e-3)
+    assert rows[0][3] == pytest.approx(0.0, rel=1e-3)
+    assert rows[1][1] == pytest.approx(1.0)
     assert rows[1][2] == pytest.approx(0.4, rel=1e-3)
-    # total probability for row A=True is 0.4 * 0.7
-    assert rows[1][3] == pytest.approx(0.28, rel=1e-3)
+    # total probability for row A=True is 0.4 * 1.0
+    assert rows[1][3] == pytest.approx(0.4, rel=1e-3)
 
 def test_marginal_probability_propagation():
     cbn = CausalBayesianNetwork()
     cbn.add_node("Rain", cpd=0.3)
-    cbn.add_node("WetGround", parents=["Rain"], cpd={(True,): 0.9, (False,): 0.1})
-    cbn.add_node(
-        "SlipperyRoad",
-        parents=["WetGround"],
-        cpd={(True,): 0.8, (False,): 0.05},
-    )
+    cbn.add_node("WetGround", parents=["Rain"])
+    cbn.add_node("SlipperyRoad", parents=["WetGround"])
     probs = cbn.marginal_probabilities()
     assert probs["Rain"] == pytest.approx(0.3, rel=1e-3)
-    assert probs["WetGround"] == pytest.approx(0.34, rel=1e-3)
-    assert probs["SlipperyRoad"] == pytest.approx(0.305, rel=1e-3)
+    assert probs["WetGround"] == pytest.approx(0.3, rel=1e-3)
+    assert probs["SlipperyRoad"] == pytest.approx(0.3, rel=1e-3)
     cbn.cpds["Rain"] = 0.6
     probs = cbn.marginal_probabilities()
-    assert probs["WetGround"] == pytest.approx(0.58, rel=1e-3)
-    assert probs["SlipperyRoad"] == pytest.approx(0.485, rel=1e-3)
+    assert probs["WetGround"] == pytest.approx(0.6, rel=1e-3)
+    assert probs["SlipperyRoad"] == pytest.approx(0.6, rel=1e-3)
 
 
 def test_cpd_rows_respect_parent_dependencies():
     cbn = CausalBayesianNetwork()
     cbn.add_node("A", cpd=0.5)
-    cbn.add_node("B", parents=["A"], cpd={(True,): 0.9, (False,): 0.1})
-    # Conditional probabilities of C are irrelevant; set all to 1 so joint column
-    # mirrors P(A,B) directly.
-    all_true = {
-        (False, False): 1.0,
-        (False, True): 1.0,
-        (True, False): 1.0,
-        (True, True): 1.0,
-    }
-    cbn.add_node("C", parents=["A", "B"], cpd=all_true)
+    cbn.add_node("B", parents=["A"])
+    cbn.add_node("C", parents=["A", "B"])
 
     rows = cbn.cpd_rows("C")
     # Expected joint distribution of (A, B) taking into account the dependency
-    # of B on A.
-    expected = [0.45, 0.05, 0.05, 0.45]
+    # of B on A. Only (A=True, B=True) and (A=False, B=False) have non-zero
+    # probability.
+    expected = [0.5, 0.0, 0.0, 0.5]
     for row, exp in zip(rows, expected):
         assert row[2] == pytest.approx(exp, rel=1e-3)

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -307,7 +307,7 @@ def test_update_all_tables_refreshes_dependencies():
     app = DummyApp()
     net = CausalBayesianNetwork()
     net.add_node("Rain", cpd=0.3)
-    net.add_node("WetGround", parents=["Rain"], cpd={(True,): 0.9, (False,): 0.1})
+    net.add_node("WetGround", parents=["Rain"])
     doc = types.SimpleNamespace(network=net, positions={"Rain": (0, 0), "WetGround": (0, 0)})
     app.active_cbn = doc
     win.app = app
@@ -347,17 +347,17 @@ def test_joint_probabilities_refresh_on_parent_change():
     win, doc = _setup_window_real()
     cbn = doc.network
     cbn.add_node("A", cpd=0.2)
-    cbn.add_node("B", parents=["A"], cpd={(True,): 0.5, (False,): 0.1})
+    cbn.add_node("B", parents=["A"])
     tree_a = DummyTree(); frame_a = DummyFrame(tree_a); win.tables["A"] = (1, frame_a, tree_a)
     tree_b = DummyTree(); frame_b = DummyFrame(tree_b); win.tables["B"] = (2, frame_b, tree_b)
     doc.positions["A"] = (0, 0)
     doc.positions["B"] = (0, 0)
 
     win._update_all_tables()
-    assert tree_b.rows[0][-1] == f"{0.8 * 0.1:.3f}"
-    assert tree_b.rows[1][-1] == f"{0.2 * 0.5:.3f}"
+    assert tree_b.rows[0][-1] == f"{0.8 * 0.0:.3f}"
+    assert tree_b.rows[1][-1] == f"{0.2 * 1.0:.3f}"
 
     cbn.cpds["A"] = 0.7
     win._update_all_tables()
-    assert tree_b.rows[0][-1] == f"{0.3 * 0.1:.3f}"
-    assert tree_b.rows[1][-1] == f"{0.7 * 0.5:.3f}"
+    assert tree_b.rows[0][-1] == f"{0.3 * 0.0:.3f}"
+    assert tree_b.rows[1][-1] == f"{0.7 * 1.0:.3f}"


### PR DESCRIPTION
## Summary
- Remove editing of conditional truth tables and assume nodes with parents are true only when all parents are true
- Update probability calculations and CPD row generation for deterministic parent conjunction
- Adjust tests for new Bayesian network behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689edae0cfe88327836c1bfcfe2d871b