### PR TITLE
Treat SPI nodes as constraints in requirements generation

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -323,7 +323,10 @@ class GovernanceDiagram:
             if obj is not None:
                 s_role = self._role_for(subject)
                 d_role = self._role_for(obj)
-                if s_role != "subject" and d_role == "subject":
+                if d_role == "constraint":
+                    constraint = obj
+                    obj = None
+                elif s_role != "subject" and d_role == "subject":
                     subject, obj = obj, subject
 
             requirements.append(

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -152,7 +152,8 @@
     "ANN": "object",
     "Data acquisition": "object",
     "Metric": "constraint",
-    "KPI": "constraint"
+    "KPI": "constraint",
+    "SPI": "constraint"
   },
 
   // Allowed Safety & AI relationships between node types

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -88,3 +88,17 @@ def test_data_acquisition_compartment_sources():
     data_reqs = [r for r in reqs if r.action == "obtain data from"]
     assert all(r.req_type == "AI safety" for r in data_reqs)
     assert {r.obj for r in data_reqs} == {"Sensor A", "Sensor B"}
+
+
+def test_spi_nodes_treated_as_constraints():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Review Data", node_type="Activity")
+    diagram.add_task("Latency SPI", node_type="SPI")
+    diagram.add_relationship("Review Data", "Latency SPI", label="monitors")
+
+    reqs = diagram.generate_requirements()
+    spi_req = next(r for r in reqs if r.action == "monitor")
+
+    assert spi_req.subject == "Review Data"
+    assert spi_req.obj is None
+    assert spi_req.constraint == "Latency SPI"


### PR DESCRIPTION
## Summary
- Consider SPI nodes as constraints during requirement generation
- Declare SPI node type in diagram rules config
- Test SPI handling in generated requirements

## Testing
- `pytest tests/test_governance_requirements_generator.py -q`
- `pytest tests/test_diagram_rules_requirements_section.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689fdc8df46c8327a788c3f8057095cb