### PR TITLE
Track requirement pattern variables

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -197,6 +197,7 @@ class SafetyManagementWindow(tk.Frame):
         req_type: str = "organizational",
         phase: str | None = None,
         diagram: str | None = None,
+        variables: list[str] | None = None,
     ) -> str:
         """Create a new requirement with a unique identifier.
 
@@ -214,6 +215,7 @@ class SafetyManagementWindow(tk.Frame):
             req = app.add_new_requirement(rid, req_type, text)
             req["phase"] = phase
             req["diagram"] = diagram
+            req["variables"] = variables or []
             global_requirements[rid] = req
         else:
             req = {
@@ -225,6 +227,7 @@ class SafetyManagementWindow(tk.Frame):
                 "parent_id": "",
                 "phase": phase,
                 "diagram": diagram,
+                "variables": variables or [],
             }
             ensure_requirement_defaults(req)
             global_requirements[rid] = req
@@ -266,8 +269,8 @@ class SafetyManagementWindow(tk.Frame):
     @staticmethod
     def _current_requirement_pairs(
         phase: str | None, diagram: str | None = None
-    ) -> list[tuple[str, str]]:
-        """Return existing requirement (text, type) pairs.
+    ) -> list[tuple[str, str, tuple[str, ...]]]:
+        """Return existing requirement (text, type, variables) tuples.
 
         Only non-obsolete requirements are considered.  When ``diagram`` is
         provided, only requirements originating from that diagram are returned.
@@ -276,6 +279,7 @@ class SafetyManagementWindow(tk.Frame):
             (
                 req.get("text", "").strip(),
                 req.get("req_type", "organizational"),
+                tuple(req.get("variables", [])),
             )
             for req in global_requirements.values()
             if req.get("phase") == phase
@@ -300,17 +304,20 @@ class SafetyManagementWindow(tk.Frame):
                 "Requirements", f"Failed to generate requirements: {exc}"
             )
             return
-        reqs: list[tuple[str, str]] = []
+        reqs: list[tuple[str, str, list[str]]] = []
         for r in raw_reqs:
             if isinstance(r, tuple):
                 text, rtype = r
+                vars_: list[str] = []
             elif hasattr(r, "text"):
                 text, rtype = r.text, getattr(r, "req_type", "organizational")
+                vars_ = getattr(r, "variables", [])
             else:
                 text, rtype = str(r), "organizational"
+                vars_ = []
             text = text.strip()
             if text:
-                reqs.append((text, rtype))
+                reqs.append((text, rtype, tuple(vars_)))
         if not reqs:
             messagebox.showinfo("Requirements", "No requirements were generated.")
             return
@@ -331,8 +338,12 @@ class SafetyManagementWindow(tk.Frame):
             if req.get("phase") == phase and req.get("diagram") == name:
                 req["status"] = "obsolete"
         ids: list[str] = []
-        for text, rtype in reqs:
-            ids.append(self._add_requirement(text, rtype, phase=phase, diagram=name))
+        for text, rtype, vars_ in reqs:
+            ids.append(
+                self._add_requirement(
+                    text, rtype, phase=phase, diagram=name, variables=vars_
+                )
+            )
         ids = [
             rid
             for rid, req in global_requirements.items()
@@ -368,7 +379,7 @@ class SafetyManagementWindow(tk.Frame):
             messagebox.showinfo("Requirements", f"No governance diagrams for phase '{phase}'.")
             return
         repo = SysMLRepository.get_instance()
-        diag_pairs: dict[str, list[tuple[str, str]]] = {}
+        diag_pairs: dict[str, list[tuple[str, str, list[str]]]] = {}
         for name in diag_names:
             diag_id = self.toolbox.diagrams.get(name)
             if not diag_id:
@@ -382,7 +393,7 @@ class SafetyManagementWindow(tk.Frame):
                     f"Failed to generate requirements for '{name}': {exc}",
                 )
                 continue
-            pairs: list[tuple[str, str]] = []
+            pairs: list[tuple[str, str, list[str]]] = []
             invalid = False
             for r in raw_reqs:
                 if isinstance(r, tuple):
@@ -390,16 +401,19 @@ class SafetyManagementWindow(tk.Frame):
                         invalid = True
                         break
                     text, rtype = r
+                    vars_: list[str] = []
                 elif hasattr(r, "text"):
                     text, rtype = r.text, getattr(r, "req_type", "organizational")
+                    vars_ = getattr(r, "variables", [])
                 elif isinstance(r, str):
                     text, rtype = r, "organizational"
+                    vars_ = []
                 else:
                     invalid = True
                     break
                 text = text.strip()
                 if text:
-                    pairs.append((text, rtype))
+                    pairs.append((text, rtype, tuple(vars_)))
             if invalid:
                 messagebox.showerror(
                     "Requirements",
@@ -430,8 +444,12 @@ class SafetyManagementWindow(tk.Frame):
                 req["status"] = "obsolete"
         ids: list[str] = []
         for name, pairs in diag_pairs.items():
-            for text, rtype in pairs:
-                ids.append(self._add_requirement(text, rtype, phase=phase, diagram=name))
+            for text, rtype, vars_ in pairs:
+                ids.append(
+                    self._add_requirement(
+                        text, rtype, phase=phase, diagram=name, variables=vars_
+                    )
+                )
         ids = [
             rid
             for rid, req in global_requirements.items()
@@ -450,7 +468,7 @@ class SafetyManagementWindow(tk.Frame):
                 "Requirements", "No lifecycle governance diagrams.")
             return
         repo = SysMLRepository.get_instance()
-        diag_pairs: dict[str, list[tuple[str, str]]] = {}
+        diag_pairs: dict[str, list[tuple[str, str, list[str]]]] = {}
         for name in diag_names:
             diag_id = self.toolbox.diagrams.get(name)
             if not diag_id:
@@ -464,7 +482,7 @@ class SafetyManagementWindow(tk.Frame):
                     f"Failed to generate requirements for '{name}': {exc}",
                 )
                 continue
-            pairs: list[tuple[str, str]] = []
+            pairs: list[tuple[str, str, list[str]]] = []
             invalid = False
             for r in raw_reqs:
                 if isinstance(r, tuple):
@@ -472,16 +490,19 @@ class SafetyManagementWindow(tk.Frame):
                         invalid = True
                         break
                     text, rtype = r
+                    vars_: list[str] = []
                 elif hasattr(r, "text"):
                     text, rtype = r.text, getattr(r, "req_type", "organizational")
+                    vars_ = getattr(r, "variables", [])
                 elif isinstance(r, str):
                     text, rtype = r, "organizational"
+                    vars_ = []
                 else:
                     invalid = True
                     break
                 text = text.strip()
                 if text:
-                    pairs.append((text, rtype))
+                    pairs.append((text, rtype, tuple(vars_)))
             if invalid:
                 messagebox.showerror(
                     "Requirements",
@@ -512,8 +533,10 @@ class SafetyManagementWindow(tk.Frame):
                 req["status"] = "obsolete"
         ids: list[str] = []
         for name, pairs in diag_pairs.items():
-            for text, rtype in pairs:
-                ids.append(self._add_requirement(text, rtype, diagram=name))
+            for text, rtype, vars_ in pairs:
+                ids.append(
+                    self._add_requirement(text, rtype, diagram=name, variables=vars_)
+                )
         ids = [rid for rid, req in global_requirements.items() if req.get("phase") is None]
         self._display_requirements("Lifecycle Requirements", ids)
 

--- a/tests/test_requirement_pattern_variables.py
+++ b/tests/test_requirement_pattern_variables.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram, GeneratedRequirement
+
+
+def test_requirement_pattern_variables_used():
+    diag = GovernanceDiagram()
+    diag.add_task("DB", node_type="Database")
+    diag.add_task("Acquire", node_type="Data acquisition")
+    diag.add_relationship("DB", "Acquire", conn_type="Acquisition")
+    reqs = [r for r in diag.generate_requirements() if isinstance(r, GeneratedRequirement)]
+    pattern_req = next((r for r in reqs if r.variables), None)
+    assert pattern_req is not None
+    assert "acceptance_criteria" in pattern_req.variables


### PR DESCRIPTION
## Summary
- capture unresolved variables from requirement pattern templates
- propagate pattern variables into generated requirements and GUI storage
- cover requirement variable tracking with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a06808bea48327b98575ba7a9238f3