### PR TITLE
Fix duplicate content in Safety Management tabs

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16767,8 +16767,14 @@ class FaultTreeApp:
         tab_exists = (
             hasattr(self, "_safety_mgmt_tab") and self._safety_mgmt_tab.winfo_exists()
         )
+        window_exists = (
+            hasattr(self, "safety_mgmt_window")
+            and getattr(self.safety_mgmt_window, "winfo_exists", lambda: False)()
+        )
         if tab_exists:
             self.doc_nb.select(self._safety_mgmt_tab)
+            if window_exists:
+                return
             parent = self._safety_mgmt_tab
         else:
             parent = self._safety_mgmt_tab = self._new_tab(

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -225,6 +225,8 @@ class SafetyManagementWindow(tk.Frame):
     # ------------------------------------------------------------------
     def _display_requirements(self, title: str, ids: list[str]) -> None:
         frame = self.app._new_tab(title)
+        for child in frame.winfo_children():
+            child.destroy()
         columns = ("ID", "Type", "Text")
         tree = ttk.Treeview(frame, columns=columns, show="headings")
         for c in columns:

--- a/tests/test_governance_ai_requirement_type.py
+++ b/tests/test_governance_ai_requirement_type.py
@@ -27,7 +27,8 @@ def test_ai_elements_generate_ai_safety_requirements(monkeypatch):
     toolbox.diagrams["AI Gov"] = diag.diag_id
 
     class DummyTab:
-        pass
+        def winfo_children(self):
+            return []
 
     tabs = []
 

--- a/tests/test_governance_lifecycle_requirements_menu.py
+++ b/tests/test_governance_lifecycle_requirements_menu.py
@@ -42,7 +42,8 @@ def test_lifecycle_requirements_menu(monkeypatch):
     monkeypatch.setattr(toolbox, "list_diagrams", lambda: list(toolbox.diagrams.keys()))
 
     class DummyTab:
-        pass
+        def winfo_children(self):
+            return []
 
     tabs = []
 

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -41,7 +41,8 @@ def test_phase_requirements_menu(monkeypatch):
     mod.diagrams.extend(["Gov1", "Gov2"])
 
     class DummyTab:
-        pass
+        def winfo_children(self):
+            return []
 
     tabs = []
 

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -27,7 +27,8 @@ def test_requirements_button_opens_tab(monkeypatch):
     toolbox.diagrams["Gov"] = diag.diag_id
 
     class DummyTab:
-        pass
+        def winfo_children(self):
+            return []
 
     tabs: list[tuple[str, DummyTab]] = []
 

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -263,7 +263,7 @@ def test_disable_work_product_rejects_existing_docs():
     assert menu.state == tk.DISABLED
 
 
-def test_open_safety_management_toolbox_uses_browser():
+def test_open_safety_management_toolbox_uses_browser(monkeypatch):
     """FaultTreeApp opens the Safety & Security Management window and toolbox."""
     SysMLRepository._instance = None
 
@@ -287,7 +287,7 @@ def test_open_safety_management_toolbox_uses_browser():
             assert toolbox is app.safety_mgmt_toolbox
 
     import gui.safety_management_toolbox as smt
-    smt.SafetyManagementWindow = DummySMW
+    monkeypatch.setattr(smt, "SafetyManagementWindow", DummySMW)
 
     class DummyApp:
         open_safety_management_toolbox = FaultTreeApp.open_safety_management_toolbox

--- a/tests/test_safety_management_dedup.py
+++ b/tests/test_safety_management_dedup.py
@@ -1,0 +1,125 @@
+import sys
+from pathlib import Path
+import types
+
+# Ensure repository root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub out Pillow dependencies so importing the main app doesn't require Pillow
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace()
+PIL_stub.ImageTk = types.SimpleNamespace()
+PIL_stub.ImageDraw = types.SimpleNamespace()
+PIL_stub.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+sys.modules.setdefault("PIL.Image", PIL_stub.Image)
+sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
+sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
+sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
+
+from AutoML import FaultTreeApp
+
+
+def test_safety_management_toolbox_single_instance(monkeypatch):
+    """Opening the Safety & Security Management toolbox twice doesn't duplicate it."""
+
+    class DummyTab:
+        def winfo_exists(self):
+            return True
+
+    class DummyNotebook:
+        def add(self, tab, text):
+            pass
+
+        def select(self, tab):
+            pass
+
+    class DummyWindow:
+        created = 0
+
+        def __init__(self, master, app, toolbox, show_diagrams=True):
+            DummyWindow.created += 1
+
+        def pack(self, **kwargs):
+            pass
+
+        def winfo_exists(self):
+            return True
+
+    import gui.safety_management_toolbox as smt
+    import analysis
+
+    monkeypatch.setattr(smt, "SafetyManagementWindow", DummyWindow)
+
+    class DummyToolbox:
+        pass
+
+    monkeypatch.setattr(analysis, "SafetyManagementToolbox", DummyToolbox)
+
+    class DummyApp:
+        open_safety_management_toolbox = FaultTreeApp.open_safety_management_toolbox
+
+        def __init__(self):
+            self.doc_nb = DummyNotebook()
+
+        def _new_tab(self, title):
+            return DummyTab()
+
+    app = DummyApp()
+    app.open_safety_management_toolbox()
+    app.open_safety_management_toolbox()
+    assert DummyWindow.created == 1
+
+
+def test_display_requirements_clears_existing(monkeypatch):
+    """_display_requirements replaces prior content in the tab."""
+
+    import gui.safety_management_toolbox as smt
+    from analysis.models import global_requirements
+
+    class DummyTab:
+        def __init__(self):
+            self.children = []
+
+        def winfo_children(self):
+            return list(self.children)
+
+    tab = DummyTab()
+
+    class DummyApp:
+        def _new_tab(self, title):
+            return tab
+
+    class DummyTree:
+        def __init__(self, master, columns, show="headings"):
+            self.master = master
+            master.children.append(self)
+            self.rows = []
+
+        def heading(self, col, text=""):
+            pass
+
+        def insert(self, parent, idx, values):
+            self.rows.append(values)
+
+        def pack(self, **kwargs):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
+    monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
+
+    win = smt.SafetyManagementWindow.__new__(smt.SafetyManagementWindow)
+    win.app = DummyApp()
+
+    global_requirements.clear()
+    global_requirements.update({"R1": {"req_type": "", "text": ""}, "R2": {"req_type": "", "text": ""}})
+
+    win._display_requirements("Phase1 Requirements", ["R1"])
+    assert len(tab.children) == 1
+    first = tab.children[0]
+
+    win._display_requirements("Phase1 Requirements", ["R2"])
+    assert len(tab.children) == 1
+    assert tab.children[0] is not first


### PR DESCRIPTION
## Summary
- prevent reopening Safety & Security Management tab from duplicating its window
- clear prior widgets when reusing Phase and Lifecycle requirements tabs
- add regression tests for toolbox and requirement tab deduplication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fc69b6ef08327a6c9b48db92dc077