### PR TITLE
Persist phase-specific requirements and fix menu binding

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -243,6 +243,7 @@ from gui.review_toolbox import (
     ReviewDocumentDialog,
     VersionCompareDialog,
 )
+from functools import partial
 from gui.safety_management_toolbox import SafetyManagementToolbox
 from gui.gsn_explorer import GSNExplorer
 from gui.safety_management_explorer import SafetyManagementExplorer
@@ -2380,20 +2381,28 @@ class FaultTreeApp:
         )
 
         requirements_menu = tk.Menu(menubar, tearoff=0)
-        requirements_menu.add_command(label="Requirements Matrix", command=self.show_requirements_matrix)
+        requirements_menu.add_command(
+            label="Requirements Matrix", command=self.show_requirements_matrix
+        )
         requirements_menu.add_command(
             label="Requirements Editor",
             command=self.show_requirements_editor,
             state=tk.DISABLED,
         )
-        req_idx = requirements_menu.index("end")
-        for wp in REQUIREMENT_WORK_PRODUCTS:
-            self.work_product_menus.setdefault(wp, []).append(
-                (requirements_menu, req_idx)
-            )
+        editor_idx = requirements_menu.index("end")
         requirements_menu.add_command(
-            label="Requirements Explorer", command=self.show_requirements_explorer
+            label="Requirements Explorer",
+            command=self.show_requirements_explorer,
+            state=tk.DISABLED,
         )
+        explorer_idx = requirements_menu.index("end")
+        for wp in REQUIREMENT_WORK_PRODUCTS:
+            self.work_product_menus.setdefault(wp, []).extend(
+                [
+                    (requirements_menu, editor_idx),
+                    (requirements_menu, explorer_idx),
+                ]
+            )
         requirements_menu.add_command(
             label="Product Goals Matrix", command=self.show_safety_goals_matrix
         )
@@ -14667,9 +14676,11 @@ class FaultTreeApp:
             return
         phases = sorted(toolbox.list_modules())
         for phase in phases:
+            # Use ``functools.partial`` to bind the phase name at creation time
+            # so each menu entry triggers generation for its own phase.
             self.phase_req_menu.add_command(
                 label=phase,
-                command=lambda p=phase: self.generate_phase_requirements(p),
+                command=partial(self.generate_phase_requirements, phase),
             )
         if phases:
             self.phase_req_menu.add_separator()

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -1,6 +1,8 @@
 import tkinter as tk
 from tkinter import ttk, simpledialog
 
