### PR TITLE
Ensure white outlines for dark style

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -7556,7 +7556,11 @@ class FaultTreeApp:
             top = y - node_h / 2
             right = x + node_w / 2
             bottom = y + node_h / 2
-            draw.rectangle([left, top, right, bottom], fill=node_colors[n], outline="black")
+            draw.rectangle(
+                [left, top, right, bottom],
+                fill=node_colors[n],
+                outline=StyleManager.get_instance().outline_color,
+            )
             lbl = node_labels.get(n, str(n))
             bbox = draw.multiline_textbbox((0, 0), lbl, font=font, align="center")
             tw = bbox[2] - bbox[0]
@@ -11046,30 +11050,50 @@ class FaultTreeApp:
         if self.review_data:
             unresolved = any(c.node_id == node.unique_id and not c.resolved for c in self.review_data.comments)
             if unresolved:
-                self.canvas.create_oval(eff_x + 35 * self.zoom, eff_y + 35 * self.zoom,
-                                        eff_x + 45 * self.zoom, eff_y + 45 * self.zoom,
-                                        fill='yellow', outline='black')
+                self.canvas.create_oval(
+                    eff_x + 35 * self.zoom,
+                    eff_y + 35 * self.zoom,
+                    eff_x + 45 * self.zoom,
+                    eff_y + 45 * self.zoom,
+                    fill='yellow',
+                    outline=StyleManager.get_instance().outline_color,
+                )
 
         if self.review_data:
             unresolved = any(c.node_id == node.unique_id and not c.resolved for c in self.review_data.comments)
             if unresolved:
-                self.canvas.create_oval(eff_x + 35 * self.zoom, eff_y + 35 * self.zoom,
-                                        eff_x + 45 * self.zoom, eff_y + 45 * self.zoom,
-                                        fill='yellow', outline='black')
+                self.canvas.create_oval(
+                    eff_x + 35 * self.zoom,
+                    eff_y + 35 * self.zoom,
+                    eff_x + 45 * self.zoom,
+                    eff_y + 45 * self.zoom,
+                    fill='yellow',
+                    outline=StyleManager.get_instance().outline_color,
+                )
 
         if self.review_data:
             unresolved = any(c.node_id == node.unique_id and not c.resolved for c in self.review_data.comments)
             if unresolved:
-                self.canvas.create_oval(eff_x + 35 * self.zoom, eff_y + 35 * self.zoom,
-                                        eff_x + 45 * self.zoom, eff_y + 45 * self.zoom,
-                                        fill='yellow', outline='black')
+                self.canvas.create_oval(
+                    eff_x + 35 * self.zoom,
+                    eff_y + 35 * self.zoom,
+                    eff_x + 45 * self.zoom,
+                    eff_y + 45 * self.zoom,
+                    fill='yellow',
+                    outline=StyleManager.get_instance().outline_color,
+                )
 
         if self.review_data:
             unresolved = any(c.node_id == node.unique_id and not c.resolved for c in self.review_data.comments)
             if unresolved:
-                self.canvas.create_oval(eff_x + 35 * self.zoom, eff_y + 35 * self.zoom,
-                                        eff_x + 45 * self.zoom, eff_y + 45 * self.zoom,
-                                        fill='yellow', outline='black')
+                self.canvas.create_oval(
+                    eff_x + 35 * self.zoom,
+                    eff_y + 35 * self.zoom,
+                    eff_x + 45 * self.zoom,
+                    eff_y + 45 * self.zoom,
+                    fill='yellow',
+                    outline=StyleManager.get_instance().outline_color,
+                )
 
     def find_node_by_id(self, node, unique_id, visited=None):
         if visited is None:
@@ -15049,7 +15073,11 @@ class FaultTreeApp:
             color = color_map.get(kind, "white")
             cx, cy = to_canvas(x, y)
             rect = [cx - box_w / 2, cy - box_h / 2, cx + box_w / 2, cy + box_h / 2]
-            draw.rectangle(rect, fill=color, outline="black")
+            draw.rectangle(
+                rect,
+                fill=color,
+                outline=StyleManager.get_instance().outline_color,
+            )
             text = textwrap.fill(str(label), 20)
             bbox = draw.multiline_textbbox((0, 0), text, font=font)
             tw = bbox[2] - bbox[0]
@@ -15185,7 +15213,7 @@ class FaultTreeApp:
                     cx + box_w / 2,
                     cy + box_h / 2,
                     fill=color,
-                    outline="black",
+                    outline=StyleManager.get_instance().outline_color,
                     tags="node",
                 )
                 label = textwrap.fill(str(label), 20)
@@ -19257,7 +19285,7 @@ class FaultTreeApp:
                     eff_x + 45,
                     eff_y + 45,
                     fill="yellow",
-                    outline="black",
+                    outline=StyleManager.get_instance().outline_color,
                 )
 
     def on_ctrl_mousewheel_page(self, event):

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6311,7 +6311,14 @@ class SysMLDiagramWindow(tk.Frame):
         y1 = bottom - size - pad
         x2 = right - pad
         y2 = bottom - pad
