### PR TITLE
feat: expose requirement generation rules

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -20,8 +20,8 @@ _AI_RELATIONS = set(_CONFIG.get("ai_relations", []))
 # constraint instead of an object, and an optional default subject.  The
 # resulting requirement follows the ISO/IEC/IEEE 29148 pattern
 # ``[CND] <SUB> shall <ACT> [OBJ] [CON].``
-_RELATIONSHIP_RULES: dict[str, dict[str, str | bool]] = _CONFIG.get(
-    "relationship_rules", {}
+_REQUIREMENT_RULES: dict[str, dict[str, str | bool]] = _CONFIG.get(
+    "requirement_rules", _CONFIG.get("relationship_rules", {})
 )
 
 # Map node types to default requirement roles so that the generator can
@@ -31,11 +31,13 @@ _NODE_ROLES = _CONFIG.get("node_roles", {})
 
 def reload_config() -> None:
     """Reload governance-related configuration."""
-    global _CONFIG, _AI_NODES, _AI_RELATIONS, _RELATIONSHIP_RULES, _NODE_ROLES
+    global _CONFIG, _AI_NODES, _AI_RELATIONS, _REQUIREMENT_RULES, _NODE_ROLES
     _CONFIG = load_diagram_rules(_CONFIG_PATH)
     _AI_NODES = set(_CONFIG.get("ai_nodes", []))
     _AI_RELATIONS = set(_CONFIG.get("ai_relations", []))
-    _RELATIONSHIP_RULES = _CONFIG.get("relationship_rules", {})
+    _REQUIREMENT_RULES = _CONFIG.get(
+        "requirement_rules", _CONFIG.get("relationship_rules", {})
+    )
     _NODE_ROLES = _CONFIG.get("node_roles", {})
 
 
@@ -285,7 +287,7 @@ class GovernanceDiagram:
                 action = "precede"
             else:
                 key = (label or conn_type or "").lower()
-                rule = _RELATIONSHIP_RULES.get(key, {})
+                rule = _REQUIREMENT_RULES.get(key, {})
                 action = str(rule.get("action", label or "relate to"))
                 explicit_subject = rule.get("subject")
                 if explicit_subject:

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -57,23 +57,25 @@ def validate_diagram_rules(data: Any) -> dict[str, Any]:
         if field in data:
             _ensure_list_of_strings(data[field], field)
 
-    if "relationship_rules" in data:
-        rr = data["relationship_rules"]
+    if "requirement_rules" in data or "relationship_rules" in data:
+        rr = data.get("requirement_rules", data.get("relationship_rules", {}))
         if not isinstance(rr, dict):
-            raise ValueError("relationship_rules must be an object")
+            raise ValueError("requirement_rules must be an object")
         for label, info in rr.items():
             if not isinstance(info, dict):
-                raise ValueError(f"relationship_rules[{label}] must be an object")
+                raise ValueError(f"requirement_rules[{label}] must be an object")
             action = info.get("action")
             if not isinstance(action, str):
-                raise ValueError(f"relationship_rules[{label}]['action'] must be a string")
+                raise ValueError(
+                    f"requirement_rules[{label}]['action'] must be a string"
+                )
             if "subject" in info and not isinstance(info["subject"], str):
                 raise ValueError(
-                    f"relationship_rules[{label}]['subject'] must be a string"
+                    f"requirement_rules[{label}]['subject'] must be a string"
                 )
             if "constraint" in info and not isinstance(info["constraint"], bool):
                 raise ValueError(
-                    f"relationship_rules[{label}]['constraint'] must be a boolean"
+                    f"requirement_rules[{label}]['constraint'] must be a boolean"
                 )
 
     if "node_roles" in data:

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -6,7 +6,7 @@
     - "arch_diagram_types": ["Type", ...] – diagram types considered part of the generic "Architecture Diagram" work product
     - "governance_node_types": ["Type", ...] – node types available in the governance toolbox
     - "gate_node_types": ["Type", ...] – FMEDA/Fault tree gate node types
-    - "relationship_rules": { "label": {"action": "verb", "subject": "default subject", "constraint": true|false } }
+    - "requirement_rules": { "label": {"action": "verb", "subject": "default subject", "constraint": true|false } }
     - "node_roles": { "Node Type": "subject|action|condition|constraint|object" } – default requirement role per node type
     - "safety_ai_relation_rules": { "Relation": { "Source": ["Target", ...] } } – allowed Safety & AI relationships
     - "connection_rules": { "Diagram": { "Connection": { "Source": ["Target", ...] } } } – per-diagram connection validation rules
@@ -69,7 +69,7 @@
 
   // Natural language mapping for relationship labels
   // Format: "label": {"action": "verb", "subject": "default subject", "constraint": true|false }
-  "relationship_rules": {
+  "requirement_rules": {
     "performs": {"action": "perform"},
     "executes": {"action": "execute"},
     "responsible for": {"action": "be responsible for"},

--- a/tests/test_diagram_rules_requirements_section.py
+++ b/tests/test_diagram_rules_requirements_section.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.diagram_rules_toolbox import DiagramRulesEditor
+
+
+def test_requirement_rules_section_loaded():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    root.withdraw()
+    editor = DiagramRulesEditor(root, app=None)
+    roots = set(editor.tree.get_children(""))
+    root.destroy()
+    assert "requirement_rules" in roots
+    assert "node_roles" in roots


### PR DESCRIPTION
## Summary
- add `requirement_rules` section to diagram rules JSON
- load requirement rules in governance and toolbox
- show requirement rules and node roles in diagram rules editor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fb6fac0d883279e16b7a5c395ba39