### PR TITLE
Reverse data acquisition relation direction

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -158,9 +158,9 @@
   // Allowed Safety & AI relationships between node types
   // Format: "Relation": {"Source": ["Allowed Target", ...] }
   "safety_ai_relation_rules": {
-    "Acquisition": {"Data acquisition": ["Database"]},
-    "Field data collection": {"Data acquisition": ["Database"]},
-    "Field risk evaluation": {"Data acquisition": ["Database"]},
+    "Acquisition": {"Database": ["Data acquisition"]},
+    "Field data collection": {"Database": ["Data acquisition"]},
+    "Field risk evaluation": {"Database": ["Data acquisition"]},
     "Annotation": {"ANN": ["Database"]},
     "Synthesis": {"ANN": ["Database"]},
     "Augmentation": {"ANN": ["Database"]},

--- a/tests/test_relation_direction.py
+++ b/tests/test_relation_direction.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from config import load_diagram_rules
+
+def _safety_ai_rules():
+    cfg_path = Path(__file__).resolve().parents[1] / 'config' / 'diagram_rules.json'
+    cfg = load_diagram_rules(cfg_path)
+    return cfg.get('safety_ai_relation_rules', {})
+
+def test_data_acquisition_relation_direction():
+    rules = _safety_ai_rules()
+    expected = {"Database": ["Data acquisition"]}
+    for rel in ("Acquisition", "Field data collection", "Field risk evaluation"):
+        assert rules.get(rel) == expected


### PR DESCRIPTION
## Summary
- reverse allowed Data acquisition relationships so Database nodes link to Data acquisition
- add regression test covering revised relationship direction

## Testing
- `pytest tests/test_relation_direction.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fc64d5644832798fd64fa256fcba9