### PR TITLE
Refine governance relationship rules and toolbox layout

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -51,13 +51,26 @@ def validate_diagram_rules(data: Any) -> dict[str, Any]:
         "arch_diagram_types",
         "governance_node_types",
         "governance_element_nodes",
-        "governance_element_relations",
         "gate_node_types",
         "guard_nodes",
     ]
     for field in list_fields:
         if field in data:
             _ensure_list_of_strings(data[field], field)
+
+    if "governance_element_relations" in data:
+        ger = data["governance_element_relations"]
+        if isinstance(ger, list):
+            _ensure_list_of_strings(ger, "governance_element_relations")
+        elif isinstance(ger, dict):
+            for group, rels in ger.items():
+                _ensure_list_of_strings(
+                    rels, f"governance_element_relations[{group}]"
+                )
+        else:
+            raise ValueError(
+                "governance_element_relations must be a list or object"
+            )
 
     if "requirement_rules" in data or "relationship_rules" in data:
         rr = data.get("requirement_rules", data.get("relationship_rules", {}))

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -57,25 +57,30 @@
     "Standard"
   ],
 
-  // Relation labels for the Governance Elements toolbox
-  "governance_element_relations": [
-    "Approves",
-    "Audits",
-    "Authorizes",
-    "Communication Path",
-    "Constrained by",
-    "Consumes",
-    "Curation",
-    "Delivers",
-    "Executes",
-    "Extend",
-    "Generalize",
-    "Monitors",
-    "Performs",
-    "Produces",
-    "Responsible for",
-    "Uses"
-  ],
+  // Relation labels for the Governance Elements toolbox grouped by category
+  "governance_element_relations": {
+    "Authority": [
+      "Approves",
+      "Audits",
+      "Authorizes",
+      "Responsible for"
+    ],
+    "Activity": [
+      "Performs",
+      "Executes",
+      "Produces",
+      "Delivers",
+      "Consumes",
+      "Uses",
+      "Monitors"
+    ],
+    "Structure": [
+      "Communication Path",
+      "Constrained by",
+      "Extend",
+      "Generalize"
+    ]
+  },
 
   // Diagram types considered part of the generic "Architecture Diagram" work product
   "arch_diagram_types": [
@@ -97,19 +102,7 @@
     "Join",
     "System Boundary",
     "Work Product",
-    "Lifecycle Phase",
-    "Business Unit",
-    "Data",
-    "Document",
-    "Guideline",
-    "Metric",
-    "Organization",
-    "Policy",
-    "Principle",
-    "Procedure",
-    "Record",
-    "Role",
-    "Standard"
+    "Lifecycle Phase"
   ],
 
   // FMEDA/Fault tree gate node types

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -67,7 +67,7 @@ SAFETY_AI_RELATION_SET = set(SAFETY_AI_RELATIONS)
 
 # Elements available in the Governance Elements toolbox
 GOV_ELEMENT_NODES = _CONFIG.get("governance_element_nodes", [])
-GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", [])
+GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", {})
 
 # Elements from the governance toolbox that may participate in
 # Safety & AI relationships
@@ -232,7 +232,7 @@ def reload_config() -> None:
     SAFETY_AI_RELATIONS = _CONFIG.get("ai_relations", [])
     SAFETY_AI_RELATION_SET = set(SAFETY_AI_RELATIONS)
     GOV_ELEMENT_NODES = _CONFIG.get("governance_element_nodes", [])
-    GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", [])
+    GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", {})
     GOVERNANCE_NODE_TYPES = set(_CONFIG.get("governance_node_types", []))
     SAFETY_AI_RELATION_RULES = {
         conn: {src: set(dests) for src, dests in srcs.items()}
@@ -9814,14 +9814,25 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                     text=name,
                     command=lambda t=name: self.select_tool(t),
                 ).pack(fill=tk.X, padx=2, pady=2)
-            ge_rel = ttk.LabelFrame(self.gov_elements_frame, text="Relationships")
-            ge_rel.pack(fill=tk.X, padx=2, pady=2)
-            for name in ge_rels:
-                ttk.Button(
-                    ge_rel,
-                    text=name,
-                    command=lambda t=name: self.select_tool(t),
-                ).pack(fill=tk.X, padx=2, pady=2)
+            if isinstance(ge_rels, dict):
+                for group, rels in ge_rels.items():
+                    ge_rel = ttk.LabelFrame(self.gov_elements_frame, text=group)
+                    ge_rel.pack(fill=tk.X, padx=2, pady=2)
+                    for name in rels:
+                        ttk.Button(
+                            ge_rel,
+                            text=name,
+                            command=lambda t=name: self.select_tool(t),
+                        ).pack(fill=tk.X, padx=2, pady=2)
+            else:
+                ge_rel = ttk.LabelFrame(self.gov_elements_frame, text="Relationships")
+                ge_rel.pack(fill=tk.X, padx=2, pady=2)
+                for name in ge_rels:
+                    ttk.Button(
+                        ge_rel,
+                        text=name,
+                        command=lambda t=name: self.select_tool(t),
+                    ).pack(fill=tk.X, padx=2, pady=2)
         else:
             self.gov_elements_frame = types.SimpleNamespace(
                 pack=lambda *a, **k: None,

--- a/tests/test_governance_relation_groups.py
+++ b/tests/test_governance_relation_groups.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+from config import load_diagram_rules
+
+
+def test_governance_relations_grouped_without_duplicates():
+    rules = load_diagram_rules(Path(__file__).resolve().parents[1] / "config/diagram_rules.json")
+    rels = rules.get("governance_element_relations")
+    assert isinstance(rels, dict)
+    all_rels: list[str] = []
+    for group in rels.values():
+        all_rels.extend(group)
+    # ensure relations are unique and no AI-specific duplicates like "Curation"
+    assert len(all_rels) == len(set(all_rels))
+    assert "Curation" not in all_rels
+


### PR DESCRIPTION
## Summary
- Group governance element relations into Authority, Activity, and Structure categories
- Remove duplicate governance element types from toolbox configuration
- Validate grouped relations and adjust GUI to display them by class
- Add regression test to ensure relations remain unique

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ff2d7c33483278bfa282dbab5cc85