### PR TITLE
feat: derive structured requirements from governance diagrams

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -22,17 +22,46 @@ _AI_RELATIONS = {
     "Model evaluation",
 }
 
+# Node type groupings for requirement component extraction.
+_SUBJECT_NODE_TYPES = {"Role", "Actor", "Stakeholder", "Organization", "Business Unit"}
+_ACTION_NODE_TYPES = {
+    "Process",
+    "Procedure",
+    "Activity",
+    "Task",
+    "Action",
+    "Control",
+    "Mechanism",
+}
+_OBJECT_NODE_TYPES = {"Document", "Artifact", "Data", "Record", "Resource"}
+_CONSTRAINT_NODE_TYPES = {
+    "Policy",
+    "Principle",
+    "Standard",
+    "Guideline",
+    "Metric",
+    "KPI",
+}
+
 
 @dataclass
 class GeneratedRequirement:
     """Container for a generated requirement.
 
-    The object behaves like both a tuple ``(text, type)`` and a string so that
-    existing code and tests that expect either representation continue to work.
+    ``GeneratedRequirement`` stores the individual requirement components so
+    governance diagrams can be translated into structured statements following
+    ISO/IEC/IEEE 29148.  The object still behaves like both a tuple
+    ``(text, type)`` and a string so existing code and tests that expect either
+    representation continue to work.
     """
 
     text: str
     req_type: str
+    cnd: str | None = None  # Condition
+    sub: str | None = None  # Subject
+    act: str | None = None  # Action
+    obj: str | None = None  # Object
+    con: str | None = None  # Constraint
 
     def __iter__(self) -> Iterator[str]:
         yield self.text
@@ -157,27 +186,46 @@ class GovernanceDiagram:
         ]
 
     def generate_requirements(self) -> List[GeneratedRequirement]:
-        """Generate textual requirements from the diagram.
+        """Generate structured requirements from the diagram.
 
