### PR TITLE
feat: show cursor feedback for CBN diagram tools

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -172,6 +172,23 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if tool != "Select":
             self._highlight_node(None)
 
+        configure = getattr(self.canvas, "configure", None)
+        if configure:
+            node_tools = {
+                "Variable",
+                "Triggering Condition",
+                "Existing Triggering Condition",
+                "Functional Insufficiency",
+                "Existing Functional Insufficiency",
+                "Existing Malfunction",
+            }
+            if tool == "Relationship":
+                configure(cursor="tcross")
+            elif tool in node_tools:
+                configure(cursor="crosshair")
+            else:
+                configure(cursor="")
+
     # ------------------------------------------------------------------
     def on_click(self, event) -> None:
         doc = getattr(self.app, "active_cbn", None)

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -362,3 +362,47 @@ def test_joint_probabilities_refresh_on_parent_change():
     win._update_all_tables()
     assert tree_b.rows[0][-1] == f"{0.3 * 0.1:.3f}"
     assert tree_b.rows[1][-1] == f"{0.7 * 0.5:.3f}"
+
+
+def test_node_tool_cursor_and_reset():
+    """Node tools show a crosshair cursor and reset after selection."""
+
+    win = object.__new__(CausalBayesianNetworkWindow)
+
+    class CanvasStub:
+        def __init__(self):
+            self.cursor = None
+
+        def configure(self, **kw):
+            if "cursor" in kw:
+                self.cursor = kw["cursor"]
+
+    win.canvas = CanvasStub()
+    win._highlight_node = lambda name: None
+
+    CausalBayesianNetworkWindow.select_tool(win, "Variable")
+    assert win.canvas.cursor == "crosshair"
+    CausalBayesianNetworkWindow.select_tool(win, "Select")
+    assert win.canvas.cursor == ""
+
+
+def test_relationship_cursor_and_reset():
+    """Relationship tool shows tcross cursor and resets after selection."""
+
+    win = object.__new__(CausalBayesianNetworkWindow)
+
+    class CanvasStub:
+        def __init__(self):
+            self.cursor = None
+
+        def configure(self, **kw):
+            if "cursor" in kw:
+                self.cursor = kw["cursor"]
+
+    win.canvas = CanvasStub()
+    win._highlight_node = lambda name: None
+
+    CausalBayesianNetworkWindow.select_tool(win, "Relationship")
+    assert win.canvas.cursor == "tcross"
+    CausalBayesianNetworkWindow.select_tool(win, "Select")
+    assert win.canvas.cursor == ""


### PR DESCRIPTION
## Summary
- change cursor to crosshair when adding Bayesian network nodes
- use tcross cursor while adding relationships
- test cursor changes for node and relationship tools

## Testing
- `PYTHONPATH=. pytest tests/test_causal_bayesian_ui.py tests/test_gsn_diagram_window.py`

------
https://chatgpt.com/codex/tasks/task_b_689ee2df015083279ce734f009fa12eb