### PR TITLE
Add configurable requirement pattern support

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -526,6 +526,7 @@ VALID_SUBTYPES = {
 _CONFIG_PATH = Path(__file__).resolve().parent / "config/diagram_rules.json"
 _CONFIG = load_diagram_rules(_CONFIG_PATH)
 GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
+_PATTERN_PATH = Path(__file__).resolve().parent / "config/requirement_patterns.json"
 
 
 def _reload_local_config() -> None:
@@ -2737,6 +2738,7 @@ class FaultTreeApp:
             "Fault Prioritization": self.open_fault_prioritization_window,
             "Cause & Effect Diagram": self.show_cause_effect_chain,
             "Diagram Rule Editor": self.open_diagram_rules_toolbox,
+            "Requirement Pattern Editor": self.open_requirement_patterns_toolbox,
         }
 
         self.tool_categories: dict[str, list[str]] = {
@@ -2752,6 +2754,7 @@ class FaultTreeApp:
             ],
             "Configuration": [
                 "Diagram Rule Editor",
+                "Requirement Pattern Editor",
             ],
         }
         self.tool_to_work_product = {}
@@ -16836,6 +16839,30 @@ class FaultTreeApp:
 
         self.diagram_rules_editor = DiagramRulesEditor(parent, self, _CONFIG_PATH)
         self.diagram_rules_editor.pack(fill=tk.BOTH, expand=True)
+
+    def open_requirement_patterns_toolbox(self):
+        """Open editor for requirement pattern definitions."""
+        tab_exists = (
+            hasattr(self, "_req_patterns_tab") and self._req_patterns_tab.winfo_exists()
+        )
+        editor_exists = (
+            hasattr(self, "requirement_patterns_editor")
+            and self.requirement_patterns_editor.winfo_exists()
+        )
+        if tab_exists:
+            self.doc_nb.select(self._req_patterns_tab)
+            if editor_exists:
+                return
+            parent = self._req_patterns_tab
+        else:
+            parent = self._req_patterns_tab = self._new_tab("Requirement Patterns")
+
+        from gui.requirement_patterns_toolbox import RequirementPatternsEditor
+
+        self.requirement_patterns_editor = RequirementPatternsEditor(
+            parent, self, _PATTERN_PATH
+        )
+        self.requirement_patterns_editor.pack(fill=tk.BOTH, expand=True)
 
     def reload_config(self) -> None:
         """Reload diagram rule configuration across modules."""

--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass, field
 from typing import Any, Iterator, List, Tuple
 
 from pathlib import Path
-from config import load_diagram_rules
+from config import load_diagram_rules, load_json_with_comments
 
 import networkx as nx
+import re
 
 _CONFIG_PATH = Path(__file__).resolve().parents[1] / "config/diagram_rules.json"
 _CONFIG = load_diagram_rules(_CONFIG_PATH)
