### PR TITLE
Add scrollbars to lifecycle and phase requirement tables

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -236,7 +236,8 @@ class SafetyManagementWindow(tk.Frame):
         for child in frame.winfo_children():
             child.destroy()
         columns = ("ID", "Type", "Text", "Phase", "Status")
-        tree = ttk.Treeview(frame, columns=columns, show="headings")
+        tree_frame = ttk.Frame(frame)
+        tree = ttk.Treeview(tree_frame, columns=columns, show="headings")
         for c in columns:
             tree.heading(c, text=c)
         for rid in ids:
@@ -252,7 +253,15 @@ class SafetyManagementWindow(tk.Frame):
                     req.get("status", ""),
                 ),
             )
-        tree.pack(fill=tk.BOTH, expand=True)
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=tree.yview)
+        hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=tree.xview)
+        tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
 
     @staticmethod
     def _current_requirement_pairs(

--- a/tests/test_display_requirements_phase_column.py
+++ b/tests/test_display_requirements_phase_column.py
@@ -10,8 +10,11 @@ from analysis.models import global_requirements
 
 def test_display_requirements_includes_phase(monkeypatch):
     class DummyTab:
+        def __init__(self):
+            self.children = []
+
         def winfo_children(self):
-            return []
+            return list(self.children)
 
     class DummyApp:
         def _new_tab(self, title):
@@ -20,9 +23,45 @@ def test_display_requirements_includes_phase(monkeypatch):
     columns_captured = []
     inserted = []
 
+    class DummyFrame:
+        def __init__(self, master):
+            self.master = master
+            self.children = []
+            master.children.append(self)
+
+        def winfo_children(self):
+            return list(self.children)
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
+    class DummyScrollbar:
+        def __init__(self, master, orient=None, command=None):
+            self.master = master
+            master.children.append(self)
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def set(self, *args):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
             columns_captured.append(columns)
+            master.children.append(self)
 
         def heading(self, col, text=""):
             pass
@@ -30,9 +69,20 @@ def test_display_requirements_includes_phase(monkeypatch):
         def insert(self, parent, idx, values):
             inserted.append(values)
 
-        def pack(self, **kwargs):
+        def configure(self, **kwargs):
             pass
 
+        def yview(self, *args):
+            pass
+
+        def xview(self, *args):
+            pass
+
+        def grid(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
 
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)

--- a/tests/test_governance_ai_requirement_type.py
+++ b/tests/test_governance_ai_requirement_type.py
@@ -27,8 +27,11 @@ def test_ai_elements_generate_ai_safety_requirements(monkeypatch):
     toolbox.diagrams["AI Gov"] = diag.diag_id
 
     class DummyTab:
+        def __init__(self):
+            self.children = []
+
         def winfo_children(self):
-            return []
+            return list(self.children)
 
     tabs = []
 
@@ -39,10 +42,46 @@ def test_ai_elements_generate_ai_safety_requirements(monkeypatch):
 
     trees = []
 
+    class DummyFrame:
+        def __init__(self, master):
+            self.master = master
+            self.children = []
+            master.children.append(self)
+
+        def winfo_children(self):
+            return list(self.children)
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
+    class DummyScrollbar:
+        def __init__(self, master, orient=None, command=None):
+            self.master = master
+            master.children.append(self)
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def set(self, *args):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
             self.rows = []
             trees.append(self)
+            master.children.append(self)
 
         def heading(self, col, text=""):
             pass
@@ -50,9 +89,20 @@ def test_ai_elements_generate_ai_safety_requirements(monkeypatch):
         def insert(self, parent, idx, values):
             self.rows.append(values)
 
-        def pack(self, **kwargs):
+        def configure(self, **kwargs):
             pass
 
+        def yview(self, *args):
+            pass
+
+        def xview(self, *args):
+            pass
+
+        def grid(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
 
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)

--- a/tests/test_governance_lifecycle_requirements_menu.py
+++ b/tests/test_governance_lifecycle_requirements_menu.py
@@ -42,8 +42,11 @@ def test_lifecycle_requirements_menu(monkeypatch):
     monkeypatch.setattr(toolbox, "list_diagrams", lambda: list(toolbox.diagrams.keys()))
 
     class DummyTab:
+        def __init__(self):
+            self.children = []
+
         def winfo_children(self):
-            return []
+            return list(self.children)
 
     tabs = []
 
@@ -54,10 +57,46 @@ def test_lifecycle_requirements_menu(monkeypatch):
 
     trees = []
 
+    class DummyFrame:
+        def __init__(self, master):
+            self.master = master
+            self.children = []
+            master.children.append(self)
+
+        def winfo_children(self):
+            return list(self.children)
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
+    class DummyScrollbar:
+        def __init__(self, master, orient=None, command=None):
+            self.master = master
+            master.children.append(self)
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def set(self, *args):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
             self.rows = []
             trees.append(self)
+            master.children.append(self)
 
         def heading(self, col, text=""):
             pass
@@ -65,9 +104,20 @@ def test_lifecycle_requirements_menu(monkeypatch):
         def insert(self, parent, idx, values):
             self.rows.append(values)
 
-        def pack(self, **kwargs):
+        def configure(self, **kwargs):
             pass
 
+        def yview(self, *args):
+            pass
+
+        def xview(self, *args):
+            pass
+
+        def grid(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
 
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -41,8 +41,11 @@ def test_phase_requirements_menu(monkeypatch):
     mod.diagrams.extend(["Gov1", "Gov2"])
 
     class DummyTab:
+        def __init__(self):
+            self.children = []
+
         def winfo_children(self):
-            return []
+            return list(self.children)
 
     tabs = []
 
@@ -53,10 +56,46 @@ def test_phase_requirements_menu(monkeypatch):
 
     trees = []
 
+    class DummyFrame:
+        def __init__(self, master):
+            self.master = master
+            self.children = []
+            master.children.append(self)
+
+        def winfo_children(self):
+            return list(self.children)
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
+    class DummyScrollbar:
+        def __init__(self, master, orient=None, command=None):
+            self.master = master
+            master.children.append(self)
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def set(self, *args):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
             self.rows = []
             trees.append(self)
+            master.children.append(self)
 
         def heading(self, col, text=""):
             pass
@@ -64,9 +103,20 @@ def test_phase_requirements_menu(monkeypatch):
         def insert(self, parent, idx, values):
             self.rows.append(values)
 
-        def pack(self, **kwargs):
+        def configure(self, **kwargs):
             pass
 
+        def yview(self, *args):
+            pass
+
+        def xview(self, *args):
+            pass
+
+        def grid(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
 
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -27,8 +27,11 @@ def test_requirements_button_opens_tab(monkeypatch):
     toolbox.diagrams["Gov"] = diag.diag_id
 
     class DummyTab:
+        def __init__(self):
+            self.children = []
+
         def winfo_children(self):
-            return []
+            return list(self.children)
 
     tabs: list[tuple[str, DummyTab]] = []
 
@@ -39,10 +42,46 @@ def test_requirements_button_opens_tab(monkeypatch):
 
     trees = []
 
+    class DummyFrame:
+        def __init__(self, master):
+            self.master = master
+            self.children = []
+            master.children.append(self)
+
+        def winfo_children(self):
+            return list(self.children)
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
+    class DummyScrollbar:
+        def __init__(self, master, orient=None, command=None):
+            self.master = master
+            master.children.append(self)
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def set(self, *args):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
             self.rows = []
             trees.append(self)
+            master.children.append(self)
 
         def heading(self, col, text=""):
             pass
@@ -50,9 +89,20 @@ def test_requirements_button_opens_tab(monkeypatch):
         def insert(self, parent, idx, values):
             self.rows.append(values)
 
-        def pack(self, **kwargs):
+        def configure(self, **kwargs):
             pass
 
+        def yview(self, *args):
+            pass
+
+        def xview(self, *args):
+            pass
+
+        def grid(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
 
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)
@@ -94,15 +144,53 @@ def test_requirements_button_no_change(monkeypatch):
     toolbox.diagrams["Gov"] = diag.diag_id
 
     class DummyTab:
+        def __init__(self):
+            self.children = []
+
         def winfo_children(self):
-            return []
+            return list(self.children)
 
     def _new_tab(title):
         return DummyTab()
 
+    class DummyFrame:
+        def __init__(self, master):
+            self.master = master
+            self.children = []
+            master.children.append(self)
+
+        def winfo_children(self):
+            return list(self.children)
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
+    class DummyScrollbar:
+        def __init__(self, master, orient=None, command=None):
+            self.master = master
+            master.children.append(self)
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def set(self, *args):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
-            pass
+            master.children.append(self)
 
         def heading(self, col, text=""):
             pass
@@ -110,9 +198,20 @@ def test_requirements_button_no_change(monkeypatch):
         def insert(self, parent, idx, values):
             pass
 
-        def pack(self, **kwargs):
+        def configure(self, **kwargs):
             pass
 
+        def yview(self, *args):
+            pass
+
+        def xview(self, *args):
+            pass
+
+        def grid(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
 
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)
@@ -154,15 +253,53 @@ def test_other_diagram_requirements_preserved(monkeypatch):
     toolbox.diagrams["Gov2"] = diag2.diag_id
 
     class DummyTab:
+        def __init__(self):
+            self.children = []
+
         def winfo_children(self):
-            return []
+            return list(self.children)
 
     def _new_tab(title):
         return DummyTab()
 
+    class DummyFrame:
+        def __init__(self, master):
+            self.master = master
+            self.children = []
+            master.children.append(self)
+
+        def winfo_children(self):
+            return list(self.children)
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
+    class DummyScrollbar:
+        def __init__(self, master, orient=None, command=None):
+            self.master = master
+            master.children.append(self)
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def set(self, *args):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
-            pass
+            master.children.append(self)
 
         def heading(self, col, text=""):
             pass
@@ -170,9 +307,20 @@ def test_other_diagram_requirements_preserved(monkeypatch):
         def insert(self, parent, idx, values):
             pass
 
-        def pack(self, **kwargs):
+        def configure(self, **kwargs):
             pass
 
+        def yview(self, *args):
+            pass
+
+        def xview(self, *args):
+            pass
+
+        def grid(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
 
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)

--- a/tests/test_safety_management_dedup.py
+++ b/tests/test_safety_management_dedup.py
@@ -90,6 +90,41 @@ def test_display_requirements_clears_existing(monkeypatch):
         def _new_tab(self, title):
             return tab
 
+    class DummyFrame:
+        def __init__(self, master):
+            self.master = master
+            self.children = []
+            master.children.append(self)
+
+        def winfo_children(self):
+            return list(self.children)
+
+        def rowconfigure(self, *args, **kwargs):
+            pass
+
+        def columnconfigure(self, *args, **kwargs):
+            pass
+
+        def pack(self, **kwargs):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
+    class DummyScrollbar:
+        def __init__(self, master, orient=None, command=None):
+            self.master = master
+            master.children.append(self)
+
+        def grid(self, *args, **kwargs):
+            pass
+
+        def set(self, *args):
+            pass
+
+        def destroy(self):
+            self.master.children.remove(self)
+
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
             self.master = master
@@ -102,12 +137,23 @@ def test_display_requirements_clears_existing(monkeypatch):
         def insert(self, parent, idx, values):
             self.rows.append(values)
 
-        def pack(self, **kwargs):
+        def configure(self, **kwargs):
+            pass
+
+        def yview(self, *args):
+            pass
+
+        def xview(self, *args):
+            pass
+
+        def grid(self, *args, **kwargs):
             pass
 
         def destroy(self):
             self.master.children.remove(self)
 
+    monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
 
     win = smt.SafetyManagementWindow.__new__(smt.SafetyManagementWindow)


### PR DESCRIPTION
## Summary
- Allow lifecycle and phase requirement tables to scroll by wrapping them in a frame and wiring vertical and horizontal scrollbars
- Update tests to use dummy scrollbars/frames now that requirement tables are scrollable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fe45d74948327ae9e0a5448df2af6