### PR TITLE
Add log window toggle button

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2629,6 +2629,10 @@ class FaultTreeApp:
         self.main_pane = tk.PanedWindow(root, orient=tk.HORIZONTAL)
         self.log_frame = logger.init_log_window(root)
         self.log_frame.pack(side=tk.BOTTOM, fill=tk.BOTH)
+        self.toggle_log_button = ttk.Button(
+            root, text="Hide Logs", command=self.toggle_logs
+        )
+        self.toggle_log_button.pack(side=tk.BOTTOM, fill=tk.X)
         self.main_pane.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
 
         self.explorer_nb = ttk.Notebook(self.main_pane)
@@ -9596,6 +9600,16 @@ class FaultTreeApp:
         self.zoom /= 1.2
         self.diagram_font.config(size=int(8 * self.zoom))
         self.redraw_canvas()
+
+    def toggle_logs(self):
+        if self.log_frame.winfo_manager():
+            self.log_frame.pack_forget()
+            self.toggle_log_button.config(text="Show Logs")
+        else:
+            self.log_frame.pack(
+                side=tk.BOTTOM, fill=tk.BOTH, before=self.toggle_log_button
+            )
+            self.toggle_log_button.config(text="Hide Logs")
 
     def auto_arrange(self):
         if self.root_node is None:

--- a/tests/test_log_window_toggle.py
+++ b/tests/test_log_window_toggle.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pytest
+import tkinter as tk
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AutoML import FaultTreeApp
+
+
+def test_toggle_log_area():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    app = FaultTreeApp(root)
+    assert app.log_frame.winfo_manager() == "pack"
+    app.toggle_logs()
+    assert app.log_frame.winfo_manager() == ""
+    app.toggle_logs()
+    assert app.log_frame.winfo_manager() == "pack"
+    root.destroy()


### PR DESCRIPTION
## Summary
- add button to hide/show the log window
- test log window toggle behavior

## Testing
- `pytest tests/test_log_window_toggle.py -q`
- `pytest tests/test_gui_classes.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689f4373bdb88327ae1dae77a32da51b