### PR TITLE
Add menu for phase-based requirement generation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2382,6 +2382,11 @@ class FaultTreeApp:
             label="Safety Performance Indicators",
             command=self.show_safety_performance_indicators,
         )
+        self.phase_req_menu = tk.Menu(requirements_menu, tearoff=0)
+        requirements_menu.add_cascade(
+            label="Phase Requirements", menu=self.phase_req_menu
+        )
+        self._refresh_phase_requirements_menu()
         requirements_menu.add_command(
             label="Export Product Goal Requirements",
             command=self.export_product_goal_requirements,
@@ -9031,6 +9036,7 @@ class FaultTreeApp:
 
     def _on_toolbox_change(self) -> None:
         self.refresh_tool_enablement()
+        self._refresh_phase_requirements_menu()
         try:
             self.update_views()
         except Exception:
@@ -14559,6 +14565,25 @@ class FaultTreeApp:
                     seen.add(rid)
                     writer.writerow([sg_text, sg_asil, te.safe_state, rid, req.get("asil", ""), req.get("text", "")])
         messagebox.showinfo("Export", "Product goal requirements exported.")
+    def generate_phase_requirements(self, phase: str) -> None:
+        """Generate requirements for all governance diagrams in a phase."""
+        self.open_safety_management_toolbox()
+        win = getattr(self, "safety_mgmt_window", None)
+        if win:
+            win.generate_phase_requirements(phase)
+
+    def _refresh_phase_requirements_menu(self) -> None:
+        if not hasattr(self, "phase_req_menu"):
+            return
+        self.phase_req_menu.delete(0, tk.END)
+        toolbox = getattr(self, "safety_mgmt_toolbox", None)
+        if not toolbox:
+            return
+        for phase in sorted(toolbox.list_modules()):
+            self.phase_req_menu.add_command(
+                label=phase,
+                command=lambda p=phase: self.generate_phase_requirements(p),
+            )
 
     def export_cybersecurity_goal_requirements(self):
         """Export cybersecurity goals with linked risk assessments."""

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -1,0 +1,82 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow, SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+from gui import safety_management_toolbox as smt
+
+
+def test_phase_requirements_menu(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    d1 = repo.create_diagram("Governance Diagram", name="Gov1")
+    t1 = repo.create_element("Action", name="Start")
+    t2 = repo.create_element("Action", name="Finish")
+    d1.objects = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t1.elem_id, "properties": {"name": "Start"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t2.elem_id, "properties": {"name": "Finish"}},
+    ]
+    d1.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+
+    d2 = repo.create_diagram("Governance Diagram", name="Gov2")
+    t3 = repo.create_element("Action", name="Check")
+    t4 = repo.create_element("Action", name="Complete")
+    d2.objects = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t3.elem_id, "properties": {"name": "Check"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t4.elem_id, "properties": {"name": "Complete"}},
+    ]
+    d2.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams["Gov1"] = d1.diag_id
+    toolbox.diagrams["Gov2"] = d2.diag_id
+    mod = toolbox.add_module("Phase1")
+    mod.diagrams.extend(["Gov1", "Gov2"])
+
+    class DummyTab:
+        pass
+
+    tabs = []
+
+    def _new_tab(title):
+        tab = DummyTab()
+        tabs.append((title, tab))
+        return tab
+
+    created_texts = []
+
+    class DummyText:
+        def __init__(self, master, wrap="word"):
+            self.content = ""
+            created_texts.append(self)
+
+        def insert(self, index, text):
+            self.content += text
+
+        def configure(self, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.tk, "Text", DummyText)
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace(_new_tab=_new_tab)
+
+    win.generate_phase_requirements("Phase1")
+
+    assert tabs
+    title, _tab = tabs[0]
+    assert "Phase1 Requirements" in title
+    assert created_texts
+    content = created_texts[0].content
+    assert "Task 'Start' shall precede task 'Finish'." in content
+    assert "Task 'Check' shall precede task 'Complete'." in content

--- a/tests/test_phase_requirements_main_menu.py
+++ b/tests/test_phase_requirements_main_menu.py
@@ -1,0 +1,64 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("ImageTk"))
+
+from AutoML import FaultTreeApp
+from analysis import SafetyManagementToolbox
+
+
+def test_phase_requirements_menu_populated(monkeypatch):
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_module("Phase1")
+    app.safety_mgmt_toolbox = toolbox
+
+    called = []
+
+    def fake_generate(phase):
+        called.append(phase)
+
+    app.generate_phase_requirements = fake_generate
+
+    class DummyMenu:
+        def __init__(self):
+            self.items = []
+
+        def delete(self, start, end):
+            self.items.clear()
+
+        def add_command(self, label, command):
+            self.items.append((label, command))
+
+    app.phase_req_menu = DummyMenu()
+
+    FaultTreeApp._refresh_phase_requirements_menu(app)
+
+    assert any(label == "Phase1" for label, _ in app.phase_req_menu.items)
+    for label, cmd in app.phase_req_menu.items:
+        if label == "Phase1":
+            cmd()
+    assert called == ["Phase1"]
+
+
+def test_generate_phase_requirements_delegates(monkeypatch):
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    events = []
+
+    def fake_open():
+        events.append("open")
+
+    app.open_safety_management_toolbox = fake_open
+    app.safety_mgmt_window = types.SimpleNamespace(
+        generate_phase_requirements=lambda p: events.append(p)
+    )
+
+    FaultTreeApp.generate_phase_requirements(app, "PhaseX")
+
+    assert events == ["open", "PhaseX"]


### PR DESCRIPTION
## Summary
- Expose Phase Requirements submenu in main Requirements menu with dynamic phase listing
- Delegate generation to Safety Management window and refresh menu when toolbox changes
- Add tests ensuring main menu population and delegation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f3186df308327a5bf52e4f7d83917