### PR TITLE
Prevent duplicate Diagram Rules Editor tabs

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16761,8 +16761,14 @@ class FaultTreeApp:
         tab_exists = (
             hasattr(self, "_diagram_rules_tab") and self._diagram_rules_tab.winfo_exists()
         )
+        editor_exists = (
+            hasattr(self, "diagram_rules_editor")
+            and self.diagram_rules_editor.winfo_exists()
+        )
         if tab_exists:
             self.doc_nb.select(self._diagram_rules_tab)
+            if editor_exists:
+                return
             parent = self._diagram_rules_tab
         else:
             parent = self._diagram_rules_tab = self._new_tab("Diagram Rules")

--- a/tests/test_diagram_rules_toolbox.py
+++ b/tests/test_diagram_rules_toolbox.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub out Pillow dependencies so importing the main app doesn't require Pillow
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace()
+PIL_stub.ImageTk = types.SimpleNamespace()
+PIL_stub.ImageDraw = types.SimpleNamespace()
+PIL_stub.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+sys.modules.setdefault("PIL.Image", PIL_stub.Image)
+sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
+sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
+sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
+
+from AutoML import FaultTreeApp
+
+
+def test_diagram_rules_toolbox_single_instance():
+    """Opening the diagram rules toolbox twice doesn't duplicate the editor."""
+
+    class DummyTab:
+        def winfo_exists(self):
+            return True
+
+    class DummyNotebook:
+        def add(self, tab, text):
+            pass
+
+        def select(self, tab):
+            pass
+
+    class DummyEditor:
+        created = 0
+
+        def __init__(self, master, app, path):
+            DummyEditor.created += 1
+
+        def pack(self, **kwargs):
+            pass
+
+        def winfo_exists(self):
+            return True
+
+    import gui.diagram_rules_toolbox as drt
+
+    drt.DiagramRulesEditor = DummyEditor
+
+    class DummyApp:
+        open_diagram_rules_toolbox = FaultTreeApp.open_diagram_rules_toolbox
+
+        def __init__(self):
+            self.doc_nb = DummyNotebook()
+
+        def _new_tab(self, title):
+            return DummyTab()
+
+    app = DummyApp()
+    app.open_diagram_rules_toolbox()
+    app.open_diagram_rules_toolbox()
+    assert DummyEditor.created == 1


### PR DESCRIPTION
## Summary
- avoid creating multiple DiagramRulesEditor widgets when the tab is already open
- add regression test ensuring only one editor instance is created

## Testing
- `pytest tests/test_diagram_rules_toolbox.py tests/test_diagram_rules_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689fb126b258832792a3a0ed9d8d0963