### PR TITLE
Show requirement phases in phase requirements view

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ window = SafetyManagementWindow(None, app=None, toolbox=toolbox)
 window.generate_phase_requirements("Concept")  # collects all Concept phase requirements
 ```
 
-This opens a tab listing the combined requirements for the chosen phase.
+This opens a tab listing the combined requirements for the chosen phase, and
+now includes a dedicated column displaying the lifecycle phase for each
+requirement.
 
 When importing governance diagrams from a SysML repository, every diagram object
 is treated as a task regardless of its type. Custom elements such as ANN or

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -227,13 +227,22 @@ class SafetyManagementWindow(tk.Frame):
         frame = self.app._new_tab(title)
         for child in frame.winfo_children():
             child.destroy()
-        columns = ("ID", "Type", "Text")
+        columns = ("ID", "Type", "Text", "Phase")
         tree = ttk.Treeview(frame, columns=columns, show="headings")
         for c in columns:
             tree.heading(c, text=c)
         for rid in ids:
             req = global_requirements.get(rid, {})
-            tree.insert("", "end", values=(rid, req.get("req_type", ""), req.get("text", "")))
+            tree.insert(
+                "",
+                "end",
+                values=(
+                    rid,
+                    req.get("req_type", ""),
+                    req.get("text", ""),
+                    req.get("phase") or "",
+                ),
+            )
         tree.pack(fill=tk.BOTH, expand=True)
 
     def generate_requirements(self) -> None:

--- a/tests/test_display_requirements_phase_column.py
+++ b/tests/test_display_requirements_phase_column.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.safety_management_toolbox import SafetyManagementWindow
+from gui import safety_management_toolbox as smt
+from analysis.models import global_requirements
+
+
+def test_display_requirements_includes_phase(monkeypatch):
+    class DummyTab:
+        def winfo_children(self):
+            return []
+
+    class DummyApp:
+        def _new_tab(self, title):
+            return DummyTab()
+
+    columns_captured = []
+    inserted = []
+
+    class DummyTree:
+        def __init__(self, master, columns, show="headings"):
+            columns_captured.append(columns)
+
+        def heading(self, col, text=""):
+            pass
+
+        def insert(self, parent, idx, values):
+            inserted.append(values)
+
+        def pack(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.app = DummyApp()
+
+    global_requirements.clear()
+    global_requirements.update({
+        "R1": {"req_type": "org", "text": "Do", "phase": "P1"}
+    })
+
+    win._display_requirements("Title", ["R1"])
+
+    assert columns_captured[0] == ("ID", "Type", "Text", "Phase")
+    assert inserted[0] == ("R1", "org", "Do", "P1")


### PR DESCRIPTION
## Summary
- Display an extra `Phase` column in the safety management requirements view to show each requirement's lifecycle phase
- Document the phase column in README
- Add unit test verifying the phase column is present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fcc85026c8327bc06d5fc43cb4789