### PR TITLE
Allow decision flows to lifecycle phases

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3461,7 +3461,7 @@ class SysMLDiagramWindow(tk.Frame):
                 allowed = {
                     "Initial": {"Action", "Decision", "Merge", *ai_targets},
                     "Action": {"Action", "Decision", "Merge", "Final", *ai_targets},
-                    "Decision": {"Action", "Decision", "Merge", "Final", *ai_targets},
+                    "Decision": {"Action", "Decision", "Merge", "Final", "Lifecycle Phase", *ai_targets},
                     "Merge": {"Action", "Decision", "Merge", *ai_targets},
                     "Final": set(),
                 }

--- a/tests/test_governance_decision_phase_flow.py
+++ b/tests/test_governance_decision_phase_flow.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+import unittest
+from dataclasses import asdict
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow, SysMLObject, SysMLDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+
+class GovernanceDecisionPhaseFlowTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        self.repo = SysMLRepository.get_instance()
+
+    def _window(self, diag):
+        class Win:
+            _decision_used_corners = SysMLDiagramWindow._decision_used_corners
+
+            def __init__(self, repo, diagram_id):
+                self.repo = repo
+                self.diagram_id = diagram_id
+                self.connections = []
+
+        return Win(self.repo, diag.diag_id)
+
+    def test_decision_to_phase_flow_allowed(self):
+        repo = self.repo
+        dec_elem = repo.create_element("Decision", name="Gate")
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        repo.add_element_to_diagram(diag.diag_id, dec_elem.elem_id)
+        decision = SysMLObject(
+            1,
+            "Decision",
+            0.0,
+            0.0,
+            element_id=dec_elem.elem_id,
+            properties={"name": "Gate"},
+        )
+        phase = SysMLObject(2, "Lifecycle Phase", 0.0, 100.0, properties={"name": "P2"})
+        diag.objects = [asdict(decision), asdict(phase)]
+        win = self._window(diag)
+        valid, _ = GovernanceDiagramWindow.validate_connection(win, decision, phase, "Flow")
+        self.assertTrue(valid)
+        valid, _ = GovernanceDiagramWindow.validate_connection(win, phase, decision, "Flow")
+        self.assertTrue(valid)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- permit decision nodes to connect to lifecycle phase shapes via flow relationships
- add regression test for decision-to-phase flow connections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f919df1dc8327aa75118344768d14