### PR TITLE
Remove duplicated safety management process area

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -10271,7 +10271,6 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             "Risk Assessment",
             "Safety & Security Management",
             "Safety Analysis",
-            "Safety & Security Management",
             "Scenario",
         ]
         dlg = self._SelectDialog(self, "Add Process Area", options)

--- a/tests/test_governance_safety_management_process_area.py
+++ b/tests/test_governance_safety_management_process_area.py
@@ -34,3 +34,4 @@ def test_safety_management_process_area_available(monkeypatch):
     win.add_process_area()
 
     assert "Safety & Security Management" in captured["options"]
+    assert len(captured["options"]) == len(set(captured["options"]))


### PR DESCRIPTION
## Summary
- remove duplicate "Safety & Security Management" option from governance diagram process area dialog
- assert process area options list has no duplicates

## Testing
- `pytest tests/test_governance_safety_management_process_area.py tests/test_governance_spi_work_product.py tests/test_governance_phase_toggle.py tests/test_governance_process_area_filter.py tests/test_governance_work_product_enablement.py`


------
https://chatgpt.com/codex/tasks/task_b_68a013b8522883278a9d0994b044ad4b