### PR TITLE
Fix JSON syntax errors in diagram rules configuration

### DIFF
--- a/diagram_rules.json
+++ b/diagram_rules.json
@@ -34,7 +34,7 @@
     "AI re-training",
     "Curation",
     "Ingestion",
-    "Model evaluation"
+    "Model evaluation",
     "Tune",
     "Hyperparameter Validation"
   ],
@@ -100,7 +100,7 @@
       "subject": "Engineering team"
     },
     "ingestion": {"action": "ingest", "subject": "Engineering team"},
-    "model evaluation": {"action": "evaluate model", "subject": "Engineering team"}
+    "model evaluation": {"action": "evaluate model", "subject": "Engineering team"},
     "tune": {"action": "tune", "subject": "Engineering team"},
     "hyperparameter validation": {
       "action": "validate hyperparameters",
@@ -206,7 +206,6 @@
       "Used By": {"Work Product": ["Work Product"]},
       "Used after Review": {"Work Product": ["Work Product"]},
       "Used after Approval": {"Work Product": ["Work Product"]}
-      }
     }
   },
 


### PR DESCRIPTION
## Summary
- fix `diagram_rules.json` formatting by adding missing commas
- remove extra closing brace from connection rules

## Testing
- `pytest -q` *(fails: tests/test_phase_requirements_main_menu.py::test_phase_requirements_menu_populated)*

------
https://chatgpt.com/codex/tasks/task_b_689fa8f9cba48327ae2d5cc2025af306