### PR TITLE
Add requirement rules for diagram connectors

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -105,7 +105,26 @@
     "hyperparameter validation": {
       "action": "validate hyperparameters",
       "subject": "Engineering team"
-    }
+    },
+    "association": {"action": "associate with"},
+    "communication path": {"action": "communicate with"},
+    "include": {"action": "include"},
+    "extend": {"action": "extend"},
+    "generalize": {"action": "generalize"},
+    "generalization": {"action": "generalize"},
+    "aggregation": {"action": "aggregate"},
+    "composite aggregation": {"action": "compose"},
+    "connector": {"action": "connect to"},
+    "propagate": {"action": "propagate"},
+    "propagate by review": {"action": "propagate by review"},
+    "propagate by approval": {"action": "propagate by approval"},
+    "re-use": {"action": "re-use"},
+    "satisfied by": {"action": "be satisfied by"},
+    "derived from": {"action": "be derived from"},
+    "trace": {"action": "trace to"},
+    "used by": {"action": "be used by"},
+    "used after review": {"action": "be used after review"},
+    "used after approval": {"action": "be used after approval"}
   },
 
   // Default requirement role per node type

--- a/tests/test_diagram_rules_requirement_mappings.py
+++ b/tests/test_diagram_rules_requirement_mappings.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from config import load_diagram_rules
+
+
+def test_all_connectors_have_requirement_rules():
+    cfg = load_diagram_rules(Path(__file__).resolve().parents[1] / "config/diagram_rules.json")
+    connectors = set()
+    for conns in cfg.get("connection_rules", {}).values():
+        for conn in conns:
+            if conn.lower() == "flow":
+                continue
+            connectors.add(conn.lower())
+    rules = set(cfg.get("requirement_rules", {}).keys())
+    missing = connectors - rules
+    assert not missing, f"Missing requirement rules for: {sorted(missing)}"


### PR DESCRIPTION
## Summary
- map remaining diagram connectors to natural-language actions in `diagram_rules.json`
- ensure every connector type has a requirement rule
- add test verifying requirement rule coverage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689fc3d84398832793a34a064cdf3529