### PR TITLE
Generate structured requirements from governance diagrams

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -22,17 +22,94 @@ _AI_RELATIONS = {
     "Model evaluation",
 }
 
+# Map relationship labels or connection types to requirement actions.  Each
+# entry defines the verb to use, whether the destination element acts as a
+# constraint instead of an object, and an optional default subject.  The
+# resulting requirement follows the ISO/IEC/IEEE 29148 pattern
+# ``[CND] <SUB> shall <ACT> [OBJ] [CON].``
+_RELATIONSHIP_RULES: dict[str, dict[str, str | bool]] = {
+    "performs": {"action": "perform"},
+    "executes": {"action": "execute"},
+    "responsible for": {"action": "be responsible for"},
+    "produces": {"action": "produce"},
+    "delivers": {"action": "deliver"},
+    "uses": {"action": "use"},
+    "consumes": {"action": "use"},
+    "monitors": {"action": "monitor"},
+    "audits": {"action": "audit"},
+    "approves": {"action": "approve"},
+    "authorizes": {"action": "authorize"},
+    "governed by": {"action": "comply with", "constraint": True},
+    "constrained by": {"action": "comply with", "constraint": True},
+    # AI specific relationship types default the subject to the engineering
+    # team because these actions are typically performed by developers rather
+    # than by elements explicitly modelled in the diagram.
+    "ai training": {"action": "train", "subject": "Engineering team"},
+    "ai re-training": {"action": "retrain", "subject": "Engineering team"},
+    "curation": {"action": "curate", "subject": "Engineering team"},
+}
+
+# Map node types to default requirement roles so that the generator can
+# identify the subject, object or constraint directly from the model.
+_NODE_ROLES = {
+    "Role": "subject",
+    "Actor": "subject",
+    "Stakeholder": "subject",
+    "Organization": "subject",
+    "Business Unit": "subject",
+    "Process": "action",
+    "Procedure": "action",
+    "Activity": "action",
+    "Task": "action",
+    "Decision": "condition",
+    "Policy": "constraint",
+    "Principle": "constraint",
+    "Standard": "constraint",
+    "Guideline": "constraint",
+    "Document": "object",
+    "Artifact": "object",
+    "Data": "object",
+    "Record": "object",
+    "Database": "object",
+    "ANN": "object",
+    "Data acquisition": "object",
+    "Metric": "constraint",
+    "KPI": "constraint",
+}
+
 
 @dataclass
 class GeneratedRequirement:
-    """Container for a generated requirement.
+    """Structured requirement composed from diagram elements.
 