@@ -28,10 +29,64 @@ _REQUIREMENT_RULES: dict[str, dict[str, str | bool]] = _CONFIG.get(
 # identify the subject, object or constraint directly from the model.
 _NODE_ROLES = _CONFIG.get("node_roles", {})
 
+# Optional requirement pattern definitions allowing users to customise
+# requirement text based on specific relationship triggers.  Each pattern
+# entry is keyed by ``(source_type, label, dest_type)`` so that users can
+# modify or extend the patterns in ``config/requirement_patterns.json``
+# without touching the code.
+_PATTERN_PATH = Path(__file__).resolve().parents[1] / "config/requirement_patterns.json"
+try:
+    _PATTERN_DEFS = load_json_with_comments(_PATTERN_PATH)
+except FileNotFoundError:  # pragma: no cover - optional file
+    _PATTERN_DEFS = []
+
+_TRIGGER_RE = re.compile(r"[^:]+:\s*(.*?)\s*--\[(.*?)\]-->\s*(.*)")
+_PATTERN_MAP: dict[tuple[str, str, str], dict[str, str]] = {}
+for pat in _PATTERN_DEFS:
+    trig = pat.get("Trigger", "")
+    tmpl = pat.get("Template", "")
+    m = _TRIGGER_RE.fullmatch(trig)
+    if not m:
+        continue
+    src_t, label, dst_t = [g.strip().lower() for g in m.groups()]
+    # Only register patterns that reference the source node in the template
+    # so that generated text includes the actual element names.
+    placeholders = [p.lower() for p in re.findall(r"<([^>]+)>", tmpl)]
+    if src_t == dst_t or (
+        src_t not in placeholders and "source_id" not in placeholders
+    ):
+        continue
+    _PATTERN_MAP[(src_t, label.lower(), dst_t)] = pat
+
+
+def _apply_pattern(
+    pat: dict[str, str],
+    src: str,
+    dst: str,
+    src_type: str,
+    dst_type: str,
+    cond: str | None,
+) -> str:
+    """Instantiate a pattern template with diagram values."""
+
+    template = pat.get("Template", "")
+
+    def repl(match: re.Match[str]) -> str:
+        key = match.group(1)
+        if key == "source_id" or key == src_type:
+            return src
+        if key == "target_id" or key == dst_type:
+            return dst
+        if key == "acceptance_criteria":
+            return cond or ""
+        return ""
+
+    return re.sub(r"<([^>]+)>", repl, template)
+
 
 def reload_config() -> None:
     """Reload governance-related configuration."""
-    global _CONFIG, _AI_NODES, _AI_RELATIONS, _REQUIREMENT_RULES, _NODE_ROLES
+    global _CONFIG, _AI_NODES, _AI_RELATIONS, _REQUIREMENT_RULES, _NODE_ROLES, _PATTERN_DEFS, _PATTERN_MAP
     _CONFIG = load_diagram_rules(_CONFIG_PATH)
     _AI_NODES = set(_CONFIG.get("ai_nodes", []))
     _AI_RELATIONS = set(_CONFIG.get("ai_relations", []))
@@ -39,6 +94,25 @@ def reload_config() -> None:
         "requirement_rules", _CONFIG.get("relationship_rules", {})
     )
     _NODE_ROLES = _CONFIG.get("node_roles", {})
+
+    try:
+        _PATTERN_DEFS = load_json_with_comments(_PATTERN_PATH)
+    except FileNotFoundError:  # pragma: no cover - optional file
+        _PATTERN_DEFS = []
+    _PATTERN_MAP = {}
+    for pat in _PATTERN_DEFS:
+        trig = pat.get("Trigger", "")
+        tmpl = pat.get("Template", "")
+        m = _TRIGGER_RE.fullmatch(trig)
+        if not m:
+            continue
+        src_t, label, dst_t = [g.strip().lower() for g in m.groups()]
+        placeholders = [p.lower() for p in re.findall(r"<([^>]+)>", tmpl)]
+        if src_t == dst_t or (
+            src_t not in placeholders and "source_id" not in placeholders
+        ):
+            continue
+        _PATTERN_MAP[(src_t, label.lower(), dst_t)] = pat
 
 
 @dataclass
@@ -61,9 +135,12 @@ class GeneratedRequirement:
     origin: str | None = None
     source: str | None = None
     req_type: str = "organizational"
+    text_override: str | None = None
 
     @property
     def text(self) -> str:
+        if self.text_override is not None:
+            return self.text_override
         parts: List[str] = []
         if self.condition:
             parts.append(f"If {self.condition},")
@@ -341,6 +418,16 @@ class GovernanceDiagram:
                 d_role = self._role_for(obj)
                 if s_role != "subject" and d_role == "subject":
                     subject, obj = obj, subject
