### PR TITLE
Fix empty Safety & Security Management tab

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16773,60 +16773,11 @@ class FaultTreeApp:
         self.safety_mgmt_window = SafetyManagementWindow(
             self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
         )
-
-    def open_safety_management_toolbox(self):
-        """Open the Safety & Security Management editor and browser."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from gui.safety_management_toolbox import SafetyManagementWindow
-        from analysis import SafetyManagementToolbox
-
-        if not hasattr(self, "safety_mgmt_toolbox"):
-            self.safety_mgmt_toolbox = SafetyManagementToolbox()
-
-        self.safety_mgmt_window = SafetyManagementWindow(
-            self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
-        )
-
-    def open_safety_management_toolbox(self):
-        """Open the Safety & Security Management editor and browser."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from gui.safety_management_toolbox import SafetyManagementWindow
-        from analysis import SafetyManagementToolbox
-
-        if not hasattr(self, "safety_mgmt_toolbox"):
-            self.safety_mgmt_toolbox = SafetyManagementToolbox()
-
-        self.safety_mgmt_window = SafetyManagementWindow(
-            self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
-        )
-
-    def open_safety_management_toolbox(self):
-        """Open the Safety & Security Management editor and browser."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from gui.safety_management_toolbox import SafetyManagementWindow
-        from analysis import SafetyManagementToolbox
-
-        if not hasattr(self, "safety_mgmt_toolbox"):
-            self.safety_mgmt_toolbox = SafetyManagementToolbox()
-
-        self.safety_mgmt_window = SafetyManagementWindow(
-            self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
-        )
+        # SafetyManagementWindow may not pack itself when embedded. If the
+        # widget exposes a ``pack`` method, invoke it so the tab shows the
+        # expected controls instead of appearing blank.
+        if hasattr(self.safety_mgmt_window, "pack"):
+            self.safety_mgmt_window.pack(fill=tk.BOTH, expand=True)
 
     def open_style_editor(self):
         """Open the diagram style editor window."""


### PR DESCRIPTION
## Summary
- Ensure Safety & Security Management toolbox frame is packed when opened so controls render

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f461833c483279496f00f23f70f05