### PR TITLE
Add Safety & Security Management process area

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -10206,6 +10206,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "System Design (Item Definition)",
             "Hazard & Threat Analysis",
             "Risk Assessment",
+            "Safety & Security Management",
             "Safety Analysis",
             "Scenario",
         ]

--- a/tests/test_governance_safety_management_process_area.py
+++ b/tests/test_governance_safety_management_process_area.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_safety_management_process_area_available(monkeypatch):
+    repo = SysMLRepository.reset_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+
+    captured = {}
+
+    class DummyDialog:
+        def __init__(self, parent, title, options):
+            captured["options"] = options
+            self.selection = ""
+
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", DummyDialog)
+
+    win.add_process_area()
+
+    assert "Safety & Security Management" in captured["options"]


### PR DESCRIPTION
## Summary
- allow governance diagrams to create a Safety & Security Management process area so SPI work products can be added
- test that Safety & Security Management is listed as an available process area

## Testing
- `pytest tests/test_governance_safety_management_process_area.py tests/test_governance_spi_work_product.py tests/test_governance_process_area_filter.py tests/test_governance_work_product_enablement.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a00f346f8c8327a6c1f5aeca607566