### PR TITLE
Expand Data acquisition nodes to fit compartment text

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5422,7 +5422,8 @@ class SysMLDiagramWindow(tk.Frame):
             lines = [""]
         text_width = max(self.font.measure(line) for line in lines)
         padding = 8 * self.zoom
-        text_height = self.font.metrics("linespace") * max(len(compartments), 1)
+        total_lines = sum(max(len(comp.splitlines()), 1) for comp in compartments)
+        text_height = self.font.metrics("linespace") * max(total_lines, 1)
         return (text_width + padding) / self.zoom, (text_height + padding) / self.zoom
 
     def _wrap_text_to_width(self, text: str, width_px: float) -> list[str]:
@@ -5623,8 +5624,8 @@ class SysMLDiagramWindow(tk.Frame):
             min_w, min_h = b_w, b_h
         elif obj.obj_type == "Data acquisition":
             min_w, min_h = self._min_data_acquisition_size(obj)
-            obj.width = min_w
-            obj.height = min_h
+            obj.width = max(obj.width, min_w)
+            obj.height = max(obj.height, min_h)
             return
         else:
             label_lines = self._object_label_lines(obj)

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -101,7 +101,7 @@ class EnsureTextFitsTests(unittest.TestCase):
             self.assertEqual(obj.width, 40)
             self.assertEqual(obj.height, 40)
 
-    def test_data_acquisition_sizes_to_text(self):
+    def test_data_acquisition_default_and_resize(self):
         win = DummyWindow()
         obj = SysMLObject(
             1,
@@ -110,12 +110,18 @@ class EnsureTextFitsTests(unittest.TestCase):
             0,
             width=120,
             height=80,
-            properties={"compartments": "abc;de"},
+            properties={"compartments": ""},
         )
         obj.requirements = []
         win.ensure_text_fits(obj)
-        self.assertEqual(obj.width, len("abc") + 8)
-        self.assertEqual(obj.height, 2 + 8)
+        self.assertEqual(obj.width, 120)
+        self.assertEqual(obj.height, 80)
+        obj.properties["compartments"] = "a" * 200 + ";de"
+        win.ensure_text_fits(obj)
+        self.assertGreater(obj.width, 120)
+        obj.properties["compartments"] = ";".join(f"line{i}" for i in range(100))
+        win.ensure_text_fits(obj)
+        self.assertGreater(obj.height, 80)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- prevent Data acquisition nodes from shrinking below default size
- compute height using total lines and expand to fit compartment text
- add tests covering default size retention and dynamic resizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fcc4ab09c832785abbc47a1b38430