### PR TITLE
Allow guards on decision relationships

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -164,32 +164,72 @@ class GovernanceDiagram:
             return diagram
 
         id_to_name: dict[int, str] = {}
+        decision_sources: dict[int, str] = {}
         for obj in getattr(src_diagram, "objects", []):
             odict = obj if isinstance(obj, dict) else obj.__dict__
-            if odict.get("obj_type") != "Action":
+            otype = odict.get("obj_type")
+            if otype == "Action":
+                elem_id = odict.get("element_id")
+                name = ""
+                if elem_id and elem_id in repo.elements:
+                    name = repo.elements[elem_id].name
+                if not name:
+                    name = odict.get("properties", {}).get("name", "")
+                if not name:
+                    continue
+                diagram.add_task(name)
+                id_to_name[odict.get("obj_id")] = name
+            elif otype == "Decision":
+                decision_sources[odict.get("obj_id")] = ""
+
+        # Map decision nodes to their predecessor action
+        for conn in getattr(src_diagram, "connections", []):
+            cdict = conn if isinstance(conn, dict) else conn.__dict__
+            if cdict.get("conn_type") != "Flow":
                 continue
-            elem_id = odict.get("element_id")
-            name = ""
-            if elem_id and elem_id in repo.elements:
-                name = repo.elements[elem_id].name
-            if not name:
-                name = odict.get("properties", {}).get("name", "")
-            if not name:
-                continue
-            diagram.add_task(name)
-            id_to_name[odict.get("obj_id")] = name
+            src_name = id_to_name.get(cdict.get("src"))
+            dst_id = cdict.get("dst")
+            if src_name and dst_id in decision_sources:
+                decision_sources[dst_id] = src_name
 
         for conn in getattr(src_diagram, "connections", []):
             cdict = conn if isinstance(conn, dict) else conn.__dict__
-            src = id_to_name.get(cdict.get("src"))
-            dst = id_to_name.get(cdict.get("dst"))
-            if not src or not dst:
-                continue
+            src_id = cdict.get("src")
+            dst_id = cdict.get("dst")
             name = cdict.get("name")
-            cond = cdict.get("properties", {}).get("condition")
+            cond_prop = cdict.get("properties", {}).get("condition")
+            guards = cdict.get("guard") or []
+            guard_ops = cdict.get("guard_ops") or []
+            if isinstance(guards, str):
+                guards = [guards]
+            if isinstance(guard_ops, str):
+                guard_ops = [guard_ops]
+            guard_text: str | None = None
+            if guards:
+                parts: list[str] = []
+                for i, g in enumerate(guards):
+                    if i == 0:
+                        parts.append(g)
+                    else:
+                        op = guard_ops[i - 1] if i - 1 < len(guard_ops) else "AND"
+                        parts.append(f"{op} {g}")
+                guard_text = " ".join(parts)
             if cdict.get("conn_type") == "Flow":
-                diagram.add_flow(src, dst, cond or name)
+                cond = cond_prop or guard_text or name
+                src = id_to_name.get(src_id)
+                dst = id_to_name.get(dst_id)
+                if src and dst:
+                    diagram.add_flow(src, dst, cond)
+                elif src_id in decision_sources and dst:
+                    prev = decision_sources.get(src_id)
+                    if prev:
+                        diagram.add_flow(prev, dst, cond)
             else:
+                src = id_to_name.get(src_id) or decision_sources.get(src_id)
+                dst = id_to_name.get(dst_id)
+                if not src or not dst:
+                    continue
+                cond = cond_prop or guard_text
                 if cond is None and name is not None:
                     # Backwards compatibility: older diagrams used the name as the condition
                     diagram.add_relationship(src, dst, condition=name)

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2746,6 +2746,16 @@ class DiagramConnection:
     stereotype: str = ""
     phase: str | None = field(default_factory=lambda: SysMLRepository.get_instance().active_phase)
 
