### PR TITLE
Validate diagram rules configuration

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -260,7 +260,7 @@ from analysis.mechanisms import (
     ANNEX_D_MECHANISMS,
     PAS_8800_MECHANISMS,
 )
-from config import load_json_with_comments
+from config import load_diagram_rules
 from pathlib import Path
 from collections.abc import Mapping
 import csv
@@ -523,14 +523,14 @@ VALID_SUBTYPES = {
 
 # Node types treated as gates when rendering and editing
 _CONFIG_PATH = Path(__file__).resolve().parent / "config/diagram_rules.json"
-_CONFIG = load_json_with_comments(_CONFIG_PATH)
+_CONFIG = load_diagram_rules(_CONFIG_PATH)
 GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 
 
 def _reload_local_config() -> None:
     """Reload gate node types from the external configuration file."""
     global _CONFIG, GATE_NODE_TYPES
-    _CONFIG = load_json_with_comments(_CONFIG_PATH)
+    _CONFIG = load_diagram_rules(_CONFIG_PATH)
     GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 
 ##########################################

--- a/analysis/fmeda_utils.py
+++ b/analysis/fmeda_utils.py
@@ -1,18 +1,18 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 from analysis.models import ASIL_ORDER, ASIL_TARGETS, component_fit_map
 from pathlib import Path
-from config import load_json_with_comments
+from config import load_diagram_rules
 
 # Node types treated as gates when determining component names
 _CONFIG_PATH = Path(__file__).resolve().parents[1] / "config/diagram_rules.json"
-_CONFIG = load_json_with_comments(_CONFIG_PATH)
+_CONFIG = load_diagram_rules(_CONFIG_PATH)
 GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 
 
 def reload_config() -> None:
     """Reload gate node types from configuration."""
     global _CONFIG, GATE_NODE_TYPES
-    _CONFIG = load_json_with_comments(_CONFIG_PATH)
+    _CONFIG = load_diagram_rules(_CONFIG_PATH)
     GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 
 

--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field
 from typing import Any, Iterator, List, Tuple
 
 from pathlib import Path
-from config import load_json_with_comments
+from config import load_diagram_rules
 
 import networkx as nx
 
 _CONFIG_PATH = Path(__file__).resolve().parents[1] / "config/diagram_rules.json"
-_CONFIG = load_json_with_comments(_CONFIG_PATH)
+_CONFIG = load_diagram_rules(_CONFIG_PATH)
 
 # Element and relationship types associated with AI & safety lifecycle nodes.
 _AI_NODES = set(_CONFIG.get("ai_nodes", []))
@@ -32,7 +32,7 @@ _NODE_ROLES = _CONFIG.get("node_roles", {})
 def reload_config() -> None:
     """Reload governance-related configuration."""
     global _CONFIG, _AI_NODES, _AI_RELATIONS, _RELATIONSHIP_RULES, _NODE_ROLES
-    _CONFIG = load_json_with_comments(_CONFIG_PATH)
+    _CONFIG = load_diagram_rules(_CONFIG_PATH)
     _AI_NODES = set(_CONFIG.get("ai_nodes", []))
     _AI_RELATIONS = set(_CONFIG.get("ai_relations", []))
     _RELATIONSHIP_RULES = _CONFIG.get("relationship_rules", {})

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,3 +1,7 @@
-from .config_loader import load_json_with_comments
+from .config_loader import (
+    load_json_with_comments,
+    load_diagram_rules,
+    validate_diagram_rules,
+)
 
-__all__ = ["load_json_with_comments"]
+__all__ = ["load_json_with_comments", "load_diagram_rules", "validate_diagram_rules"]

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -17,6 +17,119 @@ import json
 import re
 
 
+def _ensure_list_of_strings(val: Any, name: str) -> None:
+    """Raise :class:`ValueError` if *val* is not a list of strings."""
+    if not isinstance(val, list) or any(not isinstance(v, str) for v in val):
+        raise ValueError(f"{name} must be a list of strings")
+
+
+def validate_diagram_rules(data: Any) -> dict[str, Any]:
+    """Validate diagram rule configuration structure.
+
+    Parameters
+    ----------
+    data:
+        Parsed JSON object representing the diagram rules configuration.
+
+    Returns
+    -------
+    dict
+        The validated configuration.
+
+    Raises
+    ------
+    ValueError
+        If the configuration does not follow the expected structure.
+    """
+
+    if not isinstance(data, dict):
+        raise ValueError("Configuration root must be a JSON object")
+
+    list_fields = [
+        "ai_nodes",
+        "ai_relations",
+        "arch_diagram_types",
+        "governance_node_types",
+        "gate_node_types",
+        "guard_nodes",
+    ]
+    for field in list_fields:
+        if field in data:
+            _ensure_list_of_strings(data[field], field)
+
+    if "relationship_rules" in data:
+        rr = data["relationship_rules"]
+        if not isinstance(rr, dict):
+            raise ValueError("relationship_rules must be an object")
+        for label, info in rr.items():
+            if not isinstance(info, dict):
+                raise ValueError(f"relationship_rules[{label}] must be an object")
+            action = info.get("action")
+            if not isinstance(action, str):
+                raise ValueError(f"relationship_rules[{label}]['action'] must be a string")
+            if "subject" in info and not isinstance(info["subject"], str):
+                raise ValueError(
+                    f"relationship_rules[{label}]['subject'] must be a string"
+                )
+            if "constraint" in info and not isinstance(info["constraint"], bool):
+                raise ValueError(
+                    f"relationship_rules[{label}]['constraint'] must be a boolean"
+                )
+
+    if "node_roles" in data:
+        nr = data["node_roles"]
+        if not isinstance(nr, dict):
+            raise ValueError("node_roles must be an object")
+        allowed = {"subject", "action", "condition", "constraint", "object"}
+        for node, role in nr.items():
+            if role not in allowed:
+                raise ValueError(
+                    f"node_roles[{node}] has invalid role '{role}'"
+                )
+
+    if "safety_ai_relation_rules" in data:
+        sar = data["safety_ai_relation_rules"]
+        if not isinstance(sar, dict):
+            raise ValueError("safety_ai_relation_rules must be an object")
+        for rel, srcs in sar.items():
+            if not isinstance(srcs, dict):
+                raise ValueError(
+                    f"safety_ai_relation_rules[{rel}] must be an object"
+                )
+            for src, dests in srcs.items():
+                _ensure_list_of_strings(
+                    dests, f"safety_ai_relation_rules[{rel}][{src}]"
+                )
+
+    if "connection_rules" in data:
+        cr = data["connection_rules"]
+        if not isinstance(cr, dict):
+            raise ValueError("connection_rules must be an object")
+        for diag, conns in cr.items():
+            if not isinstance(conns, dict):
+                raise ValueError(f"connection_rules[{diag}] must be an object")
+            for conn, srcs in conns.items():
+                if not isinstance(srcs, dict):
+                    raise ValueError(
+                        f"connection_rules[{diag}][{conn}] must be an object"
+                    )
+                for src, dests in srcs.items():
+                    _ensure_list_of_strings(
+                        dests, f"connection_rules[{diag}][{conn}][{src}]"
+                    )
+
+    if "node_connection_limits" in data:
+        ncl = data["node_connection_limits"]
+        if not isinstance(ncl, dict) or any(
+            not isinstance(v, int) for v in ncl.values()
+        ):
+            raise ValueError(
+                "node_connection_limits must map node types to integer limits"
+            )
+
+    return data
+
+
 def _strip_comments(text: str) -> str:
     """Return *text* with // and /* ... */ comments removed.
 
@@ -70,3 +183,9 @@ def load_json_with_comments(path: str | Path) -> Any:
     # Remove trailing commas left after comment stripping
     text = re.sub(r",\s*(?=[}\]])", "", text)
     return json.loads(text)
+
+
+def load_diagram_rules(path: str | Path) -> dict[str, Any]:
+    """Load and validate the diagram rules configuration file."""
+    data = load_json_with_comments(path)
+    return validate_diagram_rules(data)

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Tuple
 from sysml.sysml_repository import SysMLRepository, SysMLDiagram, SysMLElement
 from gui.style_manager import StyleManager
 from gui.drawing_helper import fta_drawing_helper
-from config import load_json_with_comments
+from config import load_diagram_rules
 import json
 
 from sysml.sysml_spec import SYSML_PROPERTIES
@@ -52,7 +52,7 @@ CONNECTION_SELECT_RADIUS = 15
 
 
 _CONFIG_PATH = Path(__file__).resolve().parents[1] / "config/diagram_rules.json"
-_CONFIG = load_json_with_comments(_CONFIG_PATH)
+_CONFIG = load_diagram_rules(_CONFIG_PATH)
 
 # Diagram types that belong to the generic "Architecture Diagram" work product
 ARCH_DIAGRAM_TYPES = set(_CONFIG.get("arch_diagram_types", []))
@@ -93,7 +93,7 @@ def reload_config() -> None:
     """Reload diagram rule configuration at runtime."""
     global _CONFIG, ARCH_DIAGRAM_TYPES, SAFETY_AI_NODE_TYPES, GOVERNANCE_NODE_TYPES
     global SAFETY_AI_RELATION_RULES, CONNECTION_RULES, NODE_CONNECTION_LIMITS, GUARD_NODES
-    _CONFIG = load_json_with_comments(_CONFIG_PATH)
+    _CONFIG = load_diagram_rules(_CONFIG_PATH)
     ARCH_DIAGRAM_TYPES = set(_CONFIG.get("arch_diagram_types", []))
     SAFETY_AI_NODE_TYPES = set(_CONFIG.get("ai_nodes", []))
     GOVERNANCE_NODE_TYPES = set(_CONFIG.get("governance_node_types", []))

--- a/gui/diagram_rules_toolbox.py
+++ b/gui/diagram_rules_toolbox.py
@@ -2,7 +2,7 @@ import tkinter as tk
 from tkinter import ttk, simpledialog
 from pathlib import Path
 import json
-from config import load_json_with_comments
+from config import load_diagram_rules, validate_diagram_rules
 from gui import messagebox
 
 class DiagramRulesEditor(tk.Frame):
@@ -15,7 +15,7 @@ class DiagramRulesEditor(tk.Frame):
             config_path or Path(__file__).resolve().parents[1] / "config/diagram_rules.json"
         )
         try:
-            self.data = load_json_with_comments(self.config_path)
+            self.data = load_diagram_rules(self.config_path)
         except Exception as exc:  # pragma: no cover - GUI fallback
             messagebox.showerror(
                 "Diagram Rules", f"Failed to load configuration:\n{exc}"
@@ -129,6 +129,11 @@ class DiagramRulesEditor(tk.Frame):
         self.canvas.create_text((src_x + dest_x) / 2, 20, text=f"{diagram} - {connection}")
 
     def save(self):
+        try:
+            validate_diagram_rules(self.data)
+        except ValueError as exc:  # pragma: no cover - GUI feedback
+            messagebox.showerror("Diagram Rules", f"Invalid configuration:\n{exc}")
+            return
         self.config_path.write_text(json.dumps(self.data, indent=2) + "\n")
         if hasattr(self.app, "reload_config"):
             self.app.reload_config()

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -26,7 +26,7 @@ import difflib
 import sys
 import re
 from pathlib import Path
-from config import load_json_with_comments
+from config import load_diagram_rules
 import json
 try:
     from PIL import Image, ImageTk
@@ -35,14 +35,14 @@ except ModuleNotFoundError:  # pragma: no cover - pillow optional
 
 # Node types treated as gates when deriving component names
 _CONFIG_PATH = Path(__file__).resolve().parents[1] / "config/diagram_rules.json"
-_CONFIG = load_json_with_comments(_CONFIG_PATH)
+_CONFIG = load_diagram_rules(_CONFIG_PATH)
 GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 
 
 def reload_config() -> None:
     """Reload gate node types from configuration."""
     global _CONFIG, GATE_NODE_TYPES
-    _CONFIG = load_json_with_comments(_CONFIG_PATH)
+    _CONFIG = load_diagram_rules(_CONFIG_PATH)
     GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 
 EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")

--- a/tests/test_diagram_rules_validation.py
+++ b/tests/test_diagram_rules_validation.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from config import load_diagram_rules, validate_diagram_rules
+
+
+def test_load_diagram_rules_rejects_invalid_connection_rules(tmp_path: Path) -> None:
+    # Source mapping is not a list, should raise ValueError
+    bad = {"connection_rules": {"Diag": {"Conn": {"Src": "Dst"}}}}
+    path = tmp_path / "rules.json"
+    path.write_text(json.dumps(bad))
+    with pytest.raises(ValueError):
+        load_diagram_rules(path)
+
+
+def test_validate_diagram_rules_accepts_valid_structure(tmp_path: Path) -> None:
+    good = {"connection_rules": {"Diag": {"Conn": {"Src": ["Dst"]}}}}
+    path = tmp_path / "rules.json"
+    path.write_text(json.dumps(good))
+    data = load_diagram_rules(path)
+    assert data["connection_rules"]["Diag"]["Conn"]["Src"] == ["Dst"]
+
+
+def test_validate_diagram_rules_flags_invalid_list() -> None:
+    with pytest.raises(ValueError):
+        validate_diagram_rules({"ai_nodes": "not a list"})


### PR DESCRIPTION
## Summary
- add validation for diagram rules JSON and new loader `load_diagram_rules`
- integrate validation into diagram rules editor and configuration reloads
- add tests ensuring invalid configurations are rejected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689faf0f7d5c8327a89d14f5645d497b