### PR TITLE
Default missing conditional probabilities to one

### DIFF
--- a/analysis/causal_bayesian_network.py
+++ b/analysis/causal_bayesian_network.py
@@ -153,7 +153,7 @@ class CausalBayesianNetwork:
             p_true = float(self.cpds[var])
         else:
             key = tuple(evidence[p] for p in parents)
-            p_true = float(self.cpds[var].get(key, 0.0))
+            p_true = float(self.cpds[var].get(key, 1.0))
         return p_true if value else 1.0 - p_true
 
     # ------------------------------------------------------------------
@@ -211,7 +211,7 @@ class CausalBayesianNetwork:
         cpds = self.cpds.get(var, {})
         rows: List[Tuple[Tuple[bool, ...], float]] = []
         for combo in product([False, True], repeat=len(parents)):
-            rows.append((combo, float(cpds.get(combo, 0.0))))
+            rows.append((combo, float(cpds.get(combo, 1.0))))
         return rows
 
     def cpd_rows(self, var: str) -> List[Tuple[Tuple[bool, ...], float, float, float]]:
@@ -224,7 +224,8 @@ class CausalBayesianNetwork:
         where ``P(all)`` is the joint probability of the entire row, i.e. the
         probability that the parents take ``parent_values`` *and* ``var`` is
         ``True``.  Missing entries in the conditional probability table default
-        to ``0.0`` so that the table is always complete.
+        to ``1.0`` so that the table is always complete until explicitly edited
+        by the user.
         """
 
         rows = self._cpd_rows_only(var)

--- a/tests/test_causal_bayesian_network_analysis.py
+++ b/tests/test_causal_bayesian_network_analysis.py
@@ -41,11 +41,11 @@ def test_intervention_matches_conditioning_for_root():
     assert p_do == pytest.approx(p_cond, rel=1e-6)
 
 
-def test_missing_cpd_defaults_to_zero():
+def test_missing_cpd_defaults_to_one():
     cbn = CausalBayesianNetwork()
     cbn.add_node("Rain", cpd=0.5)
     cbn.add_node("WetGround", parents=["Rain"], cpd={(True,): 0.9})
-    assert cbn.query("WetGround") == pytest.approx(0.45, rel=1e-3)
+    assert cbn.query("WetGround") == pytest.approx(0.95, rel=1e-3)
 
 
 def test_truth_table_auto_fill():
@@ -55,7 +55,7 @@ def test_truth_table_auto_fill():
     rows = cbn.cpd_rows("B")
     assert len(rows) == 2
     assert rows[0][0] == (False,)
-    assert rows[0][1] == pytest.approx(0.0)
+    assert rows[0][1] == pytest.approx(1.0)
     # probability of parent combination P(A=False) = 0.6
     assert rows[0][2] == pytest.approx(0.6, rel=1e-3)
     assert rows[1][2] == pytest.approx(0.4, rel=1e-3)

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -172,7 +172,7 @@ def _setup_window():
             cpds = self.cpds.get(name, {})
             rows = []
             for combo in product([False, True], repeat=len(parents)):
-                prob = float(cpds.get(combo, 0.0))
+                prob = float(cpds.get(combo, 1.0))
                 rows.append((combo, prob, 0.0, 0.0))
             return rows
 
@@ -255,7 +255,7 @@ def test_table_auto_fills_missing_rows():
     doc.network.nodes.add("A")
     doc.network.parents["A"] = ["P1", "P2"]
     doc.positions["A"] = (0, 0)
-    # only one CPD entry; others should default to 0.0
+    # only one CPD entry; others should default to 1.0
     doc.network.cpds["A"] = {(True, False): 0.2}
     win._update_table("A")
     assert tree.height == 4


### PR DESCRIPTION
## Summary
- Assume missing parent-value combinations in Bayesian networks have probability 1.0 until edited
- Update conditional probability table helper to reflect new default
- Adjust tests to expect default probability of 1.0

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689edd41a1fc8327b01161da49b7c272