### PR TITLE
feat: add pattern configuration dialog

### DIFF
--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -24,9 +24,12 @@ def test_generate_requirements_from_governance_diagram():
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
 
-    assert "Data Steward shall perform 'Review Data'." in texts
+    assert "Data Steward (Role) shall perform 'Review Data (Activity)'." in texts
     assert "Review Data shall produce 'Report'." in texts
-    assert "If data validated, Data Steward shall approve 'Report'." in texts
+    assert (
+        "If data validated, Data Steward (Role) shall approve 'Report (Document)'."
+        in texts
+    )
     assert "Review Data shall comply with 'Policy DP-001'." in texts
     assert "Organization shall review data." in texts
 


### PR DESCRIPTION
## Summary
- replace sequential dialogs with a consolidated requirement pattern configuration window
- adjust governance requirement tests for patterns that include node types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0105140988327b99ef2e711c857c8