### PR TITLE
Ensure phase requirements menu reflects loaded phases

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -17985,7 +17985,9 @@ class FaultTreeApp:
             data.get("safety_mgmt_toolbox", {})
         )
         toolbox = self.safety_mgmt_toolbox
-        toolbox.on_change = self.refresh_tool_enablement
+        toolbox.on_change = self._on_toolbox_change
+        # Refresh menus to expose phases from the loaded toolbox
+        self._refresh_phase_requirements_menu()
         # Ensure the SysML repository knows about the active phase from the
         # loaded toolbox so diagrams and work products filter correctly.
         toolbox.set_active_module(toolbox.active_module)

--- a/tests/test_phase_requirements_main_menu.py
+++ b/tests/test_phase_requirements_main_menu.py
@@ -96,3 +96,33 @@ def test_generate_lifecycle_requirements_delegates(monkeypatch):
     FaultTreeApp.generate_lifecycle_requirements(app)
 
     assert events == [False, "lifecycle"]
+
+
+def test_apply_model_data_refreshes_phase_menu(monkeypatch):
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    # Stub required methods and attributes used during model loading
+    app.disable_work_product = lambda name: None
+    app.enable_work_product = lambda name: None
+    app.update_failure_list = lambda: None
+    app.get_all_nodes = lambda te: []
+    app.get_all_fmea_entries = lambda: []
+    app.get_all_basic_events = lambda: []
+    app.load_default_mechanisms = lambda: None
+    app.update_odd_elements = lambda: None
+    app.update_global_requirements_from_nodes = lambda event: None
+    app.refresh_tool_enablement = lambda: None
+    app.odd_libraries = []
+    app.enabled_work_products = set()
+    app.project_properties = {}
+    app.update_views = lambda: None
+
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        FaultTreeApp, "_refresh_phase_requirements_menu", lambda self: calls.append(True)
+    )
+
+    data = {"top_events": [], "safety_mgmt_toolbox": {"modules": [{"name": "P1"}]}}
+    FaultTreeApp.apply_model_data(app, data, ensure_root=False)
+
+    assert calls
+    assert app.safety_mgmt_toolbox.on_change == app._on_toolbox_change


### PR DESCRIPTION
## Summary
- Refresh the Phase Requirements submenu after loading a model so phase names from the toolbox appear
- Wire toolbox `on_change` to the main app handler for consistent menu updates
- Add regression test to verify phase menu refresh during model load

## Testing
- `pytest tests/test_phase_requirements_main_menu.py::test_phase_requirements_menu_populated tests/test_phase_requirements_main_menu.py::test_generate_phase_requirements_delegates tests/test_phase_requirements_main_menu.py::test_generate_lifecycle_requirements_delegates tests/test_phase_requirements_main_menu.py::test_apply_model_data_refreshes_phase_menu -q`

------
https://chatgpt.com/codex/tasks/task_b_689fd33017ac83279d0c65f3365d928a