### PR TITLE
Avoid duplicate work product names

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -10546,6 +10546,16 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         name = simpledialog.askstring("Add Work Product", "Enter work product name:")
         if not name:
             return
+        name = name.strip()
+        if not name:
+            return
+        existing = {wp.lower() for wp in getattr(self.app, "WORK_PRODUCT_INFO", {})}
+        if name.lower() in existing:
+            messagebox.showerror(
+                "Duplicate Work Product",
+                f"'{name}' is already a defined work product.",
+            )
+            return
         if not getattr(self, "canvas", None):
             self._place_work_product(name, 100.0, 100.0)
         else:

--- a/tests/test_governance_generic_work_product.py
+++ b/tests/test_governance_generic_work_product.py
@@ -51,3 +51,47 @@ def test_add_generic_work_product(monkeypatch):
     assert any(wp.analysis == "Custom WP" for wp in toolbox.work_products)
 
     _sm.ACTIVE_TOOLBOX = prev_tb
+
+
+def test_add_generic_work_product_name_conflict(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    from analysis import safety_management as _sm
+    prev_tb = _sm.ACTIVE_TOOLBOX
+    toolbox = SafetyManagementToolbox()
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+
+    enable_calls = []
+    errors = []
+
+    class DummyApp:
+        safety_mgmt_toolbox = toolbox
+        WORK_PRODUCT_INFO = {"FMEA": ("Safety Analysis", "", "")}
+
+        def enable_work_product(self, name, *, refresh=True):
+            enable_calls.append(name)
+
+    win.app = DummyApp()
+
+    monkeypatch.setattr("gui.architecture.simpledialog.askstring", lambda *a, **k: "FMEA")
+    monkeypatch.setattr("gui.architecture.messagebox.showerror", lambda *a, **k: errors.append(a))
+
+    win.add_generic_work_product()
+
+    assert enable_calls == []
+    assert not any(o.obj_type == "Work Product" for o in win.objects)
+    assert errors
+
+    _sm.ACTIVE_TOOLBOX = prev_tb


### PR DESCRIPTION
## Summary
- prevent custom governance work products from using existing predefined names
- test duplicate name rejection for custom work products

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a015babf0c8327988b3d99ca6d2ecc