### PR TITLE
Deduplicate governance requirements

### DIFF
--- a/tests/test_governance_requirement_dedup.py
+++ b/tests/test_governance_requirement_dedup.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram
+
+
+def test_data_acquisition_default_requirement_removed_when_sources_present():
+    diagram = GovernanceDiagram()
+    diagram.add_task(
+        "Acquire Data",
+        node_type="Data acquisition",
+        compartments=["Sensor A"],
+    )
+
+    reqs = diagram.generate_requirements()
+    texts = [r.text if hasattr(r, "text") else r[0] for r in reqs]
+
+    assert "Engineering team shall acquire data from 'Sensor A'." in texts
+    assert "Engineering team shall acquire data." not in texts
+    assert sum("acquire data" in t for t in texts) == 1

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -128,8 +128,8 @@ def test_data_acquisition_node_name_normalized():
     texts = [r.text for r in reqs]
 
     assert "Engineering team shall acquire data from 'Sensor X'." in texts
-    # Ensure the task-level requirement uses the normalized verb
-    assert "Engineering team shall acquire data." in texts
+    # Ensure the raw node name does not appear in generated text
+    assert not any("shall Data acquisition" in t for t in texts)
 
 
 def test_tasks_create_requirement_actions():


### PR DESCRIPTION
## Summary
- ignore generic governance requirements when more detailed variants exist
- add regression test for requirement deduplication
- update data acquisition normalization test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a00882b6e88327a1befa41ad2a06c2