-        Tasks, flows, relationships and any optional conditions or labels are
-        converted into simple natural language statements for downstream
-        processing or documentation.  Each returned item is a
-        :class:`GeneratedRequirement` containing the requirement text and its
-        category (``"AI safety"`` or ``"organizational"``).
+        Diagram elements are mapped onto requirement components following the
+        ``[CND] SUB shall ACT [OBJ] [CON]`` pattern.  The resulting
+        :class:`GeneratedRequirement` objects preserve these components to aid
+        downstream tooling.
         """
 
         requirements: List[GeneratedRequirement] = []
 
+        def compose(cnd: str | None, sub: str, act: str, obj: str | None = None, con: str | None = None) -> str:
+            parts: list[str] = []
+            if cnd:
+                parts.append(f"If {cnd}, ")
+            parts.append(f"{sub} shall {act}")
+            if obj:
+                parts.append(f" {obj}")
+            if con:
+                parts.append(f" {con}")
+            return "".join(parts) + "."
+
+        def req_type_for(conn_type: str | None, src: str, dst: str) -> str:
+            if (
+                conn_type in _AI_RELATIONS
+                or self.node_types.get(src) in _AI_NODES
+                or self.node_types.get(dst) in _AI_NODES
+            ):
+                return "AI safety"
+            return "organizational"
+
         for task in self.tasks():
-            req_type = (
-                "AI safety"
-                if self.node_types.get(task) in _AI_NODES
-                else "organizational"
-            )
+            ntype = self.node_types.get(task)
+            if ntype not in _ACTION_NODE_TYPES:
+                continue
+            req_type = "AI safety" if ntype in _AI_NODES else "organizational"
+            sub = "The system"
+            act = f"perform {task}"
+            text = compose(None, sub, act)
             requirements.append(
-                GeneratedRequirement(
-                    f"The system shall perform task '{task}'.", req_type
-                )
+                GeneratedRequirement(text, req_type, sub=sub, act=act)
             )
 
         for src, dst in self.graph.edges():
@@ -188,34 +236,62 @@ class GovernanceDiagram:
             kind = data.get("kind")
             label = data.get("label")
             conn_type = data.get("conn_type")
+            dst_type = self.node_types.get(dst)
+            sub = f"Task '{src}'"
+
             if kind == "flow":
-                if cond:
-                    req = f"When {cond}, task '{src}' shall precede task '{dst}'."
-                else:
-                    req = f"Task '{src}' shall precede task '{dst}'."
-            else:  # relationship
-                if label:
-                    if cond:
-                        req = (
-                            f"Task '{src}' shall {label} task '{dst}' when {cond}."
-                        )
-                    else:
-                        req = f"Task '{src}' shall {label} task '{dst}'."
-                else:
-                    if cond:
-                        req = (
-                            f"Task '{src}' shall be related to task '{dst}' when {cond}."
-                        )
-                    else:
-                        req = f"Task '{src}' shall be related to task '{dst}'."
-            req_type = "organizational"
-            if (
-                conn_type in _AI_RELATIONS
-                or self.node_types.get(src) in _AI_NODES
-                or self.node_types.get(dst) in _AI_NODES
+                act = "precede"
+                obj = f"task '{dst}'"
+                text = compose(cond, sub, act, obj=obj)
+                requirements.append(
+                    GeneratedRequirement(
+                        text,
+                        req_type_for(conn_type, src, dst),
+                        cnd=cond,
+                        sub=sub,
+                        act=act,
+                        obj=obj,
+                    )
+                )
+                continue
+
+            # relationship
+            if dst_type in _CONSTRAINT_NODE_TYPES or (
+                label and label.lower() in {"governed by", "constrained by"}
             ):
-                req_type = "AI safety"
-            requirements.append(GeneratedRequirement(req, req_type))
+                if label:
+                    lower = label.lower()
+                    act = f"be {lower}" if lower in {"governed by", "constrained by"} else label
+                else:
+                    act = "comply with"
+                con = dst
+                text = compose(cond, sub, act, con=con)
+                requirements.append(
+                    GeneratedRequirement(
+                        text,
+                        req_type_for(conn_type, src, dst),
+                        cnd=cond,
+                        sub=sub,
+                        act=act,
+                        con=con,
+                    )
+                )
+            else:
+                act = label if label else "relate to"
+                obj = (
+                    f"task '{dst}'" if dst_type in _ACTION_NODE_TYPES else dst
+                )
+                text = compose(cond, sub, act, obj=obj)
+                requirements.append(
+                    GeneratedRequirement(
+                        text,
+                        req_type_for(conn_type, src, dst),
+                        cnd=cond,
+                        sub=sub,
+                        act=act,
+                        obj=obj,
+                    )
+                )
 
         return requirements
 
@@ -252,6 +328,10 @@ class GovernanceDiagram:
         for obj in getattr(src_diagram, "objects", []):
             odict = obj if isinstance(obj, dict) else obj.__dict__
             obj_type = odict.get("obj_type")
+            obj_id = odict.get("obj_id")
+            if obj_type == "Decision":
+                decision_sources[obj_id] = ""
+                continue
             elem_id = odict.get("element_id")
             name = ""
             if elem_id and elem_id in repo.elements:
@@ -261,7 +341,7 @@ class GovernanceDiagram:
             if not name:
                 continue
             diagram.add_task(name)
-            id_to_name[odict.get("obj_id")] = name
+            id_to_name[obj_id] = name
 
         # Map decision nodes to their predecessor action
         for conn in getattr(src_diagram, "connections", []):
@@ -289,8 +369,6 @@ class GovernanceDiagram:
                 elif name and cdict.get("conn_type") == "Flow":
                     cond = name
             conn_type = cdict.get("conn_type")
-            if conn_type == "Flow":
-                diagram.add_flow(src, dst, cond, conn_type=conn_type)
             cond_prop = cdict.get("properties", {}).get("condition")
             guards = cdict.get("guard") or []
             guard_ops = cdict.get("guard_ops") or []

--- a/tests/test_governance_decision_guard.py
+++ b/tests/test_governance_decision_guard.py
@@ -1,4 +1,8 @@
+import sys
 import unittest
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from gui.architecture import SysMLObject, DiagramConnection
 from sysml.sysml_repository import SysMLRepository
@@ -31,7 +35,12 @@ class GovernanceDecisionGuardTests(unittest.TestCase):
         self.assertIn(("A", "B"), gdiag.flows())
         self.assertEqual(gdiag.edge_data[("A", "B")]["condition"], "g1")
         reqs = gdiag.generate_requirements()
-        self.assertIn("When g1, task 'A' shall precede task 'B'.", reqs)
+        texts = [r.text for r in reqs]
+        self.assertIn("If g1, Task 'A' shall precede task 'B'.", texts)
+        req = next(r for r in reqs if r.text == "If g1, Task 'A' shall precede task 'B'.")
+        self.assertEqual(req.cnd, "g1")
+        self.assertEqual(req.sub, "Task 'A'")
+        self.assertEqual(req.obj, "task 'B'")
 
 
 if __name__ == "__main__":

--- a/tests/test_governance_relationship_label.py
+++ b/tests/test_governance_relationship_label.py
@@ -19,3 +19,7 @@ def test_label_relationship_between_database_nodes():
     reqs = diagram.generate_requirements()
     texts = [t for t, _ in reqs]
     assert "Task 'User DB' shall sync with task 'Analytics DB'." in texts
+    req = next(r for r in reqs if r.text == "Task 'User DB' shall sync with task 'Analytics DB'.")
+    assert req.sub == "Task 'User DB'"
+    assert req.act == "sync with"
+    assert req.obj == "task 'Analytics DB'"

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -20,9 +20,14 @@ def test_generate_requirements_from_governance_diagram():
     reqs = diagram.generate_requirements()
     texts = [t for t, _ in reqs]
 
-    assert "The system shall perform task 'Start'." in texts
+    assert "The system shall perform Start." in texts
     assert "Task 'Start' shall precede task 'Approve'." in texts
-    assert "When approval granted, task 'Approve' shall precede task 'Finish'." in texts
-    assert (
-        "Task 'Start' shall be related to task 'Finish' when risk identified." in texts
-    )
+    assert "If approval granted, Task 'Approve' shall precede task 'Finish'." in texts
+    assert "If risk identified, Task 'Start' shall relate to task 'Finish'." in texts
+
+    # Check structured components for one requirement
+    start_req = next(r for r in reqs if r.text == "Task 'Start' shall precede task 'Approve'.")
+    assert start_req.sub == "Task 'Start'"
+    assert start_req.act == "precede"
+    assert start_req.obj == "task 'Approve'"
+    assert start_req.cnd is None


### PR DESCRIPTION
## Summary
- map governance diagram elements to requirement components
- generate ISO/IEC/IEEE 29148 style requirements with condition, subject, action, object, and constraint
- test structured requirement generation

## Testing
- `PYTHONPATH=. pytest tests/test_governance_decision_guard.py tests/test_governance_requirements_generator.py tests/test_governance_relationship_label.py tests/test_governance_requirements_button.py -q`
- `PYTHONPATH=. pytest -q` *(fails: AttributeError: type object 'SysMLDiagramWindow' has no attribute '_assign_decision_corner')*


------
https://chatgpt.com/codex/tasks/task_b_689f59d3161883279b8af9a914afda14