### PR TITLE
Place Role labels below figure

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -7453,7 +7453,7 @@ class SysMLDiagramWindow(tk.Frame):
                 label_lines = self._object_label_lines(obj)
             else:
                 label_lines = SysMLDiagramWindow._object_label_lines(self, obj)
-            if obj.obj_type in ("Actor", "Stakeholder"):
+            if obj.obj_type in ("Actor", "Stakeholder", "Role"):
                 sy = obj.height / 40.0 * self.zoom
                 label_x = x
                 label_y = y + 40 * sy + 10 * self.zoom

--- a/tests/test_role_label_position.py
+++ b/tests/test_role_label_position.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+
+class DummyCanvas:
+    def __init__(self):
+        self.text_calls = []
+    def create_oval(self, *args, **kwargs):
+        pass
+    def create_line(self, *args, **kwargs):
+        pass
+    def create_text(self, x, y, *args, **kwargs):
+        self.text_calls.append((x, y, kwargs))
+    def create_rectangle(self, *args, **kwargs):
+        pass
+
+
+def test_role_label_position():
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.canvas = DummyCanvas()
+    win.zoom = 1.0
+    win.font = ("Arial", 12)
+    win.selected_objs = []
+    # stub out label line generation to avoid repository dependencies
+    win._object_label_lines = lambda obj: [obj.properties.get("name", "")]
+
+    obj = SysMLObject(1, "Role", 100, 100, width=80, height=40, properties={"name": "Operator"})
+    win.draw_object(obj)
+
+    assert win.canvas.text_calls, "No text drawn for role label"
+    x, y, kw = win.canvas.text_calls[-1]
+    assert kw.get("anchor") == "n"
+    assert kw.get("text") == "Operator"
+    sy = obj.height / 40.0 * win.zoom
+    expected_y = obj.y * win.zoom + 40 * sy + 10 * win.zoom
+    assert x == obj.x * win.zoom
+    assert y == pytest.approx(expected_y)


### PR DESCRIPTION
## Summary
- prevent Role labels from overlapping stick figure shapes by placing them underneath
- test Role label rendering to ensure text is drawn below the figure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a017016d088327847b5f6337c24bc3