### PR TITLE
Auto-size Data acquisition compartments

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4081,6 +4081,8 @@ class SysMLDiagramWindow(tk.Frame):
                 min_w, min_h = self._min_block_size(obj)
             elif obj.obj_type in ("Action", "CallBehaviorAction"):
                 min_w, min_h = self._min_action_size(obj)
+            elif obj.obj_type == "Data acquisition":
+                min_w, min_h = self._min_data_acquisition_size(obj)
             elif obj.obj_type == "Block Boundary":
                 min_w, min_h = _boundary_min_size(obj, self.objects)
             left = obj.x - obj.width / 2
@@ -5408,6 +5410,17 @@ class SysMLDiagramWindow(tk.Frame):
         padding = 6 * self.zoom
         return (text_width + padding) / self.zoom, (text_height + padding) / self.zoom
 
+    def _min_data_acquisition_size(self, obj: SysMLObject) -> tuple[float, float]:
+        """Return minimum width and height to display Data acquisition compartments."""
+        compartments = obj.properties.get("compartments", ";;").split(";")
+        lines = [line for comp in compartments for line in comp.splitlines()]
+        if not lines:
+            lines = [""]
+        text_width = max(self.font.measure(line) for line in lines)
+        padding = 8 * self.zoom
+        text_height = self.font.metrics("linespace") * max(len(compartments), 1)
+        return (text_width + padding) / self.zoom, (text_height + padding) / self.zoom
+
     def _wrap_text_to_width(self, text: str, width_px: float) -> list[str]:
         """Return *text* wrapped to fit within *width_px* pixels."""
         if self.font.measure(text) <= width_px:
@@ -5604,6 +5617,11 @@ class SysMLDiagramWindow(tk.Frame):
         if obj.obj_type == "Block":
             b_w, b_h = self._min_block_size(obj)
             min_w, min_h = b_w, b_h
+        elif obj.obj_type == "Data acquisition":
+            min_w, min_h = self._min_data_acquisition_size(obj)
+            obj.width = min_w
+            obj.height = min_h
+            return
         else:
             label_lines = self._object_label_lines(obj)
             if not label_lines:

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -19,6 +19,7 @@ class DummyWindow:
     _object_label_lines = SysMLDiagramWindow._object_label_lines
     _min_block_size = SysMLDiagramWindow._min_block_size
     _min_action_size = SysMLDiagramWindow._min_action_size
+    _min_data_acquisition_size = SysMLDiagramWindow._min_data_acquisition_size
     _wrap_text_to_width = SysMLDiagramWindow._wrap_text_to_width
 
 class EnsureTextFitsTests(unittest.TestCase):
@@ -99,6 +100,22 @@ class EnsureTextFitsTests(unittest.TestCase):
             win.ensure_text_fits(obj)
             self.assertEqual(obj.width, 40)
             self.assertEqual(obj.height, 40)
+
+    def test_data_acquisition_sizes_to_text(self):
+        win = DummyWindow()
+        obj = SysMLObject(
+            1,
+            "Data acquisition",
+            0,
+            0,
+            width=120,
+            height=80,
+            properties={"compartments": "abc;de"},
+        )
+        obj.requirements = []
+        win.ensure_text_fits(obj)
+        self.assertEqual(obj.width, len("abc") + 8)
+        self.assertEqual(obj.height, 2 + 8)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- scale Data acquisition nodes to the minimal width and height required by their compartment text
- ensure manual resizing respects compartment content
- cover Data acquisition sizing with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689fc23078a08327a359850d07147304