### PR TITLE
Enable cause & effect tool with safety analysis

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2678,6 +2678,7 @@ class FaultTreeApp:
             "Safety & Security Case Explorer": self.manage_safety_cases,
             "Safety Performance Indicators": self.show_safety_performance_indicators,
             "Fault Prioritization": self.open_fault_prioritization_window,
+            "Cause & Effect Chain": self.show_cause_effect_chain,
         }
 
         self.tool_categories: dict[str, list[str]] = {
@@ -2689,6 +2690,7 @@ class FaultTreeApp:
             ],
             "Safety Analysis": [
                 "Fault Prioritization",
+                "Cause & Effect Chain",
             ],
         }
         self.tool_to_work_product = {}
@@ -2696,6 +2698,7 @@ class FaultTreeApp:
             tool_name = info[1]
             if tool_name:
                 self.tool_to_work_product.setdefault(tool_name, set()).add(name)
+        self.tool_to_work_product.setdefault("Cause & Effect Chain", set()).add("FTA")
         self.tool_listboxes: dict[str, tk.Listbox] = {}
         for cat, names in self.tool_categories.items():
             self._add_tool_category(cat, names)

--- a/tests/test_cause_effect_tool_enablement.py
+++ b/tests/test_cause_effect_tool_enablement.py
@@ -1,0 +1,62 @@
+import tkinter as tk
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from sysml.sysml_repository import SysMLRepository
+from AutoML import FaultTreeApp
+
+
+class DummyListbox:
+    def __init__(self):
+        self.items: list[str] = []
+        self.colors: list[tuple[int, str]] = []
+
+    def get(self, *_):
+        return self.items
+
+    def insert(self, index, item):
+        if isinstance(index, int):
+            self.items.insert(index, item)
+        else:
+            self.items.append(item)
+
+    def itemconfig(self, index, foreground="black"):
+        self.colors.append((index, foreground))
+
+
+def test_cause_effect_tool_enabled_with_fta():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule(name="P1", diagrams=["Gov"])]
+    toolbox.diagrams = {"Gov": diag.diag_id}
+    toolbox.set_active_module("P1")
+    toolbox.add_work_product("Gov", "FTA", "")
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    lb = DummyListbox()
+    lb.insert(tk.END, "Cause & Effect Chain")
+    app.tool_listboxes = {"Safety Analysis": lb}
+    app.tool_categories = {"Safety Analysis": ["Cause & Effect Chain"]}
+    app.tool_actions = {"Cause & Effect Chain": lambda: None}
+    app.enable_process_area = lambda area: None
+    app.update_views = lambda: None
+    app.work_product_menus = {}
+    app.enabled_work_products = set()
+    app.safety_mgmt_toolbox = toolbox
+    app.tool_to_work_product = {"Cause & Effect Chain": {"FTA"}}
+    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(app, FaultTreeApp)
+    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(app, FaultTreeApp)
+    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
+        app, FaultTreeApp
+    )
+
+    app.refresh_tool_enablement()
+
+    assert (0, "black") in lb.colors
+


### PR DESCRIPTION
## Summary
- ensure Cause & Effect Chain tool is registered under Safety Analysis
- wire up Cause & Effect Chain availability to FTA work product
- add regression test for Cause & Effect Chain enablement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ee7017f148327942edca0b563432d