+    def __post_init__(self) -> None:
+        if isinstance(self.guard, str):
+            self.guard = [self.guard]
+        elif self.guard is None:
+            self.guard = []
+        if isinstance(self.guard_ops, str):
+            self.guard_ops = [self.guard_ops]
+        elif self.guard_ops is None:
+            self.guard_ops = []
+
 
 def format_control_flow_label(
     conn: DiagramConnection, repo: "SysMLRepository", diag_type: str | None
@@ -2761,10 +2771,12 @@ def format_control_flow_label(
         if elem:
             label = elem.name or ""
     stereo = conn.stereotype or conn.conn_type.lower()
-    if diag_type == "Control Flow Diagram" and conn.conn_type in (
-        "Control Action",
-        "Feedback",
-    ):
+    special_case = (
+        diag_type == "Control Flow Diagram"
+        and conn.conn_type in ("Control Action", "Feedback")
+        or diag_type == "Governance Diagram"
+    )
+    if special_case:
         base = f"<<{stereo}>> {label}".strip() if stereo else label
         if conn.guard:
             lines: List[str] = []
@@ -9161,6 +9173,49 @@ class ConnectionDialog(simpledialog.Dialog):
             ttk.Button(opbtn, text="Add", command=self.add_guard_op).pack(side=tk.TOP)
             ttk.Button(opbtn, text="Remove", command=self.remove_guard_op).pack(side=tk.TOP)
             row += 1
+        elif (
+            getattr(
+                self.master.repo.diagrams.get(self.master.diagram_id), "diag_type", ""
+            )
+            == "Governance Diagram"
+        ):
+            src_obj = self.master.get_object(self.connection.src)
+            if src_obj and src_obj.obj_type == "Decision":
+                ttk.Label(master, text="Guard:").grid(
+                    row=row, column=0, sticky="ne", padx=4, pady=4
+                )
+                self.guard_list = tk.Listbox(master, height=4)
+                for g in self.connection.guard:
+                    self.guard_list.insert(tk.END, g)
+                self.guard_list.grid(row=row, column=1, padx=4, pady=4, sticky="we")
+                gbtn = ttk.Frame(master)
+                gbtn.grid(row=row, column=2, padx=2)
+                ttk.Button(gbtn, text="Add", command=self.add_guard).pack(side=tk.TOP)
+                ttk.Button(gbtn, text="Remove", command=self.remove_guard).pack(side=tk.TOP)
+                row += 1
+                ttk.Label(master, text="Guard Ops:").grid(
+                    row=row, column=0, sticky="ne", padx=4, pady=4
+                )
+                self.guard_ops_list = tk.Listbox(master, height=4)
+                for op in self.connection.guard_ops:
+                    self.guard_ops_list.insert(tk.END, op)
+                self.guard_ops_list.grid(row=row, column=1, padx=4, pady=4, sticky="we")
+                opbtn = ttk.Frame(master)
+                opbtn.grid(row=row, column=2, padx=2)
+                self.guard_op_choice = tk.StringVar(value="AND")
+                ttk.Combobox(
+                    opbtn,
+                    textvariable=self.guard_op_choice,
+                    values=["AND", "OR"],
+                    state="readonly",
+                ).pack(side=tk.TOP)
+                ttk.Button(opbtn, text="Add", command=self.add_guard_op).pack(
+                    side=tk.TOP
+                )
+                ttk.Button(opbtn, text="Remove", command=self.remove_guard_op).pack(
+                    side=tk.TOP
+                )
+                row += 1
 
         if self.connection.conn_type in ("Aggregation", "Composite Aggregation"):
             ttk.Label(master, text="Multiplicity:").grid(row=row, column=0, sticky="e", padx=4, pady=4)

--- a/tests/test_connection_stereotype_label.py
+++ b/tests/test_connection_stereotype_label.py
@@ -23,6 +23,11 @@ class ConnectionStereotypeLabelTests(unittest.TestCase):
         label = format_control_flow_label(conn, self.repo, "Governance Diagram")
         self.assertEqual(label, "<<propagate>>")
 
+    def test_governance_relationship_guard_label(self):
+        conn = DiagramConnection(1, 2, "Trace", guard=["g1"])
+        label = format_control_flow_label(conn, self.repo, "Governance Diagram")
+        self.assertEqual(label, "[g1] / <<trace>>")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_control_flow_guard.py
+++ b/tests/test_control_flow_guard.py
@@ -60,5 +60,10 @@ class ControlFlowGuardTests(unittest.TestCase):
         label = format_control_flow_label(conn, repo, "Control Flow Diagram")
         self.assertEqual(label, "[g1\nAND g2\nOR g3] / <<control action>> Do")
 
+    def test_guard_string_coercion(self):
+        conn = DiagramConnection(1, 2, "Flow", guard="g1", guard_ops="OR")
+        self.assertEqual(conn.guard, ["g1"])
+        self.assertEqual(conn.guard_ops, ["OR"])
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_governance_decision_guard.py
+++ b/tests/test_governance_decision_guard.py
@@ -1,0 +1,61 @@
+import unittest
+
+from gui.architecture import SysMLObject, DiagramConnection
+from sysml.sysml_repository import SysMLRepository
+from analysis.governance import GovernanceDiagram
+
+
+class GovernanceDecisionGuardTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def test_decision_flow_guard_generation(self):
+        repo = self.repo
+        a = repo.create_element("Action", name="A")
+        b = repo.create_element("Action", name="B")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, a.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, b.elem_id)
+        o1 = SysMLObject(1, "Action", 0, 0, element_id=a.elem_id)
+        dec = SysMLObject(2, "Decision", 50, 0)
+        o2 = SysMLObject(3, "Action", 100, 0, element_id=b.elem_id)
+        diag.objects = [o1.__dict__, dec.__dict__, o2.__dict__]
+        c1 = DiagramConnection(o1.obj_id, dec.obj_id, "Flow")
+        c2 = DiagramConnection(dec.obj_id, o2.obj_id, "Flow")
+        c2dict = c2.__dict__.copy()
+        c2dict["guard"] = "g1"
+        diag.connections = [c1.__dict__, c2dict]
+
+        gdiag = GovernanceDiagram.from_repository(repo, diag.diag_id)
+        self.assertIn(("A", "B"), gdiag.flows())
+        self.assertEqual(gdiag.edge_data[("A", "B")]["condition"], "g1")
+        reqs = gdiag.generate_requirements()
+        self.assertIn("When g1, task 'A' shall precede task 'B'.", reqs)
+
+    def test_decision_relationship_guard_generation(self):
+        repo = self.repo
+        a = repo.create_element("Action", name="A")
+        b = repo.create_element("Action", name="B")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, a.elem_id)
+        repo.add_element_to_diagram(diag.diag_id, b.elem_id)
+        o1 = SysMLObject(1, "Action", 0, 0, element_id=a.elem_id)
+        dec = SysMLObject(2, "Decision", 50, 0)
+        o2 = SysMLObject(3, "Action", 100, 0, element_id=b.elem_id)
+        diag.objects = [o1.__dict__, dec.__dict__, o2.__dict__]
+        c1 = DiagramConnection(o1.obj_id, dec.obj_id, "Flow")
+        c2 = DiagramConnection(dec.obj_id, o2.obj_id, "Trace")
+        c2dict = c2.__dict__.copy()
+        c2dict["guard"] = "g1"
+        diag.connections = [c1.__dict__, c2dict]
+
+        gdiag = GovernanceDiagram.from_repository(repo, diag.diag_id)
+        self.assertIn(("A", "B"), gdiag.relationships())
+        self.assertEqual(gdiag.edge_data[("A", "B")]["condition"], "g1")
+        reqs = gdiag.generate_requirements()
+        self.assertIn("Task 'A' shall be related to task 'B' when g1.", reqs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enable guard fields for any governance diagram connection originating from a decision node
- include guard conditions in labels and requirement generation for decision relationships
- cover decision node relationship guards with new tests

## Testing
- `PYTHONPATH=$PWD pytest tests/test_connection_stereotype_label.py tests/test_control_flow_guard.py tests/test_governance_decision_guard.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689f504ce694832783a6a8155471dc8f