### PR TITLE
feat: add dark mode for diagrams

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -229,6 +229,7 @@ import tkinter as tk
 from tkinter import ttk, filedialog, simpledialog, scrolledtext
 from gui import messagebox, logger
 from gui.tooltip import ToolTip
+from gui.style_manager import StyleManager
 from gui.review_toolbox import (
     ReviewToolbox,
     ReviewData,
@@ -373,6 +374,8 @@ from reportlab.platypus import LongTable
 from email.message import EmailMessage
 import smtplib
 import socket
+
+CANVAS_BG = StyleManager.get_instance().background
 
 styles = getSampleStyleSheet()  # Create the stylesheet.
 preformatted_style = ParagraphStyle(name="Preformatted", fontName="Courier", fontSize=10)
@@ -4305,7 +4308,7 @@ class FaultTreeApp:
         # Create a temporary Toplevel window and canvas
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
         
         # Create and redraw the page diagram
@@ -4350,7 +4353,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         try:
@@ -4576,7 +4579,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -4841,7 +4844,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5106,7 +5109,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5371,7 +5374,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5636,7 +5639,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5901,7 +5904,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -6155,7 +6158,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -6409,7 +6412,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -6663,7 +6666,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -8588,7 +8591,7 @@ class FaultTreeApp:
     def capture_event_diagram(self, event_node):
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
         self.draw_subtree_with_filter(canvas, event_node, self.get_all_nodes(event_node))
         canvas.delete("grid")
@@ -15055,7 +15058,7 @@ class FaultTreeApp:
         vsb.grid(row=0, column=1, sticky="ns")
         hsb.grid(row=1, column=0, sticky="ew")
 
-        canvas = tk.Canvas(diagram_frame, bg="white")
+        canvas = tk.Canvas(diagram_frame, bg=CANVAS_BG)
         cvs_vsb = ttk.Scrollbar(diagram_frame, orient="vertical", command=canvas.yview)
         cvs_hsb = ttk.Scrollbar(diagram_frame, orient="horizontal", command=canvas.xview)
         canvas.configure(yscrollcommand=cvs_vsb.set, xscrollcommand=cvs_hsb.set)
@@ -16747,7 +16750,7 @@ class FaultTreeApp:
         self.doc_nb.add(self.canvas_tab, text="FTA")
 
         self.canvas_frame = self.canvas_tab
-        self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+        self.canvas = tk.Canvas(self.canvas_frame, bg=CANVAS_BG)
         self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.hbar = ttk.Scrollbar(self.canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
         self.hbar.pack(side=tk.BOTTOM, fill=tk.X)
@@ -18999,7 +19002,7 @@ class FaultTreeApp:
         back_button = ttk.Button(header_frame, text="Go Back", command=self.go_back)
         back_button.grid(row=0, column=1, sticky="e", padx=5)
 
-        page_canvas = tk.Canvas(self.canvas_frame, bg="white")
+        page_canvas = tk.Canvas(self.canvas_frame, bg=CANVAS_BG)
         page_canvas.grid(row=1, column=0, sticky="nsew")
         vbar = ttk.Scrollbar(self.canvas_frame, orient=tk.VERTICAL, command=page_canvas.yview)
         vbar.grid(row=1, column=1, sticky="ns")
@@ -19183,7 +19186,7 @@ class FaultTreeApp:
             for widget in self.canvas_frame.winfo_children():
                 widget.destroy()
             if prev is None:
-                self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+                self.canvas = tk.Canvas(self.canvas_frame, bg=CANVAS_BG)
                 self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
                 self.hbar = ttk.Scrollbar(self.canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
                 self.hbar.pack(side=tk.BOTTOM, fill=tk.X)
@@ -19205,7 +19208,7 @@ class FaultTreeApp:
         else:
             for widget in self.canvas_frame.winfo_children():
                 widget.destroy()
-            self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+            self.canvas = tk.Canvas(self.canvas_frame, bg=CANVAS_BG)
             self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
             self.hbar = ttk.Scrollbar(self.canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
             self.hbar.pack(side=tk.BOTTOM, fill=tk.X)

--- a/README.md
+++ b/README.md
@@ -1547,6 +1547,11 @@ peach actions and steel-blue nodes. `modern.xml` offers a Material-inspired
 palette for a different look. Open the Style Editor via **View → Style Editor**, click **Load** and choose
 the desired style. All open diagrams update immediately.
 
+To enable a global dark theme for diagrams, set the environment variable
+`AUTOML_STYLE=dark` before launching the application. The included
+`dark.xml` defines a black canvas background and colors tuned for low-light
+environments.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2982,7 +2982,8 @@ class SysMLDiagramWindow(tk.Frame):
 
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
-        self.canvas = tk.Canvas(canvas_frame, bg="white")
+        bg = StyleManager.get_instance().background
+        self.canvas = tk.Canvas(canvas_frame, bg=bg)
         vbar = ttk.Scrollbar(canvas_frame, orient="vertical", command=self.canvas.yview)
         hbar = ttk.Scrollbar(canvas_frame, orient="horizontal", command=self.canvas.xview)
         self.canvas.configure(yscrollcommand=vbar.set, xscrollcommand=hbar.set)

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -7,6 +7,7 @@ from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
 from gui import messagebox
 from gui.tooltip import ToolTip
 from gui.drawing_helper import FTADrawingHelper
+from .style_manager import StyleManager
 
 
 class CausalBayesianNetworkWindow(tk.Frame):
@@ -52,7 +53,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
 
         canvas_container = ttk.Frame(body)
         canvas_container.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        self.canvas = tk.Canvas(canvas_container, background="white")
+        bg = StyleManager.get_instance().background
+        self.canvas = tk.Canvas(canvas_container, background=bg)
         self.canvas.grid(row=0, column=0, sticky="nsew")
         xbar = ttk.Scrollbar(canvas_container, orient=tk.HORIZONTAL, command=self.canvas.xview)
         xbar.grid(row=1, column=0, sticky="ew")

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -15,6 +15,7 @@ from gsn import GSNNode, GSNDiagram
 from .gsn_config_window import GSNElementConfig
 from .gsn_connection_config import GSNConnectionConfig
 from . import messagebox
+from .style_manager import StyleManager
 
 
 class ModuleSelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
@@ -119,7 +120,8 @@ class GSNDiagramWindow(tk.Frame):
         # drawing canvas with scrollbars so large diagrams remain accessible
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(fill=tk.BOTH, expand=True)
-        self.canvas = tk.Canvas(canvas_frame, width=800, height=600, bg="white")
+        bg = StyleManager.get_instance().background
+        self.canvas = tk.Canvas(canvas_frame, width=800, height=600, bg=bg)
         self.canvas.grid(row=0, column=0, sticky="nsew")
         hbar = ttk.Scrollbar(canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
         vbar = ttk.Scrollbar(canvas_frame, orient=tk.VERTICAL, command=self.canvas.yview)

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -6,6 +6,7 @@ from tkinter import ttk, simpledialog
 
 from gsn import GSNNode, GSNDiagram, GSNModule
 from gui import format_name_with_phase
+from .style_manager import StyleManager
 
 
 class GSNExplorer(tk.Frame):
@@ -480,7 +481,8 @@ class GSNExplorer(tk.Frame):
             return
         win = tk.Toplevel(self)
         win.title(obj.root.user_name)
-        canvas = tk.Canvas(win, width=800, height=600, bg="white")
+        bg = StyleManager.get_instance().background
+        canvas = tk.Canvas(win, width=800, height=600, bg=bg)
         canvas.pack(fill=tk.BOTH, expand=True)
         obj.draw(canvas)
 

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -25,6 +25,7 @@ import difflib
 import sys
 import json
 import re
+from .style_manager import StyleManager
 try:
     from PIL import Image, ImageTk
 except ModuleNotFoundError:  # pragma: no cover - pillow optional
@@ -849,7 +850,8 @@ class ReviewDocumentDialog(tk.Frame):
         container = tk.Frame(self)
         container.pack(fill=tk.BOTH, expand=True)
 
-        self.outer = tk.Canvas(container)
+        self.bg = StyleManager.get_instance().background
+        self.outer = tk.Canvas(container, bg=self.bg)
         vbar = tk.Scrollbar(container, orient=tk.VERTICAL, command=self.outer.yview)
         hbar = tk.Scrollbar(container, orient=tk.HORIZONTAL, command=self.outer.xview)
         self.outer.configure(yscrollcommand=vbar.set, xscrollcommand=hbar.set)
@@ -1371,7 +1373,7 @@ class ReviewDocumentDialog(tk.Frame):
             row += 1
             frame = tk.Frame(self.inner)
             frame.grid(row=row, column=0, padx=5, pady=5, sticky="nsew")
-            c = tk.Canvas(frame, width=600, height=400, bg="white")
+            c = tk.Canvas(frame, width=600, height=400, bg=self.bg)
             hbar = tk.Scrollbar(frame, orient=tk.HORIZONTAL, command=c.xview)
             vbar = tk.Scrollbar(frame, orient=tk.VERTICAL, command=c.yview)
             c.configure(xscrollcommand=hbar.set, yscrollcommand=vbar.set)
@@ -1687,7 +1689,7 @@ class VersionCompareDialog(tk.Frame):
         # canvas to display FTA differences
         canvas_frame = tk.Frame(self)
         canvas_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
-        self.tree_canvas = tk.Canvas(canvas_frame, width=600, height=300, bg="white")
+        self.tree_canvas = tk.Canvas(canvas_frame, width=600, height=300, bg=self.bg)
         vbar = tk.Scrollbar(canvas_frame, orient=tk.VERTICAL, command=self.tree_canvas.yview)
         hbar = tk.Scrollbar(canvas_frame, orient=tk.HORIZONTAL, command=self.tree_canvas.xview)
         self.tree_canvas.configure(yscrollcommand=vbar.set, xscrollcommand=hbar.set)

--- a/styles/dark.xml
+++ b/styles/dark.xml
@@ -1,14 +1,19 @@
 <style>
-  <object type="Actor" color="#0D47A1" />
-  <object type="Use Case" color="#FF8F00" />
-  <object type="System Boundary" color="#37474F" />
-  <object type="Block Boundary" color="#263238" />
-  <object type="Action Usage" color="#1B5E20" />
-  <object type="Action" color="#1B5E20" />
-  <object type="CallBehaviorAction" color="#1B5E20" />
-  <object type="Part" color="#F57F17" />
-  <object type="Port" color="#4A148C" />
-  <object type="Block" color="#455A64" />
-  <object type="Decision" color="#C8E6C9" />
-  <object type="Merge" color="#006064" />
+  <background color="#000000" />
+  <object type="Actor" color="#90CAF9" />
+  <object type="Use Case" color="#FFCC80" />
+  <object type="System Boundary" color="#90A4AE" />
+  <object type="Block Boundary" color="#B0BEC5" />
+  <object type="Existing Element" color="#90A4AE" />
+  <object type="Action Usage" color="#81C784" />
+  <object type="Action" color="#81C784" />
+  <object type="CallBehaviorAction" color="#81C784" />
+  <object type="Part" color="#FFB74D" />
+  <object type="Port" color="#CE93D8" />
+  <object type="Block" color="#CFD8DC" />
+  <object type="Decision" color="#E8F5E9" />
+  <object type="Merge" color="#4DD0E1" />
+  <object type="Database" color="#E1F5FE" />
+  <object type="ANN" color="#DCEDC8" />
+  <object type="Data acquisition" color="#FFF3E0" />
 </style>

--- a/tests/test_dark_mode.py
+++ b/tests/test_dark_mode.py
@@ -1,0 +1,9 @@
+import importlib
+
+def test_dark_mode_background(monkeypatch):
+    monkeypatch.setenv('AUTOML_STYLE', 'dark')
+    import gui.style_manager as sm
+    importlib.reload(sm)
+    mgr = sm.StyleManager.get_instance()
+    assert mgr.background == '#000000'
+    assert mgr.get_color('Actor') == '#90CAF9'


### PR DESCRIPTION
## Summary
- allow selecting diagram style via `AUTOML_STYLE` env var
- support style-defined canvas background and bundle dark theme with light-colored shapes
- use style-driven background for all diagram canvases
- document dark mode usage

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f93b61fa88327ba1b4be2ced16938