### PR TITLE
fix: filter explorer requirements by active phase

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -294,7 +294,7 @@ class SafetyManagementWindow(tk.Frame):
         ids = [
             rid
             for rid, req in global_requirements.items()
-            if req.get("phase") in (phase, None)
+            if req.get("phase") == phase
         ]
         self._display_requirements(f"{name} Requirements", ids)
 
@@ -387,7 +387,7 @@ class SafetyManagementWindow(tk.Frame):
         ids = [
             rid
             for rid, req in global_requirements.items()
-            if req.get("phase") in (phase, None)
+            if req.get("phase") == phase
         ]
         self._display_requirements(f"{phase} Requirements", ids)
 

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -4113,7 +4113,7 @@ class RequirementsExplorerWindow(tk.Frame):
             phase = getattr(self.app.safety_mgmt_toolbox, "active_module", None)
         for rid, req in global_requirements.items():
             req_phase = req.get("phase")
-            if phase and req_phase not in (phase, None):
+            if phase and req_phase != phase:
                 continue
             if query and query not in req.get("id", "").lower() and query not in req.get("text", "").lower():
                 continue

--- a/tests/test_phase_requirement_updates.py
+++ b/tests/test_phase_requirement_updates.py
@@ -81,7 +81,7 @@ def test_lifecycle_requirements_visible_in_phases(monkeypatch):
     life_rid = next(iter(global_requirements))
     assert global_requirements[life_rid]["phase"] is None
 
-    # Generate phase requirements; lifecycle requirement should be included
+    # Generate phase requirements; lifecycle requirement should not be included
     win.generate_phase_requirements("Phase1")
     ids = captured.get("Phase1 Requirements", [])
-    assert life_rid in ids
+    assert life_rid not in ids

--- a/tests/test_requirements_explorer_phase_filter.py
+++ b/tests/test_requirements_explorer_phase_filter.py
@@ -56,11 +56,11 @@ def test_explorer_filters_by_active_phase():
 
     win = _make_window("P1")
     win.refresh()
-    assert [v[0] for v in win.tree.data] == ["R1", "R2"]
+    assert [v[0] for v in win.tree.data] == ["R1"]
 
     win.app.safety_mgmt_toolbox.active_module = "P2"
     win.refresh()
-    assert [v[0] for v in win.tree.data] == ["R2", "R3"]
+    assert [v[0] for v in win.tree.data] == ["R3"]
 
     win.app.safety_mgmt_toolbox.active_module = None
     win.refresh()


### PR DESCRIPTION
## Summary
- avoid showing lifecycle requirements when a phase is active in Requirements Explorer
- update phase filter tests to match new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fce40f16083278a6397a8cf530bd8