+from functools import partial
+
 from analysis import SafetyManagementToolbox
 from analysis.governance import GovernanceDiagram
 from analysis.models import (
@@ -141,6 +143,11 @@ class SafetyManagementWindow(tk.Frame):
                     pass
 
         self.refresh_diagrams()
+        if app and hasattr(app, "refresh_all"):
+            try:
+                app.refresh_all()
+            except Exception:
+                pass
 
     def new_diagram(self):
         messagebox.showerror(
@@ -184,15 +191,23 @@ class SafetyManagementWindow(tk.Frame):
         self.current_window.pack(fill=tk.BOTH, expand=True)
 
     # ------------------------------------------------------------------
-    def _add_requirement(self, text: str, req_type: str = "organizational") -> str:
-        """Create a new requirement with a unique identifier."""
+    def _add_requirement(
+        self, text: str, req_type: str = "organizational", phase: str | None = None
+    ) -> str:
+        """Create a new requirement with a unique identifier.
+
+        ``phase`` indicates the lifecycle phase the requirement originates from.
+        ``None`` means it is a lifecycle requirement visible in all phases.
+        """
         idx = 1
         while f"R{idx}" in global_requirements:
             idx += 1
         rid = f"R{idx}"
         app = getattr(self, "app", None)
         if app and hasattr(app, "add_new_requirement"):
-            app.add_new_requirement(rid, req_type, text)
+            req = app.add_new_requirement(rid, req_type, text)
+            req["phase"] = phase
+            global_requirements[rid] = req
         else:
             req = {
                 "id": rid,
@@ -201,6 +216,7 @@ class SafetyManagementWindow(tk.Frame):
                 "text": text,
                 "status": "draft",
                 "parent_id": "",
+                "phase": phase,
             }
             ensure_requirement_defaults(req)
             global_requirements[rid] = req
@@ -248,16 +264,42 @@ class SafetyManagementWindow(tk.Frame):
         if not reqs:
             messagebox.showinfo("Requirements", "No requirements were generated.")
             return
-        ids = [self._add_requirement(text, rtype) for text, rtype in reqs]
+        phase = self.toolbox.module_for_diagram(name)
+        ids: list[str] = []
+        for text, rtype in reqs:
+            existing_id = next(
+                (
+                    rid
+                    for rid, req in global_requirements.items()
+                    if req.get("phase") == phase and req.get("text") == text
+                ),
+                None,
+            )
+            if existing_id:
+                global_requirements[existing_id]["req_type"] = rtype
+                ids.append(existing_id)
+            else:
+                ids.append(self._add_requirement(text, rtype, phase=phase))
+        ids = [
+            rid
+            for rid, req in global_requirements.items()
+            if req.get("phase") in (phase, None)
+        ]
         self._display_requirements(f"{name} Requirements", ids)
 
     def _refresh_phase_menu(self) -> None:
         self.phase_menu.delete(0, tk.END)
         phases = sorted(self.toolbox.list_modules())
         for phase in phases:
+            # Use ``functools.partial`` to bind the current ``phase`` to the
+            # callback.  Using ``lambda`` without binding would result in all
+            # menu entries invoking the handler with the last value from the
+            # loop.  ``partial`` creates a function with ``phase`` fixed to the
+            # desired value so selecting a phase generates the correct
+            # requirements.
             self.phase_menu.add_command(
                 label=phase,
-                command=lambda p=phase: self.generate_phase_requirements(p),
+                command=partial(self.generate_phase_requirements, phase),
             )
         if phases:
             self.phase_menu.add_separator()
@@ -310,13 +352,32 @@ class SafetyManagementWindow(tk.Frame):
                 )
                 continue
             for text, rtype in pairs:
-                ids.append(self._add_requirement(text, rtype))
-        if not ids:
+                existing_id = next(
+                    (
+                        rid
+                        for rid, req in global_requirements.items()
+                        if req.get("phase") == phase and req.get("text") == text
+                    ),
+                    None,
+                )
+                if existing_id:
+                    global_requirements[existing_id]["req_type"] = rtype
+                    ids.append(existing_id)
+                else:
+                    ids.append(self._add_requirement(text, rtype, phase=phase))
+        if not ids and not any(
+            req.get("phase") == phase for req in global_requirements.values()
+        ):
             messagebox.showinfo(
                 "Requirements",
                 f"No requirements were generated for phase '{phase}'.",
             )
             return
+        ids = [
+            rid
+            for rid, req in global_requirements.items()
+            if req.get("phase") in (phase, None)
+        ]
         self._display_requirements(f"{phase} Requirements", ids)
 
     def generate_lifecycle_requirements(self) -> None:
@@ -368,13 +429,26 @@ class SafetyManagementWindow(tk.Frame):
                 )
                 continue
             for text, rtype in pairs:
-                ids.append(self._add_requirement(text, rtype))
-        if not ids:
+                existing_id = next(
+                    (
+                        rid
+                        for rid, req in global_requirements.items()
+                        if req.get("phase") is None and req.get("text") == text
+                    ),
+                    None,
+                )
+                if existing_id:
+                    global_requirements[existing_id]["req_type"] = rtype
+                    ids.append(existing_id)
+                else:
+                    ids.append(self._add_requirement(text, rtype))
+        if not ids and not any(req.get("phase") is None for req in global_requirements.values()):
             messagebox.showinfo(
                 "Requirements",
                 "No requirements were generated for lifecycle diagrams.",
             )
             return
+        ids = [rid for rid, req in global_requirements.items() if req.get("phase") is None]
         self._display_requirements("Lifecycle Requirements", ids)
 
     @staticmethod

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -4102,7 +4102,13 @@ class RequirementsExplorerWindow(tk.Frame):
         rtype = self.type_var.get().strip()
         asil = self.asil_var.get().strip()
         status = self.status_var.get().strip()
