### PR TITLE
Add generic work product option to governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -9574,6 +9574,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
 
         node_cmds = [
             ("Add Work Product", self.add_work_product),
+            ("Add Generic Work Product", self.add_generic_work_product),
             ("Add Process Area", self.add_process_area),
             ("Add Lifecycle Phase", self.add_lifecycle_phase),
         ]
@@ -9730,6 +9731,19 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                 "Missing Process Area",
                 f"Add process area '{required}' before adding this work product.",
             )
+            return
+        if not getattr(self, "canvas", None):
+            self._place_work_product(name, 100.0, 100.0)
+        else:
+            self._pending_wp_name = name
+            try:
+                self.canvas.configure(cursor="crosshair")
+            except Exception:
+                pass
+
+    def add_generic_work_product(self):  # pragma: no cover - requires tkinter
+        name = simpledialog.askstring("Add Work Product", "Enter work product name:")
+        if not name:
             return
         if not getattr(self, "canvas", None):
             self._place_work_product(name, 100.0, 100.0)

--- a/tests/test_governance_generic_work_product.py
+++ b/tests/test_governance_generic_work_product.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+from analysis import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+import pytest
+
+
+def test_add_generic_work_product(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    from analysis import safety_management as _sm
+    prev_tb = _sm.ACTIVE_TOOLBOX
+    toolbox = SafetyManagementToolbox()
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+
+    enable_calls = []
+
+    class DummyApp:
+        safety_mgmt_toolbox = toolbox
+
+        def enable_work_product(self, name, *, refresh=True):
+            enable_calls.append(name)
+
+    win.app = DummyApp()
+
+    monkeypatch.setattr("gui.architecture.simpledialog.askstring", lambda *a, **k: "Custom WP")
+
+    win.add_generic_work_product()
+
+    assert enable_calls == ["Custom WP"]
+    assert any(
+        o.obj_type == "Work Product" and o.properties.get("name") == "Custom WP"
+        for o in win.objects
+    )
+    assert any(wp.analysis == "Custom WP" for wp in toolbox.work_products)
+
+    _sm.ACTIVE_TOOLBOX = prev_tb


### PR DESCRIPTION
## Summary
- allow custom work product names through new "Add Generic Work Product" button
- support generic work product placement via `add_generic_work_product`
- test custom work product creation and enablement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f468ef0688327844fe437750cb1d1