### PR TITLE
Centralize all diagram rules in external configuration

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -258,6 +258,7 @@ from analysis.mechanisms import (
     PAS_8800_MECHANISMS,
 )
 import json
+from pathlib import Path
 from collections.abc import Mapping
 import csv
 try:
@@ -518,7 +519,10 @@ VALID_SUBTYPES = {
 }
 
 # Node types treated as gates when rendering and editing
-GATE_NODE_TYPES = {"GATE", "RIGOR LEVEL", "TOP EVENT", "FUNCTIONAL INSUFFICIENCY"}
+_CONFIG_PATH = Path(__file__).resolve().parent / "diagram_rules.json"
+with _CONFIG_PATH.open() as f:
+    _CONFIG = json.load(f)
+GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 
 ##########################################
 # Global Unique ID Counter for Nodes

--- a/analysis/fmeda_utils.py
+++ b/analysis/fmeda_utils.py
@@ -1,8 +1,13 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 from analysis.models import ASIL_ORDER, ASIL_TARGETS, component_fit_map
+import json
+from pathlib import Path
 
 # Node types treated as gates when determining component names
-GATE_NODE_TYPES = {"GATE", "RIGOR LEVEL", "TOP EVENT", "FUNCTIONAL INSUFFICIENCY"}
+_CONFIG_PATH = Path(__file__).resolve().parents[1] / "diagram_rules.json"
+with _CONFIG_PATH.open() as f:
+    _CONFIG = json.load(f)
+GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 
 
 def _aggregate_goal_metrics(entries, components, sg_to_asil, sg_targets=None, get_node=lambda x: x):

--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -3,79 +3,31 @@
 from dataclasses import dataclass, field
 from typing import Any, Iterator, List, Tuple
 
+from pathlib import Path
+import json
+
 import networkx as nx
 
+_CONFIG_PATH = Path(__file__).resolve().parents[1] / "diagram_rules.json"
+with _CONFIG_PATH.open() as f:
+    _CONFIG = json.load(f)
+
 # Element and relationship types associated with AI & safety lifecycle nodes.
-_AI_NODES = {"Database", "ANN", "Data acquisition"}
-_AI_RELATIONS = {
-    "Annotation",
-    "Synthesis",
-    "Augmentation",
-    "Acquisition",
-    "Labeling",
-    "Field risk evaluation",
-    "Field data collection",
-    "AI training",
-    "AI re-training",
-    "Curation",
-    "Ingestion",
-    "Model evaluation",
-}
+_AI_NODES = set(_CONFIG.get("ai_nodes", []))
+_AI_RELATIONS = set(_CONFIG.get("ai_relations", []))
 
 # Map relationship labels or connection types to requirement actions.  Each
 # entry defines the verb to use, whether the destination element acts as a
 # constraint instead of an object, and an optional default subject.  The
 # resulting requirement follows the ISO/IEC/IEEE 29148 pattern
 # ``[CND] <SUB> shall <ACT> [OBJ] [CON].``
-_RELATIONSHIP_RULES: dict[str, dict[str, str | bool]] = {
-    "performs": {"action": "perform"},
-    "executes": {"action": "execute"},
-    "responsible for": {"action": "be responsible for"},
-    "produces": {"action": "produce"},
-    "delivers": {"action": "deliver"},
-    "uses": {"action": "use"},
-    "consumes": {"action": "use"},
-    "monitors": {"action": "monitor"},
-    "audits": {"action": "audit"},
-    "approves": {"action": "approve"},
-    "authorizes": {"action": "authorize"},
-    "governed by": {"action": "comply with", "constraint": True},
-    "constrained by": {"action": "comply with", "constraint": True},
-    # AI specific relationship types default the subject to the engineering
-    # team because these actions are typically performed by developers rather
-    # than by elements explicitly modelled in the diagram.
-    "ai training": {"action": "train", "subject": "Engineering team"},
-    "ai re-training": {"action": "retrain", "subject": "Engineering team"},
-    "curation": {"action": "curate", "subject": "Engineering team"},
-}
+_RELATIONSHIP_RULES: dict[str, dict[str, str | bool]] = _CONFIG.get(
+    "relationship_rules", {}
+)
 
 # Map node types to default requirement roles so that the generator can
 # identify the subject, object or constraint directly from the model.
