### PR TITLE
fix: show only phase-specific requirements in explorer

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -294,7 +294,7 @@ class SafetyManagementWindow(tk.Frame):
         ids = [
             rid
             for rid, req in global_requirements.items()
-            if req.get("phase") in (phase, None)
+            if req.get("phase") == phase
         ]
         self._display_requirements(f"{name} Requirements", ids)
 
@@ -387,7 +387,7 @@ class SafetyManagementWindow(tk.Frame):
         ids = [
             rid
             for rid, req in global_requirements.items()
-            if req.get("phase") in (phase, None)
+            if req.get("phase") == phase
         ]
         self._display_requirements(f"{phase} Requirements", ids)
 

--- a/tests/test_phase_requirement_updates.py
+++ b/tests/test_phase_requirement_updates.py
@@ -81,7 +81,7 @@ def test_lifecycle_requirements_visible_in_phases(monkeypatch):
     life_rid = next(iter(global_requirements))
     assert global_requirements[life_rid]["phase"] is None
 
-    # Generate phase requirements; lifecycle requirement should be included
+    # Generate phase requirements; lifecycle requirement should not be included
     win.generate_phase_requirements("Phase1")
     ids = captured.get("Phase1 Requirements", [])
-    assert life_rid in ids
+    assert life_rid not in ids


### PR DESCRIPTION
## Summary
- ensure phase requirement displays exclude lifecycle items
- update tests to reflect phase-specific requirement filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fce40f16083278a6397a8cf530bd8