### PR TITLE
Preserve Safety Management window instance to show content

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16756,7 +16756,7 @@ class FaultTreeApp:
         if not hasattr(self, "safety_mgmt_toolbox"):
             self.safety_mgmt_toolbox = SafetyManagementToolbox()
 
-        SafetyManagementWindow(
+        self.safety_mgmt_window = SafetyManagementWindow(
             self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
         )
 
@@ -16774,7 +16774,7 @@ class FaultTreeApp:
         if not hasattr(self, "safety_mgmt_toolbox"):
             self.safety_mgmt_toolbox = SafetyManagementToolbox()
 
-        SafetyManagementWindow(
+        self.safety_mgmt_window = SafetyManagementWindow(
             self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
         )
 
@@ -16792,7 +16792,7 @@ class FaultTreeApp:
         if not hasattr(self, "safety_mgmt_toolbox"):
             self.safety_mgmt_toolbox = SafetyManagementToolbox()
 
-        SafetyManagementWindow(
+        self.safety_mgmt_window = SafetyManagementWindow(
             self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
         )
 
@@ -16810,7 +16810,7 @@ class FaultTreeApp:
         if not hasattr(self, "safety_mgmt_toolbox"):
             self.safety_mgmt_toolbox = SafetyManagementToolbox()
 
-        SafetyManagementWindow(
+        self.safety_mgmt_window = SafetyManagementWindow(
             self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
         )
 


### PR DESCRIPTION
## Summary
- keep a reference to `SafetyManagementWindow` so the Safety & Security Management tab retains its UI when opened

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f42b04f3c83279cce54d324600e44