### PR TITLE
feat: add configurable requirement patterns

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -307,5 +307,8 @@
 
   // Node types that require guards on outgoing flows
   // Format: ["Node Type", ...]
-  "guard_nodes": ["Decision"]
+  "guard_nodes": ["Decision"],
+
+  // Optional external file listing requirement pattern definitions
+  "requirement_pattern_file": "requirement_patterns.json"
 }

--- a/config/requirement_patterns.json
+++ b/config/requirement_patterns.json
@@ -1,0 +1,57 @@
+[
+  {
+    "Pattern ID": "SA-acquisition-Database-Data_acquisition",
+    "Trigger": "Safety&AI: Database --[Acquisition]--> Data acquisition",
+    "Template": "Engineering team shall acquire the <Data acquisition> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-Database-Data_acquisition",
+    "Trigger": "Safety&AI: Database --[Field data collection]--> Data acquisition",
+    "Template": "Engineering team shall collect field data the <Data acquisition> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-annotation-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Annotation]--> Database",
+    "Template": "Engineering team shall annotate the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "GOV-propagate-Work_Product-Work_Product",
+    "Trigger": "Gov: Work Product --[Propagate]--> Work Product",
+    "Template": "System shall propagate the <Work Product>.",
+    "Variables": [
+      "<owner>",
+      "<due_date>",
+      "<evidence_ref>"
+    ],
+    "Notes": "Use when a governance edge is present."
+  },
+  {
+    "Pattern ID": "GOV-approves-Role-Document",
+    "Trigger": "Gov: Role --[Approves]--> Document",
+    "Template": "Role shall approve the <Document>.",
+    "Variables": [
+      "<owner>",
+      "<due_date>",
+      "<evidence_ref>"
+    ],
+    "Notes": "Use when a governance edge is present."
+  }
+]

--- a/tests/test_governance_requirement_patterns.py
+++ b/tests/test_governance_requirement_patterns.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram
+
+
+def test_requirement_pattern_generation():
+    diagram = GovernanceDiagram()
+    diagram.add_task("WP1", node_type="Work Product")
+    diagram.add_task("WP2", node_type="Work Product")
+    diagram.add_relationship("WP1", "WP2", conn_type="Propagate")
+
+    reqs = diagram.generate_requirements()
+    texts = [r[0] if isinstance(r, tuple) else r.text for r in reqs]
+    assert any("propagate" in t and "WP2" in t for t in texts)


### PR DESCRIPTION
## Summary
- load requirement pattern definitions from a configurable JSON file
- match governance edges against patterns and emit template-based requirements
- add tests for pattern-based requirement generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ff59f5d188327b735f4dd86505fb9