### PR TITLE
Avoid regenerating unchanged requirements

### DIFF
--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -74,3 +74,124 @@ def test_requirements_button_opens_tab(monkeypatch):
     assert all(row[4] == "draft" for row in trees[0].rows)
     # Requirements added to global registry
     assert len(global_requirements) == len(trees[0].rows)
+    assert all(req.get("diagram") == "Gov" for req in global_requirements.values())
+
+
+def test_requirements_button_no_change(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+    t1 = repo.create_element("Action", name="Start")
+    t2 = repo.create_element("Action", name="Finish")
+    diag.objects = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t1.elem_id, "properties": {"name": "Start"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t2.elem_id, "properties": {"name": "Finish"}},
+    ]
+    diag.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams["Gov"] = diag.diag_id
+
+    class DummyTab:
+        def winfo_children(self):
+            return []
+
+    def _new_tab(title):
+        return DummyTab()
+
+    class DummyTree:
+        def __init__(self, master, columns, show="headings"):
+            pass
+
+        def heading(self, col, text=""):
+            pass
+
+        def insert(self, parent, idx, values):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace(_new_tab=_new_tab)
+    win.diag_var = types.SimpleNamespace(get=lambda: "Gov")
+
+    global_requirements.clear()
+    win.generate_requirements()
+    rid = next(iter(global_requirements))
+
+    # Regenerate without changes; requirement should remain unchanged
+    win.generate_requirements()
+    assert len(global_requirements) == 1
+    assert global_requirements[rid]["status"] == "draft"
+    assert global_requirements[rid]["diagram"] == "Gov"
+
+
+def test_other_diagram_requirements_preserved(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    diag1 = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag2 = repo.create_diagram("Governance Diagram", name="Gov2")
+    t1 = repo.create_element("Action", name="Start")
+    t2 = repo.create_element("Action", name="Finish")
+    objs = [
+        {"obj_id": 1, "obj_type": "Action", "x": 0, "y": 0, "element_id": t1.elem_id, "properties": {"name": "Start"}},
+        {"obj_id": 2, "obj_type": "Action", "x": 0, "y": 0, "element_id": t2.elem_id, "properties": {"name": "Finish"}},
+    ]
+    conns = [
+        {"src": 1, "dst": 2, "conn_type": "Flow", "name": "", "properties": {}}
+    ]
+    diag1.objects = [dict(o) for o in objs]
+    diag1.connections = list(conns)
+    diag2.objects = [dict(o) for o in objs]
+    diag2.connections = list(conns)
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams["Gov1"] = diag1.diag_id
+    toolbox.diagrams["Gov2"] = diag2.diag_id
+
+    class DummyTab:
+        def winfo_children(self):
+            return []
+
+    def _new_tab(title):
+        return DummyTab()
+
+    class DummyTree:
+        def __init__(self, master, columns, show="headings"):
+            pass
+
+        def heading(self, col, text=""):
+            pass
+
+        def insert(self, parent, idx, values):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
+
+    win = SafetyManagementWindow.__new__(SafetyManagementWindow)
+    win.toolbox = toolbox
+    win.app = types.SimpleNamespace(_new_tab=_new_tab)
+
+    global_requirements.clear()
+    win.diag_var = types.SimpleNamespace(get=lambda: "Gov1")
+    win.generate_requirements()
+    rid1 = next(iter(global_requirements))
+    win.diag_var = types.SimpleNamespace(get=lambda: "Gov2")
+    win.generate_requirements()
+    rid2 = [rid for rid in global_requirements if rid != rid1][0]
+
+    # Move object in first diagram; requirements unchanged
+    diag1.objects[0]["x"] = 10
+    win.diag_var = types.SimpleNamespace(get=lambda: "Gov1")
+    win.generate_requirements()
+
+    assert len(global_requirements) == 2
+    assert global_requirements[rid1]["status"] == "draft"
+    assert global_requirements[rid2]["status"] == "draft"

--- a/tests/test_phase_requirement_updates.py
+++ b/tests/test_phase_requirement_updates.py
@@ -66,6 +66,24 @@ def test_phase_requirement_updates_existing(monkeypatch):
     assert global_requirements[new_rid]["status"] == "draft"
 
 
+def test_phase_requirement_no_change(monkeypatch):
+    win = _setup_window(monkeypatch)
+
+    monkeypatch.setattr(
+        smt.GovernanceDiagram,
+        "from_repository",
+        lambda repo, diag_id: DummyGov([("Req", "organizational")]),
+    )
+    global_requirements.clear()
+    win.generate_phase_requirements("Phase1")
+    rid = next(iter(global_requirements))
+
+    # Regenerate without changes; requirement should remain and not become obsolete
+    win.generate_phase_requirements("Phase1")
+    assert len(global_requirements) == 1
+    assert global_requirements[rid]["status"] == "draft"
+
+
 def test_lifecycle_requirements_visible_in_phases(monkeypatch):
     win = _setup_window(monkeypatch)
 


### PR DESCRIPTION
## Summary
- Track originating diagram for each requirement to compare updates per diagram
- Skip regeneration and preserve existing requirements when diagram changes do not alter requirement text
- Extend tests to ensure moving elements in one diagram leaves existing requirements untouched

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fd85387f883279a182dd247d7e76b