+        phase = None
+        if self.app and getattr(self.app, "safety_mgmt_toolbox", None):
+            phase = getattr(self.app.safety_mgmt_toolbox, "active_module", None)
         for rid, req in global_requirements.items():
+            req_phase = req.get("phase")
+            if phase and req_phase not in (phase, None):
+                continue
             if query and query not in req.get("id", "").lower() and query not in req.get("text", "").lower():
                 continue
             if rtype and req.get("req_type") != rtype:

--- a/tests/test_phase_requirement_updates.py
+++ b/tests/test_phase_requirement_updates.py
@@ -1,0 +1,87 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow
+from gui import safety_management_toolbox as smt
+from analysis.models import global_requirements
+
+
+class DummyGov:
+    def __init__(self, reqs):
+        self._reqs = reqs
+
+    def generate_requirements(self):
+        return self._reqs
+
+
+def _setup_window(monkeypatch):
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    toolbox = types.SimpleNamespace(
+        diagrams={"D": "id1", "L": "id2"},
+        diagrams_for_module=lambda phase: {"D"} if phase == "Phase1" else set(),
+        list_modules=lambda: ["Phase1"],
+        module_for_diagram=lambda name: "Phase1" if name == "D" else None,
+        list_diagrams=lambda: {"D", "L"},
+    )
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace()
+    win._display_requirements = lambda *args, **kwargs: None
+    monkeypatch.setattr(smt.SysMLRepository, "get_instance", lambda: object())
+    return win
+
+
+def test_phase_requirement_updates_existing(monkeypatch):
+    win = _setup_window(monkeypatch)
+
+    # First generation with organizational type
+    monkeypatch.setattr(
+        smt.GovernanceDiagram,
+        "from_repository",
+        lambda repo, diag_id: DummyGov([("Req", "organizational")]),
+    )
+    global_requirements.clear()
+    win.generate_phase_requirements("Phase1")
+    rid = next(iter(global_requirements))
+    assert global_requirements[rid]["phase"] == "Phase1"
+    assert global_requirements[rid]["req_type"] == "organizational"
+
+    # Regenerate with a different type; same id should be reused
+    monkeypatch.setattr(
+        smt.GovernanceDiagram,
+        "from_repository",
+        lambda repo, diag_id: DummyGov([("Req", "product")]),
+    )
+    win.generate_phase_requirements("Phase1")
+    assert list(global_requirements.keys()) == [rid]
+    assert global_requirements[rid]["req_type"] == "product"
+
+
+def test_lifecycle_requirements_visible_in_phases(monkeypatch):
+    win = _setup_window(monkeypatch)
+
+    req_map = {
+        "id1": [("Phase req", "organizational")],
+        "id2": [("Life req", "organizational")],
+    }
+
+    def from_repo(_repo, diag_id):
+        return DummyGov(req_map[diag_id])
+
+    monkeypatch.setattr(smt.GovernanceDiagram, "from_repository", from_repo)
+
+    captured = {}
+    win._display_requirements = lambda title, ids: captured.setdefault(title, ids)
+
+    global_requirements.clear()
+    # Generate lifecycle requirement
+    win.generate_lifecycle_requirements()
+    life_rid = next(iter(global_requirements))
+    assert global_requirements[life_rid]["phase"] is None
+
+    # Generate phase requirements; lifecycle requirement should be included
+    win.generate_phase_requirements("Phase1")
+    ids = captured.get("Phase1 Requirements", [])
+    assert life_rid in ids

--- a/tests/test_phase_requirements_menu.py
+++ b/tests/test_phase_requirements_menu.py
@@ -1,0 +1,52 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow
+from analysis.safety_management import SafetyManagementToolbox
+
+
+class DummyMenu:
+    """Minimal stand-in for ``tk.Menu`` used in tests.
+
+    The real Tk menu cannot be created in the test environment because it
+    requires a display.  This dummy object only records commands registered via
+    :meth:`add_command` so we can invoke them directly.
+    """
+
+    def __init__(self):
+        self.commands = []
+
+    def delete(self, _start, _end):  # pragma: no cover - simply satisfies API
+        pass
+
+    def add_command(self, label, command):
+        self.commands.append((label, command))
+
+    def add_separator(self):  # pragma: no cover - not needed for test
+        pass
+
+
+def test_phase_menu_binds_correct_phase():
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_module("Phase1")
+    toolbox.add_module("Phase2")
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.phase_menu = DummyMenu()
+
+    called = []
+    win.generate_phase_requirements = lambda phase: called.append(phase)
+
+    win._refresh_phase_menu()
+
+    # The first entries correspond to the lifecycle phases in alphabetical order
+    for label, cmd in win.phase_menu.commands:
+        if label == "Lifecycle":
+            continue
+        called.clear()
+        cmd()
+        assert called == [label]