-_NODE_ROLES = {
-    "Role": "subject",
-    "Actor": "subject",
-    "Stakeholder": "subject",
-    "Organization": "subject",
-    "Business Unit": "subject",
-    "Process": "action",
-    "Procedure": "action",
-    "Activity": "action",
-    "Task": "action",
-    "Decision": "condition",
-    "Policy": "constraint",
-    "Principle": "constraint",
-    "Standard": "constraint",
-    "Guideline": "constraint",
-    "Document": "object",
-    "Artifact": "object",
-    "Data": "object",
-    "Record": "object",
-    "Database": "object",
-    "ANN": "object",
-    "Data acquisition": "object",
-    "Metric": "constraint",
-    "KPI": "constraint",
-}
+_NODE_ROLES = _CONFIG.get("node_roles", {})
 
 
 @dataclass

--- a/diagram_rules.json
+++ b/diagram_rules.json
@@ -1,0 +1,100 @@
+{
+  "ai_nodes": [
+    "Database",
+    "ANN",
+    "Data acquisition"
+  ],
+  "ai_relations": [
+    "Annotation",
+    "Synthesis",
+    "Augmentation",
+    "Acquisition",
+    "Labeling",
+    "Field risk evaluation",
+    "Field data collection",
+    "AI training",
+    "AI re-training",
+    "Curation",
+    "Ingestion",
+    "Model evaluation"
+  ],
+  "arch_diagram_types": [
+    "Use Case Diagram",
+    "Activity Diagram",
+    "Block Diagram",
+    "Internal Block Diagram"
+  ],
+  "governance_node_types": [
+    "Action",
+    "Initial",
+    "Final",
+    "Decision",
+    "Merge",
+    "System Boundary",
+    "Work Product",
+    "Lifecycle Phase"
+  ],
+  "gate_node_types": [
+    "GATE",
+    "RIGOR LEVEL",
+    "TOP EVENT",
+    "FUNCTIONAL INSUFFICIENCY"
+  ],
+  "relationship_rules": {
+    "performs": {"action": "perform"},
+    "executes": {"action": "execute"},
+    "responsible for": {"action": "be responsible for"},
+    "produces": {"action": "produce"},
+    "delivers": {"action": "deliver"},
+    "uses": {"action": "use"},
+    "consumes": {"action": "use"},
+    "monitors": {"action": "monitor"},
+    "audits": {"action": "audit"},
+    "approves": {"action": "approve"},
+    "authorizes": {"action": "authorize"},
+    "governed by": {"action": "comply with", "constraint": true},
+    "constrained by": {"action": "comply with", "constraint": true},
+    "ai training": {"action": "train", "subject": "Engineering team"},
+    "ai re-training": {"action": "retrain", "subject": "Engineering team"},
+    "curation": {"action": "curate", "subject": "Engineering team"}
+  },
+  "node_roles": {
+    "Role": "subject",
+    "Actor": "subject",
+    "Stakeholder": "subject",
+    "Organization": "subject",
+    "Business Unit": "subject",
+    "Process": "action",
+    "Procedure": "action",
+    "Activity": "action",
+    "Task": "action",
+    "Decision": "condition",
+    "Policy": "constraint",
+    "Principle": "constraint",
+    "Standard": "constraint",
+    "Guideline": "constraint",
+    "Document": "object",
+    "Artifact": "object",
+    "Data": "object",
+    "Record": "object",
+    "Database": "object",
+    "ANN": "object",
+    "Data acquisition": "object",
+    "Metric": "constraint",
+    "KPI": "constraint"
+  },
+  "safety_ai_relation_rules": {
+    "Acquisition": {"Data acquisition": ["Database"]},
+    "Field data collection": {"Data acquisition": ["Database"]},
+    "Field risk evaluation": {"Data acquisition": ["Database"]},
+    "Annotation": {"ANN": ["Database"]},
+    "Synthesis": {"ANN": ["Database"]},
+    "Augmentation": {"ANN": ["Database"]},
+    "Labeling": {"ANN": ["Database"]},
+    "AI training": {"Database": ["ANN"]},
+    "AI re-training": {"Database": ["ANN"]},
+    "Model evaluation": {"ANN": ["Database"]},
+    "Curation": {"Database": ["Database"]},
+    "Ingestion": {"Database": ["Database"]}
+  }
+}

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -12,6 +12,7 @@ import json
 import math
 import re
 import types