+            text_override: str | None = None
+            src_type = self.node_types.get(src, "")
+            dst_type = self.node_types.get(dst, "")
+            pattern = _PATTERN_MAP.get(
+                (src_type.lower(), (label or conn_type or "").lower(), dst_type.lower())
+            )
+            if pattern:
+                text_override = _apply_pattern(pattern, src, dst, src_type, dst_type, cond)
+                if cond and "<acceptance_criteria>" not in pattern.get("Template", ""):
+                    text_override = f"If {cond}, {text_override}"
 
             requirements.append(
                 GeneratedRequirement(
@@ -352,6 +439,7 @@ class GovernanceDiagram:
                     origin=origin if (origin and kind != "flow") else None,
                     source=src,
                     req_type=req_type,
+                    text_override=text_override,
                 )
             )
 

--- a/config/requirement_patterns.json
+++ b/config/requirement_patterns.json
@@ -1,0 +1,156 @@
+[
+  {
+    "Pattern ID": "SA-acquisition-Database-Data_acquisition",
+    "Trigger": "Safety&AI: Database --[Acquisition]--> Data acquisition",
+    "Template": "Engineering team shall acquire the <Data acquisition> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-Database-Data_acquisition",
+    "Trigger": "Safety&AI: Database --[Field data collection]--> Data acquisition",
+    "Template": "Engineering team shall collect field data the <Data acquisition> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-field_data_collection-Database-Task",
+    "Trigger": "Safety&AI: Database --[Field data collection]--> Task",
+    "Template": "Engineering team shall collect field data the <Task> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-field_risk_evaluation-Database-Data_acquisition",
+    "Trigger": "Safety&AI: Database --[Field risk evaluation]--> Data acquisition",
+    "Template": "Engineering team shall evaluate field risk the <Data acquisition> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-annotation-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Annotation]--> Database",
+    "Template": "Engineering team shall annotate the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-synthesis-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Synthesis]--> Database",
+    "Template": "Engineering team shall synthesize the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-augmentation-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Augmentation]--> Database",
+    "Template": "Engineering team shall augment the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-labeling-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Labeling]--> Database",
+    "Template": "Engineering team shall label the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-ai_training-Database-ANN",
+    "Trigger": "Safety&AI: Database --[AI training]--> ANN",
+    "Template": "Engineering team shall train the <ANN> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-ai_re-training-Database-ANN",
+    "Trigger": "Safety&AI: Database --[AI re-training]--> ANN",
+    "Template": "Engineering team shall retrain the <ANN> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-model_evaluation-ANN-Database",
+    "Trigger": "Safety&AI: ANN --[Model evaluation]--> Database",
+    "Template": "Engineering team shall evaluate model the <Database> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-curation-Database-Database",
+    "Trigger": "Safety&AI: Database --[Curation]--> Database",
+    "Template": "Engineering team shall curate the <Database> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "SA-ingestion-Database-Database",
+    "Trigger": "Safety&AI: Database --[Ingestion]--> Database",
+    "Template": "Engineering team shall ingest the <Database> using the <Database>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "GOV-propagate-Work_Product-Work_Product",
+    "Trigger": "Gov: Work Product --[Propagate]--> Work Product",
+    "Template": "System shall propagate the <Work Product>.",
+    "Variables": [
+      "<owner>",
+      "<due_date>",
+      "<evidence_ref>"
+    ],
+    "Notes": "Use when a governance edge is present."
+  }
+]

