### PR TITLE
Add requirement pattern syntax validation

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -2,6 +2,14 @@ from .config_loader import (
     load_json_with_comments,
     load_diagram_rules,
     validate_diagram_rules,
+    load_requirement_patterns,
+    validate_requirement_patterns,
 )
 
-__all__ = ["load_json_with_comments", "load_diagram_rules", "validate_diagram_rules"]
+__all__ = [
+    "load_json_with_comments",
+    "load_diagram_rules",
+    "validate_diagram_rules",
+    "load_requirement_patterns",
+    "validate_requirement_patterns",
+]

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -134,6 +134,49 @@ def validate_diagram_rules(data: Any) -> dict[str, Any]:
     return data
 
 
+def validate_requirement_patterns(data: Any) -> list[dict[str, Any]]:
+    """Validate requirement pattern configuration structure.
+
+    Parameters
+    ----------
+    data:
+        Parsed JSON object representing the requirement pattern configuration.
+
+    Returns
+    -------
+    list
+        The validated list of pattern dictionaries.
+
+    Raises
+    ------
+    ValueError
+        If the configuration does not follow the expected structure.
+    """
+
+    if not isinstance(data, list):
+        raise ValueError("Configuration root must be a list")
+
+    for idx, pat in enumerate(data):
+        if not isinstance(pat, dict):
+            raise ValueError(f"Pattern at index {idx} must be an object")
+
+        required = ["Pattern ID", "Trigger", "Template", "Variables"]
+        for field in required:
+            if field not in pat:
+                raise ValueError(f"Pattern at index {idx} missing '{field}'")
+        if not isinstance(pat["Pattern ID"], str):
+            raise ValueError(f"Pattern ID at index {idx} must be a string")
+        if not isinstance(pat["Trigger"], str):
+            raise ValueError(f"Trigger at index {idx} must be a string")
+        if not isinstance(pat["Template"], str):
+            raise ValueError(f"Template at index {idx} must be a string")
+        _ensure_list_of_strings(pat["Variables"], f"pattern[{idx}]['Variables']")
+        if "Notes" in pat and not isinstance(pat["Notes"], str):
+            raise ValueError(f"Notes at index {idx} must be a string")
+
+    return data
+
+
 def _strip_comments(text: str) -> str:
     """Return *text* with // and /* ... */ comments removed.
 
@@ -193,3 +236,9 @@ def load_diagram_rules(path: str | Path) -> dict[str, Any]:
     """Load and validate the diagram rules configuration file."""
     data = load_json_with_comments(path)
     return validate_diagram_rules(data)
+
+
+def load_requirement_patterns(path: str | Path) -> list[dict[str, Any]]:
+    """Load and validate the requirement pattern configuration file."""
+    data = load_json_with_comments(path)
+    return validate_requirement_patterns(data)

--- a/gui/requirement_patterns_toolbox.py
+++ b/gui/requirement_patterns_toolbox.py
@@ -2,7 +2,7 @@ import tkinter as tk
 from tkinter import ttk
 from pathlib import Path
 import json
-from config import load_json_with_comments
+from config import load_requirement_patterns, validate_requirement_patterns
 from gui import messagebox
 
 
@@ -100,7 +100,7 @@ class RequirementPatternsEditor(tk.Frame):
             config_path or Path(__file__).resolve().parents[1] / "config/requirement_patterns.json"
         )
         try:
-            self.data = load_json_with_comments(self.config_path)
+            self.data = load_requirement_patterns(self.config_path)
         except Exception as exc:  # pragma: no cover - GUI fallback
             messagebox.showerror(
                 "Requirement Patterns", f"Failed to load configuration:\n{exc}"
@@ -172,6 +172,13 @@ class RequirementPatternsEditor(tk.Frame):
         self._populate_tree()
 
     def save(self):
+        try:
+            validate_requirement_patterns(self.data)
+        except ValueError as exc:  # pragma: no cover - GUI feedback
+            messagebox.showerror(
+                "Requirement Patterns", f"Invalid configuration:\n{exc}"
+            )
+            return
         try:
             self.config_path.write_text(json.dumps(self.data, indent=2) + "\n")
             if hasattr(self.app, "reload_config"):

--- a/tests/test_requirement_patterns_validation.py
+++ b/tests/test_requirement_patterns_validation.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from config import load_requirement_patterns, validate_requirement_patterns
+
+
+def test_load_requirement_patterns_rejects_invalid_structure(tmp_path: Path) -> None:
+    bad = [{"Pattern ID": "A", "Trigger": "t", "Template": "tmpl", "Variables": "x"}]
+    path = tmp_path / "patterns.json"
+    path.write_text(json.dumps(bad))
+    with pytest.raises(ValueError):
+        load_requirement_patterns(path)
+
+
+def test_validate_requirement_patterns_accepts_valid_structure(tmp_path: Path) -> None:
+    good = [{"Pattern ID": "A", "Trigger": "t", "Template": "tmpl", "Variables": ["<v>"]}]
+    path = tmp_path / "patterns.json"
+    path.write_text(json.dumps(good))
+    data = load_requirement_patterns(path)
+    assert data[0]["Pattern ID"] == "A"
+
+
+def test_validate_requirement_patterns_requires_list() -> None:
+    with pytest.raises(ValueError):
+        validate_requirement_patterns({})


### PR DESCRIPTION
## Summary
- validate requirement pattern configuration files
- enforce pattern validation in the Requirement Patterns editor
- test requirement pattern validation helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a01d73065c83279260c9a735b5aeb7