### PR TITLE
Add lifecycle requirements generation option

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14598,6 +14598,13 @@ class FaultTreeApp:
         if win:
             win.generate_phase_requirements(phase)
 
+    def generate_lifecycle_requirements(self) -> None:
+        """Generate requirements for all governance diagrams outside phases."""
+        self.open_safety_management_toolbox(show_diagrams=False)
+        win = getattr(self, "safety_mgmt_window", None)
+        if win:
+            win.generate_lifecycle_requirements()
+
     def _refresh_phase_requirements_menu(self) -> None:
         if not hasattr(self, "phase_req_menu"):
             return
@@ -14605,11 +14612,18 @@ class FaultTreeApp:
         toolbox = getattr(self, "safety_mgmt_toolbox", None)
         if not toolbox:
             return
-        for phase in sorted(toolbox.list_modules()):
+        phases = sorted(toolbox.list_modules())
+        for phase in phases:
             self.phase_req_menu.add_command(
                 label=phase,
                 command=lambda p=phase: self.generate_phase_requirements(p),
             )
+        if phases:
+            self.phase_req_menu.add_separator()
+        self.phase_req_menu.add_command(
+            label="Lifecycle",
+            command=self.generate_lifecycle_requirements,
+        )
 
     def export_cybersecurity_goal_requirements(self):
         """Export cybersecurity goals with linked risk assessments."""

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -248,11 +248,18 @@ class SafetyManagementWindow(tk.Frame):
 
     def _refresh_phase_menu(self) -> None:
         self.phase_menu.delete(0, tk.END)
-        for phase in sorted(self.toolbox.list_modules()):
+        phases = sorted(self.toolbox.list_modules())
+        for phase in phases:
             self.phase_menu.add_command(
                 label=phase,
                 command=lambda p=phase: self.generate_phase_requirements(p),
             )
+        if phases:
+            self.phase_menu.add_separator()
+        self.phase_menu.add_command(
+            label="Lifecycle",
+            command=self.generate_lifecycle_requirements,
+        )
 
     def generate_phase_requirements(self, phase: str) -> None:
         diag_names = sorted(self.toolbox.diagrams_for_module(phase))
@@ -306,6 +313,64 @@ class SafetyManagementWindow(tk.Frame):
             )
             return
         self._display_requirements(f"{phase} Requirements", ids)
+
+    def generate_lifecycle_requirements(self) -> None:
+        """Generate requirements for diagrams outside of any phase."""
+        all_diags = set(self.toolbox.list_diagrams())
+        for phase in self.toolbox.list_modules():
+            all_diags -= self.toolbox.diagrams_for_module(phase)
+        diag_names = sorted(all_diags)
+        if not diag_names:
+            messagebox.showinfo(
+                "Requirements", "No lifecycle governance diagrams.")
+            return
+        repo = SysMLRepository.get_instance()
+        ids: list[str] = []
+        for name in diag_names:
+            diag_id = self.toolbox.diagrams.get(name)
+            if not diag_id:
+                continue
+            gov = GovernanceDiagram.from_repository(repo, diag_id)
+            try:
+                raw_reqs = gov.generate_requirements()
+            except Exception as exc:  # pragma: no cover - defensive
+                messagebox.showerror(
+                    "Requirements",
+                    f"Failed to generate requirements for '{name}': {exc}",
+                )
+                continue
+            pairs: list[tuple[str, str]] = []
+            invalid = False
+            for r in raw_reqs:
+                if isinstance(r, tuple):
+                    if len(r) != 2:
+                        invalid = True
+                        break
+                    text, rtype = r
+                elif hasattr(r, "text"):
+                    text, rtype = r.text, getattr(r, "req_type", "organizational")
+                elif isinstance(r, str):
+                    text, rtype = r, "organizational"
+                else:
+                    invalid = True
+                    break
+                if text.strip():
+                    pairs.append((text, rtype))
+            if invalid:
+                messagebox.showerror(
+                    "Requirements",
+                    "Requirement entries must be strings or (text, type) pairs.",
+                )
+                continue
+            for text, rtype in pairs:
+                ids.append(self._add_requirement(text, rtype))
+        if not ids:
+            messagebox.showinfo(
+                "Requirements",
+                "No requirements were generated for lifecycle diagrams.",
+            )
+            return
+        self._display_requirements("Lifecycle Requirements", ids)
 
     @staticmethod
     def _collect_requirements(gov: GovernanceDiagram) -> list[str]:

