### PR TITLE
Add Stakeholder and KPI toolboxes and SPI work product

### DIFF
--- a/analysis/models.py
+++ b/analysis/models.py
@@ -606,6 +606,7 @@ REQUIREMENT_TYPE_OPTIONS = [
     "product",
     "legal",
     "organizational",
+    "spi",
 ]
 
 # Work product names corresponding to each requirement category. These are used
@@ -625,6 +626,7 @@ REQUIREMENT_WORK_PRODUCTS = [
     "Product Requirement Specification",
     "Legal Requirement Specification",
     "Organizational Requirement Specification",
+    "Spi Requirement Specification",
 ]
 # ASIL level options including decomposition levels
 ASIL_LEVEL_OPTIONS = [

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -50,13 +50,18 @@
   // Node types available in the governance toolbox
   "governance_node_types": [
     "Action",
+    "CallBehaviorAction",
     "Initial",
     "Final",
     "Decision",
     "Merge",
+    "Fork",
+    "Join",
     "System Boundary",
     "Work Product",
-    "Lifecycle Phase"
+    "Lifecycle Phase",
+    "Stakeholder",
+    "KPI"
   ],
 
   // FMEDA/Fault tree gate node types
@@ -205,13 +210,15 @@
     },
     "Governance Diagram": {
       "Flow": {
-        "Initial": ["Action", "Decision", "Merge", "Fork", "Join", "Database", "ANN", "Data acquisition"],
-        "Action": ["Action", "Decision", "Merge", "Fork", "Join", "Final", "Database", "ANN", "Data acquisition"],
-        "Decision": ["Action", "Decision", "Merge", "Fork", "Join", "Final", "Lifecycle Phase", "Database", "ANN", "Data acquisition"],
-        "Merge": ["Action", "Decision", "Merge", "Fork", "Join", "Database", "ANN", "Data acquisition"],
-        "Fork": ["Action", "Decision", "Merge", "Fork", "Join", "Database", "ANN", "Data acquisition"],
-        "Join": ["Action", "Decision", "Merge", "Database", "ANN", "Data acquisition"],
-        "Lifecycle Phase": ["Decision", "Action", "Merge", "Fork", "Join", "Final", "Database", "ANN", "Data acquisition"],
+        "Initial": ["Action", "Decision", "Merge", "Fork", "Join", "Database", "ANN", "Data acquisition", "Stakeholder", "KPI"],
+        "Action": ["Action", "Decision", "Merge", "Fork", "Join", "Final", "Database", "ANN", "Data acquisition", "Stakeholder", "KPI"],
+        "Decision": ["Action", "Decision", "Merge", "Fork", "Join", "Final", "Lifecycle Phase", "Database", "ANN", "Data acquisition", "Stakeholder", "KPI"],
+        "Merge": ["Action", "Decision", "Merge", "Fork", "Join", "Database", "ANN", "Data acquisition", "Stakeholder", "KPI"],
+        "Fork": ["Action", "Decision", "Merge", "Fork", "Join", "Database", "ANN", "Data acquisition", "Stakeholder", "KPI"],
+        "Join": ["Action", "Decision", "Merge", "Database", "ANN", "Data acquisition", "Stakeholder", "KPI"],
+        "Lifecycle Phase": ["Decision", "Action", "Merge", "Fork", "Join", "Final", "Database", "ANN", "Data acquisition", "Stakeholder", "KPI"],
+        "Stakeholder": ["Action", "Decision", "Merge", "Fork", "Join", "Lifecycle Phase", "Work Product", "Stakeholder", "KPI"],
+        "KPI": ["Action", "Decision", "Merge", "Fork", "Join", "Lifecycle Phase", "Work Product", "Stakeholder", "KPI"],
         "Final": []
       },
       // Relationships between governance work products and phases


### PR DESCRIPTION
## Summary
- expose Stakeholder and KPI nodes in governance diagrams through dedicated toggleable toolboxes
- allow Stakeholder and KPI nodes to connect via Flow in governance diagrams
- introduce SPI requirement specification to enable governance of SPI work products
- render Stakeholder (stick figure) and KPI (hexagon) shapes and expose Fork/Join control nodes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689fddf2a7b88327b79275c87d45138a