### PR TITLE
Enable task-based requirements

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -343,18 +343,37 @@ class GovernanceDiagram:
         # configured compartments as data sources.  Each compartment becomes a
         # separate requirement so that individual data sources remain traceable.
         for node, sources in self.node_sources.items():
+
             req_type = (
                 "AI safety" if self.node_types.get(node) in _AI_NODES else "organizational"
             )
+            subject = "Engineering team" if req_type == "AI safety" else "Organization"
+            action = f"{node.lower()} from"
             for src in sources:
                 requirements.append(
                     GeneratedRequirement(
-                        action="obtain data from",
-                        subject=node,
+                        action=action,
+                        subject=subject,
                         obj=src,
                         req_type=req_type,
                     )
                 )
+
+        for node in self.graph.nodes():
+            role = self._role_for(node)
+            if role != "action" and self.node_types.get(node) != "Data acquisition":
+                continue
+            req_type = (
+                "AI safety" if self.node_types.get(node) in _AI_NODES else "organizational"
+            )
+            subject = "Engineering team" if req_type == "AI safety" else "Organization"
+            requirements.append(
+                GeneratedRequirement(
+                    action=node.lower(),
+                    subject=subject,
+                    req_type=req_type,
+                )
+            )
 
         return requirements
 

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -159,7 +159,7 @@
   // Format: "Relation": {"Source": ["Allowed Target", ...] }
   "safety_ai_relation_rules": {
     "Acquisition": {"Database": ["Data acquisition"]},
-    "Field data collection": {"Database": ["Data acquisition"]},
+    "Field data collection": {"Database": ["Data acquisition", "Task"]},
     "Field risk evaluation": {"Database": ["Data acquisition"]},
     "Annotation": {"ANN": ["Database"]},
     "Synthesis": {"ANN": ["Database"]},

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -122,13 +122,13 @@ def test_requirements_button_no_change(monkeypatch):
 
     global_requirements.clear()
     win.generate_requirements()
-    rid = next(iter(global_requirements))
+    rids = set(global_requirements)
 
-    # Regenerate without changes; requirement should remain unchanged
+    # Regenerate without changes; requirements should remain unchanged
     win.generate_requirements()
-    assert len(global_requirements) == 1
-    assert global_requirements[rid]["status"] == "draft"
-    assert global_requirements[rid]["diagram"] == "Gov"
+    assert len(global_requirements) == len(rids)
+    assert all(global_requirements[rid]["status"] == "draft" for rid in rids)
+    assert all(global_requirements[rid]["diagram"] == "Gov" for rid in rids)
 
 
 def test_other_diagram_requirements_preserved(monkeypatch):
@@ -182,16 +182,14 @@ def test_other_diagram_requirements_preserved(monkeypatch):
     global_requirements.clear()
     win.diag_var = types.SimpleNamespace(get=lambda: "Gov1")
     win.generate_requirements()
-    rid1 = next(iter(global_requirements))
     win.diag_var = types.SimpleNamespace(get=lambda: "Gov2")
     win.generate_requirements()
-    rid2 = [rid for rid in global_requirements if rid != rid1][0]
+    rids = set(global_requirements)
 
     # Move object in first diagram; requirements unchanged
     diag1.objects[0]["x"] = 10
     win.diag_var = types.SimpleNamespace(get=lambda: "Gov1")
     win.generate_requirements()
 
-    assert len(global_requirements) == 2
-    assert global_requirements[rid1]["status"] == "draft"
-    assert global_requirements[rid2]["status"] == "draft"
+    assert len(global_requirements) == len(rids)
+    assert all(global_requirements[rid]["status"] == "draft" for rid in rids)

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -28,6 +28,7 @@ def test_generate_requirements_from_governance_diagram():
     assert "Review Data shall produce 'Report'." in texts
     assert "If data validated, Data Steward shall approve 'Report'." in texts
     assert "Review Data shall comply with 'Policy DP-001'." in texts
+    assert "Organization shall review data." in texts
 
     perf_req = next(r for r in reqs if r.action == "perform")
     assert perf_req.subject == "Data Steward"
@@ -37,6 +38,9 @@ def test_generate_requirements_from_governance_diagram():
     assert approve_req.condition == "data validated"
     assert approve_req.subject == "Data Steward"
     assert approve_req.obj == "Report"
+    review_req = next(r for r in reqs if r.action == "review data")
+    assert review_req.subject == "Organization"
+    assert review_req.req_type == "organizational"
 
 def test_ai_training_and_curation_requirements():
     diagram = GovernanceDiagram()
@@ -82,9 +86,29 @@ def test_data_acquisition_compartment_sources():
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
 
-    assert "Acquire Data shall obtain data from 'Sensor A'." in texts
-    assert "Acquire Data shall obtain data from 'Sensor B'." in texts
+    assert "Engineering team shall acquire data from 'Sensor A'." in texts
+    assert "Engineering team shall acquire data from 'Sensor B'." in texts
 
-    data_reqs = [r for r in reqs if r.action == "obtain data from"]
+    data_reqs = [r for r in reqs if r.action == "acquire data from"]
     assert all(r.req_type == "AI safety" for r in data_reqs)
+    assert all(r.subject == "Engineering team" for r in data_reqs)
     assert {r.obj for r in data_reqs} == {"Sensor A", "Sensor B"}
+
+
+def test_tasks_create_requirement_actions():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Review Data", node_type="Activity")
+    diagram.add_task("Acquire Data", node_type="Data acquisition")
+
+    reqs = diagram.generate_requirements()
+    texts = [r.text for r in reqs]
+
+    assert "Organization shall review data." in texts
+    assert "Engineering team shall acquire data." in texts
+
+    review_req = next(r for r in reqs if r.action == "review data")
+    assert review_req.subject == "Organization"
+    assert review_req.req_type == "organizational"
+    acquire_req = next(r for r in reqs if r.action == "acquire data")
+    assert acquire_req.subject == "Engineering team"
+    assert acquire_req.req_type == "AI safety"

--- a/tests/test_relation_direction.py
+++ b/tests/test_relation_direction.py
@@ -12,5 +12,7 @@ def _safety_ai_rules():
 def test_data_acquisition_relation_direction():
     rules = _safety_ai_rules()
     expected = {"Database": ["Data acquisition"]}
-    for rel in ("Acquisition", "Field data collection", "Field risk evaluation"):
-        assert rules.get(rel) == expected
+    assert rules.get("Acquisition") == expected
+    assert rules.get("Field risk evaluation") == expected
+    expected_collect = {"Database": ["Data acquisition", "Task"]}
+    assert rules.get("Field data collection") == expected_collect


### PR DESCRIPTION
## Summary
- Allow field data collection relations to target tasks
- Generate requirements for tasks, using organization or engineering team as subject based on requirement type
- Update tests for task-based requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689fe1f519a88327a8ce70b412eb562e