### PR TITLE
Remove dark mode menu options

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2374,10 +2374,6 @@ class FaultTreeApp:
             label="Light Mode",
             command=lambda: self.apply_style('pastel.xml'),
         )
-        view_menu.add_command(
-            label="Dark Mode",
-            command=lambda: self.apply_style('dark.xml'),
-        )
 
         requirements_menu = tk.Menu(menubar, tearoff=0)
         requirements_menu.add_command(label="Requirements Matrix", command=self.show_requirements_matrix)

--- a/gui/faults_gui.py
+++ b/gui/faults_gui.py
@@ -636,11 +636,6 @@ class FaultsWindow(QMainWindow):
         act_light.triggered.connect(lambda: apply_fusion_palette(light=True))
         tb.addAction(act_light)
 
-        act_dark = QAction("Dark Theme", self)
-        act_dark.setToolTip("Switch to a dark Fusion palette.")
-        act_dark.triggered.connect(lambda: apply_fusion_palette(light=False))
-        tb.addAction(act_dark)
-
     def build_help_menu(self):
         menubar = self.menuBar()
         help_menu: QMenu = menubar.addMenu("&Help")


### PR DESCRIPTION
## Summary
- Drop "Dark Mode" entry from the View menu so only Light Mode remains
- Remove unused "Dark Theme" toolbar action in the Faults GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689fbea225cc8327809caafbda236d93