-    The object behaves like both a tuple ``(text, type)`` and a string so that
-    existing code and tests that expect either representation continue to work.
+    The dataclass exposes the individual requirement components (condition,
+    subject, action, object and constraint) alongside the requirement category.
+    For backward compatibility the object behaves like a tuple ``(text,
+    req_type)`` and can be treated as a string containing the rendered
+    requirement sentence.
     """
 
-    text: str
+    condition: str | None
+    subject: str | None
+    action: str
+    obj: str | None
+    constraint: str | None
     req_type: str
+
+    @property
+    def text(self) -> str:
+        parts: List[str] = []
+        if self.condition:
+            parts.append(f"If {self.condition},")
+        subject = self.subject or "Task"
+        main = f"{subject} shall {self.action}"
+        if self.obj:
+            main += f" '{self.obj}'"
+        if self.constraint:
+            main += f" '{self.constraint}'"
+        main += "."
+        parts.append(main)
+        return " ".join(parts)
 
     def __iter__(self) -> Iterator[str]:
         yield self.text
@@ -67,6 +144,11 @@ class GovernanceDiagram:
     # be categorised.  Tasks originating from AI & safety nodes produce AI
     # safety requirements.
     node_types: dict[str, str] = field(default_factory=dict)
+
+    def _role_for(self, name: str) -> str:
+        """Return the requirement role for a node name."""
+        ntype = self.node_types.get(name, "")
+        return _NODE_ROLES.get(ntype, "object")
 
     def add_task(self, name: str, node_type: str = "Action") -> None:
         """Add a task node to the diagram."""
@@ -157,28 +239,9 @@ class GovernanceDiagram:
         ]
 
     def generate_requirements(self) -> List[GeneratedRequirement]:
-        """Generate textual requirements from the diagram.
-
-        Tasks, flows, relationships and any optional conditions or labels are
-        converted into simple natural language statements for downstream
-        processing or documentation.  Each returned item is a
-        :class:`GeneratedRequirement` containing the requirement text and its
-        category (``"AI safety"`` or ``"organizational"``).
-        """
+        """Generate structured requirements from the diagram."""
 
         requirements: List[GeneratedRequirement] = []
-
-        for task in self.tasks():
-            req_type = (
-                "AI safety"
-                if self.node_types.get(task) in _AI_NODES
-                else "organizational"
-            )
-            requirements.append(
-                GeneratedRequirement(
-                    f"The system shall perform task '{task}'.", req_type
-                )
-            )
 
         for src, dst in self.graph.edges():
             data = self.edge_data.get(
@@ -188,26 +251,33 @@ class GovernanceDiagram:
             kind = data.get("kind")
             label = data.get("label")
             conn_type = data.get("conn_type")
+
+            subject = src
+            obj: str | None = dst
+            constraint: str | None = None
+            action: str
+
             if kind == "flow":
-                if cond:
-                    req = f"When {cond}, task '{src}' shall precede task '{dst}'."
-                else:
-                    req = f"Task '{src}' shall precede task '{dst}'."
-            else:  # relationship
-                if label:
-                    if cond:
-                        req = (
-                            f"Task '{src}' shall {label} task '{dst}' when {cond}."
-                        )
-                    else:
-                        req = f"Task '{src}' shall {label} task '{dst}'."
-                else:
-                    if cond:
-                        req = (
-                            f"Task '{src}' shall be related to task '{dst}' when {cond}."
-                        )
-                    else:
-                        req = f"Task '{src}' shall be related to task '{dst}'."
+                action = "precede"
+            else:
+                key = (label or conn_type or "").lower()
+                rule = _RELATIONSHIP_RULES.get(key, {})
+                action = str(rule.get("action", label or "relate to"))
+                explicit_subject = rule.get("subject")
+                if explicit_subject:
+                    subject = str(explicit_subject)
+                if rule.get("constraint"):
+                    constraint = dst
+                    obj = None
+                elif not label and not rule:
+                    action = "be related to"
+
+            if obj is not None:
+                s_role = self._role_for(subject)
+                d_role = self._role_for(obj)
+                if s_role != "subject" and d_role == "subject":
+                    subject, obj = obj, subject
+
             req_type = "organizational"
             if (
                 conn_type in _AI_RELATIONS
@@ -215,7 +285,10 @@ class GovernanceDiagram:
                 or self.node_types.get(dst) in _AI_NODES
             ):
                 req_type = "AI safety"
-            requirements.append(GeneratedRequirement(req, req_type))
+
+            requirements.append(
+                GeneratedRequirement(cond, subject, action, obj, constraint, req_type)
+            )
 
         return requirements
 
@@ -258,10 +331,11 @@ class GovernanceDiagram:
                 name = repo.elements[elem_id].name
             if not name:
                 name = odict.get("properties", {}).get("name", "")
-            if not name:
-                continue
-            diagram.add_task(name)
-            id_to_name[odict.get("obj_id")] = name
+            if name:
+                diagram.add_task(name)
+                id_to_name[odict.get("obj_id")] = name
+            if obj_type == "Decision":
+                decision_sources[odict.get("obj_id")] = ""
 
         # Map decision nodes to their predecessor action
         for conn in getattr(src_diagram, "connections", []):
@@ -289,8 +363,6 @@ class GovernanceDiagram:
                 elif name and cdict.get("conn_type") == "Flow":
                     cond = name
             conn_type = cdict.get("conn_type")
-            if conn_type == "Flow":
-                diagram.add_flow(src, dst, cond, conn_type=conn_type)
             cond_prop = cdict.get("properties", {}).get("condition")
             guards = cdict.get("guard") or []
             guard_ops = cdict.get("guard_ops") or []

--- a/tests/test_governance_decision_guard.py
+++ b/tests/test_governance_decision_guard.py
@@ -31,7 +31,8 @@ class GovernanceDecisionGuardTests(unittest.TestCase):
         self.assertIn(("A", "B"), gdiag.flows())
         self.assertEqual(gdiag.edge_data[("A", "B")]["condition"], "g1")
         reqs = gdiag.generate_requirements()
-        self.assertIn("When g1, task 'A' shall precede task 'B'.", reqs)
+        texts = [r.text for r in reqs]
+        self.assertIn("If g1, A shall precede 'B'.", texts)
 
 
 if __name__ == "__main__":

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -80,7 +80,7 @@ def test_phase_requirements_menu(monkeypatch):
     assert "Phase1 Requirements" in title
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
-    assert any("Task 'Start' shall precede task 'Finish'." in t for t in texts)
-    assert any("Task 'Check' shall precede task 'Complete'." in t for t in texts)
+    assert any("Start shall precede 'Finish'." in t for t in texts)
+    assert any("Check shall precede 'Complete'." in t for t in texts)
     assert all(row[1] == "organizational" for row in trees[0].rows)
     assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_governance_relationship_label.py
+++ b/tests/test_governance_relationship_label.py
@@ -17,5 +17,5 @@ def test_label_relationship_between_database_nodes():
     assert diagram.edge_data[("User DB", "Analytics DB")]["label"] == "sync with"
 
     reqs = diagram.generate_requirements()
-    texts = [t for t, _ in reqs]
-    assert "Task 'User DB' shall sync with task 'Analytics DB'." in texts
+    texts = [r.text for r in reqs]
+    assert "User DB shall sync with 'Analytics DB'." in texts

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -67,7 +67,7 @@ def test_requirements_button_opens_tab(monkeypatch):
     assert "Gov Requirements" in title
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
-    assert any("Task 'Start' shall precede task 'Finish'." in t for t in texts)
+    assert any("Start shall precede 'Finish'." in t for t in texts)
     # Ensure requirement types are organizational
     assert all(row[1] == "organizational" for row in trees[0].rows)
     # Requirements added to global registry

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -10,19 +10,63 @@ from analysis.governance import GovernanceDiagram
 
 def test_generate_requirements_from_governance_diagram():
     diagram = GovernanceDiagram()
-    diagram.add_task("Start")
-    diagram.add_task("Approve")
-    diagram.add_task("Finish")
-    diagram.add_flow("Start", "Approve")
-    diagram.add_flow("Approve", "Finish", condition="approval granted")
-    diagram.add_relationship("Start", "Finish", condition="risk identified")
+    diagram.add_task("Data Steward", node_type="Role")
+    diagram.add_task("Review Data", node_type="Activity")
+    diagram.add_task("Report", node_type="Document")
+    diagram.add_task("Policy DP-001", node_type="Policy")
+    diagram.add_relationship("Data Steward", "Review Data", label="performs")
+    diagram.add_relationship("Review Data", "Report", label="produces")
+    diagram.add_relationship(
+        "Data Steward", "Report", label="approves", condition="data validated"
+    )
+    diagram.add_relationship("Review Data", "Policy DP-001", label="governed by")
 
     reqs = diagram.generate_requirements()
-    texts = [t for t, _ in reqs]
+    texts = [r.text for r in reqs]
 
-    assert "The system shall perform task 'Start'." in texts
-    assert "Task 'Start' shall precede task 'Approve'." in texts
-    assert "When approval granted, task 'Approve' shall precede task 'Finish'." in texts
-    assert (
-        "Task 'Start' shall be related to task 'Finish' when risk identified." in texts
+    assert "Data Steward shall perform 'Review Data'." in texts
+    assert "Review Data shall produce 'Report'." in texts
+    assert "If data validated, Data Steward shall approve 'Report'." in texts
+    assert "Review Data shall comply with 'Policy DP-001'." in texts
+
+    perf_req = next(r for r in reqs if r.action == "perform")
+    assert perf_req.subject == "Data Steward"
+    assert perf_req.obj == "Review Data"
+
+    approve_req = next(r for r in reqs if r.action == "approve")
+    assert approve_req.condition == "data validated"
+    assert approve_req.subject == "Data Steward"
+    assert approve_req.obj == "Report"
+
+
+def test_ai_training_and_curation_requirements():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Decision1", node_type="Decision")
+    diagram.add_task("ANN1", node_type="ANN")
+    diagram.add_task("Database1", node_type="Database")
+    diagram.add_relationship(
+        "Decision1",
+        "ANN1",
+        condition="completion >= 0.98",
+        conn_type="AI training",
     )
+    diagram.add_relationship(
+        "Decision1",
+        "Database1",
+        condition="completion < 0.98",
+        conn_type="Curation",
+    )
+    reqs = diagram.generate_requirements()
+    texts = [r.text for r in reqs]
+    assert "If completion >= 0.98, Engineering team shall train 'ANN1'." in texts
+    assert "If completion < 0.98, Engineering team shall curate 'Database1'." in texts
+
+    train_req = next(r for r in reqs if r.action == "train")
+    assert train_req.subject == "Engineering team"
+    assert train_req.obj == "ANN1"
+    assert train_req.condition == "completion >= 0.98"
+
+    curate_req = next(r for r in reqs if r.action == "curate")
+    assert curate_req.subject == "Engineering team"
+    assert curate_req.obj == "Database1"
+    assert curate_req.condition == "completion < 0.98"


### PR DESCRIPTION
## Summary
- Classify diagram elements into requirement roles and actions
- Generate structured requirements capturing condition, subject, action, object and constraint
- Update tests for structured requirement fields and new wording

## Testing
- `pytest -q tests/test_governance_requirements_generator.py tests/test_governance_relationship_label.py tests/test_governance_requirements_button.py tests/test_governance_phase_requirements_menu.py tests/test_governance_decision_guard.py`
- `pytest -q` *(fails: AttributeError: type object 'SysMLDiagramWindow' has no attribute '_assign_decision_corner')*

------
https://chatgpt.com/codex/tasks/task_b_689f59d3161883279b8af9a914afda14