--- a/tests/test_governance_lifecycle_requirements_menu.py
+++ b/tests/test_governance_lifecycle_requirements_menu.py
@@ -1,0 +1,87 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow, SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+from gui import safety_management_toolbox as smt
+from analysis.models import global_requirements
+
+
+def test_lifecycle_requirements_menu(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    d1 = repo.create_diagram("Governance Diagram", name="PhaseDiag")
+    t1 = repo.create_element("Action", name="Start")
+    t2 = repo.create_element("Action", name="Finish")
+    d1.objects = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t1.elem_id, "properties": {"name": "Start"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t2.elem_id, "properties": {"name": "Finish"}},
+    ]
+    d1.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+
+    d2 = repo.create_diagram("Governance Diagram", name="LifeDiag")
+    t3 = repo.create_element("Action", name="Alpha")
+    t4 = repo.create_element("Action", name="Beta")
+    d2.objects = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t3.elem_id, "properties": {"name": "Alpha"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t4.elem_id, "properties": {"name": "Beta"}},
+    ]
+    d2.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams["PhaseDiag"] = d1.diag_id
+    toolbox.diagrams["LifeDiag"] = d2.diag_id
+    mod = toolbox.add_module("Phase1")
+    mod.diagrams.append("PhaseDiag")
+    monkeypatch.setattr(toolbox, "list_diagrams", lambda: list(toolbox.diagrams.keys()))
+
+    class DummyTab:
+        pass
+
+    tabs = []
+
+    def _new_tab(title):
+        tab = DummyTab()
+        tabs.append((title, tab))
+        return tab
+
+    trees = []
+
+    class DummyTree:
+        def __init__(self, master, columns, show="headings"):
+            self.rows = []
+            trees.append(self)
+
+        def heading(self, col, text=""):
+            pass
+
+        def insert(self, parent, idx, values):
+            self.rows.append(values)
+
+        def pack(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace(_new_tab=_new_tab)
+
+    global_requirements.clear()
+    win.generate_lifecycle_requirements()
+
+    assert tabs
+    title, _tab = tabs[0]
+    assert "Lifecycle Requirements" in title
+    assert trees and trees[0].rows
+    texts = [row[2] for row in trees[0].rows]
+    assert any("Alpha shall precede 'Beta'." in t for t in texts)
+    assert not any("Start shall precede 'Finish'." in t for t in texts)
+    assert all(row[1] == "organizational" for row in trees[0].rows)
+    assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_phase_requirements_main_menu.py
+++ b/tests/test_phase_requirements_main_menu.py
@@ -23,10 +23,14 @@ def test_phase_requirements_menu_populated(monkeypatch):
 
     called = []
 
-    def fake_generate(phase):
+    def fake_generate_phase(phase):
         called.append(phase)
 
-    app.generate_phase_requirements = fake_generate
+    def fake_generate_lifecycle():
+        called.append("lifecycle")
+
+    app.generate_phase_requirements = fake_generate_phase
+    app.generate_lifecycle_requirements = fake_generate_lifecycle
 
     class DummyMenu:
         def __init__(self):
@@ -38,15 +42,19 @@ def test_phase_requirements_menu_populated(monkeypatch):
         def add_command(self, label, command):
             self.items.append((label, command))
 
+        def add_separator(self):
+            self.items.append(("-", None))
+
     app.phase_req_menu = DummyMenu()
 
     FaultTreeApp._refresh_phase_requirements_menu(app)
 
-    assert any(label == "Phase1" for label, _ in app.phase_req_menu.items)
+    labels = [label for label, _ in app.phase_req_menu.items]
+    assert "Phase1" in labels and "Lifecycle" in labels
     for label, cmd in app.phase_req_menu.items:
-        if label == "Phase1":
+        if label == "Phase1" or label == "Lifecycle":
             cmd()
-    assert called == ["Phase1"]
+    assert called == ["Phase1", "lifecycle"]
 
 
 def test_generate_phase_requirements_delegates(monkeypatch):
@@ -64,3 +72,20 @@ def test_generate_phase_requirements_delegates(monkeypatch):
     FaultTreeApp.generate_phase_requirements(app, "PhaseX")
 
     assert events == [False, "PhaseX"]
+
+
+def test_generate_lifecycle_requirements_delegates(monkeypatch):
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    events = []
+
+    def fake_open(show_diagrams=True):
+        events.append(show_diagrams)
+
+    app.open_safety_management_toolbox = fake_open
+    app.safety_mgmt_window = types.SimpleNamespace(
+        generate_lifecycle_requirements=lambda: events.append("lifecycle")
+    )
+
+    FaultTreeApp.generate_lifecycle_requirements(app)
+
+    assert events == [False, "lifecycle"]


### PR DESCRIPTION
## Summary
- allow Safety Management toolbox to generate requirements from diagrams outside phases
- expose lifecycle requirements through GUI and main menu
- add regression tests for lifecycle requirement generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f979f993c83279c6bf200365b6a21