--- a/gui/requirement_patterns_toolbox.py
+++ b/gui/requirement_patterns_toolbox.py
@@ -1,0 +1,128 @@
+import tkinter as tk
+from tkinter import ttk, simpledialog
+from pathlib import Path
+import json
+from config import load_json_with_comments
+from gui import messagebox
+
+class RequirementPatternsEditor(tk.Frame):
+    """Visual editor for requirement pattern configuration."""
+
+    def __init__(self, master, app, config_path: Path | None = None):
+        super().__init__(master)
+        self.app = app
+        self.config_path = Path(
+            config_path or Path(__file__).resolve().parents[1] / "config/requirement_patterns.json"
+        )
+        try:
+            self.data = load_json_with_comments(self.config_path)
+        except Exception as exc:  # pragma: no cover - GUI fallback
+            messagebox.showerror(
+                "Requirement Patterns", f"Failed to load configuration:\n{exc}"
+            )
+            self.data = []
+
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        tree_frame = ttk.Frame(self)
+        tree_frame.grid(row=0, column=0, sticky="nsew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        self.tree = ttk.Treeview(tree_frame, columns=("trigger", "template"), show="headings")
+        self.tree.heading("trigger", text="Trigger")
+        self.tree.heading("template", text="Template")
+        self.tree.column("trigger", width=250, stretch=True)
+        self.tree.column("template", width=250, stretch=True)
+        self.tree.bind("<Double-1>", self._edit_item)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+
+        ybar = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        xbar = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=ybar.set, xscrollcommand=xbar.set)
+        ybar.grid(row=0, column=1, sticky="ns")
+        xbar.grid(row=1, column=0, sticky="ew")
+
+        btn_frame = ttk.Frame(self)
+        btn_frame.grid(row=1, column=0, sticky="e", pady=4, padx=4)
+        ttk.Button(btn_frame, text="Add", command=self.add_pattern).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Delete", command=self.delete_pattern).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Save", command=self.save).pack(side=tk.LEFT, padx=2)
+
+        self._populate_tree()
+
+    def _populate_tree(self):
+        self.tree.delete(*self.tree.get_children(""))
+        for idx, pat in enumerate(self.data):
+            trig = pat.get("Trigger", "")
+            tmpl = pat.get("Template", "")
+            self.tree.insert("", "end", iid=str(idx), values=(trig, tmpl))
+
+    def _edit_item(self, _event=None):
+        item = self.tree.focus()
+        if not item:
+            return
+        idx = int(item)
+        pat = self.data[idx]
+        pid = simpledialog.askstring(
+            "Pattern ID", "Pattern ID", initialvalue=pat.get("Pattern ID", ""), parent=self
+        )
+        if pid is None:
+            return
+        trig = simpledialog.askstring(
+            "Trigger", "Trigger", initialvalue=pat.get("Trigger", ""), parent=self
+        )
+        if trig is None:
+            return
+        tmpl = simpledialog.askstring(
+            "Template", "Template", initialvalue=pat.get("Template", ""), parent=self
+        )
+        if tmpl is None:
+            return
+        vars_str = simpledialog.askstring(
+            "Variables", "Comma-separated variables", initialvalue=", ".join(pat.get("Variables", [])), parent=self
+        )
+        if vars_str is None:
+            return
+        notes = simpledialog.askstring(
+            "Notes", "Notes", initialvalue=pat.get("Notes", ""), parent=self
+        )
+        if notes is None:
+            return
+        pat.update(
+            {
+                "Pattern ID": pid.strip(),
+                "Trigger": trig.strip(),
+                "Template": tmpl.strip(),
+                "Variables": [v.strip() for v in vars_str.split(",") if v.strip()],
+                "Notes": notes.strip(),
+            }
+        )
+        self._populate_tree()
+
+    def add_pattern(self):
+        self.data.append({})
+        self._populate_tree()
+        self.tree.selection_set(str(len(self.data) - 1))
+        self._edit_item()
+
+    def delete_pattern(self):
+        item = self.tree.focus()
+        if not item:
+            return
+        idx = int(item)
+        del self.data[idx]
+        self._populate_tree()
+
+    def save(self):
+        try:
+            self.config_path.write_text(json.dumps(self.data, indent=2) + "\n")
+            if hasattr(self.app, "reload_config"):
+                self.app.reload_config()
+            messagebox.showinfo("Requirement Patterns", "Configuration saved")
+            self._populate_tree()
+        except Exception as exc:  # pragma: no cover - GUI feedback
+            messagebox.showerror(
+                "Requirement Patterns", f"Failed to save configuration:\n{exc}"
+            )

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -44,11 +44,11 @@ def test_generate_requirements_from_governance_diagram():
 
 def test_ai_training_and_curation_requirements():
     diagram = GovernanceDiagram()
