### PR TITLE
Handle lifecycle phase transition requirements

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14647,12 +14647,11 @@ class FaultTreeApp:
                 label=phase,
                 command=lambda p=phase: self.generate_phase_requirements(p),
             )
-        if phases:
-            self.phase_req_menu.add_separator()
-        self.phase_req_menu.add_command(
-            label="Lifecycle",
-            command=self.generate_lifecycle_requirements,
-        )
+        if not phases:
+            self.phase_req_menu.add_command(
+                label="Lifecycle",
+                command=self.generate_lifecycle_requirements,
+            )
 
     def export_cybersecurity_goal_requirements(self):
         """Export cybersecurity goals with linked risk assessments."""

--- a/tests/test_governance_phase_transition_requirements.py
+++ b/tests/test_governance_phase_transition_requirements.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram
+
+
+def _texts(reqs):
+    texts = []
+    for r in reqs:
+        if isinstance(r, tuple):
+            texts.append(r[0])
+        elif hasattr(r, "text"):
+            texts.append(r.text)
+        else:
+            texts.append(str(r))
+    return texts
+
+
+def test_phase_transition_requirement_direct_flow():
+    diagram = GovernanceDiagram()
+    diagram.add_task("P1", node_type="Lifecycle Phase")
+    diagram.add_task("P2", node_type="Lifecycle Phase")
+    diagram.add_flow("P1", "P2")
+
+    reqs = diagram.generate_requirements()
+    texts = _texts(reqs)
+    assert "P1 shall transition to 'P2'." in texts
+
+
+def test_phase_transition_requirement_with_reuse_and_condition():
+    diagram = GovernanceDiagram()
+    diagram.add_task("P1", node_type="Lifecycle Phase")
+    diagram.add_task("P2", node_type="Lifecycle Phase")
+    diagram.add_flow("P1", "P2", "design approved")
+    diagram.add_relationship("P2", "P1", conn_type="Re-use")
+
+    reqs = diagram.generate_requirements()
+    texts = _texts(reqs)
+    assert (
+        "P1 shall transition to 'P2' reusing outputs from 'P1' only after design approved." in texts
+    )


### PR DESCRIPTION
## Summary
- Generate lifecycle requirements that describe transitions between phases, capturing reuse and conditional flows
- Avoid duplicate lifecycle entries in the phase requirements menu
- Test lifecycle phase transition requirement generation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689fa29b303c832793e0fc61a692854b