### PR TITLE
Add AI safety requirement type generation

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -5,6 +5,23 @@ from typing import Any, List, Tuple
 
 import networkx as nx
 
+# Element and relationship types associated with AI & safety lifecycle nodes.
+_AI_NODES = {"Database", "ANN", "Data acquisition"}
+_AI_RELATIONS = {
+    "Annotation",
+    "Synthesis",
+    "Augmentation",
+    "Acquisition",
+    "Labeling",
+    "Field risk evaluation",
+    "Field data collection",
+    "AI training",
+    "AI re-training",
+    "Curation",
+    "Ingestion",
+    "Model evaluation",
+}
+
 
 @dataclass
 class GovernanceDiagram:
@@ -21,12 +38,23 @@ class GovernanceDiagram:
     edge_data: dict[tuple[str, str], dict[str, str | None]] = field(
         default_factory=dict
     )
+    # Track the original diagram object type for each task so requirements can
+    # be categorised.  Tasks originating from AI & safety nodes produce AI
+    # safety requirements.
+    node_types: dict[str, str] = field(default_factory=dict)
 
-    def add_task(self, name: str) -> None:
+    def add_task(self, name: str, node_type: str = "Action") -> None:
         """Add a task node to the diagram."""
         self.graph.add_node(name)
+        self.node_types[name] = node_type
 
-    def add_flow(self, src: str, dst: str, condition: str | None = None) -> None:
+    def add_flow(
+        self,
+        src: str,
+        dst: str,
+        condition: str | None = None,
+        conn_type: str = "Flow",
+    ) -> None:
         """Add a directed flow between two existing tasks.
 
         Parameters
@@ -35,12 +63,19 @@ class GovernanceDiagram:
             Names of the existing source and destination tasks.
         condition:
             Optional textual condition that must hold for the flow to occur.
+        conn_type:
+            Connection type from the original diagram; defaults to ``"Flow"``.
         """
 
         if not self.graph.has_node(src) or not self.graph.has_node(dst):
             raise ValueError("Both tasks must exist before creating a flow")
         self.graph.add_edge(src, dst)
-        self.edge_data[(src, dst)] = {"kind": "flow", "condition": condition}
+        self.edge_data[(src, dst)] = {
+            "kind": "flow",
+            "condition": condition,
+            "label": None,
+            "conn_type": conn_type,
+        }
 
     def add_relationship(
         self,
@@ -48,6 +83,7 @@ class GovernanceDiagram:
         dst: str,
         condition: str | None = None,
         label: str | None = None,
+        conn_type: str | None = None,
     ) -> None:
         """Add a non-flow relationship between two existing tasks.
 
@@ -59,6 +95,9 @@ class GovernanceDiagram:
             Optional textual condition that must hold for the relationship.
         label:
             Optional label describing the relationship between the tasks.
+        conn_type:
+            Connection type from the original diagram, used to determine the
+            requirement category.
         """
 
         if not self.graph.has_node(src) or not self.graph.has_node(dst):
@@ -68,6 +107,7 @@ class GovernanceDiagram:
             "kind": "relationship",
             "condition": condition,
             "label": label,
+            "conn_type": conn_type,
         }
 
     def tasks(self) -> List[str]:
@@ -91,18 +131,24 @@ class GovernanceDiagram:
             if data.get("kind") == "relationship"
         ]
 
-    def generate_requirements(self) -> List[str]:
+    def generate_requirements(self) -> List[tuple[str, str]]:
         """Generate textual requirements from the diagram.
 
         Tasks, flows, relationships and any optional conditions or labels are
         converted into simple natural language statements for downstream
-        processing or documentation.
+        processing or documentation.  Each returned item is a ``(text, type)``
+        tuple where ``type`` is either ``"AI safety"`` or ``"organizational``.
         """
 
-        requirements: List[str] = []
+        requirements: List[tuple[str, str]] = []
 
         for task in self.tasks():
