### PR TITLE
Enable cross-toolbox Safety & AI connections

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3310,10 +3310,28 @@ class SysMLDiagramWindow(tk.Frame):
                 "Ingestion",
                 "Model evaluation",
             ):
-                allowed_types = {"Database", "ANN", "Data acquisition"}
-                if src.obj_type not in allowed_types or dst.obj_type not in allowed_types:
+                ai_types = {"Database", "ANN", "Data acquisition"}
+                gov_types = {
+                    "Work Product",
+                    "Lifecycle Phase",
+                    "Initial",
+                    "Action",
+                    "CallBehaviorAction",
+                    "Decision",
+                    "Merge",
+                    "Fork",
+                    "Join",
+                    "Final",
+                }
+                if not (
+                    (src.obj_type in ai_types and dst.obj_type in ai_types | gov_types)
+                    or (
+                        dst.obj_type in ai_types
+                        and src.obj_type in ai_types | gov_types
+                    )
+                ):
                     return False, (
-                        "Safety & AI relationships must connect Safety & AI elements"
+                        "Safety & AI relationships must involve a Safety & AI element"
                     )
             elif conn_type in (
                 "Used By",
@@ -3365,29 +3383,12 @@ class SysMLDiagramWindow(tk.Frame):
                             "already exists in this phase",
                         )
             else:
+                ai_types = {"Database", "ANN", "Data acquisition"}
                 allowed = {
-                    "Initial": {
-                        "Action",
-                        "Decision",
-                        "Merge",
-                    },
-                    "Action": {
-                        "Action",
-                        "Decision",
-                        "Merge",
-                        "Final",
-                    },
-                    "Decision": {
-                        "Action",
-                        "Decision",
-                        "Merge",
-                        "Final",
-                    },
-                    "Merge": {
-                        "Action",
-                        "Decision",
-                        "Merge",
-                    },
+                    "Initial": {"Action", "Decision", "Merge"} | ai_types,
+                    "Action": {"Action", "Decision", "Merge", "Final"} | ai_types,
+                    "Decision": {"Action", "Decision", "Merge", "Final"} | ai_types,
+                    "Merge": {"Action", "Decision", "Merge"} | ai_types,
                     "Final": set(),
                 }
                 if src.obj_type == "Final":

--- a/tests/test_safety_ai_connections.py
+++ b/tests/test_safety_ai_connections.py
@@ -1,0 +1,87 @@
+import os
+import sys
+import types
+import unittest
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Provide dummy PIL modules so tests run without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+class DummyCanvas:
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+    def configure(self, **kwargs):
+        pass
+
+
+class SafetyAIGovernanceConnectionTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def _window(self, diag):
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = self.repo
+        win.diagram_id = diag.diag_id
+        win.connections = []
+        win.canvas = DummyCanvas()
+        return win
+
+    def test_safety_ai_relationship_governance_to_ai(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        src = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "Risk Assessment"})
+        dst = SysMLObject(2, "Database", 0, 100, element_id=e2.elem_id)
+        diag.objects = [src.__dict__, dst.__dict__]
+        win = self._window(diag)
+        valid, msg = win.validate_connection(src, dst, "Annotation")
+        self.assertTrue(valid, msg)
+
+    def test_safety_ai_relationship_ai_to_governance(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        src = SysMLObject(1, "ANN", 0, 0, element_id=e1.elem_id)
+        dst = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Risk Assessment"})
+        diag.objects = [src.__dict__, dst.__dict__]
+        win = self._window(diag)
+        valid, msg = win.validate_connection(src, dst, "Synthesis")
+        self.assertTrue(valid, msg)
+
+    def test_flow_from_action_to_ai(self):
+        repo = self.repo
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, e1.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, e2.elem_id)
+        src = SysMLObject(1, "Action", 0, 0, element_id=e1.elem_id)
+        dst = SysMLObject(2, "Database", 0, 100, element_id=e2.elem_id)
+        diag.objects = [src.__dict__, dst.__dict__]
+        win = self._window(diag)
+        valid, msg = win.validate_connection(src, dst, "Flow")
+        self.assertTrue(valid, msg)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Allow Safety & AI relationships to connect governance elements with AI nodes in Governance Diagrams
- Permit flow connections from governance diagram tasks to Safety & AI nodes
- Add tests covering Safety & AI relationships and flows between governance and AI elements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f35bdc0bc8327a77d508f56ad2d3a