### PR TITLE
Handle errors during governance requirement generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,35 @@ When plan complete, task 'Draft Plan' shall precede task 'Review Plan'.
 Task 'Review Plan' shall be related to task 'Draft Plan' when changes requested.
 ```
 
+To generate requirements for every governance diagram in a particular phase,
+iterate over the diagrams registered with a
+``SafetyManagementToolbox``:
+
+```python
+from analysis.governance import GovernanceDiagram
+from analysis.safety_management import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+
+repo = SysMLRepository.get_instance()
+toolbox = SafetyManagementToolbox()
+
+# Assume the repository already contains governance diagrams "Gov1" and "Gov2"
+mod = toolbox.add_module("Phase1")
+mod.diagrams.extend(["Gov1", "Gov2"])
+
+reqs: list[str] = []
+for name in toolbox.diagrams_for_module("Phase1"):
+    diag_id = toolbox.diagrams[name]
+    gov = GovernanceDiagram.from_repository(repo, diag_id)
+    reqs.extend(gov.generate_requirements())
+
+for r in reqs:
+    print(r)
+```
+
+This example prints the requirements derived from all governance diagrams in the
+``Phase1`` module.
+
 ## Workflow Overview
 
 The diagram below illustrates how information flows through the major work products. Each box lists the main inputs and outputs so you can see how analyses feed into one another and where the review workflow fits. Approved reviews update the ASIL and CAL values propagated throughout the model.

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -208,8 +208,15 @@ class SafetyManagementWindow(tk.Frame):
         if not diag_id:
             return
         repo = SysMLRepository.get_instance()
-        gov = GovernanceDiagram.from_repository(repo, diag_id)
-        reqs = gov.generate_requirements()
+        try:
+            gov = GovernanceDiagram.from_repository(repo, diag_id)
+            reqs = gov.generate_requirements()
+        except Exception as exc:  # pragma: no cover - defensive
+            messagebox.showerror(
+                "Requirements",
+                f"Unable to generate requirements for '{name}': {exc}",
+            )
+            return
         if not reqs:
             messagebox.showinfo("Requirements", "No requirements were generated.")
             return
@@ -235,8 +242,15 @@ class SafetyManagementWindow(tk.Frame):
             diag_id = self.toolbox.diagrams.get(name)
             if not diag_id:
                 continue
-            gov = GovernanceDiagram.from_repository(repo, diag_id)
-            reqs = gov.generate_requirements()
+            try:
+                gov = GovernanceDiagram.from_repository(repo, diag_id)
+                reqs = gov.generate_requirements()
+            except Exception as exc:  # pragma: no cover - defensive
+                messagebox.showerror(
+                    "Requirements",
+                    f"Unable to generate requirements for '{name}': {exc}",
+                )
+                return
             for text in reqs:
                 ids.append(self._add_requirement(text))
         if not ids:

--- a/tests/test_governance_requirements_error.py
+++ b/tests/test_governance_requirements_error.py
@@ -1,0 +1,57 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow, SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+from gui import safety_management_toolbox as smt
+
+def _raise_error(self):
+    raise RuntimeError("boom")
+
+def test_generate_requirements_error(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams["Gov"] = diag.diag_id
+
+    monkeypatch.setattr(smt.GovernanceDiagram, "generate_requirements", _raise_error)
+    errors: list[tuple[str, str]] = []
+    monkeypatch.setattr(smt.messagebox, "showerror", lambda t, m: errors.append((t, m)))
+    called: list[str] = []
+    monkeypatch.setattr(SafetyManagementWindow, "_display_requirements", lambda self, title, ids: called.append(title))
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace()
+    win.diag_var = types.SimpleNamespace(get=lambda: "Gov")
+
+    win.generate_requirements()
+
+    assert errors
+    assert not called
+
+def test_generate_phase_requirements_error(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams["Gov1"] = diag.diag_id
+    mod = toolbox.add_module("Phase1")
+    mod.diagrams.append("Gov1")
+
+    monkeypatch.setattr(smt.GovernanceDiagram, "generate_requirements", _raise_error)
+    errors: list[tuple[str, str]] = []
+    monkeypatch.setattr(smt.messagebox, "showerror", lambda t, m: errors.append((t, m)))
+    called: list[str] = []
+    monkeypatch.setattr(SafetyManagementWindow, "_display_requirements", lambda self, title, ids: called.append(title))
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace()
+
+    win.generate_phase_requirements("Phase1")
+
+    assert errors
+    assert not called


### PR DESCRIPTION
## Summary
- Notify users when requirement generation from governance diagrams fails
- Add example demonstrating phase-based requirement generation
- Test error handling for diagram and phase requirement generation

## Testing
- `pytest tests/test_governance_requirements_button.py tests/test_governance_phase_requirements_menu.py tests/test_governance_requirements_error.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689f431d6ab883278c5bf00df0dcda1f