-            requirements.append(f"The system shall perform task '{task}'.")
+            req_type = (
+                "AI safety"
+                if self.node_types.get(task) in _AI_NODES
+                else "organizational"
+            )
+            requirements.append((f"The system shall perform task '{task}'.", req_type))
 
         for src, dst in self.graph.edges():
             data = self.edge_data.get(
@@ -111,6 +157,7 @@ class GovernanceDiagram:
             cond = data.get("condition")
             kind = data.get("kind")
             label = data.get("label")
+            conn_type = data.get("conn_type")
             if kind == "flow":
                 if cond:
                     req = f"When {cond}, task '{src}' shall precede task '{dst}'."
@@ -131,7 +178,14 @@ class GovernanceDiagram:
                         )
                     else:
                         req = f"Task '{src}' shall be related to task '{dst}'."
-            requirements.append(req)
+            req_type = "organizational"
+            if (
+                conn_type in _AI_RELATIONS
+                or self.node_types.get(src) in _AI_NODES
+                or self.node_types.get(dst) in _AI_NODES
+            ):
+                req_type = "AI safety"
+            requirements.append((req, req_type))
 
         return requirements
 
@@ -166,7 +220,8 @@ class GovernanceDiagram:
         id_to_name: dict[int, str] = {}
         for obj in getattr(src_diagram, "objects", []):
             odict = obj if isinstance(obj, dict) else obj.__dict__
-            if odict.get("obj_type") != "Action":
+            obj_type = odict.get("obj_type")
+            if obj_type not in _AI_NODES and obj_type != "Action":
                 continue
             elem_id = odict.get("element_id")
             name = ""
@@ -176,7 +231,7 @@ class GovernanceDiagram:
                 name = odict.get("properties", {}).get("name", "")
             if not name:
                 continue
-            diagram.add_task(name)
+            diagram.add_task(name, obj_type)
             id_to_name[odict.get("obj_id")] = name
 
         for conn in getattr(src_diagram, "connections", []):
@@ -187,14 +242,17 @@ class GovernanceDiagram:
                 continue
             name = cdict.get("name")
             cond = cdict.get("properties", {}).get("condition")
-            if cdict.get("conn_type") == "Flow":
-                diagram.add_flow(src, dst, cond or name)
+            conn_type = cdict.get("conn_type")
+            if conn_type == "Flow":
+                diagram.add_flow(src, dst, cond or name, conn_type=conn_type)
             else:
                 if cond is None and name is not None:
                     # Backwards compatibility: older diagrams used the name as the condition
-                    diagram.add_relationship(src, dst, condition=name)
+                    diagram.add_relationship(src, dst, condition=name, conn_type=conn_type)
                 else:
-                    diagram.add_relationship(src, dst, condition=cond, label=name)
+                    diagram.add_relationship(
+                        src, dst, condition=cond, label=name, conn_type=conn_type
+                    )
 
         return diagram
 

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -172,13 +172,12 @@ class SafetyManagementWindow(tk.Frame):
         self.current_window.pack(fill=tk.BOTH, expand=True)
 
     # ------------------------------------------------------------------
-    def _add_requirement(self, text: str) -> str:
+    def _add_requirement(self, text: str, req_type: str = "organizational") -> str:
         """Create a new requirement with a unique identifier."""
         idx = 1
         while f"R{idx}" in global_requirements:
             idx += 1
         rid = f"R{idx}"
-        req_type = "organizational"
         app = getattr(self, "app", None)
         if app and hasattr(app, "add_new_requirement"):
             app.add_new_requirement(rid, req_type, text)
@@ -228,7 +227,7 @@ class SafetyManagementWindow(tk.Frame):
         if not reqs:
             messagebox.showinfo("Requirements", "No requirements were generated.")
             return
-        ids = [self._add_requirement(text) for text in reqs]
+        ids = [self._add_requirement(text, rtype) for text, rtype in reqs]
         self._display_requirements(f"{name} Requirements", ids)
 
     def _refresh_phase_menu(self) -> None:
