### PR TITLE
Add organizational requirement type for governance requirements

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -1259,6 +1259,7 @@ class EditNodeDialog(simpledialog.Dialog):
                 "service",
                 "product",
                 "legal",
+                "organizational",
             ):
                 self.result["asil"] = asil
                 self.result["cal"] = cal
@@ -1288,6 +1289,7 @@ class EditNodeDialog(simpledialog.Dialog):
                 "service",
                 "product",
                 "legal",
+                "organizational",
             )
             widgets = [self.asil_label, self.req_asil_combo, self.cal_label, self.req_cal_combo]
             if hide:
@@ -1392,6 +1394,7 @@ class EditNodeDialog(simpledialog.Dialog):
             "service",
             "product",
             "legal",
+            "organizational",
         ):
             req["asil"] = asil
             req["cal"] = cal
@@ -1594,6 +1597,7 @@ class EditNodeDialog(simpledialog.Dialog):
                 "service",
                 "product",
                 "legal",
+                "organizational",
             ):
                 req["asil"] = (
                     asil_default
@@ -1623,6 +1627,7 @@ class EditNodeDialog(simpledialog.Dialog):
                 "service",
                 "product",
                 "legal",
+                "organizational",
             ):
                 req["asil"] = (
                     asil_default
@@ -1679,6 +1684,7 @@ class EditNodeDialog(simpledialog.Dialog):
             "service",
             "product",
             "legal",
+            "organizational",
         ):
             if self.node.node_type.upper() == "BASIC EVENT":
                 # Leave the ASIL untouched for decomposed requirements when
@@ -11857,6 +11863,7 @@ class FaultTreeApp:
                     "service",
                     "product",
                     "legal",
+                    "organizational",
                 ):
                     self.result["asil"] = self.asil_var.get().strip()
                     self.result["cal"] = self.cal_var.get().strip()
@@ -11877,6 +11884,7 @@ class FaultTreeApp:
                     "service",
                     "product",
                     "legal",
+                    "organizational",
                 )
                 widgets = [self.asil_label, self.asil_combo, self.cal_label, self.cal_combo]
                 if hide:

--- a/analysis/models.py
+++ b/analysis/models.py
@@ -601,6 +601,7 @@ REQUIREMENT_TYPE_OPTIONS = [
     "service",
     "product",
     "legal",
+    "organizational",
 ]
 
 # Work product names corresponding to each requirement category. These are used
@@ -619,6 +620,7 @@ REQUIREMENT_WORK_PRODUCTS = [
     "Service Requirement Specification",
     "Product Requirement Specification",
     "Legal Requirement Specification",
+    "Organizational Requirement Specification",
 ]
 # ASIL level options including decomposition levels
 ASIL_LEVEL_OPTIONS = [

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -170,7 +170,7 @@ class SafetyManagementWindow(tk.Frame):
         while f"R{idx}" in global_requirements:
             idx += 1
         rid = f"R{idx}"
-        req_type = REQUIREMENT_TYPE_OPTIONS[0]
+        req_type = "organizational"
         app = getattr(self, "app", None)
         if app and hasattr(app, "add_new_requirement"):
             app.add_new_requirement(rid, req_type, text)

--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -479,6 +479,7 @@ class StpaWindow(tk.Frame):
                     "service",
                     "product",
                     "legal",
+                    "organizational",
                 ],
             )
             if dlg.result:
@@ -513,6 +514,7 @@ class StpaWindow(tk.Frame):
                     "service",
                     "product",
                     "legal",
+                    "organizational",
                 ],
             )
             if dlg.result:

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -300,6 +300,7 @@ class _RequirementDialog(simpledialog.Dialog):
             "service",
             "product",
             "legal",
+            "organizational",
         ):
             self.result["asil"] = self.asil_var.get().strip()
             self.result["cal"] = self.cal_var.get().strip()
@@ -313,6 +314,7 @@ class _RequirementDialog(simpledialog.Dialog):
             "service",
             "product",
             "legal",
+            "organizational",
         )
         widgets = [self.asil_label, self.asil_combo, self.cal_label, self.cal_combo]
         if hide:

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -7,7 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from gui.safety_management_toolbox import SafetyManagementWindow, SafetyManagementToolbox
 from sysml.sysml_repository import SysMLRepository
 from gui import safety_management_toolbox as smt
-from analysis.models import global_requirements, REQUIREMENT_TYPE_OPTIONS
+from analysis.models import global_requirements
 
 
 def test_phase_requirements_menu(monkeypatch):
@@ -82,5 +82,5 @@ def test_phase_requirements_menu(monkeypatch):
     texts = [row[2] for row in trees[0].rows]
     assert any("Task 'Start' shall precede task 'Finish'." in t for t in texts)
     assert any("Task 'Check' shall precede task 'Complete'." in t for t in texts)
-    assert all(row[1] in REQUIREMENT_TYPE_OPTIONS for row in trees[0].rows)
+    assert all(row[1] == "organizational" for row in trees[0].rows)
     assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -7,7 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from gui.safety_management_toolbox import SafetyManagementWindow, SafetyManagementToolbox
 from sysml.sysml_repository import SysMLRepository
 from gui import safety_management_toolbox as smt
-from analysis.models import global_requirements, REQUIREMENT_TYPE_OPTIONS
+from analysis.models import global_requirements
 
 
 def test_requirements_button_opens_tab(monkeypatch):
@@ -68,7 +68,7 @@ def test_requirements_button_opens_tab(monkeypatch):
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
     assert any("Task 'Start' shall precede task 'Finish'." in t for t in texts)
-    # Ensure requirement types are valid
-    assert all(row[1] in REQUIREMENT_TYPE_OPTIONS for row in trees[0].rows)
+    # Ensure requirement types are organizational
+    assert all(row[1] == "organizational" for row in trees[0].rows)
     # Requirements added to global registry
     assert len(global_requirements) == len(trees[0].rows)


### PR DESCRIPTION
## Summary
- introduce `organizational` to requirement types and work products
- default governance-derived requirements to `organizational`
- treat organizational requirements as non-ASIL in requirement dialogs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f4842fb688327b46a137ce09c18d4