### PR TITLE
Deduplicate governance requirements

### DIFF
--- a/config/requirement_patterns.json
+++ b/config/requirement_patterns.json
@@ -1024,5 +1024,116 @@
       "<record>"
     ],
     "Notes": "Compliance requirement with auditable trail."
+  },
+  {
+    "Pattern ID": "ORG-establish-Organization-Process",
+    "Trigger": "Organization: Organization --[Establish]--> Process",
+    "Template": "<organization> shall establish the <process> and record evidence in <record>.",
+    "Variables": [
+      "<organization>",
+      "<process>",
+      "<record>",
+      "<due_date>"
+    ],
+    "Notes": "Organizational process definition requirement."
+  },
+  {
+    "Pattern ID": "SA-monitoring-ANN-Operation",
+    "Trigger": "Safety&AI: ANN --[Monitoring]--> Operation",
+    "Template": "Engineering team shall monitor the <Operation> using the <ANN>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Instantiate on detected edge; add measurable criteria."
+  },
+  {
+    "Pattern ID": "AVD-implement-Driving_Function-Software_Component",
+    "Trigger": "AV Dev: Driving Function --[Implement]--> Software Component",
+    "Template": "Engineering team shall implement the <Software Component> for the <Driving Function>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "For autonomous vehicle functionality development."
+  },
+  {
+    "Pattern ID": "VAL-validate-Test_Suite-System",
+    "Trigger": "Validation: Test Suite --[Validate]--> System",
+    "Template": "Validation team shall validate the <System> using the <Test Suite>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Validation coverage requirement."
+  },
+  {
+    "Pattern ID": "VER-verify-Verification_Plan-Component",
+    "Trigger": "Verification: Verification Plan --[Verify]--> Component",
+    "Template": "Verification team shall verify the <Component> according to the <Verification Plan>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Verification requirement."
+  },
+  {
+    "Pattern ID": "PROD-manufacture-Manufacturing_Process-Vehicle",
+    "Trigger": "Production: Manufacturing Process --[Manufacture]--> Vehicle",
+    "Template": "Manufacturing team shall manufacture the <Vehicle> using the <Manufacturing Process>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Production requirement."
+  },
+  {
+    "Pattern ID": "OP-operate-Fleet-Vehicle",
+    "Trigger": "Operation: Fleet --[Operate]--> Vehicle",
+    "Template": "Operations team shall operate the <Vehicle> within the <Fleet>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Operational requirement."
+  },
+  {
+    "Pattern ID": "INSP-inspect-Vehicle-Safety_Compliance",
+    "Trigger": "Inspection: Vehicle --[Inspect]--> Safety Compliance",
+    "Template": "Inspection team shall inspect the <Vehicle> for <Safety Compliance>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Periodic inspection requirement."
+  },
+  {
+    "Pattern ID": "TRI-triage-Incident-Safety_Issue",
+    "Trigger": "Triage: Incident --[Triage]--> Safety Issue",
+    "Template": "Support team shall triage the <Safety Issue> from the <Incident>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Incident triage requirement."
+  },
+  {
+    "Pattern ID": "IMP-improve-Field_Data-Model",
+    "Trigger": "Improvement: Field Data --[Improve]--> Model",
+    "Template": "Engineering team shall improve the <Model> using the <Field Data>.",
+    "Variables": [
+      "<source_id>",
+      "<target_id>",
+      "<acceptance_criteria>"
+    ],
+    "Notes": "Post-deployment improvement requirement."
   }
 ]

--- a/tests/test_governance_requirement_dedup.py
+++ b/tests/test_governance_requirement_dedup.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram
+
+
+def test_data_acquisition_default_requirement_removed_when_sources_present():
+    diagram = GovernanceDiagram()
+    diagram.add_task(
+        "Acquire Data",
+        node_type="Data acquisition",
+        compartments=["Sensor A"],
+    )
+
+    reqs = diagram.generate_requirements()
+    texts = [r.text if hasattr(r, "text") else r[0] for r in reqs]
+
+    assert "Engineering team shall acquire data from 'Sensor A'." in texts
+    assert "Engineering team shall acquire data." not in texts
+    assert sum("acquire data" in t for t in texts) == 1

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -128,8 +128,8 @@ def test_data_acquisition_node_name_normalized():
     texts = [r.text for r in reqs]
 
     assert "Engineering team shall acquire data from 'Sensor X'." in texts
-    # Ensure the task-level requirement uses the normalized verb
-    assert "Engineering team shall acquire data." in texts
+    # Ensure the raw node name does not appear in generated text
+    assert not any("shall Data acquisition" in t for t in texts)
 
 
 def test_tasks_create_requirement_actions():


### PR DESCRIPTION
## Summary
- ignore generic governance requirements when more detailed variants exist
- add regression test for requirement deduplication
- update data acquisition normalization test
- expand requirement patterns covering organization through post-deployment improvement

## Testing
- `pytest tests/test_governance_requirement_dedup.py tests/test_governance_requirements_generator.py tests/test_requirement_patterns_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_68a00882b6e88327a1befa41ad2a06c2