### PR TITLE
Refine governance relationship rules and toolbox grouping

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -275,7 +275,33 @@
       "Trace": {"Work Product": ["Work Product"]},
       "Used By": {"Work Product": ["Work Product"]},
       "Used after Review": {"Work Product": ["Work Product"]},
-      "Used after Approval": {"Work Product": ["Work Product"]}
+      "Used after Approval": {"Work Product": ["Work Product"]},
+      // Relationships between governance elements
+      "Approves": {"Role": ["Document", "Policy", "Procedure", "Record"]},
+      "Audits": {"Role": ["Process", "Procedure", "Record"]},
+      "Authorizes": {
+        "Organization": ["Policy", "Procedure", "Process"],
+        "Role": ["Policy", "Procedure"]
+      },
+      "Communication Path": {
+        "Role": ["Role", "Organization", "Business Unit"],
+        "Organization": ["Organization", "Business Unit"],
+        "Business Unit": ["Business Unit"]
+      },
+      "Constrained by": {
+        "Procedure": ["Policy", "Guideline", "Standard", "Principle"]
+      },
+      "Consumes": {"Process": ["Data", "Record"]},
+      "Curation": {"Process": ["Data"]},
+      "Delivers": {"Process": ["Document", "Record"]},
+      "Executes": {"Role": ["Process", "Procedure"]},
+      "Extend": {"Policy": ["Policy"], "Standard": ["Standard"]},
+      "Generalize": {"Policy": ["Policy"], "Standard": ["Standard"]},
+      "Monitors": {"Role": ["Metric", "Process", "Activity"]},
+      "Performs": {"Role": ["Activity", "Task", "Procedure"]},
+      "Produces": {"Process": ["Document", "Data", "Record"]},
+      "Responsible for": {"Role": ["Process", "Activity", "Task"]},
+      "Uses": {"Role": ["Document", "Data", "Record"]}
     }
   },
 

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -69,6 +69,21 @@ SAFETY_AI_RELATION_SET = set(SAFETY_AI_RELATIONS)
 GOV_ELEMENT_NODES = _CONFIG.get("governance_element_nodes", [])
 GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", [])
 
+# Group governance elements into meaningful classes for toolbox organisation
+GOV_ELEMENT_CLASSES = {
+    "Entities": [
+        n
+        for n in ["Organization", "Business Unit", "Role"]
+        if n in GOV_ELEMENT_NODES
+    ],
+    "Artifacts": [n for n in ["Data", "Document", "Record"] if n in GOV_ELEMENT_NODES],
+    "Governance": [
+        n
+        for n in ["Policy", "Principle", "Procedure", "Guideline", "Standard", "Metric"]
+        if n in GOV_ELEMENT_NODES
+    ],
+}
+
 # Elements from the governance toolbox that may participate in
 # Safety & AI relationships
 GOVERNANCE_NODE_TYPES = set(_CONFIG.get("governance_node_types", []))
@@ -9798,9 +9813,8 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                 pack_forget=lambda *a, **k: None,
             )
 
-        # Create toolbox for additional governance elements
-        ge_nodes = GOV_ELEMENT_NODES
-        ge_rels = GOV_ELEMENT_RELATIONS
+        # Create toolbox for additional governance elements grouped by class
+        ge_nodes = GOV_ELEMENT_CLASSES
         if hasattr(self.toolbox, "tk"):
             self.gov_elements_frame = ttk.Frame(self.toolbox)
             ttk.Button(
@@ -9808,20 +9822,15 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                 text="Select",
                 command=lambda: self.select_tool("Select"),
             ).pack(fill=tk.X, padx=2, pady=2)
-            for name in ge_nodes:
-                ttk.Button(
-                    self.gov_elements_frame,
-                    text=name,
-                    command=lambda t=name: self.select_tool(t),
-                ).pack(fill=tk.X, padx=2, pady=2)
-            ge_rel = ttk.LabelFrame(self.gov_elements_frame, text="Relationships")
-            ge_rel.pack(fill=tk.X, padx=2, pady=2)
-            for name in ge_rels:
-                ttk.Button(
-                    ge_rel,
-                    text=name,
-                    command=lambda t=name: self.select_tool(t),
-                ).pack(fill=tk.X, padx=2, pady=2)
+            for group, nodes in ge_nodes.items():
+                frame = ttk.LabelFrame(self.gov_elements_frame, text=group)
+                frame.pack(fill=tk.X, padx=2, pady=2)
+                for name in nodes:
+                    ttk.Button(
+                        frame,
+                        text=name,
+                        command=lambda t=name: self.select_tool(t),
+                    ).pack(fill=tk.X, padx=2, pady=2)
         else:
             self.gov_elements_frame = types.SimpleNamespace(
                 pack=lambda *a, **k: None,
@@ -9854,7 +9863,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         governance_panel = ttk.LabelFrame(self, text="Governance")
         governance_panel.pack(side=tk.RIGHT, fill=tk.Y, padx=2, pady=2)
 
-        rel_names = [
+        work_rel_names = [
             "Propagate",
             "Propagate by Review",
             "Propagate by Approval",
@@ -9865,28 +9874,21 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "Trace",
             "Satisfied by",
             "Derived from",
-            "Approves",
-            "Audits",
-            "Authorizes",
-            "Communication Path",
-            "Constrained by",
-            "Consumes",
-            "Curation",
-            "Delivers",
-            "Executes",
-            "Extend",
-            "Generalize",
-            "Monitors",
-            "Performs",
-            "Produces",
-            "Responsible for",
-            "Uses",
         ]
-        rel_frame = ttk.LabelFrame(governance_panel, text="Relationships")
-        rel_frame.pack(fill=tk.X, padx=2, pady=2)
-        for name in rel_names:
+        wp_rel = ttk.LabelFrame(governance_panel, text="Work Product Links")
+        wp_rel.pack(fill=tk.X, padx=2, pady=2)
+        for name in work_rel_names:
             ttk.Button(
-                rel_frame,
+                wp_rel,
+                text=name,
+                command=lambda t=name: self.select_tool(t),
+            ).pack(fill=tk.X, padx=2, pady=2)
+
+        elem_rel = ttk.LabelFrame(governance_panel, text="Element Relationships")
+        elem_rel.pack(fill=tk.X, padx=2, pady=2)
+        for name in GOV_ELEMENT_RELATIONS:
+            ttk.Button(
+                elem_rel,
                 text=name,
                 command=lambda t=name: self.select_tool(t),
             ).pack(fill=tk.X, padx=2, pady=2)

--- a/tests/test_governance_element_connection_rules.py
+++ b/tests/test_governance_element_connection_rules.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from config import load_diagram_rules
+
+
+def test_governance_element_connection_rules():
+    cfg = load_diagram_rules(Path(__file__).resolve().parents[1] / "config/diagram_rules.json")
+    rules = cfg["connection_rules"]["Governance Diagram"]
+    assert set(rules["Approves"]["Role"]) == {"Document", "Policy", "Procedure", "Record"}
+    assert set(rules["Uses"]["Role"]) == {"Document", "Data", "Record"}


### PR DESCRIPTION
## Summary
- Add detailed relationship rules for governance elements to diagram configuration
- Group governance elements and relationships in UI toolboxes to avoid duplicates
- Test governance element connection rules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ff2d7c33483278bfa282dbab5cc85