### PR TITLE
Enable selecting CBN nodes via fill area

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -459,7 +459,9 @@ class CausalBayesianNetworkWindow(tk.Frame):
         else:
             color = "lightyellow"
         fill_tag = f"fill_{name}"
-        self.drawing_helper._fill_gradient_circle(self.canvas, x, y, r, color, tag=fill_tag)
+        fill_ids = self.drawing_helper._fill_gradient_circle(
+            self.canvas, x, y, r, color, tag=fill_tag
+        ) or []
         oval = self.canvas.create_oval(
             x - r, y - r, x + r, y + r, outline="black", fill=""
         )
@@ -471,6 +473,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
         self.nodes[name] = (oval, text, fill_tag)
         self.id_to_node[oval] = name
         self.id_to_node[text] = name
+        for fid in fill_ids:
+            self.id_to_node[fid] = name
         self._place_table(name)
         self._update_scroll_region()
 
@@ -783,6 +787,10 @@ class CausalBayesianNetworkWindow(tk.Frame):
         self.nodes[new] = (oval_id, text_id, fill_tag)
         self.id_to_node[oval_id] = new
         self.id_to_node[text_id] = new
+        find_withtag = getattr(self.canvas, "find_withtag", None)
+        if find_withtag:
+            for fid in find_withtag(fill_tag):
+                self.id_to_node[fid] = new
         if hasattr(self, "text_font"):
             self.canvas.itemconfigure(text_id, text=new, font=self.text_font)
         else:

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -215,7 +215,7 @@ def _setup_window_real():
 
 def test_fill_moves_with_node():
     win, doc = _setup_window()
-    doc.network.nodes.add("A")
+    doc.network.add_node("A", cpd=0.5)
     doc.positions["A"] = (0, 0)
     win._draw_node("A", 0, 0)
     win.drag_node = "A"
@@ -223,6 +223,29 @@ def test_fill_moves_with_node():
     event = types.SimpleNamespace(x=10, y=15)
     win.on_drag(event)
     assert ("fill_A", 10, 15) in win.canvas.moves
+
+
+def test_node_selectable_from_fill_area():
+    win, doc = _setup_window_real()
+    captured = []
+
+    real_fill = win.drawing_helper._fill_gradient_circle
+
+    def capture(canvas, *args, **kwargs):
+        ids = real_fill(canvas, *args, **kwargs)
+        captured.extend(ids)
+        return ids
+
+    win.drawing_helper._fill_gradient_circle = capture
+
+    doc.network.add_node("A", cpd=0.5)
+    doc.positions["A"] = (0, 0)
+    win._draw_node("A", 0, 0)
+
+    fill_id = captured[0]
+    win.canvas.find_overlapping = lambda *a, **k: [fill_id]
+
+    assert win._find_node(0, 0) == "A"
 
 
 def test_table_resizes_for_new_rows():


### PR DESCRIPTION
## Summary
- Allow selecting nodes in causal Bayesian network diagrams by clicking filled area
- Update node renaming to keep fill elements selectable
- Test selection from fill area to prevent regressions

## Testing
- `PYTHONPATH=. pytest tests/test_causal_bayesian_ui.py -vv`

------
https://chatgpt.com/codex/tasks/task_b_689ee520efa08327b0b6c4ba01ad8d59