### PR TITLE
Add configurable requirement pattern support

### DIFF
--- a/config/requirement_patterns.json
+++ b/config/requirement_patterns.json
@@ -1,0 +1,156 @@
+[
+  {
+    "Pattern ID": "SA-acquisition-Database-Data_acquisition",
+    "Trigger": "Safety&AI: Database --[Acquisition]--> Data acquisition",
+    "Template": "Engineering team shall acquire the <Data acquisition> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-Database-Data_acquisition",
+    "Trigger": "Safety&AI: Database --[Field data collection]--> Data acquisition",
+    "Template": "Engineering team shall collect field data the <Data acquisition> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-Database-Task",
+    "Trigger": "Safety&AI: Database --[Field data collection]--> Task",
+    "Template": "Engineering team shall collect field data the <Task> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-field_risk_evaluation-Database-Data_acquisition",
+    "Trigger": "Safety&AI: Database --[Field risk evaluation]--> Data acquisition",
+    "Template": "Engineering team shall evaluate field risk the <Data acquisition> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-annotation-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Annotation]--> Database",
+    "Template": "Engineering team shall annotate the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-synthesis-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Synthesis]--> Database",
+    "Template": "Engineering team shall synthesize the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-augmentation-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Augmentation]--> Database",
+    "Template": "Engineering team shall augment the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-labeling-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Labeling]--> Database",
+    "Template": "Engineering team shall label the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-ai_training-Database-ANN",
+    "Trigger": "Safety&AI: Database --[AI training]--> ANN",
+    "Template": "Engineering team shall train the <ANN> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-ai_re-training-Database-ANN",
+    "Trigger": "Safety&AI: Database --[AI re-training]--> ANN",
+    "Template": "Engineering team shall retrain the <ANN> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-model_evaluation-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Model evaluation]--> Database",
+    "Template": "Engineering team shall evaluate model the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-curation-Database-Database",
+    "Trigger": "Safety&AI: Database --[Curation]--> Database",
+    "Template": "Engineering team shall curate the <Database> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-ingestion-Database-Database",
+    "Trigger": "Safety&AI: Database --[Ingestion]--> Database",
+    "Template": "Engineering team shall ingest the <Database> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "GOV-propagate-Work_Product-Work_Product",
+    "Trigger": "Gov: Work Product --[Propagate]--> Work Product",
+    "Template": "System shall propagate the <Work Product>.",
+    "Variables": [
+      "<owner>",
+      "<due_date>",
+      "<evidence_ref>"
+    ],
+    "Notes": "Use when a governance edge is present."
+  }
+]

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -44,11 +44,11 @@ def test_generate_requirements_from_governance_diagram():
 
 def test_ai_training_and_curation_requirements():
     diagram = GovernanceDiagram()
-    diagram.add_task("Decision1", node_type="Decision")
-    diagram.add_task("ANN1", node_type="ANN")
     diagram.add_task("Database1", node_type="Database")
+    diagram.add_task("ANN1", node_type="ANN")
+    diagram.add_task("Decision1", node_type="Decision")
     diagram.add_relationship(
-        "Decision1",
+        "Database1",
         "ANN1",
         condition="completion >= 0.98",
         conn_type="AI training",
@@ -61,7 +61,10 @@ def test_ai_training_and_curation_requirements():
     )
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
-    assert "If completion >= 0.98, Engineering team shall train 'ANN1'." in texts
+    assert (
+        "If completion >= 0.98, Engineering team shall train the ANN1 using the Database1."
+        in texts
+    )
     assert "If completion < 0.98, Engineering team shall curate 'Database1'." in texts
 
     train_req = next(r for r in reqs if r.action == "train")
@@ -73,6 +76,16 @@ def test_ai_training_and_curation_requirements():
     assert curate_req.subject == "Engineering team"
     assert curate_req.obj == "Database1"
     assert curate_req.condition == "completion < 0.98"
+
+
+def test_acquisition_pattern_requirement():
+    diagram = GovernanceDiagram()
+    diagram.add_task("DB1", node_type="Database")
+    diagram.add_task("DAQ1", node_type="Data acquisition")
+    diagram.add_relationship("DB1", "DAQ1", conn_type="Acquisition")
+    reqs = diagram.generate_requirements()
+    texts = [r.text for r in reqs]
+    assert "Engineering team shall acquire the DAQ1 using the DB1." in texts
 
 
 def test_data_acquisition_compartment_sources():


### PR DESCRIPTION
## Summary
- allow governance analysis to load requirement patterns from `config/requirement_patterns.json`
- support templated requirement text per relationship trigger
- add tests for AI training and acquisition pattern detection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ff59f5d188327b735f4dd86505fb9