### PR TITLE
Switch outlines based on selected theme

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -57,6 +57,7 @@ class GeneratedRequirement:
     obj: str | None = None
     constraint: str | None = None
     origin: str | None = None
+    source: str | None = None
     req_type: str = "organizational"
 
     @property
@@ -87,7 +88,12 @@ class GeneratedRequirement:
         return self.text
 
     def __contains__(self, item: str) -> bool:  # pragma: no cover - trivial
-        return item in self.text or item in self.req_type
+        return (
+            item in self.text
+            or item in self.req_type
+            or (self.origin and item in self.origin)
+            or (self.source and item in self.source)
+        )
 
 
 @dataclass
@@ -300,6 +306,7 @@ class GovernanceDiagram:
                     obj=obj,
                     constraint=constraint,
                     origin=origin if (origin and kind != "flow") else None,
+                    source=src,
                     req_type=req_type,
                 )
             )

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -2,6 +2,7 @@
 import math
 import tkinter as tk
 import tkinter.font as tkFont
+from gui.style_manager import StyleManager
 
 TEXT_BOX_COLOR = "#CFD8DC"
 
@@ -41,6 +42,12 @@ class FTADrawingHelper:
     def clear_cache(self):
         """No-op for API compatibility."""
         pass
+
+    def _resolve_outline(self, color: str | None) -> str:
+        """Return *color* or the style manager's default outline color."""
+        if color is None:
+            return StyleManager.get_instance().get_outline_color()
+        return color
 
     def _interpolate_color(self, color: str, ratio: float) -> str:
         """Return *color* blended with white by *ratio* (0..1)."""
@@ -144,12 +151,13 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Node",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
         """Draw a page connector for a cloned node using GSN's shared-marker notation."""
+        outline_color = self._resolve_outline(outline_color)
         # Draw the base triangle.
         self.draw_triangle_shape(
             canvas,
@@ -253,13 +261,14 @@ class FTADrawingHelper:
                 return best[0], best[1]
         return target_pt
 
-    def draw_90_connection(self, canvas, parent_pt, child_pt, outline_color="dimgray", line_width=1,
+    def draw_90_connection(self, canvas, parent_pt, child_pt, outline_color=None, line_width=1,
                            fixed_length=40, parent_shape=None, child_shape=None):
         """Draw a 90° connection line from a parent point to a child point.
 
         If *parent_shape* or *child_shape* dictionaries are provided, the start
         and end points are adjusted so the connector touches the object's surface.
         """
+        outline_color = self._resolve_outline(outline_color)
         if parent_shape:
             parent_pt = self.point_on_shape(parent_shape, child_pt)
         if child_shape:
@@ -317,12 +326,13 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Event",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
         """Draw a rotated AND gate shape with top and bottom text labels."""
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = tkFont.Font(family="Arial", size=10)
         raw_verts = self.compute_rotated_and_gate_vertices(scale)
@@ -415,12 +425,13 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Event",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
         """Draw a rotated OR gate shape with text labels."""
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = tkFont.Font(family="Arial", size=10)
         def cubic_bezier(P0, P1, P2, P3, t):
@@ -522,12 +533,13 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Node",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
         """Draw a rotated AND gate shape and mark it as a clone using GSN notation."""
+        outline_color = self._resolve_outline(outline_color)
         self.draw_rotated_and_gate_shape(
             canvas,
             x,
@@ -555,12 +567,13 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Node",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
         """Draw a rotated OR gate shape and mark it as a clone using GSN notation."""
+        outline_color = self._resolve_outline(outline_color)
         self.draw_rotated_or_gate_shape(
             canvas,
             x,
@@ -588,11 +601,12 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Event",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = tkFont.Font(family="Arial", size=10)
         effective_scale = scale * 2  
@@ -676,13 +690,14 @@ class FTADrawingHelper:
         top_text="",
         bottom_text="",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         base_event=False,
         obj_id: str = "",
     ):
         """Draw a circular event shape with optional text labels."""
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = self._scaled_font(radius * 2)
         left = x - radius
@@ -769,12 +784,13 @@ class FTADrawingHelper:
         top_text="Desc:\n\nRationale:",
         bottom_text="Node",
         fill="lightgray",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
         """Draw a triangle-shaped event and mark it as a clone using GSN notation."""
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = tkFont.Font(family="Arial", size=10)
         # Draw the base triangle as usual.
@@ -815,11 +831,12 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Goal",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = self._scaled_font(scale)
         padding = 4
@@ -859,11 +876,12 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Module",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = self._scaled_font(scale)
         padding = 4
@@ -957,11 +975,12 @@ class GSNDrawingHelper(FTADrawingHelper):
         canvas,
         parent_pt,
         child_pt,
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         obj_id: str = "",
     ):
         """Draw a curved connector indicating a 'solved by' relationship."""
+        outline_color = self._resolve_outline(outline_color)
         px, py = parent_pt
         cx, cy = child_pt
         if parent_pt == child_pt:
@@ -1023,8 +1042,8 @@ class GSNDrawingHelper(FTADrawingHelper):
             canvas,
             start,
             end,
-            fill="black",
-            outline="black",
+            fill=outline_color,
+            outline=outline_color,
             obj_id=obj_id,
         )
 
@@ -1033,11 +1052,12 @@ class GSNDrawingHelper(FTADrawingHelper):
         canvas,
         parent_pt,
         child_pt,
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         obj_id: str = "",
     ):
         """Draw a dashed curved connector for an 'in context of' relationship."""