+from pathlib import Path
 from dataclasses import dataclass, field, asdict, replace
 from typing import Dict, List, Tuple
 
@@ -48,48 +49,28 @@ _next_obj_id = 1
 # Pixel distance used when detecting clicks on connection lines
 CONNECTION_SELECT_RADIUS = 15
 
+
+_CONFIG_PATH = Path(__file__).resolve().parents[1] / "diagram_rules.json"
+with _CONFIG_PATH.open() as f:
+    _CONFIG = json.load(f)
+
 # Diagram types that belong to the generic "Architecture Diagram" work product
-ARCH_DIAGRAM_TYPES = {
-    "Use Case Diagram",
-    "Activity Diagram",
-    "Block Diagram",
-    "Internal Block Diagram",
-}
+ARCH_DIAGRAM_TYPES = set(_CONFIG.get("arch_diagram_types", []))
 
 # Elements available in the Safety & AI Lifecycle toolbox
-SAFETY_AI_NODE_TYPES = {"Database", "ANN", "Data acquisition"}
+SAFETY_AI_NODE_TYPES = set(_CONFIG.get("ai_nodes", []))
 
 # Elements from the governance toolbox that may participate in
 # Safety & AI relationships
-GOVERNANCE_NODE_TYPES = {
-    "Action",
-    "Initial",
-    "Final",
-    "Decision",
-    "Merge",
-    "System Boundary",
-    "Work Product",
-    "Lifecycle Phase",
-}
-
+GOVERNANCE_NODE_TYPES = set(_CONFIG.get("governance_node_types", []))
 
 # Directed relationship rules for connections between Safety & AI elements.
 # Each entry maps a connection type to allowed source and target element
 # combinations. Rules are only enforced when both endpoints are Safety & AI
 # nodes.
 SAFETY_AI_RELATION_RULES: dict[str, dict[str, set[str]]] = {
-    "Acquisition": {"Data acquisition": {"Database"}},
-    "Field data collection": {"Data acquisition": {"Database"}},
-    "Field risk evaluation": {"Data acquisition": {"Database"}},
-    "Annotation": {"ANN": {"Database"}},
-    "Synthesis": {"ANN": {"Database"}},
-    "Augmentation": {"ANN": {"Database"}},
-    "Labeling": {"ANN": {"Database"}},
-    "AI training": {"Database": {"ANN"}},
-    "AI re-training": {"Database": {"ANN"}},
-    "Model evaluation": {"ANN": {"Database"}},
-    "Curation": {"Database": {"Database"}},
-    "Ingestion": {"Database": {"Database"}},
+    conn: {src: set(dests) for src, dests in srcs.items()}
+    for conn, srcs in _CONFIG.get("safety_ai_relation_rules", {}).items()
 }
 
 

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -25,13 +25,17 @@ import difflib
 import sys
 import json
 import re
+from pathlib import Path
 try:
     from PIL import Image, ImageTk
 except ModuleNotFoundError:  # pragma: no cover - pillow optional
     Image = ImageTk = None
 
 # Node types treated as gates when deriving component names
-GATE_NODE_TYPES = {"GATE", "RIGOR LEVEL", "TOP EVENT", "FUNCTIONAL INSUFFICIENCY"}
+_CONFIG_PATH = Path(__file__).resolve().parents[1] / "diagram_rules.json"
+with _CONFIG_PATH.open() as f:
+    _CONFIG = json.load(f)
+GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 
 EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")
 


### PR DESCRIPTION
## Summary
- Expand `diagram_rules.json` to define architecture diagram types, governance nodes, and fault-tree gate node types
- Load diagram node and relation sets from the JSON config in `gui/architecture.py`, `AutoML.py`, `analysis/fmeda_utils.py`, and `gui/review_toolbox.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f937f33908327b7406cb9e722ba64