### PR TITLE
feat: include data acquisition compartments in requirements

### DIFF
--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -69,3 +69,22 @@ def test_ai_training_and_curation_requirements():
     assert curate_req.subject == "Engineering team"
     assert curate_req.obj == "Database1"
     assert curate_req.condition == "completion < 0.98"
+
+
+def test_data_acquisition_compartment_sources():
+    diagram = GovernanceDiagram()
+    diagram.add_task(
+        "Acquire Data",
+        node_type="Data acquisition",
+        compartments=["Sensor A", "Sensor B"],
+    )
+
+    reqs = diagram.generate_requirements()
+    texts = [r.text for r in reqs]
+
+    assert "Acquire Data shall obtain data from 'Sensor A'." in texts
+    assert "Acquire Data shall obtain data from 'Sensor B'." in texts
+
+    data_reqs = [r for r in reqs if r.action == "obtain data from"]
+    assert all(r.req_type == "AI safety" for r in data_reqs)
+    assert {r.obj for r in data_reqs} == {"Sensor A", "Sensor B"}


### PR DESCRIPTION
## Summary
- track data source compartments for Data acquisition nodes
- generate AI safety requirements for each compartment as a data source
- test requirement generation for Data acquisition compartments

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689fc2aa6f9c8327a9c738f00da74072