### PR TITLE
Add selection helpers for CBN window

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -667,6 +667,48 @@ class CausalBayesianNetworkWindow(tk.Frame):
         self._update_all_tables()
 
     # ------------------------------------------------------------------
+    def _select_triggering_conditions(self) -> list[str]:
+        """Return existing triggering conditions chosen by the user."""
+        tcs = sorted(getattr(self.app, "triggering_conditions", []))
+        if not tcs:
+            messagebox.showinfo(
+                "No Triggering Conditions",
+                "No triggering conditions available.",
+                parent=self,
+            )
+            return []
+        prompt = ", ".join(tcs)
+        sel = simpledialog.askstring(
+            "Existing Triggering Conditions",
+            f"Names (comma separated):\n{prompt}",
+            parent=self,
+        )
+        if not sel:
+            return []
+        return [n.strip() for n in sel.split(",") if n.strip() in tcs]
+
+    # ------------------------------------------------------------------
+    def _select_functional_insufficiencies(self) -> list[str]:
+        """Return existing functional insufficiencies chosen by the user."""
+        fis = sorted(getattr(self.app, "functional_insufficiencies", []))
+        if not fis:
+            messagebox.showinfo(
+                "No Functional Insufficiencies",
+                "No functional insufficiencies available.",
+                parent=self,
+            )
+            return []
+        prompt = ", ".join(fis)
+        sel = simpledialog.askstring(
+            "Existing Functional Insufficiencies",
+            f"Names (comma separated):\n{prompt}",
+            parent=self,
+        )
+        if not sel:
+            return []
+        return [n.strip() for n in sel.split(",") if n.strip() in fis]
+
+    # ------------------------------------------------------------------
     def _select_malfunctions(self) -> list[str]:
         """Return a list of existing malfunctions chosen by the user."""
         mals = sorted(getattr(self.app, "malfunctions", []))

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -315,6 +315,32 @@ def test_click_adds_existing_malfunction_nodes():
     assert doc.positions["M2"][0] == expected_x
 
 
+def test_click_adds_existing_triggering_condition_nodes():
+    win, doc = _setup_window()
+    win.current_tool = "Existing Triggering Condition"
+    with mock.patch.object(
+        win, "_select_triggering_conditions", return_value=["TC1", "TC2"]
+    ):
+        win.on_click(types.SimpleNamespace(x=0, y=0))
+    assert "TC1" in doc.network.nodes and "TC2" in doc.network.nodes
+    assert doc.types["TC1"] == doc.types["TC2"] == "trigger"
+    expected_x = (2 * win.NODE_RADIUS + 10)
+    assert doc.positions["TC2"][0] == expected_x
+
+
+def test_click_adds_existing_functional_insufficiency_nodes():
+    win, doc = _setup_window()
+    win.current_tool = "Existing Functional Insufficiency"
+    with mock.patch.object(
+        win, "_select_functional_insufficiencies", return_value=["FI1", "FI2"]
+    ):
+        win.on_click(types.SimpleNamespace(x=0, y=0))
+    assert "FI1" in doc.network.nodes and "FI2" in doc.network.nodes
+    assert doc.types["FI1"] == doc.types["FI2"] == "insufficiency"
+    expected_x = (2 * win.NODE_RADIUS + 10)
+    assert doc.positions["FI2"][0] == expected_x
+
+
 def test_update_all_tables_refreshes_dependencies():
     win = object.__new__(CausalBayesianNetworkWindow)
     win.NODE_RADIUS = CausalBayesianNetworkWindow.NODE_RADIUS


### PR DESCRIPTION
## Summary
- implement missing selection dialogs for existing triggering conditions and functional insufficiencies in the CBN editor
- add tests verifying existing trigger and insufficiency nodes are added correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ee8e80dd083279eb3fa05856742c7