### PR TITLE
Fix Safety Management toolbox initialization

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16667,102 +16667,18 @@ class FaultTreeApp:
             from gui.fault_prioritization import FaultPrioritizationWindow
             self._fault_prio_window = FaultPrioritizationWindow(self._fault_prio_tab, self)
         self.refresh_all()
-
-    def open_safety_management_toolbox(self):
-        """Open a placeholder tab for the Safety & Security Management toolbox."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        msg = (
-            "Safety & Security Management toolbox initialized.\n"
-            "Future versions will provide a full graphical interface."
-        )
-        ttk.Label(self._safety_mgmt_tab, text=msg, justify=tk.CENTER).pack(
-            fill=tk.BOTH, expand=True, padx=10, pady=10
-        )
-
-    def open_safety_management_toolbox(self):
-        """Open a placeholder tab for the Safety & Security Management toolbox."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        msg = (
-            "Safety & Security Management toolbox initialized.\n"
-            "Future versions will provide a full graphical interface."
-        )
-        ttk.Label(self._safety_mgmt_tab, text=msg, justify=tk.CENTER).pack(
-            fill=tk.BOTH, expand=True, padx=10, pady=10
-        )
-
-    def open_safety_management_toolbox(self):
-        """Open the Safety & Security Management toolbox tab."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-        from gui.safety_management_toolbox import SafetyManagementToolbox as SMTGUI
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        gui = SMTGUI(self._safety_mgmt_tab, toolbox=self.safety_toolbox)
-        gui.pack(fill=tk.BOTH, expand=True)
-
-    def open_safety_management_toolbox(self):
-        """Open the Safety & Security Management toolbox tab."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-        from gui.safety_management_toolbox import SafetyManagementToolbox as SMTGUI
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        gui = SMTGUI(self._safety_mgmt_tab, toolbox=self.safety_toolbox)
-        gui.pack(fill=tk.BOTH, expand=True)
-
-    def open_safety_management_toolbox(self):
-        """Open a Safety & Security Management tab with an Activity Diagram."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from gui.architecture import ActivityDiagramWindow
-
-        ActivityDiagramWindow(self._safety_mgmt_tab, self)
-
     def open_safety_management_toolbox(self):
         """Open the Safety & Security Management editor and browser."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
+        tab_exists = (
+            hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists()
+        )
+        if tab_exists:
             self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
+            parent = self._safety_mgmt_tab
+        else:
+            parent = self._safety_mgmt_tab = self._new_tab(
+                "Safety & Security Management"
+            )
 
         from gui.safety_management_toolbox import SafetyManagementWindow
         from analysis import SafetyManagementToolbox
@@ -16770,14 +16686,15 @@ class FaultTreeApp:
         if not hasattr(self, "safety_mgmt_toolbox"):
             self.safety_mgmt_toolbox = SafetyManagementToolbox()
 
-        self.safety_mgmt_window = SafetyManagementWindow(
-            self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
-        )
-        # SafetyManagementWindow may not pack itself when embedded. If the
-        # widget exposes a ``pack`` method, invoke it so the tab shows the
-        # expected controls instead of appearing blank.
-        if hasattr(self.safety_mgmt_window, "pack"):
-            self.safety_mgmt_window.pack(fill=tk.BOTH, expand=True)
+        if (
+            not getattr(self, "safety_mgmt_window", None)
+            or not self.safety_mgmt_window.winfo_exists()
+        ):
+            self.safety_mgmt_window = SafetyManagementWindow(
+                parent, self, self.safety_mgmt_toolbox
+            )
+            if hasattr(self.safety_mgmt_window, "pack"):
+                self.safety_mgmt_window.pack(fill=tk.BOTH, expand=True)
 
     def open_style_editor(self):
         """Open the diagram style editor window."""


### PR DESCRIPTION
## Summary
- ensure Safety & Security Management toolbox instantiates its window and packs it
- remove placeholder versions of toolbox opener

## Testing
- `pytest tests/test_phase_requirements_main_menu.py tests/test_governance_phase_requirements_menu.py tests/test_governance_requirements_error.py tests/test_safety_management.py::test_open_safety_management_toolbox_uses_browser -q`

------
https://chatgpt.com/codex/tasks/task_b_689f49ebeb708327b296d9ab0c8515e1