### PR TITLE
Track requirement status during governance updates

### DIFF
--- a/tests/test_display_requirements_phase_column.py
+++ b/tests/test_display_requirements_phase_column.py
@@ -40,10 +40,10 @@ def test_display_requirements_includes_phase(monkeypatch):
 
     global_requirements.clear()
     global_requirements.update({
-        "R1": {"req_type": "org", "text": "Do", "phase": "P1"}
+        "R1": {"req_type": "org", "text": "Do", "phase": "P1", "status": "draft"}
     })
 
     win._display_requirements("Title", ["R1"])
 
-    assert columns_captured[0] == ("ID", "Type", "Text", "Phase")
-    assert inserted[0] == ("R1", "org", "Do", "P1")
+    assert columns_captured[0] == ("ID", "Type", "Text", "Phase", "Status")
+    assert inserted[0] == ("R1", "org", "Do", "P1", "draft")

--- a/tests/test_governance_lifecycle_requirements_menu.py
+++ b/tests/test_governance_lifecycle_requirements_menu.py
@@ -85,4 +85,5 @@ def test_lifecycle_requirements_menu(monkeypatch):
     assert any("Alpha shall precede 'Beta'." in t for t in texts)
     assert not any("Start shall precede 'Finish'." in t for t in texts)
     assert all(row[1] == "organizational" for row in trees[0].rows)
+    assert all(row[4] == "draft" for row in trees[0].rows)
     assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -84,4 +84,5 @@ def test_phase_requirements_menu(monkeypatch):
     assert any("Start shall precede 'Finish'." in t for t in texts)
     assert any("Check shall precede 'Complete'." in t for t in texts)
     assert all(row[1] == "organizational" for row in trees[0].rows)
+    assert all(row[4] == "draft" for row in trees[0].rows)
     assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -71,5 +71,6 @@ def test_requirements_button_opens_tab(monkeypatch):
     assert any("Start shall precede 'Finish'." in t for t in texts)
     # Ensure requirement types are organizational
     assert all(row[1] == "organizational" for row in trees[0].rows)
+    assert all(row[4] == "draft" for row in trees[0].rows)
     # Requirements added to global registry
     assert len(global_requirements) == len(trees[0].rows)


### PR DESCRIPTION
## Summary
- Mark existing phase and lifecycle requirements as obsolete when governance models change
- Always generate fresh requirements and track their status in requirement tables
- Extend phase requirement display to include status column

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fd5d50834832783f8ab9e8f9f28d7