### PR TITLE
Respect explicit subjects in requirement generation

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -435,7 +435,7 @@ class GovernanceDiagram:
                 elif not label and not rule:
                     action = "be related to"
 
-            if obj is not None:
+            if obj is not None and explicit_subject is None:
                 s_role = self._role_for(subject)
                 d_role = self._role_for(obj)
                 if s_role != "subject" and d_role == "subject":

--- a/tests/test_governance_requirement_rule_subject.py
+++ b/tests/test_governance_requirement_rule_subject.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from analysis.governance import GovernanceDiagram, GeneratedRequirement
+
+
+def test_requirement_rule_subject_overrides_node_roles():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Source", node_type="Task")
+    diagram.add_task("ActorNode", node_type="Role")
+    diagram.add_relationship("Source", "ActorNode", label="annotation")
+
+    reqs = [r for r in diagram.generate_requirements() if isinstance(r, GeneratedRequirement)]
+    assert any(r.subject == "Engineering team" and r.obj == "ActorNode" and r.action == "annotate" for r in reqs)


### PR DESCRIPTION
## Summary
- avoid swapping subject and object when requirement rules provide an explicit subject
- add regression test to ensure rule-defined subject overrides node roles

## Testing
- `pytest tests/test_governance_requirement_rule_subject.py tests/test_governance_additional_relationship_requirements.py tests/test_diagram_rules_requirement_mappings.py tests/test_diagram_rules_requirements_section.py`


------
https://chatgpt.com/codex/tasks/task_b_68a0688ce1688327bdca99984dd1add0