### PR TITLE
test: ensure requirements generated for additional relationships

### DIFF
--- a/tests/test_governance_additional_relationship_requirements.py
+++ b/tests/test_governance_additional_relationship_requirements.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram, GeneratedRequirement
+
+
+@pytest.mark.parametrize(
+    "conn_type, action",
+    [
+        ("Re-use", "re-use"),
+        ("Propagate", "propagate"),
+        ("Propagate by Review", "propagate by review"),
+        ("Propagate by Approval", "propagate by approval"),
+        ("Used By", "be used by"),
+        ("Used after Review", "be used after review"),
+        ("Used after Approval", "be used after approval"),
+        ("Trace", "trace to"),
+        ("Satisfied by", "be satisfied by"),
+        ("Derived from", "be derived from"),
+    ],
+)
+def test_generate_requirements_for_additional_relationships(conn_type, action):
+    diagram = GovernanceDiagram()
+    diagram.add_task("Source")
+    diagram.add_task("Target")
+    diagram.add_relationship("Source", "Target", conn_type=conn_type)
+
+    reqs = [r for r in diagram.generate_requirements() if isinstance(r, GeneratedRequirement)]
+    assert any(r.action == action for r in reqs)


### PR DESCRIPTION
## Summary
- add tests covering requirement generation for additional governance relationships like Re-use, Propagate, Used after Review, and others

## Testing
- `pytest tests/test_governance_additional_relationship_requirements.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fe2b0561483279f5527d78315e65e