### PR TITLE
Disallow invalid CBN relationships

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -358,15 +358,30 @@ class CausalBayesianNetworkWindow(tk.Frame):
             dst = self._find_node(event.x, event.y)
             src = self.edge_start
             if dst and dst != src:
-                undo = getattr(self.app, "push_undo_state", None)
-                if undo:
-                    undo()
-                self._draw_edge(src, dst)
-                parents = doc.network.parents.setdefault(dst, [])
-                if src not in parents:
-                    parents.append(src)
-                    doc.network.cpds[dst] = {}
-                    self._rebuild_table(dst)
+                kind_src = doc.types.get(src)
+                kind_dst = doc.types.get(dst)
+                if kind_src == "insufficiency" and kind_dst == "trigger":
+                    messagebox.showerror(
+                        "Invalid Relationship",
+                        "Functional insufficiency cannot connect to a triggering condition.",
+                        parent=self,
+                    )
+                elif kind_src == "malfunction":
+                    messagebox.showerror(
+                        "Invalid Relationship",
+                        "Malfunction nodes cannot connect to other nodes.",
+                        parent=self,
+                    )
+                else:
+                    undo = getattr(self.app, "push_undo_state", None)
+                    if undo:
+                        undo()
+                    self._draw_edge(src, dst)
+                    parents = doc.network.parents.setdefault(dst, [])
+                    if src not in parents:
+                        parents.append(src)
+                        doc.network.cpds[dst] = {}
+                        self._rebuild_table(dst)
             self.edge_start = None
             if self.temp_edge_line:
                 self.canvas.delete(self.temp_edge_line)

--- a/tests/test_causal_bayesian_ui.py
+++ b/tests/test_causal_bayesian_ui.py
@@ -388,6 +388,50 @@ def test_drag_relationship_creates_edge():
     assert win.current_tool == "Select"
 
 
+def test_disallow_insufficiency_to_trigger_relationship():
+    from gui import causal_bayesian_network_window as cbn_mod
+
+    win, doc = _setup_window()
+    doc.network.nodes.update({"FI", "TC"})
+    doc.positions["FI"] = (0, 0)
+    doc.positions["TC"] = (100, 0)
+    doc.types["FI"] = "insufficiency"
+    doc.types["TC"] = "trigger"
+    win._draw_node("FI", 0, 0, "insufficiency")
+    win._draw_node("TC", 100, 0, "trigger")
+    win.current_tool = "Relationship"
+    with mock.patch.object(cbn_mod.messagebox, "showerror") as err:
+        win.on_click(types.SimpleNamespace(x=0, y=0))
+        win.on_drag(types.SimpleNamespace(x=100, y=0))
+        win.on_release(types.SimpleNamespace(x=100, y=0))
+    assert len(win.edges) == 0
+    assert "FI" not in doc.network.parents.get("TC", [])
+    assert win.current_tool == "Select"
+    err.assert_called_once()
+
+
+def test_disallow_malfunction_relationship():
+    from gui import causal_bayesian_network_window as cbn_mod
+
+    win, doc = _setup_window()
+    doc.network.nodes.update({"M", "V"})
+    doc.positions["M"] = (0, 0)
+    doc.positions["V"] = (100, 0)
+    doc.types["M"] = "malfunction"
+    doc.types["V"] = "variable"
+    win._draw_node("M", 0, 0, "malfunction")
+    win._draw_node("V", 100, 0, "variable")
+    win.current_tool = "Relationship"
+    with mock.patch.object(cbn_mod.messagebox, "showerror") as err:
+        win.on_click(types.SimpleNamespace(x=0, y=0))
+        win.on_drag(types.SimpleNamespace(x=100, y=0))
+        win.on_release(types.SimpleNamespace(x=100, y=0))
+    assert len(win.edges) == 0
+    assert "M" not in doc.network.parents.get("V", [])
+    assert win.current_tool == "Select"
+    err.assert_called_once()
+
+
 def test_add_node_returns_to_select():
     from gui import causal_bayesian_network_window as cbn_mod
 


### PR DESCRIPTION
## Summary
- Prevent functional insufficiency-to-triggering-condition and malfunction-to-any-node relationships in causal Bayesian network diagrams
- Add regression tests covering forbidden relationship cases

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f3796f51c8327be073145727ef33c