### PR TITLE
Add dark mode for diagrams

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -229,6 +229,7 @@ import tkinter as tk
 from tkinter import ttk, filedialog, simpledialog, scrolledtext
 from gui import messagebox, logger
 from gui.tooltip import ToolTip
+from gui.style_manager import StyleManager
 from gui.review_toolbox import (
     ReviewToolbox,
     ReviewData,
@@ -251,6 +252,7 @@ from gsn import GSNDiagram, GSNModule
 from gsn.nodes import GSNNode
 from gui.closable_notebook import ClosableNotebook
 from dataclasses import asdict
+from pathlib import Path
 from analysis.mechanisms import (
     DiagnosticMechanism,
     MechanismLibrary,
@@ -2357,6 +2359,14 @@ class FaultTreeApp:
         view_menu.add_command(label="Zoom In", command=self.zoom_in, accelerator="Ctrl++")
         view_menu.add_command(label="Zoom Out", command=self.zoom_out, accelerator="Ctrl+-")
         view_menu.add_command(label="Style Editor", command=self.open_style_editor)
+        view_menu.add_command(
+            label="Light Mode",
+            command=lambda: self.apply_style('pastel.xml'),
+        )
+        view_menu.add_command(
+            label="Dark Mode",
+            command=lambda: self.apply_style('dark.xml'),
+        )
 
         requirements_menu = tk.Menu(menubar, tearoff=0)
         requirements_menu.add_command(label="Requirements Matrix", command=self.show_requirements_matrix)
@@ -4305,7 +4315,7 @@ class FaultTreeApp:
         # Create a temporary Toplevel window and canvas
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
         
         # Create and redraw the page diagram
@@ -4350,7 +4360,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         try:
@@ -4576,7 +4586,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -4841,7 +4851,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5106,7 +5116,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5371,7 +5381,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5636,7 +5646,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5901,7 +5911,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -6155,7 +6165,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -6409,7 +6419,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -6663,7 +6673,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -8588,7 +8598,7 @@ class FaultTreeApp:
     def capture_event_diagram(self, event_node):
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
         canvas.pack()
         self.draw_subtree_with_filter(canvas, event_node, self.get_all_nodes(event_node))
         canvas.delete("grid")
@@ -15055,7 +15065,7 @@ class FaultTreeApp:
         vsb.grid(row=0, column=1, sticky="ns")
         hsb.grid(row=1, column=0, sticky="ew")
 
-        canvas = tk.Canvas(diagram_frame, bg="white")
+        canvas = tk.Canvas(diagram_frame, bg=StyleManager.get_instance().canvas_bg)
         cvs_vsb = ttk.Scrollbar(diagram_frame, orient="vertical", command=canvas.yview)
         cvs_hsb = ttk.Scrollbar(diagram_frame, orient="horizontal", command=canvas.xview)
         canvas.configure(yscrollcommand=cvs_vsb.set, xscrollcommand=cvs_hsb.set)
@@ -16713,8 +16723,15 @@ class FaultTreeApp:
         """Open the diagram style editor window."""
         StyleEditor(self.root)
 
+    def apply_style(self, filename: str) -> None:
+        path = Path(__file__).resolve().parent / 'styles' / filename
+        StyleManager.get_instance().load_style(path)
+        self.root.event_generate('<<StyleChanged>>', when='tail')
+
     def refresh_styles(self, event=None):
         """Redraw all open diagram windows using current styles."""
+        if getattr(self, 'canvas', None):
+            self.canvas.config(bg=StyleManager.get_instance().canvas_bg)
         for tab in getattr(self, 'diagram_tabs', {}).values():
             for child in tab.winfo_children():
                 if hasattr(child, 'redraw'):
@@ -16747,7 +16764,7 @@ class FaultTreeApp:
         self.doc_nb.add(self.canvas_tab, text="FTA")
 
         self.canvas_frame = self.canvas_tab
-        self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+        self.canvas = tk.Canvas(self.canvas_frame, bg=StyleManager.get_instance().canvas_bg)
         self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.hbar = ttk.Scrollbar(self.canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
         self.hbar.pack(side=tk.BOTTOM, fill=tk.X)
@@ -18999,7 +19016,7 @@ class FaultTreeApp:
         back_button = ttk.Button(header_frame, text="Go Back", command=self.go_back)
         back_button.grid(row=0, column=1, sticky="e", padx=5)
 
-        page_canvas = tk.Canvas(self.canvas_frame, bg="white")
+        page_canvas = tk.Canvas(self.canvas_frame, bg=StyleManager.get_instance().canvas_bg)
         page_canvas.grid(row=1, column=0, sticky="nsew")
         vbar = ttk.Scrollbar(self.canvas_frame, orient=tk.VERTICAL, command=page_canvas.yview)
         vbar.grid(row=1, column=1, sticky="ns")
@@ -19183,7 +19200,7 @@ class FaultTreeApp:
             for widget in self.canvas_frame.winfo_children():
                 widget.destroy()
             if prev is None:
-                self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+                self.canvas = tk.Canvas(self.canvas_frame, bg=StyleManager.get_instance().canvas_bg)
                 self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
                 self.hbar = ttk.Scrollbar(self.canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
                 self.hbar.pack(side=tk.BOTTOM, fill=tk.X)
@@ -19205,7 +19222,7 @@ class FaultTreeApp:
         else:
             for widget in self.canvas_frame.winfo_children():
                 widget.destroy()
-            self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+            self.canvas = tk.Canvas(self.canvas_frame, bg=StyleManager.get_instance().canvas_bg)
             self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
             self.hbar = ttk.Scrollbar(self.canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
             self.hbar.pack(side=tk.BOTTOM, fill=tk.X)

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2982,7 +2982,7 @@ class SysMLDiagramWindow(tk.Frame):
 
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
-        self.canvas = tk.Canvas(canvas_frame, bg="white")
+        self.canvas = tk.Canvas(canvas_frame, bg=StyleManager.get_instance().canvas_bg)
         vbar = ttk.Scrollbar(canvas_frame, orient="vertical", command=self.canvas.yview)
         hbar = ttk.Scrollbar(canvas_frame, orient="horizontal", command=self.canvas.xview)
         self.canvas.configure(yscrollcommand=vbar.set, xscrollcommand=hbar.set)
@@ -5910,6 +5910,7 @@ class SysMLDiagramWindow(tk.Frame):
         self.objects.sort(key=key)
 
     def redraw(self):
+        self.canvas.configure(bg=StyleManager.get_instance().canvas_bg)
         self.canvas.delete("all")
         self.gradient_cache.clear()
         self.compartment_buttons = []

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -7,6 +7,7 @@ from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
 from gui import messagebox
 from gui.tooltip import ToolTip
 from gui.drawing_helper import FTADrawingHelper
+from gui.style_manager import StyleManager
 
 
 class CausalBayesianNetworkWindow(tk.Frame):
@@ -52,7 +53,10 @@ class CausalBayesianNetworkWindow(tk.Frame):
 
         canvas_container = ttk.Frame(body)
         canvas_container.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        self.canvas = tk.Canvas(canvas_container, background="white")
+        self.canvas = tk.Canvas(
+            canvas_container,
+            background=StyleManager.get_instance().canvas_bg,
+        )
         self.canvas.grid(row=0, column=0, sticky="nsew")
         xbar = ttk.Scrollbar(canvas_container, orient=tk.HORIZONTAL, command=self.canvas.xview)
         xbar.grid(row=1, column=0, sticky="ew")
@@ -103,6 +107,11 @@ class CausalBayesianNetworkWindow(tk.Frame):
             self.doc_var.set("")
             self.app.active_cbn = None
             self.canvas.delete("all")
+
+    # ------------------------------------------------------------------
+    def redraw(self):
+        self.canvas.configure(background=StyleManager.get_instance().canvas_bg)
+        self.select_doc()
 
     # ------------------------------------------------------------------
     def select_doc(self, *_):

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -15,6 +15,7 @@ from gsn import GSNNode, GSNDiagram
 from .gsn_config_window import GSNElementConfig
 from .gsn_connection_config import GSNConnectionConfig
 from . import messagebox
+from .style_manager import StyleManager
 
 
 class ModuleSelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
@@ -119,7 +120,12 @@ class GSNDiagramWindow(tk.Frame):
         # drawing canvas with scrollbars so large diagrams remain accessible
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(fill=tk.BOTH, expand=True)
-        self.canvas = tk.Canvas(canvas_frame, width=800, height=600, bg="white")
+        self.canvas = tk.Canvas(
+            canvas_frame,
+            width=800,
+            height=600,
+            bg=StyleManager.get_instance().canvas_bg,
+        )
         self.canvas.grid(row=0, column=0, sticky="nsew")
         hbar = ttk.Scrollbar(canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
         vbar = ttk.Scrollbar(canvas_frame, orient=tk.VERTICAL, command=self.canvas.yview)
@@ -180,6 +186,11 @@ class GSNDiagramWindow(tk.Frame):
         # update scroll region to encompass all drawn items
         bbox = self.canvas.bbox("all") or (0, 0, 0, 0)
         self.canvas.configure(scrollregion=bbox)
+
+    # ------------------------------------------------------------------
+    def redraw(self):
+        self.canvas.configure(bg=StyleManager.get_instance().canvas_bg)
+        self.refresh()
 
     # ------------------------------------------------------------------
     def _bind_shortcuts(self):

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -6,6 +6,7 @@ from tkinter import ttk, simpledialog
 
 from gsn import GSNNode, GSNDiagram, GSNModule
 from gui import format_name_with_phase
+from gui.style_manager import StyleManager
 
 
 class GSNExplorer(tk.Frame):
@@ -480,7 +481,12 @@ class GSNExplorer(tk.Frame):
             return
         win = tk.Toplevel(self)
         win.title(obj.root.user_name)
-        canvas = tk.Canvas(win, width=800, height=600, bg="white")
+        canvas = tk.Canvas(
+            win,
+            width=800,
+            height=600,
+            bg=StyleManager.get_instance().canvas_bg,
+        )
         canvas.pack(fill=tk.BOTH, expand=True)
         obj.draw(canvas)
 
@@ -489,7 +495,7 @@ class GSNExplorer(tk.Frame):
         """Return a simple 16x16 icon for treeview items."""
         size = 16
         img = tk.PhotoImage(width=size, height=size)
-        img.put("white", to=(0, 0, size - 1, size - 1))
+        img.put(StyleManager.get_instance().canvas_bg, to=(0, 0, size - 1, size - 1))
         c = color
         if shape == "circle":
             r = size // 2 - 2

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -19,6 +19,7 @@
 import tkinter as tk
 from tkinter import simpledialog, ttk
 from gui import messagebox
+from gui.style_manager import StyleManager
 from dataclasses import dataclass, field
 from typing import List
 import difflib
@@ -1371,7 +1372,12 @@ class ReviewDocumentDialog(tk.Frame):
             row += 1
             frame = tk.Frame(self.inner)
             frame.grid(row=row, column=0, padx=5, pady=5, sticky="nsew")
-            c = tk.Canvas(frame, width=600, height=400, bg="white")
+            c = tk.Canvas(
+                frame,
+                width=600,
+                height=400,
+                bg=StyleManager.get_instance().canvas_bg,
+            )
             hbar = tk.Scrollbar(frame, orient=tk.HORIZONTAL, command=c.xview)
             vbar = tk.Scrollbar(frame, orient=tk.VERTICAL, command=c.yview)
             c.configure(xscrollcommand=hbar.set, yscrollcommand=vbar.set)
@@ -1687,7 +1693,12 @@ class VersionCompareDialog(tk.Frame):
         # canvas to display FTA differences
         canvas_frame = tk.Frame(self)
         canvas_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
-        self.tree_canvas = tk.Canvas(canvas_frame, width=600, height=300, bg="white")
+        self.tree_canvas = tk.Canvas(
+            canvas_frame,
+            width=600,
+            height=300,
+            bg=StyleManager.get_instance().canvas_bg,
+        )
         vbar = tk.Scrollbar(canvas_frame, orient=tk.VERTICAL, command=self.tree_canvas.yview)
         hbar = tk.Scrollbar(canvas_frame, orient=tk.HORIZONTAL, command=self.tree_canvas.xview)
         self.tree_canvas.configure(yscrollcommand=vbar.set, xscrollcommand=hbar.set)

--- a/gui/style_manager.py
+++ b/gui/style_manager.py
@@ -15,11 +15,13 @@ class StyleManager:
 
     def __init__(self):
         self.styles = {}
+        self.canvas_bg = "#FFFFFF"
         try:
             self.load_style(_DEFAULT_STYLE)
         except Exception:
             # fallback to hard coded white style
             self.styles = {}
+            self.canvas_bg = "#FFFFFF"
 
     @classmethod
     def get_instance(cls):
@@ -35,6 +37,10 @@ class StyleManager:
         tree = ET.parse(path)
         root = tree.getroot()
         self.styles.clear()
+        self.canvas_bg = "#FFFFFF"
+        canvas = root.find('canvas')
+        if canvas is not None:
+            self.canvas_bg = canvas.get('color', "#FFFFFF")
         for obj in root.findall('object'):
             typ = obj.get('type')
             color = obj.get('color')
@@ -43,6 +49,7 @@ class StyleManager:
 
     def save_style(self, path: str) -> None:
         root = ET.Element('style')
+        ET.SubElement(root, 'canvas', color=self.canvas_bg)
         for typ, color in self.styles.items():
             ET.SubElement(root, 'object', type=typ, color=color)
         tree = ET.ElementTree(root)
@@ -50,3 +57,6 @@ class StyleManager:
 
     def get_color(self, obj_type: str) -> str:
         return self.styles.get(obj_type, '#FFFFFF')
+
+    def get_canvas_color(self) -> str:
+        return self.canvas_bg

--- a/styles/dark.xml
+++ b/styles/dark.xml
@@ -1,4 +1,5 @@
 <style>
+  <canvas color="#1e1e1e" />
   <object type="Actor" color="#0D47A1" />
   <object type="Use Case" color="#FF8F00" />
   <object type="System Boundary" color="#37474F" />

--- a/styles/pastel.xml
+++ b/styles/pastel.xml
@@ -1,4 +1,5 @@
 <style>
+  <canvas color="#FFFFFF" />
   <object type="Actor" color="#F4D698" />
   <object type="Use Case" color="#B0E0E6" />
   <object type="System Boundary" color="#CFD8DC" />


### PR DESCRIPTION
## Summary
- support configurable canvas background via StyleManager
- include dark and default canvas colors in style definitions
- allow switching between light and dark diagram themes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f93b61fa88327ba1b4be2ced16938