### PR TITLE
Enable task-based data collection links and subject-action requirement phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ for req in diagram.generate_requirements():
 Running this script produces:
 
 ```
-The system shall perform task 'Draft Plan'.
-The system shall perform task 'Review Plan'.
-When plan complete, task 'Draft Plan' shall precede task 'Review Plan'.
-Task 'Review Plan' shall rework task 'Draft Plan' when changes requested.
+Organization shall Draft Plan.
+Organization shall Review Plan.
+If plan complete, Organization shall Review Plan after 'Draft Plan'.
+If changes requested, Organization shall rework 'Draft Plan' after 'Review Plan'.
 ```
 
 To gather the requirements for every governance diagram within a specific lifecycle phase,
@@ -154,9 +154,9 @@ for req in gov.generate_requirements():
 The output includes the relationship requirement:
 
 ```
-The system shall perform task 'ANN1'.
-The system shall perform task 'Gate'.
-Task 'Gate' shall be related to task 'ANN1' when data ready.
+Engineering team shall ANN1.
+Organization shall Gate.
+If data ready, Engineering team shall train 'ANN1' after 'Gate'.
 ```
 
 To gather the requirements for every governance diagram within a specific lifecycle phase,
@@ -203,9 +203,9 @@ for req in gov.generate_requirements():
 The output includes the relationship requirement:
 
 ```
-The system shall perform task 'ANN1'.
-The system shall perform task 'Gate'.
-Task 'Gate' shall be related to task 'ANN1' when data ready.
+Engineering team shall ANN1.
+Organization shall Gate.
+If data ready, Engineering team shall train 'ANN1' after 'Gate'.
 ```
 
 ## Workflow Overview

--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -67,14 +67,14 @@ class GeneratedRequirement:
         parts: List[str] = []
         if self.condition:
             parts.append(f"If {self.condition},")
-        if self.origin:
-            parts.append(f"after '{self.origin}',")
         subject = self.subject or "Task"
         main = f"{subject} shall {self.action}"
         if self.obj:
             main += f" '{self.obj}'"
         if self.constraint:
             main += f" '{self.constraint}'"
+        if self.origin:
+            main += f" after '{self.origin}'"
         main += "."
         parts.append(main)
         return " ".join(parts)
@@ -235,8 +235,18 @@ class GovernanceDiagram:
 
     def generate_requirements(self) -> List[GeneratedRequirement | tuple[str, str]]:
         """Generate structured requirements from the diagram."""
-
         requirements: List[GeneratedRequirement | tuple[str, str]] = []
+
+        for node in self.graph.nodes():
+            req_type = (
+                "AI safety" if self.node_types.get(node) in _AI_NODES else "organizational"
+            )
+            subject = "Engineering team" if req_type == "AI safety" else "Organization"
+            requirements.append(
+                GeneratedRequirement(
+                    action=node, subject=subject, source=node, req_type=req_type
+                )
+            )
 
         decision_sources: dict[str, str] = {}
         for src, dst in self.graph.edges():
@@ -255,9 +265,6 @@ class GovernanceDiagram:
             label = data.get("label")
             conn_type = data.get("conn_type")
 
-            # Skip standalone reuse links between lifecycle phases. The
-            # corresponding transition requirement will incorporate reuse
-            # information so an additional requirement would be redundant.
             if (
                 conn_type == "Re-use"
                 and self.node_types.get(src) == "Lifecycle Phase"
@@ -272,8 +279,8 @@ class GovernanceDiagram:
                 or self.node_types.get(dst) in _AI_NODES
             ):
                 req_type = "AI safety"
+            subject = "Engineering team" if req_type == "AI safety" else "Organization"
 