@@ -259,8 +258,8 @@ class SafetyManagementWindow(tk.Frame):
                     f"Unable to generate requirements for '{name}': {exc}",
                 )
                 return
-            for text in reqs:
-                ids.append(self._add_requirement(text))
+            for text, rtype in reqs:
+                ids.append(self._add_requirement(text, rtype))
         if not ids:
             messagebox.showinfo(
                 "Requirements",

--- a/tests/test_governance_ai_requirement_type.py
+++ b/tests/test_governance_ai_requirement_type.py
@@ -1,0 +1,67 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow, SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+from gui import safety_management_toolbox as smt
+from analysis.models import global_requirements
+
+
+def test_ai_elements_generate_ai_safety_requirements(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    diag = repo.create_diagram("Governance Diagram", name="AI Gov")
+    e1 = repo.create_element("Block", name="DB")
+    e2 = repo.create_element("Block", name="NN")
+    diag.objects = [
+        {"obj_id": 1, "obj_type": "Database", "x": 0, "y": 0, "element_id": e1.elem_id, "properties": {"name": "DB"}},
+        {"obj_id": 2, "obj_type": "ANN", "x": 100, "y": 0, "element_id": e2.elem_id, "properties": {"name": "NN"}},
+    ]
+    diag.connections = [
+        {"src": 1, "dst": 2, "conn_type": "AI training", "name": "", "properties": {}}
+    ]
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams["AI Gov"] = diag.diag_id
+
+    class DummyTab:
+        pass
+
+    tabs = []
+
+    def _new_tab(title):
+        tab = DummyTab()
+        tabs.append((title, tab))
+        return tab
+
+    trees = []
+
+    class DummyTree:
+        def __init__(self, master, columns, show="headings"):
+            self.rows = []
+            trees.append(self)
+
+        def heading(self, col, text=""):
+            pass
+
+        def insert(self, parent, idx, values):
+            self.rows.append(values)
+
+        def pack(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace(_new_tab=_new_tab)
+    win.diag_var = types.SimpleNamespace(get=lambda: "AI Gov")
+
+    global_requirements.clear()
+    win.generate_requirements()
+
+    assert tabs
+    assert trees and trees[0].rows
+    assert all(row[1] == "AI safety" for row in trees[0].rows)

--- a/tests/test_governance_relationship_label.py
+++ b/tests/test_governance_relationship_label.py
@@ -17,4 +17,5 @@ def test_label_relationship_between_database_nodes():
     assert diagram.edge_data[("User DB", "Analytics DB")]["label"] == "sync with"
 
     reqs = diagram.generate_requirements()
-    assert "Task 'User DB' shall sync with task 'Analytics DB'." in reqs
+    texts = [t for t, _ in reqs]
+    assert "Task 'User DB' shall sync with task 'Analytics DB'." in texts

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -18,10 +18,11 @@ def test_generate_requirements_from_governance_diagram():
     diagram.add_relationship("Start", "Finish", condition="risk identified")
 
     reqs = diagram.generate_requirements()
+    texts = [t for t, _ in reqs]
 
-    assert "The system shall perform task 'Start'." in reqs
-    assert "Task 'Start' shall precede task 'Approve'." in reqs
-    assert "When approval granted, task 'Approve' shall precede task 'Finish'." in reqs
+    assert "The system shall perform task 'Start'." in texts
+    assert "Task 'Start' shall precede task 'Approve'." in texts
+    assert "When approval granted, task 'Approve' shall precede task 'Finish'." in texts
     assert (
-        "Task 'Start' shall be related to task 'Finish' when risk identified." in reqs
+        "Task 'Start' shall be related to task 'Finish' when risk identified." in texts
     )


### PR DESCRIPTION
## Summary
- classify requirements from governance diagrams as AI safety when AI-specific nodes or relationships are used
- propagate requirement types through Safety Management toolbox
- test AI safety requirement generation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f50f19c048327b4deb4e00a1e7d56