### PR TITLE
Configure Safety & AI toolbox items from diagram rules

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -156,6 +156,7 @@ class GovernanceDiagram:
         condition: str | None = None,
         label: str | None = None,
         conn_type: str | None = None,
+        from_repo: bool = False,
     ) -> None:
         """Add a non-flow relationship between two existing tasks.
 
@@ -180,6 +181,7 @@ class GovernanceDiagram:
             "condition": condition,
             "label": label,
             "conn_type": conn_type,
+            "from_repo": from_repo,
         }
 
     def tasks(self) -> List[str]:
@@ -280,6 +282,8 @@ class GovernanceDiagram:
                 explicit_subject = rule.get("subject")
                 if explicit_subject:
                     subject = str(explicit_subject)
+                    if origin is None and data.get("from_repo"):
+                        origin = src
                 if rule.get("constraint"):
                     constraint = dst
                     obj = None
@@ -413,10 +417,15 @@ class GovernanceDiagram:
                     continue
                 cond = cond_prop or guard_text
                 if cond is None and name is not None:
-                    diagram.add_relationship(src, dst, condition=name, conn_type=conn_type)
+                    diagram.add_relationship(src, dst, condition=name, conn_type=conn_type, from_repo=True)
                 else:
                     diagram.add_relationship(
-                        src, dst, condition=cond, label=name, conn_type=conn_type
+                        src,
+                        dst,
+                        condition=cond,
+                        label=name,
+                        conn_type=conn_type,
+                        from_repo=True,
                     )
 
         return diagram

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -2,7 +2,7 @@
   /*
     Configuration format overview:
     - "ai_nodes": ["Type", ...] – node types available in the Safety & AI toolbox
-    - "ai_relations": ["Label", ...] – relation labels treated as Safety & AI links
+    - "ai_relations": ["Label", ...] – relation labels available in the Safety & AI toolbox and treated as Safety & AI links
     - "arch_diagram_types": ["Type", ...] – diagram types considered part of the generic "Architecture Diagram" work product
     - "governance_node_types": ["Type", ...] – node types available in the governance toolbox
     - "gate_node_types": ["Type", ...] – FMEDA/Fault tree gate node types

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -60,6 +60,9 @@ ARCH_DIAGRAM_TYPES = set(_CONFIG.get("arch_diagram_types", []))
 # Elements available in the Safety & AI Lifecycle toolbox
 SAFETY_AI_NODE_TYPES = set(_CONFIG.get("ai_nodes", []))
 
+# Relationship labels available in the Safety & AI toolbox
+SAFETY_AI_RELATIONS: list[str] = _CONFIG.get("ai_relations", [])
+
 # Elements from the governance toolbox that may participate in
 # Safety & AI relationships
 GOVERNANCE_NODE_TYPES = set(_CONFIG.get("governance_node_types", []))
@@ -92,10 +95,12 @@ GUARD_NODES = set(_CONFIG.get("guard_nodes", []))
 def reload_config() -> None:
     """Reload diagram rule configuration at runtime."""
     global _CONFIG, ARCH_DIAGRAM_TYPES, SAFETY_AI_NODE_TYPES, GOVERNANCE_NODE_TYPES
-    global SAFETY_AI_RELATION_RULES, CONNECTION_RULES, NODE_CONNECTION_LIMITS, GUARD_NODES
+    global SAFETY_AI_RELATIONS, SAFETY_AI_RELATION_RULES, CONNECTION_RULES
+    global NODE_CONNECTION_LIMITS, GUARD_NODES
     _CONFIG = load_diagram_rules(_CONFIG_PATH)
     ARCH_DIAGRAM_TYPES = set(_CONFIG.get("arch_diagram_types", []))
     SAFETY_AI_NODE_TYPES = set(_CONFIG.get("ai_nodes", []))
+    SAFETY_AI_RELATIONS = _CONFIG.get("ai_relations", [])
     GOVERNANCE_NODE_TYPES = set(_CONFIG.get("governance_node_types", []))
     SAFETY_AI_RELATION_RULES = {
         conn: {src: set(dests) for src, dests in srcs.items()}
@@ -9688,28 +9693,9 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         self.gov_tools_frame = self.tools_frame
         self.gov_rel_frame = getattr(self, "rel_frame", None)
 
-        # Create Safety & AI Lifecycle toolbox frame
-        ai_nodes = [
-            "Database",
-            "ANN",
-            "Data acquisition",
-        ]
-        ai_relations = [
-            "Annotation",
-            "Synthesis",
-            "Augmentation",
-            "Acquisition",
-            "Labeling",
-            "Field risk evaluation",
-            "Field data collection",
-            "AI training",
-            "AI re-training",
-            "Curation",
-            "Ingestion",
-            "Model evaluation",
-            "Tune",
-            "Hyperparameter Validation",
-        ]
+        # Create Safety & AI Lifecycle toolbox frame using configurable rules
+        ai_nodes = sorted(SAFETY_AI_NODE_TYPES)
+        ai_relations = sorted(SAFETY_AI_RELATIONS)
         if hasattr(self.toolbox, "tk"):
             self.ai_tools_frame = ttk.Frame(self.toolbox)
             ttk.Button(


### PR DESCRIPTION
## Summary
- load Safety & AI toolbox nodes and relation labels from diagram_rules.json
- track repository-origin relationships in governance diagrams to preserve decision context

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fb1ad75c483279368739dbcc3e25e