-        self.canvas.create_rectangle(x1, y1, x2, y2, outline="black", fill="white")
+        self.canvas.create_rectangle(
+            x1,
+            y1,
+            x2,
+            y2,
+            outline=StyleManager.get_instance().outline_color,
+            fill="white",
+        )
         cx = (x1 + x2) / 2
         cy = (y1 + y2) / 2
         self.canvas.create_text(
@@ -6328,7 +6335,7 @@ class SysMLDiagramWindow(tk.Frame):
         w = obj.width * self.zoom / 2
         h = obj.height * self.zoom / 2
         color = StyleManager.get_instance().get_color(obj.obj_type)
-        outline = "black"
+        outline = StyleManager.get_instance().outline_color
         if color == "#FFFFFF":
             if obj.obj_type == "Database":
                 color = "#cfe2f3"
@@ -6760,7 +6767,14 @@ class SysMLDiagramWindow(tk.Frame):
                 by1 = cy + (20 * self.zoom - btn_sz) / 2
                 bx2 = bx1 + btn_sz
                 by2 = by1 + btn_sz
-                self.canvas.create_rectangle(bx1, by1, bx2, by2, outline="black", fill="white")
+                self.canvas.create_rectangle(
+                    bx1,
+                    by1,
+                    bx2,
+                    by2,
+                    outline=StyleManager.get_instance().outline_color,
+                    fill="white",
+                )
                 self.canvas.create_text((bx1 + bx2) / 2, (by1 + by2) / 2, text="-" if not collapsed else "+", font=self.font)
                 self.compartment_buttons.append((obj.obj_id, label, (bx1, by1, bx2, by2)))
                 tx = bx2 + 2 * self.zoom

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -492,7 +492,12 @@ class CausalBayesianNetworkWindow(tk.Frame):
             self.canvas, x, y, r, color, tag=fill_tag
         ) or []
         oval = self.canvas.create_oval(
-            x - r, y - r, x + r, y + r, outline="black", fill=""
+            x - r,
+            y - r,
+            x + r,
+            y + r,
+            outline=StyleManager.get_instance().outline_color,
+            fill="",
         )
         label = f"<<{stereo}>>\n{name}" if stereo else name
         font = getattr(self, "text_font", None)

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -2,6 +2,7 @@
 import math
 import tkinter as tk
 import tkinter.font as tkFont
+from gui.style_manager import StyleManager
 
 TEXT_BOX_COLOR = "#CFD8DC"
 
@@ -175,7 +176,11 @@ class FTADrawingHelper:
         v1 = (x, y)
         v2 = (x - size, y)
         v3 = (x, y - size)
-        canvas.create_polygon([v1, v2, v3], fill="black", outline="black")
+        canvas.create_polygon(
+            [v1, v2, v3],
+            fill="black",
+            outline=StyleManager.get_instance().outline_color,
+        )
 
     def _segment_intersection(self, p1, p2, p3, p4):
         """Return intersection point (x, y, t) of segments *p1*-*p2* and *p3*-*p4* or None."""
@@ -916,7 +921,7 @@ class GSNDrawingHelper(FTADrawingHelper):
         end_pt,
         *,
         fill="black",
-        outline="black",
+        outline=None,
         obj_id: str = "",
     ) -> None:
         """Draw a triangular arrow head from *start_pt* to *end_pt*."""
@@ -927,6 +932,8 @@ class GSNDrawingHelper(FTADrawingHelper):
         length = math.hypot(dx, dy)
         if length == 0:
             return
+        if outline is None:
+            outline = StyleManager.get_instance().outline_color
         ux, uy = dx / length, dy / length
         arrow_length = 10
         arrow_width = 6
@@ -1024,7 +1031,7 @@ class GSNDrawingHelper(FTADrawingHelper):
             start,
             end,
             fill="black",
-            outline="black",
+            outline=StyleManager.get_instance().outline_color,
             obj_id=obj_id,
         )
 

--- a/gui/style_manager.py
+++ b/gui/style_manager.py
@@ -16,12 +16,14 @@ class StyleManager:
     def __init__(self):
         self.styles = {}
         self.canvas_bg = "#FFFFFF"
+        self.outline_color = "black"
         try:
             self.load_style(_DEFAULT_STYLE)
         except Exception:
             # fallback to hard coded white style
             self.styles = {}
             self.canvas_bg = "#FFFFFF"
+            self.outline_color = "black"
 
     @classmethod
     def get_instance(cls):
@@ -38,9 +40,18 @@ class StyleManager:
         root = tree.getroot()
         self.styles.clear()
         self.canvas_bg = "#FFFFFF"
+        self.outline_color = "black"
         canvas = root.find('canvas')
         if canvas is not None:
             self.canvas_bg = canvas.get('color', "#FFFFFF")
+        # Choose a contrasting outline color based on canvas brightness.
+        try:
+            bg = self.canvas_bg.lstrip('#')
+            r, g, b = int(bg[0:2], 16), int(bg[2:4], 16), int(bg[4:6], 16)
+            brightness = (r * 299 + g * 587 + b * 114) / 1000
+            self.outline_color = "white" if brightness < 128 else "black"
+        except Exception:
+            self.outline_color = "black"
         for obj in root.findall('object'):
             typ = obj.get('type')
             color = obj.get('color')


### PR DESCRIPTION
## Summary
- set `StyleManager` to choose a contrasting outline colour based on canvas brightness
- use the dynamic outline colour across diagram drawing helpers and windows

## Testing
- `pytest` *(fails: tests/test_governance_non_action_objects.py::test_requirements_with_non_action_objects)*

------
https://chatgpt.com/codex/tasks/task_b_689fb03075bc8327a2221f76c9b0b501