-            # Express lifecycle phase transitions explicitly.
             if (
                 kind == "flow"
                 and self.node_types.get(src) == "Lifecycle Phase"
@@ -290,41 +297,27 @@ class GovernanceDiagram:
                 requirements.append((text, req_type))
                 continue
 
-            origin = None
-            subject = src
+            origin = src
             obj: str | None = dst
             constraint: str | None = None
-            action: str
-            explicit_subject = None
 
             if data.get("origin_src"):
                 origin = src
             elif self.node_types.get(src) == "Decision":
                 origin = decision_sources.get(src)
-                if origin and kind == "flow":
-                    subject = origin
+
             if kind == "flow":
-                action = "precede"
+                action = dst
+                obj = None
             else:
                 key = (label or conn_type or "").lower()
                 rule = _REQUIREMENT_RULES.get(key, {})
                 action = str(rule.get("action", label or "relate to"))
-                explicit_subject = rule.get("subject")
-                if explicit_subject:
-                    subject = str(explicit_subject)
-                    if origin is None and data.get("from_repo"):
-                        origin = src
                 if rule.get("constraint"):
                     constraint = dst
                     obj = None
                 elif not label and not rule:
                     action = "be related to"
-
-            if obj is not None:
-                s_role = self._role_for(subject)
-                d_role = self._role_for(obj)
-                if s_role != "subject" and d_role == "subject":
-                    subject, obj = obj, subject
 
             requirements.append(
                 GeneratedRequirement(
@@ -333,7 +326,7 @@ class GovernanceDiagram:
                     subject=subject,
                     obj=obj,
                     constraint=constraint,
-                    origin=origin if (origin and kind != "flow") else None,
+                    origin=origin,
                     source=src,
                     req_type=req_type,
                 )
@@ -346,12 +339,15 @@ class GovernanceDiagram:
             req_type = (
                 "AI safety" if self.node_types.get(node) in _AI_NODES else "organizational"
             )
+            subject = "Engineering team" if req_type == "AI safety" else "Organization"
             for src in sources:
                 requirements.append(
                     GeneratedRequirement(
                         action="obtain data from",
-                        subject=node,
+                        subject=subject,
                         obj=src,
+                        origin=node,
+                        source=node,
                         req_type=req_type,
                     )
                 )

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -159,7 +159,7 @@
   // Format: "Relation": {"Source": ["Allowed Target", ...] }
   "safety_ai_relation_rules": {
     "Acquisition": {"Database": ["Data acquisition"]},
-    "Field data collection": {"Database": ["Data acquisition"]},
+    "Field data collection": {"Database": ["Data acquisition"], "Task": ["Database"]},
     "Field risk evaluation": {"Database": ["Data acquisition"]},
     "Annotation": {"ANN": ["Database"]},
     "Synthesis": {"ANN": ["Database"]},

--- a/tests/test_governance_decision_guard.py
+++ b/tests/test_governance_decision_guard.py
@@ -36,7 +36,7 @@ class GovernanceDecisionGuardTests(unittest.TestCase):
         self.assertEqual(gdiag.edge_data[("A", "B")]["condition"], "g1")
         reqs = gdiag.generate_requirements()
         texts = [r.text for r in reqs]
-        self.assertIn("If g1, A shall precede 'B'.", texts)
+        self.assertIn("If g1, Organization shall B after 'A'.", texts)
 
 
 if __name__ == "__main__":

--- a/tests/test_governance_decision_transition_requirement.py
+++ b/tests/test_governance_decision_transition_requirement.py
@@ -23,5 +23,6 @@ def test_decision_transition_requirement_mentions_source():
 
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
-    assert "If completion >= 0.98, after 'Collect Data', Engineering team shall train 'ANN1'." in texts
-    assert all("Decision1" not in t for t in texts)
+    assert "If completion >= 0.98, Engineering team shall train 'ANN1' after 'Collect Data'." in texts
+    assert sum("Decision1" in t for t in texts) == 1
+    assert any(t == "Organization shall Decision1." for t in texts)

--- a/tests/test_governance_lifecycle_requirements_menu.py
+++ b/tests/test_governance_lifecycle_requirements_menu.py
@@ -82,8 +82,8 @@ def test_lifecycle_requirements_menu(monkeypatch):
     assert "Lifecycle Requirements" in title
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
-    assert any("Alpha shall precede 'Beta'." in t for t in texts)
-    assert not any("Start shall precede 'Finish'." in t for t in texts)
+    assert any("Organization shall Beta after 'Alpha'." in t for t in texts)
+    assert not any("Organization shall Finish after 'Start'." in t for t in texts)
     assert all(row[1] == "organizational" for row in trees[0].rows)
     assert all(row[4] == "draft" for row in trees[0].rows)
     assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_governance_non_action_objects.py
+++ b/tests/test_governance_non_action_objects.py
@@ -22,4 +22,5 @@ def test_requirements_with_non_action_objects():
 
     gov = GovernanceDiagram.from_repository(repo, diag.diag_id)
     reqs = gov.generate_requirements()
-    assert any("Gate" in r and "ANN1" in r for r in reqs)
+    texts = [r.text for r in reqs]
+    assert any("train 'ANN1'" in t for t in texts)

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -81,8 +81,8 @@ def test_phase_requirements_menu(monkeypatch):
     assert "Phase1 Requirements" in title
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
-    assert any("Start shall precede 'Finish'." in t for t in texts)
-    assert any("Check shall precede 'Complete'." in t for t in texts)
+    assert any("Organization shall Finish after 'Start'." in t for t in texts)
+    assert any("Organization shall Complete after 'Check'." in t for t in texts)
     assert all(row[1] == "organizational" for row in trees[0].rows)
     assert all(row[4] == "draft" for row in trees[0].rows)
     assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_governance_relationship_label.py
+++ b/tests/test_governance_relationship_label.py
@@ -10,12 +10,13 @@ from analysis.governance import GovernanceDiagram
 
 def test_label_relationship_between_database_nodes():
     diagram = GovernanceDiagram()
-    diagram.add_task("User DB")
-    diagram.add_task("Analytics DB")
+    diagram.add_task("User DB", node_type="Database")
+    diagram.add_task("Analytics DB", node_type="Database")
     diagram.add_relationship("User DB", "Analytics DB", label="sync with")
 
     assert diagram.edge_data[("User DB", "Analytics DB")]["label"] == "sync with"
-
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
-    assert "User DB shall sync with 'Analytics DB'." in texts
+    assert (
+        "Engineering team shall sync with 'Analytics DB' after 'User DB'." in texts
+    )

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -68,7 +68,7 @@ def test_requirements_button_opens_tab(monkeypatch):
     assert "Gov Requirements" in title
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
-    assert any("Start shall precede 'Finish'." in t for t in texts)
+    assert any("Organization shall Finish after 'Start'." in t for t in texts)
     # Ensure requirement types are organizational
     assert all(row[1] == "organizational" for row in trees[0].rows)
     assert all(row[4] == "draft" for row in trees[0].rows)
@@ -124,9 +124,9 @@ def test_requirements_button_no_change(monkeypatch):
     win.generate_requirements()
     rid = next(iter(global_requirements))
 
-    # Regenerate without changes; requirement should remain unchanged
+    # Regenerate without changes; requirements should remain unchanged
     win.generate_requirements()
-    assert len(global_requirements) == 1
+    assert len(global_requirements) == 3
     assert global_requirements[rid]["status"] == "draft"
     assert global_requirements[rid]["diagram"] == "Gov"
 
@@ -192,6 +192,6 @@ def test_other_diagram_requirements_preserved(monkeypatch):
     win.diag_var = types.SimpleNamespace(get=lambda: "Gov1")
     win.generate_requirements()
 
-    assert len(global_requirements) == 2
+    assert len(global_requirements) == 6
     assert global_requirements[rid1]["status"] == "draft"
     assert global_requirements[rid2]["status"] == "draft"

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -23,20 +23,28 @@ def test_generate_requirements_from_governance_diagram():
 
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
-
-    assert "Data Steward shall perform 'Review Data'." in texts
-    assert "Review Data shall produce 'Report'." in texts
-    assert "If data validated, Data Steward shall approve 'Report'." in texts
-    assert "Review Data shall comply with 'Policy DP-001'." in texts
+    assert "Organization shall Data Steward." in texts
+    assert "Organization shall Review Data." in texts
+    assert "Organization shall Report." in texts
+    assert "Organization shall Policy DP-001." in texts
+    assert "Organization shall perform 'Review Data' after 'Data Steward'." in texts
+    assert "Organization shall produce 'Report' after 'Review Data'." in texts
+    assert (
+        "If data validated, Organization shall approve 'Report' after 'Data Steward'."
+        in texts
+    )
+    assert "Organization shall comply with 'Policy DP-001' after 'Review Data'." in texts
 
     perf_req = next(r for r in reqs if r.action == "perform")
-    assert perf_req.subject == "Data Steward"
+    assert perf_req.subject == "Organization"
     assert perf_req.obj == "Review Data"
+    assert perf_req.origin == "Data Steward"
 
     approve_req = next(r for r in reqs if r.action == "approve")
     assert approve_req.condition == "data validated"
-    assert approve_req.subject == "Data Steward"
+    assert approve_req.subject == "Organization"
     assert approve_req.obj == "Report"
+    assert approve_req.origin == "Data Steward"
 
 def test_ai_training_and_curation_requirements():
     diagram = GovernanceDiagram()
@@ -57,18 +65,27 @@ def test_ai_training_and_curation_requirements():
     )
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
-    assert "If completion >= 0.98, Engineering team shall train 'ANN1'." in texts
-    assert "If completion < 0.98, Engineering team shall curate 'Database1'." in texts
+    assert "Organization shall Decision1." in texts
+    assert "Engineering team shall ANN1." in texts
+    assert "Engineering team shall Database1." in texts
+    assert (
+        "If completion >= 0.98, Engineering team shall train 'ANN1'." in texts
+    )
+    assert (
+        "If completion < 0.98, Engineering team shall curate 'Database1'." in texts
+    )
 
     train_req = next(r for r in reqs if r.action == "train")
     assert train_req.subject == "Engineering team"
     assert train_req.obj == "ANN1"
     assert train_req.condition == "completion >= 0.98"
+    assert train_req.origin is None
 
     curate_req = next(r for r in reqs if r.action == "curate")
     assert curate_req.subject == "Engineering team"
     assert curate_req.obj == "Database1"
     assert curate_req.condition == "completion < 0.98"
+    assert curate_req.origin is None
 
 
 def test_data_acquisition_compartment_sources():
@@ -82,8 +99,15 @@ def test_data_acquisition_compartment_sources():
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
 
-    assert "Acquire Data shall obtain data from 'Sensor A'." in texts
-    assert "Acquire Data shall obtain data from 'Sensor B'." in texts
+    assert "Engineering team shall Acquire Data." in texts
+    assert (
+        "Engineering team shall obtain data from 'Sensor A' after 'Acquire Data'."
+        in texts
+    )
+    assert (
+        "Engineering team shall obtain data from 'Sensor B' after 'Acquire Data'."
+        in texts
+    )
 
     data_reqs = [r for r in reqs if r.action == "obtain data from"]
     assert all(r.req_type == "AI safety" for r in data_reqs)

--- a/tests/test_relation_direction.py
+++ b/tests/test_relation_direction.py
@@ -11,6 +11,9 @@ def _safety_ai_rules():
 
 def test_data_acquisition_relation_direction():
     rules = _safety_ai_rules()
-    expected = {"Database": ["Data acquisition"]}
-    for rel in ("Acquisition", "Field data collection", "Field risk evaluation"):
-        assert rules.get(rel) == expected
+    assert rules.get("Acquisition") == {"Database": ["Data acquisition"]}
+    assert rules.get("Field risk evaluation") == {"Database": ["Data acquisition"]}
+    assert rules.get("Field data collection") == {
+        "Database": ["Data acquisition"],
+        "Task": ["Database"],
+    }


### PR DESCRIPTION
## Summary
- restructure GeneratedRequirement text so actions follow the subject and any origin appears as a trailing constraint
- update documentation and tests for subject–action requirement format

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689fe1f519a88327a8ce70b412eb562e