--- a/tests/test_requirements_explorer_enablement.py
+++ b/tests/test_requirements_explorer_enablement.py
@@ -1,0 +1,43 @@
+import sys
+import types
+from pathlib import Path
+
+import tkinter as tk
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from AutoML import FaultTreeApp
+
+
+class DummyMenu:
+    def __init__(self):
+        self.states = {}
+
+    def entryconfig(self, idx, state=tk.DISABLED):
+        self.states[idx] = state
+
+
+def test_explorer_menu_enabled_with_work_product():
+    menu = DummyMenu()
+    app = types.SimpleNamespace(
+        WORK_PRODUCT_INFO={
+            "Requirement Specification": (
+                "Area",
+                "Tool",
+                "show_requirements_editor",
+            )
+        },
+        enable_process_area=lambda area: None,
+        tool_actions={},
+        tool_listboxes={},
+        work_product_menus={"Requirement Specification": [(menu, 0), (menu, 1)]},
+        enabled_work_products=set(),
+        WORK_PRODUCT_PARENTS={},
+        tool_to_work_product={},
+        update_views=lambda: None,
+    )
+
+    FaultTreeApp.enable_work_product(app, "Requirement Specification", refresh=False)
+
+    assert menu.states[1] == tk.NORMAL
+

--- a/tests/test_requirements_explorer_phase_filter.py
+++ b/tests/test_requirements_explorer_phase_filter.py
@@ -1,0 +1,68 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.toolboxes import RequirementsExplorerWindow
+from analysis.models import global_requirements
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class DummyTree:
+    def __init__(self):
+        self.data = []
+
+    def delete(self, *items):
+        self.data = []
+
+    def get_children(self):  # pragma: no cover - structure only
+        return list(range(len(self.data)))
+
+    def insert(self, _parent, _index, values=()):
+        self.data.append(values)
+
+
+def _make_window(active_phase):
+    app = types.SimpleNamespace(
+        safety_mgmt_toolbox=types.SimpleNamespace(active_module=active_phase)
+    )
+    win = RequirementsExplorerWindow.__new__(RequirementsExplorerWindow)
+    win.app = app
+    win.tree = DummyTree()
+    win.query_var = DummyVar()
+    win.type_var = DummyVar()
+    win.asil_var = DummyVar()
+    win.status_var = DummyVar()
+    return win
+
+
+def test_explorer_filters_by_active_phase():
+    global_requirements.clear()
+    global_requirements.update(
+        {
+            "R1": {"text": "Req1", "req_type": "organizational", "phase": "P1"},
+            "R2": {"text": "Req2", "req_type": "organizational", "phase": None},
+            "R3": {"text": "Req3", "req_type": "organizational", "phase": "P2"},
+        }
+    )
+
+    win = _make_window("P1")
+    win.refresh()
+    assert [v[0] for v in win.tree.data] == ["R1", "R2"]
+
+    win.app.safety_mgmt_toolbox.active_module = "P2"
+    win.refresh()
+    assert [v[0] for v in win.tree.data] == ["R2", "R3"]
+
+    win.app.safety_mgmt_toolbox.active_module = None
+    win.refresh()
+    assert [v[0] for v in win.tree.data] == ["R1", "R2", "R3"]
+


### PR DESCRIPTION
## Summary
- filter Requirements Explorer to show lifecycle requirements plus those for the active phase
- refresh open windows on phase change and enable Requirements Explorer only after a requirements work product is declared
- add regression tests for phase filtering and menu enablement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fb9023258832787a73f6a0683a899