### PR TITLE
Use light green for decision nodes

### DIFF
--- a/styles/dark.xml
+++ b/styles/dark.xml
@@ -9,6 +9,6 @@
   <object type="Part" color="#F57F17" />
   <object type="Port" color="#4A148C" />
   <object type="Block" color="#455A64" />
-  <object type="Decision" color="#006064" />
+  <object type="Decision" color="#C8E6C9" />
   <object type="Merge" color="#006064" />
 </style>

--- a/styles/light.xml
+++ b/styles/light.xml
@@ -9,6 +9,6 @@
   <object type="Part" color="#FFF9C4" />
   <object type="Port" color="#E1BEE7" />
   <object type="Block" color="#B0BEC5" />
-  <object type="Decision" color="#B2EBF2" />
+  <object type="Decision" color="#C8E6C9" />
   <object type="Merge" color="#B2EBF2" />
 </style>

--- a/styles/modern.xml
+++ b/styles/modern.xml
@@ -9,6 +9,6 @@
   <object type="Part" color="#FFF9C4" />
   <object type="Port" color="#E1BEE7" />
   <object type="Block" color="#B0BEC5" />
-  <object type="Decision" color="#B2EBF2" />
+  <object type="Decision" color="#C8E6C9" />
   <object type="Merge" color="#B2EBF2" />
 </style>

--- a/styles/pastel.xml
+++ b/styles/pastel.xml
@@ -10,7 +10,7 @@
   <object type="Part" color="#FFB6C1" />
   <object type="Port" color="#FFA07A" />
   <object type="Block" color="#B0C4DE" />
-  <object type="Decision" color="#FFFFFF" />
+  <object type="Decision" color="#C8E6C9" />
   <object type="Merge" color="#FFFFFF" />
   <object type="Database" color="#cfe2f3" />
   <object type="ANN" color="#d5e8d4" />

--- a/styles/vibrant.xml
+++ b/styles/vibrant.xml
@@ -9,6 +9,6 @@
   <object type="Part" color="#FDD835" />
   <object type="Port" color="#8E24AA" />
   <object type="Block" color="#546E7A" />
-  <object type="Decision" color="#00ACC1" />
+  <object type="Decision" color="#C8E6C9" />
   <object type="Merge" color="#00ACC1" />
 </style>


### PR DESCRIPTION
## Summary
- render decision nodes in light green so their gradient transitions from white to a soft green across all style themes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f928b2bf08327b05425f4f2646e6f