### PR TITLE
Prevent duplicate tabs in notebook

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14647,11 +14647,12 @@ class FaultTreeApp:
                 label=phase,
                 command=lambda p=phase: self.generate_phase_requirements(p),
             )
-        if not phases:
-            self.phase_req_menu.add_command(
-                label="Lifecycle",
-                command=self.generate_lifecycle_requirements,
-            )
+        if phases:
+            self.phase_req_menu.add_separator()
+        self.phase_req_menu.add_command(
+            label="Lifecycle",
+            command=self.generate_lifecycle_requirements,
+        )
 
     def export_cybersecurity_goal_requirements(self):
         """Export cybersecurity goals with linked risk assessments."""
@@ -16931,7 +16932,16 @@ class FaultTreeApp:
             self.doc_nb.select(tabs[index + 1])
 
     def _new_tab(self, title: str) -> ttk.Frame:
-        """Create and select a new tab in the document notebook."""
+        """Create or select a tab in the document notebook.
+
+        If a tab with the given title already exists, it will be selected and
+        returned instead of creating a duplicate tab. Otherwise a new tab is
+        created and selected.
+        """
+        for tab_id in self.doc_nb.tabs():
+            if self.doc_nb.tab(tab_id, "text") == title:
+                self.doc_nb.select(tab_id)
+                return self.doc_nb.nametowidget(tab_id)
         tab = ttk.Frame(self.doc_nb)
         self.doc_nb.add(tab, text=title)
         self.doc_nb.select(tab)

--- a/tests/test_tab_dedup.py
+++ b/tests/test_tab_dedup.py
@@ -1,0 +1,46 @@
+import types
+
+import AutoML
+from AutoML import FaultTreeApp
+
+
+def test_new_tab_reuses_existing(monkeypatch):
+    class DummyFrame:
+        pass
+
+    class DummyNotebook:
+        def __init__(self):
+            self._tabs = []
+            self._titles = {}
+            self._widgets = {}
+            self.selected = None
+
+        def tabs(self):
+            return self._tabs
+
+        def tab(self, tab_id, option):
+            assert option == "text"
+            return self._titles[tab_id]
+
+        def add(self, widget, text):
+            tab_id = f"id{len(self._tabs)}"
+            self._tabs.append(tab_id)
+            self._titles[tab_id] = text
+            self._widgets[tab_id] = widget
+
+        def select(self, tab):
+            self.selected = tab
+
+        def nametowidget(self, tab_id):
+            return self._widgets[tab_id]
+
+    monkeypatch.setattr(AutoML, "ttk", types.SimpleNamespace(Frame=lambda master: DummyFrame()))
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    app.doc_nb = DummyNotebook()
+
+    first = app._new_tab("My Tab")
+    second = app._new_tab("My Tab")
+
+    assert first is second
+    assert len(app.doc_nb.tabs()) == 1


### PR DESCRIPTION
## Summary
- Reuse existing notebook tabs based on title instead of creating duplicates
- Always include Lifecycle option in phase requirements menu
- Add unit test covering tab deduplication behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fa667fd408327b194a259fdbfd3f1