+        outline_color = self._resolve_outline(outline_color)
         px, py = parent_pt
         cx, cy = child_pt
         dash = (4, 2)
@@ -1118,11 +1138,12 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Strategy",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = self._scaled_font(scale)
         padding = 4
@@ -1156,11 +1177,12 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=40.0,
         text="Solution",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
+        outline_color = self._resolve_outline(outline_color)
         radius = scale / 2
         if font_obj is None:
             font_obj = self._scaled_font(scale)
@@ -1197,11 +1219,12 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Assumption",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = self._scaled_font(scale)
         padding = 4
@@ -1251,11 +1274,12 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Justification",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = self._scaled_font(scale)
         padding = 4
@@ -1305,11 +1329,12 @@ class GSNDrawingHelper(FTADrawingHelper):
         scale=60.0,
         text="Context",
         fill="lightyellow",
-        outline_color="dimgray",
+        outline_color=None,
         line_width=1,
         font_obj=None,
         obj_id: str = "",
     ):
+        outline_color = self._resolve_outline(outline_color)
         if font_obj is None:
             font_obj = self._scaled_font(scale)
         padding = 4

--- a/gui/style_manager.py
+++ b/gui/style_manager.py
@@ -16,12 +16,17 @@ class StyleManager:
     def __init__(self):
         self.styles = {}
         self.canvas_bg = "#FFFFFF"
+        # Default outline color follows canvas background.  For light
+        # backgrounds we use black outlines, while a dark canvas uses
+        # white outlines for visibility.
+        self.outline_color = "black"
         try:
             self.load_style(_DEFAULT_STYLE)
         except Exception:
             # fallback to hard coded white style
             self.styles = {}
             self.canvas_bg = "#FFFFFF"
+            self.outline_color = "black"
 
     @classmethod
     def get_instance(cls):
@@ -41,6 +46,8 @@ class StyleManager:
         canvas = root.find('canvas')
         if canvas is not None:
             self.canvas_bg = canvas.get('color', "#FFFFFF")
+        # Determine default outline color based on canvas brightness.
+        self.outline_color = "#FFFFFF" if self._is_dark(self.canvas_bg) else "black"
         for obj in root.findall('object'):
             typ = obj.get('type')
             color = obj.get('color')
@@ -60,3 +67,26 @@ class StyleManager:
 
     def get_canvas_color(self) -> str:
         return self.canvas_bg
+
+    def get_outline_color(self) -> str:
+        """Return the default outline color for shapes."""
+        return self.outline_color
+
+    @staticmethod
+    def _is_dark(color: str) -> bool:
+        """Return True if *color* is perceptually dark.
+
+        The check converts the hex color to RGB and computes the luminance
+        using the Rec. 601 luma formula.  Colors with luminance below 128 are
+        treated as dark backgrounds.
+        """
+        if not isinstance(color, str) or not color.startswith("#") or len(color) != 7:
+            return False
+        try:
+            r = int(color[1:3], 16)
+            g = int(color[3:5], 16)
+            b = int(color[5:7], 16)
+        except ValueError:
+            return False
+        luminance = 0.299 * r + 0.587 * g + 0.114 * b
+        return luminance < 128


### PR DESCRIPTION
## Summary
- derive a default outline color from the loaded style and switch to white on dark canvases
- have drawing helpers resolve outline color dynamically via the style manager
- keep original connection sources in governance requirement objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fb03075bc8327a2221f76c9b0b501