### PR TITLE
Add stakeholder & KPI toolboxes and SPI work product

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2055,6 +2055,11 @@ class FaultTreeApp:
             "GSN Explorer",
             "manage_gsn",
         ),
+        "SPI": (
+            "Safety Analysis",
+            "Safety Performance Indicators",
+            "show_safety_performance_indicators",
+        ),
         "Requirement Specification": (
             "System Design (Item Definition)",
             "Requirements Editor",
@@ -2177,6 +2182,7 @@ class FaultTreeApp:
         "Mission Profile": "Quantitative Analysis",
         "Reliability Analysis": "Quantitative Analysis",
         "Causal Bayesian Network Analysis": "Quantitative Analysis",
+        "SPI": "Quantitative Analysis",
         "FTA": "Process",
         "Safety & Security Case": "GSN",
         "GSN Argumentation": "GSN",

--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -71,6 +71,7 @@ SAFETY_ANALYSIS_WORK_PRODUCTS: set[str] = {
     "Causal Bayesian Network Analysis",
     "Safety & Security Case",
     "GSN Argumentation",
+    "SPI",
     "Scenario Library",
     "ODD",
 }

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -39,6 +39,22 @@
     "Hyperparameter Validation"
   ],
 
+  // Types shown in the Stakeholder toolbox
+  "stakeholder_nodes": [
+    "Stakeholder"
+  ],
+
+  // Relation labels for the Stakeholder toolbox
+  "stakeholder_relations": [],
+
+  // Types shown in the KPI toolbox
+  "kpi_nodes": [
+    "KPI"
+  ],
+
+  // Relation labels for the KPI toolbox
+  "kpi_relations": [],
+
   // Diagram types considered part of the generic "Architecture Diagram" work product
   "arch_diagram_types": [
     "Use Case Diagram",

--- a/tests/test_governance_spi_work_product.py
+++ b/tests/test_governance_spi_work_product.py
@@ -1,0 +1,57 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
+from analysis import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_governance_spi_work_product_enablement(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    from analysis import safety_management as _sm
+    prev_tb = _sm.ACTIVE_TOOLBOX
+    toolbox = SafetyManagementToolbox()
+
+    area = SysMLObject(1, "System Boundary", 0, 0, properties={"name": "Safety Analysis"})
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = [area]
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+
+    enable_calls = []
+    captured = {}
+
+    class DummyApp:
+        safety_mgmt_toolbox = toolbox
+
+        def enable_work_product(self, name, *, refresh=True):
+            enable_calls.append(name)
+
+    win.app = DummyApp()
+
+    class DummyDialog:
+        def __init__(self, parent, title, options):
+            captured["options"] = options
+            self.selection = "SPI"
+
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", DummyDialog)
+
+    win.add_work_product()
+
+    assert "SPI" in captured["options"]
+    assert enable_calls == ["SPI"]
+    assert any(wp.analysis == "SPI" for wp in toolbox.work_products)
+    _sm.ACTIVE_TOOLBOX = prev_tb

--- a/tests/test_governance_toolbox_switch.py
+++ b/tests/test_governance_toolbox_switch.py
@@ -1,0 +1,36 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+
+
+def test_switch_toolbox_handles_stakeholder_and_kpi():
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+
+    class Frame:
+        def __init__(self):
+            self.packed = False
+        def pack(self, *a, **k):
+            self.packed = True
+        def pack_forget(self, *a, **k):
+            self.packed = False
+
+    win.gov_tools_frame = Frame()
+    win.gov_rel_frame = Frame()
+    win.ai_tools_frame = Frame()
+    win.stakeholder_tools_frame = Frame()
+    win.kpi_tools_frame = Frame()
+    win.prop_frame = Frame()
+
+    win.toolbox_var = types.SimpleNamespace(get=lambda: "Stakeholder")
+    GovernanceDiagramWindow._switch_toolbox(win)
+    assert win.stakeholder_tools_frame.packed
+    assert not win.gov_tools_frame.packed
+
+    win.toolbox_var = types.SimpleNamespace(get=lambda: "KPI")
+    GovernanceDiagramWindow._switch_toolbox(win)
+    assert win.kpi_tools_frame.packed
+    assert not win.stakeholder_tools_frame.packed


### PR DESCRIPTION
## Summary
- expose Stakeholder and KPI elements via dedicated governance toolboxes
- support SPI as a governed work product
- expand governance tests for toolbox switching and SPI enablement

## Testing
- `pytest tests/test_governance_toolbox_switch.py tests/test_governance_spi_work_product.py tests/test_governance_work_product_enablement.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689fddf2a7b88327b79275c87d45138a