### PR TITLE
Record lifecycle phase for requirements

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -1392,6 +1392,10 @@ class EditNodeDialog(simpledialog.Dialog):
    
     def add_new_requirement(self,custom_id, req_type, text, asil="QM", cal=CAL_LEVEL_OPTIONS[0]):
         # When a requirement is created, register it in the global registry.
+        phase = None
+        toolbox = getattr(getattr(self, "app", None), "safety_mgmt_toolbox", None)
+        if toolbox is not None:
+            phase = getattr(toolbox, "active_module", None)
         req = {
             "id": custom_id,
             "req_type": req_type,
@@ -1399,6 +1403,7 @@ class EditNodeDialog(simpledialog.Dialog):
             "custom_id": custom_id,
             "status": "draft",
             "parent_id": "",
+            "phase": phase,
         }
         ensure_requirement_defaults(req)
         if req_type not in (

--- a/analysis/models.py
+++ b/analysis/models.py
@@ -577,10 +577,14 @@ def ensure_requirement_defaults(req: dict) -> dict:
     Each requirement now carries a ``traces`` list capturing diagram or
     element identifiers that reference the requirement.  When older
     models are loaded the field may be missing; this helper guarantees the
-    key exists so callers can rely on it.
+    key exists so callers can rely on it.  Requirements may also be
+    associated with a lifecycle ``phase``.  Older models without this
+    information should default to ``None`` so they remain visible
+    globally.
     """
 
     req.setdefault("traces", [])
+    req.setdefault("phase", None)
     return req
 
 # Requirement type options used throughout the GUI when creating or

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -216,6 +216,11 @@ class _RequirementDialog(simpledialog.Dialog):
         self.req_type = req_type
         self.type_options = type_options or REQUIREMENT_TYPE_OPTIONS
         self.req = req or {}
+        app = getattr(parent, "app", None)
+        if app and hasattr(app, "safety_mgmt_toolbox"):
+            self.phase = getattr(app.safety_mgmt_toolbox, "active_module", None)
+        else:
+            self.phase = None
         super().__init__(parent, title="Requirement")
 
     def body(self, master):
@@ -293,6 +298,7 @@ class _RequirementDialog(simpledialog.Dialog):
             "status": self.status_var.get().strip(),
             "parent_id": self.parent_var.get().strip(),
         }
+        self.result["phase"] = self.req.get("phase", self.phase)
         if req_type not in (
             "operational",
             "functional modification",

--- a/tests/test_requirement_phase_registration.py
+++ b/tests/test_requirement_phase_registration.py
@@ -1,0 +1,32 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("ImageTk"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("ImageFont"))
+
+from AutoML import EditNodeDialog
+from analysis.models import global_requirements
+
+
+def test_add_new_requirement_records_phase():
+    dlg = EditNodeDialog.__new__(EditNodeDialog)
+    dlg.app = types.SimpleNamespace(
+        safety_mgmt_toolbox=types.SimpleNamespace(active_module="Phase1")
+    )
+    global_requirements.clear()
+
+    req = dlg.add_new_requirement("R1", "vehicle", "Req1")
+    assert req["phase"] == "Phase1"
+    assert global_requirements["R1"]["phase"] == "Phase1"
+
+    dlg.app.safety_mgmt_toolbox.active_module = None
+    req2 = dlg.add_new_requirement("R2", "vehicle", "Req2")
+    assert req2["phase"] is None
+    assert global_requirements["R2"]["phase"] is None


### PR DESCRIPTION
## Summary
- Ensure requirements default to a lifecycle phase, tracking phase for new ones
- Preserve phase info when creating/editing requirements through dialogs
- Test that manual requirement creation registers the active phase

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689fca8c3fbc8327861c14e5a8175b60