### PR TITLE
feat: add dark mode for diagrams

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -229,6 +229,7 @@ import tkinter as tk
 from tkinter import ttk, filedialog, simpledialog, scrolledtext
 from gui import messagebox, logger
 from gui.tooltip import ToolTip
+from gui.style_manager import StyleManager
 from gui.review_toolbox import (
     ReviewToolbox,
     ReviewData,
@@ -373,6 +374,8 @@ from reportlab.platypus import LongTable
 from email.message import EmailMessage
 import smtplib
 import socket
+
+CANVAS_BG = StyleManager.get_instance().background
 
 styles = getSampleStyleSheet()  # Create the stylesheet.
 preformatted_style = ParagraphStyle(name="Preformatted", fontName="Courier", fontSize=10)
@@ -4305,7 +4308,7 @@ class FaultTreeApp:
         # Create a temporary Toplevel window and canvas
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
         
         # Create and redraw the page diagram
@@ -4350,7 +4353,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         try:
@@ -4576,7 +4579,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -4841,7 +4844,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5106,7 +5109,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5371,7 +5374,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5636,7 +5639,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -5901,7 +5904,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -6155,7 +6158,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -6409,7 +6412,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -6663,7 +6666,7 @@ class FaultTreeApp:
 
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
 
         def draw_connections(n):
@@ -8588,7 +8591,7 @@ class FaultTreeApp:
     def capture_event_diagram(self, event_node):
         temp = tk.Toplevel(self.root)
         temp.withdraw()
-        canvas = tk.Canvas(temp, bg="white", width=2000, height=2000)
+        canvas = tk.Canvas(temp, bg=CANVAS_BG, width=2000, height=2000)
         canvas.pack()
         self.draw_subtree_with_filter(canvas, event_node, self.get_all_nodes(event_node))
         canvas.delete("grid")
@@ -15055,7 +15058,7 @@ class FaultTreeApp:
         vsb.grid(row=0, column=1, sticky="ns")
         hsb.grid(row=1, column=0, sticky="ew")
 
-        canvas = tk.Canvas(diagram_frame, bg="white")
+        canvas = tk.Canvas(diagram_frame, bg=CANVAS_BG)
         cvs_vsb = ttk.Scrollbar(diagram_frame, orient="vertical", command=canvas.yview)
         cvs_hsb = ttk.Scrollbar(diagram_frame, orient="horizontal", command=canvas.xview)
         canvas.configure(yscrollcommand=cvs_vsb.set, xscrollcommand=cvs_hsb.set)
@@ -16747,7 +16750,7 @@ class FaultTreeApp:
         self.doc_nb.add(self.canvas_tab, text="FTA")
 
         self.canvas_frame = self.canvas_tab
-        self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+        self.canvas = tk.Canvas(self.canvas_frame, bg=CANVAS_BG)
         self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.hbar = ttk.Scrollbar(self.canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
         self.hbar.pack(side=tk.BOTTOM, fill=tk.X)
@@ -18999,7 +19002,7 @@ class FaultTreeApp:
         back_button = ttk.Button(header_frame, text="Go Back", command=self.go_back)
         back_button.grid(row=0, column=1, sticky="e", padx=5)
 
-        page_canvas = tk.Canvas(self.canvas_frame, bg="white")
+        page_canvas = tk.Canvas(self.canvas_frame, bg=CANVAS_BG)
         page_canvas.grid(row=1, column=0, sticky="nsew")
         vbar = ttk.Scrollbar(self.canvas_frame, orient=tk.VERTICAL, command=page_canvas.yview)
         vbar.grid(row=1, column=1, sticky="ns")
@@ -19183,7 +19186,7 @@ class FaultTreeApp:
             for widget in self.canvas_frame.winfo_children():
                 widget.destroy()
             if prev is None:
-                self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+                self.canvas = tk.Canvas(self.canvas_frame, bg=CANVAS_BG)
                 self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
                 self.hbar = ttk.Scrollbar(self.canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
                 self.hbar.pack(side=tk.BOTTOM, fill=tk.X)
@@ -19205,7 +19208,7 @@ class FaultTreeApp:
         else:
             for widget in self.canvas_frame.winfo_children():
                 widget.destroy()
-            self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+            self.canvas = tk.Canvas(self.canvas_frame, bg=CANVAS_BG)
             self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
             self.hbar = ttk.Scrollbar(self.canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
             self.hbar.pack(side=tk.BOTTOM, fill=tk.X)

--- a/README.md
+++ b/README.md
@@ -1547,6 +1547,11 @@ peach actions and steel-blue nodes. `modern.xml` offers a Material-inspired
 palette for a different look. Open the Style Editor via **View → Style Editor**, click **Load** and choose
 the desired style. All open diagrams update immediately.
 
+To enable a global dark theme for diagrams, set the environment variable
+`AUTOML_STYLE=dark` before launching the application. The included
+`dark.xml` defines a black canvas background and colors tuned for low-light
+environments.
+
 ## License
 
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2982,7 +2982,8 @@ class SysMLDiagramWindow(tk.Frame):
 
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
-        self.canvas = tk.Canvas(canvas_frame, bg="white")
+        bg = StyleManager.get_instance().background
+        self.canvas = tk.Canvas(canvas_frame, bg=bg)
         vbar = ttk.Scrollbar(canvas_frame, orient="vertical", command=self.canvas.yview)
         hbar = ttk.Scrollbar(canvas_frame, orient="horizontal", command=self.canvas.xview)
         self.canvas.configure(yscrollcommand=vbar.set, xscrollcommand=hbar.set)
@@ -6381,7 +6382,11 @@ class SysMLDiagramWindow(tk.Frame):
         y1 = bottom - size - pad
         x2 = right - pad
         y2 = bottom - pad
-        self.canvas.create_rectangle(x1, y1, x2, y2, outline="black", fill="white")
+        self.canvas.create_rectangle(
+            x1, y1, x2, y2,
+            outline=StyleManager.get_instance().get_outline(),
+            fill="white",
+        )
         cx = (x1 + x2) / 2
         cy = (y1 + y2) / 2
         self.canvas.create_text(
@@ -6398,7 +6403,7 @@ class SysMLDiagramWindow(tk.Frame):
         w = obj.width * self.zoom / 2
         h = obj.height * self.zoom / 2
         color = StyleManager.get_instance().get_color(obj.obj_type)
-        outline = "black"
+        outline = StyleManager.get_instance().get_outline()
         if color == "#FFFFFF":
             if obj.obj_type == "Database":
                 color = "#cfe2f3"
@@ -6830,7 +6835,11 @@ class SysMLDiagramWindow(tk.Frame):
                 by1 = cy + (20 * self.zoom - btn_sz) / 2
                 bx2 = bx1 + btn_sz
                 by2 = by1 + btn_sz
-                self.canvas.create_rectangle(bx1, by1, bx2, by2, outline="black", fill="white")
+                self.canvas.create_rectangle(
+                    bx1, by1, bx2, by2,
+                    outline=StyleManager.get_instance().get_outline(),
+                    fill="white",
+                )
                 self.canvas.create_text((bx1 + bx2) / 2, (by1 + by2) / 2, text="-" if not collapsed else "+", font=self.font)
                 self.compartment_buttons.append((obj.obj_id, label, (bx1, by1, bx2, by2)))
                 tx = bx2 + 2 * self.zoom

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -7,6 +7,7 @@ from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
 from gui import messagebox
 from gui.tooltip import ToolTip
 from gui.drawing_helper import FTADrawingHelper
+from .style_manager import StyleManager
 
 
 class CausalBayesianNetworkWindow(tk.Frame):
@@ -52,7 +53,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
 
         canvas_container = ttk.Frame(body)
         canvas_container.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        self.canvas = tk.Canvas(canvas_container, background="white")
+        bg = StyleManager.get_instance().background
+        self.canvas = tk.Canvas(canvas_container, background=bg)
         self.canvas.grid(row=0, column=0, sticky="nsew")
         xbar = ttk.Scrollbar(canvas_container, orient=tk.HORIZONTAL, command=self.canvas.xview)
         xbar.grid(row=1, column=0, sticky="ew")
@@ -482,8 +484,9 @@ class CausalBayesianNetworkWindow(tk.Frame):
         fill_ids = self.drawing_helper._fill_gradient_circle(
             self.canvas, x, y, r, color, tag=fill_tag
         ) or []
+        outline = StyleManager.get_instance().get_outline()
         oval = self.canvas.create_oval(
-            x - r, y - r, x + r, y + r, outline="black", fill=""
+            x - r, y - r, x + r, y + r, outline=outline, fill=""
         )
         label = f"<<{stereo}>>\n{name}" if stereo else name
         font = getattr(self, "text_font", None)

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -3,19 +3,12 @@ import math
 import tkinter as tk
 import tkinter.font as tkFont
 
-TEXT_BOX_COLOR = "#CFD8DC"
+from .style_manager import StyleManager
 
-# Basic mapping of a few common color names to their hex equivalents. The
-# gradient routines expect ``#RRGGBB`` colors; previously passing a named color
-# such as ``"lightyellow"`` caused a ``ValueError`` when converting to integers.
-# The small table below covers the named colors used by the drawing helpers and
-# can be extended easily if additional names are required.
-_NAMED_COLORS = {
-    "lightgray": "#d3d3d3",
-    "lightgrey": "#d3d3d3",
-    "lightblue": "#add8e6",
-    "lightyellow": "#ffffe0",
-}
+DEFAULT_OUTLINE = StyleManager.get_instance().get_outline()
+DEFAULT_FILL = "black" if DEFAULT_OUTLINE.lower() == "#000000" else DEFAULT_OUTLINE
+
+TEXT_BOX_COLOR = "#CFD8DC"
 
 # Basic mapping of a few common color names to their hex equivalents. The
 # gradient routines expect ``#RRGGBB`` colors; previously passing a named color
@@ -144,7 +137,7 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Node",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -175,7 +168,7 @@ class FTADrawingHelper:
         v1 = (x, y)
         v2 = (x - size, y)
         v3 = (x, y - size)
-        canvas.create_polygon([v1, v2, v3], fill="black", outline="black")
+        canvas.create_polygon([v1, v2, v3], fill=DEFAULT_FILL, outline=DEFAULT_OUTLINE)
 
     def _segment_intersection(self, p1, p2, p3, p4):
         """Return intersection point (x, y, t) of segments *p1*-*p2* and *p3*-*p4* or None."""
@@ -253,7 +246,7 @@ class FTADrawingHelper:
                 return best[0], best[1]
         return target_pt
 
-    def draw_90_connection(self, canvas, parent_pt, child_pt, outline_color="dimgray", line_width=1,
+    def draw_90_connection(self, canvas, parent_pt, child_pt, outline_color=DEFAULT_OUTLINE, line_width=1,
                            fixed_length=40, parent_shape=None, child_shape=None):
         """Draw a 90° connection line from a parent point to a child point.
 
@@ -317,7 +310,7 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Event",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -415,7 +408,7 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Event",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -522,7 +515,7 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Node",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -555,7 +548,7 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Node",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -588,7 +581,7 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Event",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -676,7 +669,7 @@ class FTADrawingHelper:
         top_text="",
         bottom_text="",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         base_event=False,
@@ -769,7 +762,7 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Node",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -815,7 +808,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Goal",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -859,7 +852,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Module",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -915,8 +908,8 @@ class GSNDrawingHelper(FTADrawingHelper):
         start_pt,
         end_pt,
         *,
-        fill="black",
-        outline="black",
+        fill=DEFAULT_FILL,
+        outline=DEFAULT_OUTLINE,
         obj_id: str = "",
     ) -> None:
         """Draw a triangular arrow head from *start_pt* to *end_pt*."""
@@ -957,7 +950,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         canvas,
         parent_pt,
         child_pt,
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         obj_id: str = "",
     ):
@@ -1023,8 +1016,8 @@ class GSNDrawingHelper(FTADrawingHelper):
             canvas,
             start,
             end,
-            fill="black",
-            outline="black",
+            fill=DEFAULT_FILL,
+            outline=DEFAULT_OUTLINE,
             obj_id=obj_id,
         )
 
@@ -1033,7 +1026,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         canvas,
         parent_pt,
         child_pt,
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         obj_id: str = "",
     ):
@@ -1118,7 +1111,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Strategy",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -1156,7 +1149,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=40.0,
         text="Solution",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -1197,7 +1190,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Assumption",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -1251,7 +1244,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Justification",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
@@ -1305,7 +1298,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Context",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=DEFAULT_OUTLINE,
         line_width=1,
         font_obj=None,
         obj_id: str = "",

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -15,6 +15,7 @@ from gsn import GSNNode, GSNDiagram
 from .gsn_config_window import GSNElementConfig
 from .gsn_connection_config import GSNConnectionConfig
 from . import messagebox
+from .style_manager import StyleManager
 
 
 class ModuleSelectDialog(simpledialog.Dialog):  # pragma: no cover - requires tkinter
@@ -119,7 +120,8 @@ class GSNDiagramWindow(tk.Frame):
         # drawing canvas with scrollbars so large diagrams remain accessible
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(fill=tk.BOTH, expand=True)
-        self.canvas = tk.Canvas(canvas_frame, width=800, height=600, bg="white")
+        bg = StyleManager.get_instance().background
+        self.canvas = tk.Canvas(canvas_frame, width=800, height=600, bg=bg)
         self.canvas.grid(row=0, column=0, sticky="nsew")
         hbar = ttk.Scrollbar(canvas_frame, orient=tk.HORIZONTAL, command=self.canvas.xview)
         vbar = ttk.Scrollbar(canvas_frame, orient=tk.VERTICAL, command=self.canvas.yview)

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -6,6 +6,7 @@ from tkinter import ttk, simpledialog
 
 from gsn import GSNNode, GSNDiagram, GSNModule
 from gui import format_name_with_phase
+from .style_manager import StyleManager
 
 
 class GSNExplorer(tk.Frame):
@@ -480,7 +481,8 @@ class GSNExplorer(tk.Frame):
             return
         win = tk.Toplevel(self)
         win.title(obj.root.user_name)
-        canvas = tk.Canvas(win, width=800, height=600, bg="white")
+        bg = StyleManager.get_instance().background
+        canvas = tk.Canvas(win, width=800, height=600, bg=bg)
         canvas.pack(fill=tk.BOTH, expand=True)
         obj.draw(canvas)
 

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -25,6 +25,7 @@ import difflib
 import sys
 import json
 import re
+from .style_manager import StyleManager
 try:
     from PIL import Image, ImageTk
 except ModuleNotFoundError:  # pragma: no cover - pillow optional
@@ -849,7 +850,8 @@ class ReviewDocumentDialog(tk.Frame):
         container = tk.Frame(self)
         container.pack(fill=tk.BOTH, expand=True)
 
-        self.outer = tk.Canvas(container)
+        self.bg = StyleManager.get_instance().background
+        self.outer = tk.Canvas(container, bg=self.bg)
         vbar = tk.Scrollbar(container, orient=tk.VERTICAL, command=self.outer.yview)
         hbar = tk.Scrollbar(container, orient=tk.HORIZONTAL, command=self.outer.xview)
         self.outer.configure(yscrollcommand=vbar.set, xscrollcommand=hbar.set)
@@ -1371,7 +1373,7 @@ class ReviewDocumentDialog(tk.Frame):
             row += 1
             frame = tk.Frame(self.inner)
             frame.grid(row=row, column=0, padx=5, pady=5, sticky="nsew")
-            c = tk.Canvas(frame, width=600, height=400, bg="white")
+            c = tk.Canvas(frame, width=600, height=400, bg=self.bg)
             hbar = tk.Scrollbar(frame, orient=tk.HORIZONTAL, command=c.xview)
             vbar = tk.Scrollbar(frame, orient=tk.VERTICAL, command=c.yview)
             c.configure(xscrollcommand=hbar.set, yscrollcommand=vbar.set)
@@ -1687,7 +1689,7 @@ class VersionCompareDialog(tk.Frame):
         # canvas to display FTA differences
         canvas_frame = tk.Frame(self)
         canvas_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
-        self.tree_canvas = tk.Canvas(canvas_frame, width=600, height=300, bg="white")
+        self.tree_canvas = tk.Canvas(canvas_frame, width=600, height=300, bg=self.bg)
         vbar = tk.Scrollbar(canvas_frame, orient=tk.VERTICAL, command=self.tree_canvas.yview)
         hbar = tk.Scrollbar(canvas_frame, orient=tk.HORIZONTAL, command=self.tree_canvas.xview)
         self.tree_canvas.configure(yscrollcommand=vbar.set, xscrollcommand=hbar.set)

--- a/gui/style_manager.py
+++ b/gui/style_manager.py
@@ -3,10 +3,12 @@ import sys
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
-_DEFAULT_STYLE = Path(__file__).resolve().parent.parent / 'styles' / 'pastel.xml'
+# Allow overriding the default style (e.g. dark mode) via env var
+_STYLE_NAME = os.environ.get("AUTOML_STYLE", "pastel")
+_DEFAULT_STYLE = Path(__file__).resolve().parent.parent / 'styles' / f"{_STYLE_NAME}.xml"
 if getattr(sys, 'frozen', False):
     # When packaged by PyInstaller resources live under sys._MEIPASS
-    _DEFAULT_STYLE = Path(sys._MEIPASS) / 'styles' / 'pastel.xml'
+    _DEFAULT_STYLE = Path(sys._MEIPASS) / 'styles' / f"{_STYLE_NAME}.xml"
 
 class StyleManager:
     """Singleton manager for diagram styles loaded from XML files."""
@@ -15,11 +17,15 @@ class StyleManager:
 
     def __init__(self):
         self.styles = {}
+        self.background = '#FFFFFF'
+        self.outline = '#000000'
         try:
             self.load_style(_DEFAULT_STYLE)
         except Exception:
             # fallback to hard coded white style
             self.styles = {}
+            self.background = '#FFFFFF'
+            self.outline = '#000000'
 
     @classmethod
     def get_instance(cls):
@@ -35,6 +41,16 @@ class StyleManager:
         tree = ET.parse(path)
         root = tree.getroot()
         self.styles.clear()
+        bg = root.find('background')
+        if bg is not None and bg.get('color'):
+            self.background = bg.get('color')
+        else:
+            self.background = '#FFFFFF'
+        ol = root.find('outline')
+        if ol is not None and ol.get('color'):
+            self.outline = ol.get('color')
+        else:
+            self.outline = '#000000'
         for obj in root.findall('object'):
             typ = obj.get('type')
             color = obj.get('color')
@@ -43,6 +59,8 @@ class StyleManager:
 
     def save_style(self, path: str) -> None:
         root = ET.Element('style')
+        ET.SubElement(root, 'background', color=self.background)
+        ET.SubElement(root, 'outline', color=self.outline)
         for typ, color in self.styles.items():
             ET.SubElement(root, 'object', type=typ, color=color)
         tree = ET.ElementTree(root)
@@ -50,3 +68,7 @@ class StyleManager:
 
     def get_color(self, obj_type: str) -> str:
         return self.styles.get(obj_type, '#FFFFFF')
+
+    def get_outline(self) -> str:
+        """Return the default outline color for shapes."""
+        return self.outline

--- a/styles/dark.xml
+++ b/styles/dark.xml
@@ -1,14 +1,20 @@
 <style>
-  <object type="Actor" color="#0D47A1" />
-  <object type="Use Case" color="#FF8F00" />
-  <object type="System Boundary" color="#37474F" />
-  <object type="Block Boundary" color="#263238" />
-  <object type="Action Usage" color="#1B5E20" />
-  <object type="Action" color="#1B5E20" />
-  <object type="CallBehaviorAction" color="#1B5E20" />
-  <object type="Part" color="#F57F17" />
-  <object type="Port" color="#4A148C" />
-  <object type="Block" color="#455A64" />
-  <object type="Decision" color="#C8E6C9" />
-  <object type="Merge" color="#006064" />
+  <background color="#000000" />
+  <outline color="#FFFFFF" />
+  <object type="Actor" color="#90CAF9" />
+  <object type="Use Case" color="#FFCC80" />
+  <object type="System Boundary" color="#90A4AE" />
+  <object type="Block Boundary" color="#B0BEC5" />
+  <object type="Existing Element" color="#90A4AE" />
+  <object type="Action Usage" color="#81C784" />
+  <object type="Action" color="#81C784" />
+  <object type="CallBehaviorAction" color="#81C784" />
+  <object type="Part" color="#FFB74D" />
+  <object type="Port" color="#CE93D8" />
+  <object type="Block" color="#CFD8DC" />
+  <object type="Decision" color="#E8F5E9" />
+  <object type="Merge" color="#4DD0E1" />
+  <object type="Database" color="#E1F5FE" />
+  <object type="ANN" color="#DCEDC8" />
+  <object type="Data acquisition" color="#FFF3E0" />
 </style>

--- a/tests/test_dark_mode.py
+++ b/tests/test_dark_mode.py
@@ -1,0 +1,10 @@
+import importlib
+
+def test_dark_mode_background(monkeypatch):
+    monkeypatch.setenv('AUTOML_STYLE', 'dark')
+    import gui.style_manager as sm
+    importlib.reload(sm)
+    mgr = sm.StyleManager.get_instance()
+    assert mgr.background == '#000000'
+    assert mgr.get_color('Actor') == '#90CAF9'
+    assert mgr.get_outline() == '#FFFFFF'


### PR DESCRIPTION
## Summary
- allow selecting diagram style via `AUTOML_STYLE` env var
- support style-defined canvas background and bundle dark theme with light-colored shapes
- use style-driven background for all diagram canvases
- document dark mode usage
- make shape outlines configurable and default to white in dark mode

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f93b61fa88327ba1b4be2ced16938