### PR TITLE
Fix phase requirements menu binding

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -1,6 +1,8 @@
 import tkinter as tk
 from tkinter import ttk, simpledialog
 
+from functools import partial
+
 from analysis import SafetyManagementToolbox
 from analysis.governance import GovernanceDiagram
 from analysis.models import (
@@ -255,9 +257,15 @@ class SafetyManagementWindow(tk.Frame):
         self.phase_menu.delete(0, tk.END)
         phases = sorted(self.toolbox.list_modules())
         for phase in phases:
+            # Use ``functools.partial`` to bind the current ``phase`` to the
+            # callback.  Using ``lambda`` without binding would result in all
+            # menu entries invoking the handler with the last value from the
+            # loop.  ``partial`` creates a function with ``phase`` fixed to the
+            # desired value so selecting a phase generates the correct
+            # requirements.
             self.phase_menu.add_command(
                 label=phase,
-                command=lambda p=phase: self.generate_phase_requirements(p),
+                command=partial(self.generate_phase_requirements, phase),
             )
         if phases:
             self.phase_menu.add_separator()

--- a/tests/test_phase_requirements_menu.py
+++ b/tests/test_phase_requirements_menu.py
@@ -1,0 +1,52 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow
+from analysis.safety_management import SafetyManagementToolbox
+
+
+class DummyMenu:
+    """Minimal stand-in for ``tk.Menu`` used in tests.
+
+    The real Tk menu cannot be created in the test environment because it
+    requires a display.  This dummy object only records commands registered via
+    :meth:`add_command` so we can invoke them directly.
+    """
+
+    def __init__(self):
+        self.commands = []
+
+    def delete(self, _start, _end):  # pragma: no cover - simply satisfies API
+        pass
+
+    def add_command(self, label, command):
+        self.commands.append((label, command))
+
+    def add_separator(self):  # pragma: no cover - not needed for test
+        pass
+
+
+def test_phase_menu_binds_correct_phase():
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_module("Phase1")
+    toolbox.add_module("Phase2")
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.phase_menu = DummyMenu()
+
+    called = []
+    win.generate_phase_requirements = lambda phase: called.append(phase)
+
+    win._refresh_phase_menu()
+
+    # The first entries correspond to the lifecycle phases in alphabetical order
+    for label, cmd in win.phase_menu.commands:
+        if label == "Lifecycle":
+            continue
+        called.clear()
+        cmd()
+        assert called == [label]


### PR DESCRIPTION
## Summary
- bind lifecycle phase names using `functools.partial` so Phase Requirements menu triggers the correct phase
- add regression test ensuring each menu item calls the generator with its own phase

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fb9023258832787a73f6a0683a899