### PR TITLE
Add lifecycle requirements generation option

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2392,6 +2392,7 @@ class FaultTreeApp:
             label="Safety Performance Indicators",
             command=self.show_safety_performance_indicators,
         )
+        self._add_lifecycle_requirements_menu(requirements_menu)
         self.phase_req_menu = tk.Menu(requirements_menu, tearoff=0)
         requirements_menu.add_cascade(
             label="Phase Requirements", menu=self.phase_req_menu
@@ -14597,6 +14598,20 @@ class FaultTreeApp:
         win = getattr(self, "safety_mgmt_window", None)
         if win:
             win.generate_phase_requirements(phase)
+
+    def generate_lifecycle_requirements(self) -> None:
+        """Generate requirements for all governance diagrams outside phases."""
+        self.open_safety_management_toolbox(show_diagrams=False)
+        win = getattr(self, "safety_mgmt_window", None)
+        if win:
+            win.generate_lifecycle_requirements()
+
+    def _add_lifecycle_requirements_menu(self, menu: tk.Menu) -> None:
+        """Insert a menu entry for lifecycle requirements."""
+        menu.add_command(
+            label="Lifecycle Requirements",
+            command=self.generate_lifecycle_requirements,
+        )
 
     def _refresh_phase_requirements_menu(self) -> None:
         if not hasattr(self, "phase_req_menu"):

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -60,10 +60,15 @@ class SafetyManagementWindow(tk.Frame):
         ttk.Button(top, text="Requirements", command=self.generate_requirements).pack(
             side=tk.LEFT
         )
-        self.phase_menu_btn = tk.Menubutton(top, text="Phase Requirements")
+        self.phase_menu_btn = ttk.Menubutton(top, text="Phase Requirements")
         self.phase_menu = tk.Menu(self.phase_menu_btn, tearoff=False)
         self.phase_menu_btn.configure(menu=self.phase_menu)
         self.phase_menu_btn.pack(side=tk.LEFT)
+        ttk.Button(
+            top,
+            text="Lifecycle Requirements",
+            command=self.generate_lifecycle_requirements,
+        ).pack(side=tk.LEFT)
 
         self.diagram_frame = ttk.Frame(self)
         self.diagram_frame.pack(fill=tk.BOTH, expand=True)
@@ -248,7 +253,8 @@ class SafetyManagementWindow(tk.Frame):
 
     def _refresh_phase_menu(self) -> None:
         self.phase_menu.delete(0, tk.END)
-        for phase in sorted(self.toolbox.list_modules()):
+        phases = sorted(self.toolbox.list_modules())
+        for phase in phases:
             self.phase_menu.add_command(
                 label=phase,
                 command=lambda p=phase: self.generate_phase_requirements(p),
@@ -306,6 +312,64 @@ class SafetyManagementWindow(tk.Frame):
             )
             return
         self._display_requirements(f"{phase} Requirements", ids)
+
+    def generate_lifecycle_requirements(self) -> None:
+        """Generate requirements for diagrams outside of any phase."""
+        all_diags = set(self.toolbox.list_diagrams())
+        for phase in self.toolbox.list_modules():
+            all_diags -= self.toolbox.diagrams_for_module(phase)
+        diag_names = sorted(all_diags)
+        if not diag_names:
+            messagebox.showinfo(
+                "Requirements", "No lifecycle governance diagrams.")
+            return
+        repo = SysMLRepository.get_instance()
+        ids: list[str] = []
+        for name in diag_names:
+            diag_id = self.toolbox.diagrams.get(name)
+            if not diag_id:
+                continue
+            gov = GovernanceDiagram.from_repository(repo, diag_id)
+            try:
+                raw_reqs = gov.generate_requirements()
+            except Exception as exc:  # pragma: no cover - defensive
+                messagebox.showerror(
+                    "Requirements",
+                    f"Failed to generate requirements for '{name}': {exc}",
+                )
+                continue
+            pairs: list[tuple[str, str]] = []
+            invalid = False
+            for r in raw_reqs:
+                if isinstance(r, tuple):
+                    if len(r) != 2:
+                        invalid = True
+                        break
+                    text, rtype = r
+                elif hasattr(r, "text"):
+                    text, rtype = r.text, getattr(r, "req_type", "organizational")
+                elif isinstance(r, str):
+                    text, rtype = r, "organizational"
+                else:
+                    invalid = True
+                    break
+                if text.strip():
+                    pairs.append((text, rtype))
+            if invalid:
+                messagebox.showerror(
+                    "Requirements",
+                    "Requirement entries must be strings or (text, type) pairs.",
+                )
+                continue
+            for text, rtype in pairs:
+                ids.append(self._add_requirement(text, rtype))
+        if not ids:
+            messagebox.showinfo(
+                "Requirements",
+                "No requirements were generated for lifecycle diagrams.",
+            )
+            return
+        self._display_requirements("Lifecycle Requirements", ids)
 
     @staticmethod
     def _collect_requirements(gov: GovernanceDiagram) -> list[str]:

--- a/tests/test_governance_lifecycle_requirements_menu.py
+++ b/tests/test_governance_lifecycle_requirements_menu.py
@@ -1,0 +1,87 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow, SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+from gui import safety_management_toolbox as smt
+from analysis.models import global_requirements
+
+
+def test_lifecycle_requirements_menu(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    d1 = repo.create_diagram("Governance Diagram", name="PhaseDiag")
+    t1 = repo.create_element("Action", name="Start")
+    t2 = repo.create_element("Action", name="Finish")
+    d1.objects = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t1.elem_id, "properties": {"name": "Start"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t2.elem_id, "properties": {"name": "Finish"}},
+    ]
+    d1.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+
+    d2 = repo.create_diagram("Governance Diagram", name="LifeDiag")
+    t3 = repo.create_element("Action", name="Alpha")
+    t4 = repo.create_element("Action", name="Beta")
+    d2.objects = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t3.elem_id, "properties": {"name": "Alpha"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t4.elem_id, "properties": {"name": "Beta"}},
+    ]
+    d2.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams["PhaseDiag"] = d1.diag_id
+    toolbox.diagrams["LifeDiag"] = d2.diag_id
+    mod = toolbox.add_module("Phase1")
+    mod.diagrams.append("PhaseDiag")
+    monkeypatch.setattr(toolbox, "list_diagrams", lambda: list(toolbox.diagrams.keys()))
+
+    class DummyTab:
+        pass
+
+    tabs = []
+
+    def _new_tab(title):
+        tab = DummyTab()
+        tabs.append((title, tab))
+        return tab
+
+    trees = []
+
+    class DummyTree:
+        def __init__(self, master, columns, show="headings"):
+            self.rows = []
+            trees.append(self)
+
+        def heading(self, col, text=""):
+            pass
+
+        def insert(self, parent, idx, values):
+            self.rows.append(values)
+
+        def pack(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace(_new_tab=_new_tab)
+
+    global_requirements.clear()
+    win.generate_lifecycle_requirements()
+
+    assert tabs
+    title, _tab = tabs[0]
+    assert "Lifecycle Requirements" in title
+    assert trees and trees[0].rows
+    texts = [row[2] for row in trees[0].rows]
+    assert any("Alpha shall precede 'Beta'." in t for t in texts)
+    assert not any("Start shall precede 'Finish'." in t for t in texts)
+    assert all(row[1] == "organizational" for row in trees[0].rows)
+    assert len(global_requirements) == len(trees[0].rows)


### PR DESCRIPTION
## Summary
- expose lifecycle requirement generation via explicit menu entries in main and toolbox UIs
- ensure phase menu lists only phase-specific options; lifecycle handled separately
- update tests for lifecycle menu command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f979f993c83279c6bf200365b6a21