### PR TITLE
Fix Safety Management toolbox activation

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14581,7 +14581,7 @@ class FaultTreeApp:
         messagebox.showinfo("Export", "Product goal requirements exported.")
     def generate_phase_requirements(self, phase: str) -> None:
         """Generate requirements for all governance diagrams in a phase."""
-        self.open_safety_management_toolbox()
+        self.open_safety_management_toolbox(show_diagrams=False)
         win = getattr(self, "safety_mgmt_window", None)
         if win:
             win.generate_phase_requirements(phase)
@@ -16668,95 +16668,7 @@ class FaultTreeApp:
             self._fault_prio_window = FaultPrioritizationWindow(self._fault_prio_tab, self)
         self.refresh_all()
 
-    def open_safety_management_toolbox(self):
-        """Open a placeholder tab for the Safety & Security Management toolbox."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        msg = (
-            "Safety & Security Management toolbox initialized.\n"
-            "Future versions will provide a full graphical interface."
-        )
-        ttk.Label(self._safety_mgmt_tab, text=msg, justify=tk.CENTER).pack(
-            fill=tk.BOTH, expand=True, padx=10, pady=10
-        )
-
-    def open_safety_management_toolbox(self):
-        """Open a placeholder tab for the Safety & Security Management toolbox."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        msg = (
-            "Safety & Security Management toolbox initialized.\n"
-            "Future versions will provide a full graphical interface."
-        )
-        ttk.Label(self._safety_mgmt_tab, text=msg, justify=tk.CENTER).pack(
-            fill=tk.BOTH, expand=True, padx=10, pady=10
-        )
-
-    def open_safety_management_toolbox(self):
-        """Open the Safety & Security Management toolbox tab."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-        from gui.safety_management_toolbox import SafetyManagementToolbox as SMTGUI
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        gui = SMTGUI(self._safety_mgmt_tab, toolbox=self.safety_toolbox)
-        gui.pack(fill=tk.BOTH, expand=True)
-
-    def open_safety_management_toolbox(self):
-        """Open the Safety & Security Management toolbox tab."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from analysis.safety_management import SafetyManagementToolbox
-        from gui.safety_management_toolbox import SafetyManagementToolbox as SMTGUI
-
-        # Reuse existing toolbox instance if present; otherwise create one
-        self.safety_toolbox = getattr(self, "safety_toolbox", SafetyManagementToolbox())
-
-        gui = SMTGUI(self._safety_mgmt_tab, toolbox=self.safety_toolbox)
-        gui.pack(fill=tk.BOTH, expand=True)
-
-    def open_safety_management_toolbox(self):
-        """Open a Safety & Security Management tab with an Activity Diagram."""
-        if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
-            self.doc_nb.select(self._safety_mgmt_tab)
-            return
-
-        self._safety_mgmt_tab = self._new_tab("Safety & Security Management")
-
-        from gui.architecture import ActivityDiagramWindow
-
-        ActivityDiagramWindow(self._safety_mgmt_tab, self)
-
-    def open_safety_management_toolbox(self):
+    def open_safety_management_toolbox(self, show_diagrams: bool = True):
         """Open the Safety & Security Management editor and browser."""
         if hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists():
             self.doc_nb.select(self._safety_mgmt_tab)
@@ -16771,13 +16683,18 @@ class FaultTreeApp:
             self.safety_mgmt_toolbox = SafetyManagementToolbox()
 
         self.safety_mgmt_window = SafetyManagementWindow(
-            self._safety_mgmt_tab, self, self.safety_mgmt_toolbox
+            self._safety_mgmt_tab, self, self.safety_mgmt_toolbox, show_diagrams=show_diagrams
         )
         # SafetyManagementWindow may not pack itself when embedded. If the
         # widget exposes a ``pack`` method, invoke it so the tab shows the
         # expected controls instead of appearing blank.
         if hasattr(self.safety_mgmt_window, "pack"):
             self.safety_mgmt_window.pack(fill=tk.BOTH, expand=True)
+
+        # Opening the toolbox can affect menu enablement, so refresh the UI.
+        refresh = getattr(self, "refresh_all", None)
+        if callable(refresh):
+            refresh()
 
     def open_style_editor(self):
         """Open the diagram style editor window."""

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -21,10 +21,17 @@ class SafetyManagementWindow(tk.Frame):
     :class:`SafetyManagementToolbox` are listed.
     """
 
-    def __init__(self, master, app, toolbox: SafetyManagementToolbox | None = None):
+    def __init__(
+        self,
+        master,
+        app,
+        toolbox: SafetyManagementToolbox | None = None,
+        show_diagrams: bool = True,
+    ):
         super().__init__(master)
         self.app = app
         self.toolbox = toolbox or SafetyManagementToolbox()
+        self._auto_show_diagram = show_diagrams
         try:
             self.app.safety_mgmt_window = self
         except Exception:
@@ -79,8 +86,9 @@ class SafetyManagementWindow(tk.Frame):
             current = self.diag_var.get()
             if current not in names:
                 self.diag_var.set(names[0])
-            self.open_diagram(self.diag_var.get())
-        else:
+            if self._auto_show_diagram:
+                self.open_diagram(self.diag_var.get())
+        elif self._auto_show_diagram:
             self.diag_var.set("")
             self.open_diagram(None)
 

--- a/tests/test_phase_requirements_main_menu.py
+++ b/tests/test_phase_requirements_main_menu.py
@@ -8,6 +8,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 sys.modules.setdefault("PIL", types.ModuleType("PIL"))
 sys.modules.setdefault("PIL.Image", types.ModuleType("Image"))
 sys.modules.setdefault("PIL.ImageTk", types.ModuleType("ImageTk"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("ImageFont"))
 
 from AutoML import FaultTreeApp
 from analysis import SafetyManagementToolbox
@@ -51,8 +53,8 @@ def test_generate_phase_requirements_delegates(monkeypatch):
     app = FaultTreeApp.__new__(FaultTreeApp)
     events = []
 
-    def fake_open():
-        events.append("open")
+    def fake_open(show_diagrams=True):
+        events.append(show_diagrams)
 
     app.open_safety_management_toolbox = fake_open
     app.safety_mgmt_window = types.SimpleNamespace(
@@ -61,4 +63,4 @@ def test_generate_phase_requirements_delegates(monkeypatch):
 
     FaultTreeApp.generate_phase_requirements(app, "PhaseX")
 
-    assert events == ["open", "PhaseX"]
+    assert events == [False, "PhaseX"]

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -282,7 +282,7 @@ def test_open_safety_management_toolbox_uses_browser():
             pass
 
     class DummySMW:
-        def __init__(self, master, app, toolbox):
+        def __init__(self, master, app, toolbox, show_diagrams=True):
             DummySMW.created = True
             assert toolbox is app.safety_mgmt_toolbox
 


### PR DESCRIPTION
## Summary
- allow Safety Management window to skip loading diagrams when requested
- avoid diagram creation during phase requirement generation

## Testing
- `pytest tests/test_phase_requirements_main_menu.py tests/test_safety_management.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689f49ebeb708327b296d9ab0c8515e1