-    diagram.add_task("Decision1", node_type="Decision")
-    diagram.add_task("ANN1", node_type="ANN")
     diagram.add_task("Database1", node_type="Database")
+    diagram.add_task("ANN1", node_type="ANN")
+    diagram.add_task("Decision1", node_type="Decision")
     diagram.add_relationship(
-        "Decision1",
+        "Database1",
         "ANN1",
         condition="completion >= 0.98",
         conn_type="AI training",
@@ -61,7 +61,10 @@ def test_ai_training_and_curation_requirements():
     )
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
-    assert "If completion >= 0.98, Engineering team shall train 'ANN1'." in texts
+    assert (
+        "If completion >= 0.98, Engineering team shall train the ANN1 using the Database1."
+        in texts
+    )
     assert "If completion < 0.98, Engineering team shall curate 'Database1'." in texts
 
     train_req = next(r for r in reqs if r.action == "train")
@@ -73,6 +76,16 @@ def test_ai_training_and_curation_requirements():
     assert curate_req.subject == "Engineering team"
     assert curate_req.obj == "Database1"
     assert curate_req.condition == "completion < 0.98"
+
+
+def test_acquisition_pattern_requirement():
+    diagram = GovernanceDiagram()
+    diagram.add_task("DB1", node_type="Database")
+    diagram.add_task("DAQ1", node_type="Data acquisition")
+    diagram.add_relationship("DB1", "DAQ1", conn_type="Acquisition")
+    reqs = diagram.generate_requirements()
+    texts = [r.text for r in reqs]
+    assert "Engineering team shall acquire the DAQ1 using the DB1." in texts
 
 
 def test_data_acquisition_compartment_sources():

--- a/tests/test_requirement_patterns_toolbox.py
+++ b/tests/test_requirement_patterns_toolbox.py
@@ -1,0 +1,64 @@
+import sys
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace()
+PIL_stub.ImageTk = types.SimpleNamespace()
+PIL_stub.ImageDraw = types.SimpleNamespace()
+PIL_stub.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+sys.modules.setdefault("PIL.Image", PIL_stub.Image)
+sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
+sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
+sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
+
+from AutoML import FaultTreeApp
+
+
+def test_requirement_patterns_toolbox_single_instance():
+    """Opening requirement patterns toolbox twice doesn't duplicate editor."""
+
+    class DummyTab:
+        def winfo_exists(self):
+            return True
+
+    class DummyNotebook:
+        def add(self, tab, text):
+            pass
+
+        def select(self, tab):
+            pass
+
+    class DummyEditor:
+        created = 0
+
+        def __init__(self, master, app, path):
+            DummyEditor.created += 1
+
+        def pack(self, **kwargs):
+            pass
+
+        def winfo_exists(self):
+            return True
+
+    import gui.requirement_patterns_toolbox as rpt
+
+    rpt.RequirementPatternsEditor = DummyEditor
+
+    class DummyApp:
+        open_requirement_patterns_toolbox = FaultTreeApp.open_requirement_patterns_toolbox
+
+        def __init__(self):
+            self.doc_nb = DummyNotebook()
+
+        def _new_tab(self, title):
+            return DummyTab()
+
+    app = DummyApp()
+    app.open_requirement_patterns_toolbox()
+    app.open_requirement_patterns_toolbox()
+    assert DummyEditor.created == 1


### PR DESCRIPTION
## Summary
- allow governance analysis to load requirement patterns from `config/requirement_patterns.json`
- support templated requirement text per relationship trigger
- add tests for AI training and acquisition pattern detection
- add GUI editor to manage requirement patterns
- reload requirement patterns when configuration changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689ff59f5d188327b735f4dd86505fb9