### PR TITLE
feat: add guard support for governance decision flows

### DIFF
--- a/tests/test_control_flow_guard.py
+++ b/tests/test_control_flow_guard.py
@@ -60,5 +60,10 @@ class ControlFlowGuardTests(unittest.TestCase):
         label = format_control_flow_label(conn, repo, "Control Flow Diagram")
         self.assertEqual(label, "[g1\nAND g2\nOR g3] / <<control action>> Do")
 
+    def test_guard_string_coercion(self):
+        conn = DiagramConnection(1, 2, "Flow", guard="g1", guard_ops="OR")
+        self.assertEqual(conn.guard, ["g1"])
+        self.assertEqual(conn.guard_ops, ["OR"])
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_governance_decision_guard.py
+++ b/tests/test_governance_decision_guard.py
@@ -1,0 +1,38 @@
+import unittest
+
+from gui.architecture import SysMLObject, DiagramConnection
+from sysml.sysml_repository import SysMLRepository
+from analysis.governance import GovernanceDiagram
+
+
+class GovernanceDecisionGuardTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def test_decision_flow_guard_generation(self):
+        repo = self.repo
+        a = repo.create_element("Action", name="A")
+        b = repo.create_element("Action", name="B")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, a.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, b.elem_id)
+        o1 = SysMLObject(1, "Action", 0, 0, element_id=a.elem_id)
+        dec = SysMLObject(2, "Decision", 50, 0)
+        o2 = SysMLObject(3, "Action", 100, 0, element_id=b.elem_id)
+        diag.objects = [o1.__dict__, dec.__dict__, o2.__dict__]
+        c1 = DiagramConnection(o1.obj_id, dec.obj_id, "Flow")
+        c2 = DiagramConnection(dec.obj_id, o2.obj_id, "Flow")
+        c2dict = c2.__dict__.copy()
+        c2dict["guard"] = "g1"
+        diag.connections = [c1.__dict__, c2dict]
+
+        gdiag = GovernanceDiagram.from_repository(repo, diag.diag_id)
+        self.assertIn(("A", "B"), gdiag.flows())
+        self.assertEqual(gdiag.edge_data[("A", "B")]["condition"], "g1")
+        reqs = gdiag.generate_requirements()
+        self.assertIn("When g1, task 'A' shall precede task 'B'.", reqs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow specifying guards on governance flows exiting decision nodes
- display guard conditions on governance flow labels
- convert decision node guards into conditional flows when generating requirements
- ensure saved guard values reappear when reopening connection configuration

## Testing
- `PYTHONPATH=$PWD pytest tests/test_connection_stereotype_label.py tests/test_control_flow_guard.py tests/test_governance_decision_guard.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689f504ce694832783a6a8155471dc8f