### PR TITLE
Add menu for phase-based requirement generation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2382,6 +2382,11 @@ class FaultTreeApp:
             label="Safety Performance Indicators",
             command=self.show_safety_performance_indicators,
         )
+        self.phase_req_menu = tk.Menu(requirements_menu, tearoff=0)
+        requirements_menu.add_cascade(
+            label="Phase Requirements", menu=self.phase_req_menu
+        )
+        self._refresh_phase_requirements_menu()
         requirements_menu.add_command(
             label="Export Product Goal Requirements",
             command=self.export_product_goal_requirements,
@@ -9031,6 +9036,7 @@ class FaultTreeApp:
 
     def _on_toolbox_change(self) -> None:
         self.refresh_tool_enablement()
+        self._refresh_phase_requirements_menu()
         try:
             self.update_views()
         except Exception:
@@ -14559,6 +14565,25 @@ class FaultTreeApp:
                     seen.add(rid)
                     writer.writerow([sg_text, sg_asil, te.safe_state, rid, req.get("asil", ""), req.get("text", "")])
         messagebox.showinfo("Export", "Product goal requirements exported.")
+    def generate_phase_requirements(self, phase: str) -> None:
+        """Generate requirements for all governance diagrams in a phase."""
+        self.open_safety_management_toolbox()
+        win = getattr(self, "safety_mgmt_window", None)
+        if win:
+            win.generate_phase_requirements(phase)
+
+    def _refresh_phase_requirements_menu(self) -> None:
+        if not hasattr(self, "phase_req_menu"):
+            return
+        self.phase_req_menu.delete(0, tk.END)
+        toolbox = getattr(self, "safety_mgmt_toolbox", None)
+        if not toolbox:
+            return
+        for phase in sorted(toolbox.list_modules()):
+            self.phase_req_menu.add_command(
+                label=phase,
+                command=lambda p=phase: self.generate_phase_requirements(p),
+            )
 
     def export_cybersecurity_goal_requirements(self):
         """Export cybersecurity goals with linked risk assessments."""

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -3,6 +3,11 @@ from tkinter import ttk, simpledialog
 
 from analysis import SafetyManagementToolbox
 from analysis.governance import GovernanceDiagram
+from analysis.models import (
+    REQUIREMENT_TYPE_OPTIONS,
+    ensure_requirement_defaults,
+    global_requirements,
+)
 from gui.architecture import GovernanceDiagramWindow
 from gui import messagebox
 from sysml.sysml_repository import SysMLRepository
@@ -48,6 +53,10 @@ class SafetyManagementWindow(tk.Frame):
         ttk.Button(top, text="Requirements", command=self.generate_requirements).pack(
             side=tk.LEFT
         )
+        self.phase_menu_btn = tk.Menubutton(top, text="Phase Requirements")
+        self.phase_menu = tk.Menu(self.phase_menu_btn, tearoff=False)
+        self.phase_menu_btn.configure(menu=self.phase_menu)
+        self.phase_menu_btn.pack(side=tk.LEFT)
 
         self.diagram_frame = ttk.Frame(self)
         self.diagram_frame.pack(fill=tk.BOTH, expand=True)
@@ -82,6 +91,7 @@ class SafetyManagementWindow(tk.Frame):
         if current not in phases:
             self.phase_var.set("All")
         self.select_phase()
+        self._refresh_phase_menu()
 
     def select_phase(self, *_):
         phase = self.phase_var.get()
@@ -153,6 +163,42 @@ class SafetyManagementWindow(tk.Frame):
         self.current_window = GovernanceDiagramWindow(self.diagram_frame, self.app, diagram_id=diag_id)
         self.current_window.pack(fill=tk.BOTH, expand=True)
 
+    # ------------------------------------------------------------------
+    def _add_requirement(self, text: str) -> str:
+        """Create a new requirement with a unique identifier."""
+        idx = 1
+        while f"R{idx}" in global_requirements:
+            idx += 1
+        rid = f"R{idx}"
+        req_type = REQUIREMENT_TYPE_OPTIONS[0]
+        app = getattr(self, "app", None)
+        if app and hasattr(app, "add_new_requirement"):
+            app.add_new_requirement(rid, req_type, text)
+        else:
+            req = {
+                "id": rid,
+                "custom_id": rid,
+                "req_type": req_type,
+                "text": text,
+                "status": "draft",
+                "parent_id": "",
+            }
+            ensure_requirement_defaults(req)
+            global_requirements[rid] = req
+        return rid
+
+    # ------------------------------------------------------------------
+    def _display_requirements(self, title: str, ids: list[str]) -> None:
+        frame = self.app._new_tab(title)
+        columns = ("ID", "Type", "Text")
+        tree = ttk.Treeview(frame, columns=columns, show="headings")
+        for c in columns:
+            tree.heading(c, text=c)
+        for rid in ids:
+            req = global_requirements.get(rid, {})
+            tree.insert("", "end", values=(rid, req.get("req_type", ""), req.get("text", "")))
+        tree.pack(fill=tk.BOTH, expand=True)
+
     def generate_requirements(self) -> None:
         """Generate requirements for the selected governance diagram."""
         name = self.diag_var.get()
@@ -167,8 +213,36 @@ class SafetyManagementWindow(tk.Frame):
         if not reqs:
             messagebox.showinfo("Requirements", "No requirements were generated.")
             return
-        frame = self.app._new_tab(f"{name} Requirements")
-        txt = tk.Text(frame, wrap="word")
-        txt.insert("1.0", "\n".join(reqs))
-        txt.configure(state="disabled")
-        txt.pack(fill=tk.BOTH, expand=True)
+        ids = [self._add_requirement(text) for text in reqs]
+        self._display_requirements(f"{name} Requirements", ids)
+
+    def _refresh_phase_menu(self) -> None:
+        self.phase_menu.delete(0, tk.END)
+        for phase in sorted(self.toolbox.list_modules()):
+            self.phase_menu.add_command(
+                label=phase,
+                command=lambda p=phase: self.generate_phase_requirements(p),
+            )
+
+    def generate_phase_requirements(self, phase: str) -> None:
+        diag_names = sorted(self.toolbox.diagrams_for_module(phase))
+        if not diag_names:
+            messagebox.showinfo("Requirements", f"No governance diagrams for phase '{phase}'.")
+            return
+        repo = SysMLRepository.get_instance()
+        ids: list[str] = []
+        for name in diag_names:
+            diag_id = self.toolbox.diagrams.get(name)
+            if not diag_id:
+                continue
+            gov = GovernanceDiagram.from_repository(repo, diag_id)
+            reqs = gov.generate_requirements()
+            for text in reqs:
+                ids.append(self._add_requirement(text))
+        if not ids:
+            messagebox.showinfo(
+                "Requirements",
+                f"No requirements were generated for phase '{phase}'.",
+            )
+            return
+        self._display_requirements(f"{phase} Requirements", ids)

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -10,26 +10,40 @@ from gui import safety_management_toolbox as smt
 from analysis.models import global_requirements, REQUIREMENT_TYPE_OPTIONS
 
 
-def test_requirements_button_opens_tab(monkeypatch):
+def test_phase_requirements_menu(monkeypatch):
     repo = SysMLRepository.reset_instance()
-    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    d1 = repo.create_diagram("Governance Diagram", name="Gov1")
     t1 = repo.create_element("Action", name="Start")
     t2 = repo.create_element("Action", name="Finish")
-    diag.objects = [
+    d1.objects = [
         {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t1.elem_id, "properties": {"name": "Start"}},
         {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t2.elem_id, "properties": {"name": "Finish"}},
     ]
-    diag.connections = [
+    d1.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+
+    d2 = repo.create_diagram("Governance Diagram", name="Gov2")
+    t3 = repo.create_element("Action", name="Check")
+    t4 = repo.create_element("Action", name="Complete")
+    d2.objects = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t3.elem_id, "properties": {"name": "Check"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t4.elem_id, "properties": {"name": "Complete"}},
+    ]
+    d2.connections = [
         {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
     ]
 
     toolbox = SafetyManagementToolbox()
-    toolbox.diagrams["Gov"] = diag.diag_id
+    toolbox.diagrams["Gov1"] = d1.diag_id
+    toolbox.diagrams["Gov2"] = d2.diag_id
+    mod = toolbox.add_module("Phase1")
+    mod.diagrams.extend(["Gov1", "Gov2"])
 
     class DummyTab:
         pass
 
-    tabs: list[tuple[str, DummyTab]] = []
+    tabs = []
 
     def _new_tab(title):
         tab = DummyTab()
@@ -57,18 +71,16 @@ def test_requirements_button_opens_tab(monkeypatch):
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)
     win.toolbox = toolbox
     win.app = types.SimpleNamespace(_new_tab=_new_tab)
-    win.diag_var = types.SimpleNamespace(get=lambda: "Gov")
 
     global_requirements.clear()
-    win.generate_requirements()
+    win.generate_phase_requirements("Phase1")
 
     assert tabs
     title, _tab = tabs[0]
-    assert "Gov Requirements" in title
+    assert "Phase1 Requirements" in title
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
     assert any("Task 'Start' shall precede task 'Finish'." in t for t in texts)
-    # Ensure requirement types are valid
+    assert any("Task 'Check' shall precede task 'Complete'." in t for t in texts)
     assert all(row[1] in REQUIREMENT_TYPE_OPTIONS for row in trees[0].rows)
-    # Requirements added to global registry
     assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_phase_requirements_main_menu.py
+++ b/tests/test_phase_requirements_main_menu.py
@@ -1,0 +1,64 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("ImageTk"))
+
+from AutoML import FaultTreeApp
+from analysis import SafetyManagementToolbox
+
+
+def test_phase_requirements_menu_populated(monkeypatch):
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_module("Phase1")
+    app.safety_mgmt_toolbox = toolbox
+
+    called = []
+
+    def fake_generate(phase):
+        called.append(phase)
+
+    app.generate_phase_requirements = fake_generate
+
+    class DummyMenu:
+        def __init__(self):
+            self.items = []
+
+        def delete(self, start, end):
+            self.items.clear()
+
+        def add_command(self, label, command):
+            self.items.append((label, command))
+
+    app.phase_req_menu = DummyMenu()
+
+    FaultTreeApp._refresh_phase_requirements_menu(app)
+
+    assert any(label == "Phase1" for label, _ in app.phase_req_menu.items)
+    for label, cmd in app.phase_req_menu.items:
+        if label == "Phase1":
+            cmd()
+    assert called == ["Phase1"]
+
+
+def test_generate_phase_requirements_delegates(monkeypatch):
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    events = []
+
+    def fake_open():
+        events.append("open")
+
+    app.open_safety_management_toolbox = fake_open
+    app.safety_mgmt_window = types.SimpleNamespace(
+        generate_phase_requirements=lambda p: events.append(p)
+    )
+
+    FaultTreeApp.generate_phase_requirements(app, "PhaseX")
+
+    assert events == ["open", "PhaseX"]


### PR DESCRIPTION
## Summary
- Expose Phase Requirements submenu in main Requirements menu with dynamic phase listing
- Delegate generation to Safety Management window and refresh menu when toolbox changes
- Add tests ensuring main menu population and delegation
- Convert governance-generated requirements into project entries and display them in tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f3186df308327a5bf52e4f7d83917