### PR TITLE
Add icons to reliability toolbox buttons

### DIFF
--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -643,44 +643,96 @@ class ReliabilityWindow(tk.Frame):
 
         btn_frame = ttk.Frame(self)
         btn_frame.pack(fill=tk.X)
-        load_btn = ttk.Button(btn_frame, text="Load CSV", command=self.load_csv)
+
+        # create small icons so buttons are visually representative
+        self._icons = {
+            "load": self._create_icon("folder", "#4682b4"),
+            "add": self._create_icon("plus", "#2e8b57"),
+            "cfg": self._create_icon("gear", "#8b008b"),
+            "del": self._create_icon("cross", "#b22222"),
+            "calc": self._create_icon("sigma", "#ff8c00"),
+            "save": self._create_icon("disk", "#1e90ff"),
+        }
+
+        load_btn = ttk.Button(
+            btn_frame,
+            text="Load CSV",
+            image=self._icons["load"],
+            compound=tk.LEFT,
+            command=self.load_csv,
+        )
         load_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(load_btn, "Import components from a CSV Bill of Materials.")
+
         add_btn = ttk.Button(
-            btn_frame, text="Add Component", command=self.add_component
+            btn_frame,
+            text="Add Component",
+            image=self._icons["add"],
+            compound=tk.LEFT,
+            command=self.add_component,
         )
         add_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(add_btn, "Create a new component entry manually.")
+
         cfg_btn = ttk.Button(
-            btn_frame, text="Configure Component", command=self.configure_component
+            btn_frame,
+            text="Configure Component",
+            image=self._icons["cfg"],
+            compound=tk.LEFT,
+            command=self.configure_component,
         )
         cfg_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(cfg_btn, "Edit parameters of the selected component.")
+
         del_comp_btn = ttk.Button(
-            btn_frame, text="Delete Component", command=self.delete_component
+            btn_frame,
+            text="Delete Component",
+            image=self._icons["del"],
+            compound=tk.LEFT,
+            command=self.delete_component,
         )
         del_comp_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(del_comp_btn, "Remove the selected component from the table.")
+
         calc_btn = ttk.Button(
-            btn_frame, text="Calculate FIT", command=self.calculate_fit
+            btn_frame,
+            text="Calculate FIT",
+            image=self._icons["calc"],
+            compound=tk.LEFT,
+            command=self.calculate_fit,
         )
         calc_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(
             calc_btn,
             "Compute total FIT rate using the selected model and mission profile.",
         )
+
         save_btn = ttk.Button(
-            btn_frame, text="Save Analysis", command=self.save_analysis
+            btn_frame,
+            text="Save Analysis",
+            image=self._icons["save"],
+            compound=tk.LEFT,
+            command=self.save_analysis,
         )
         save_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(save_btn, "Store the current analysis in the project file.")
+
         load_an_btn = ttk.Button(
-            btn_frame, text="Load Analysis", command=self.load_analysis
+            btn_frame,
+            text="Load Analysis",
+            image=self._icons["load"],
+            compound=tk.LEFT,
+            command=self.load_analysis,
         )
         load_an_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(load_an_btn, "Reload a previously saved reliability analysis.")
+
         del_btn = ttk.Button(
-            btn_frame, text="Delete Analysis", command=self.delete_analysis
+            btn_frame,
+            text="Delete Analysis",
+            image=self._icons["del"],
+            compound=tk.LEFT,
+            command=self.delete_analysis,
         )
         del_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(del_btn, "Remove the selected analysis from the project.")
@@ -1158,6 +1210,59 @@ class ReliabilityWindow(tk.Frame):
         self.formula_label.config(
             text=f"Total FIT: {ra.total_fit:.2f}  DC: {ra.dc:.2f}  SPFM: {ra.spfm:.2f}  LPFM: {ra.lpfm:.2f}"
         )
+
+    def _create_icon(self, shape: str, color: str = "black") -> tk.PhotoImage:
+        """Return a simple 16x16 icon for toolbox buttons."""
+        size = 16
+        img = tk.PhotoImage(width=size, height=size)
+        img.put("white", to=(0, 0, size - 1, size - 1))
+        c = color
+        if shape == "plus":
+            mid = size // 2
+            for x in range(3, size - 3):
+                img.put(c, (x, mid))
+            for y in range(3, size - 3):
+                img.put(c, (mid, y))
+        elif shape == "cross":
+            for i in range(3, size - 3):
+                img.put(c, (i, i))
+                img.put(c, (i, size - i - 1))
+        elif shape == "gear":
+            mid = size // 2
+            r = size // 2 - 4
+            for y in range(size):
+                for x in range(size):
+                    if (x - mid) ** 2 + (y - mid) ** 2 <= r * r:
+                        img.put(c, (x, y))
+            for t in (-r, r):
+                for x in range(mid - 1, mid + 2):
+                    img.put(c, (x, mid + t))
+                for y in range(mid - 1, mid + 2):
+                    img.put(c, (mid + t, y))
+        elif shape == "sigma":
+            for x in range(3, size - 3):
+                img.put(c, (x, 3))
+                img.put(c, (x, size - 4))
+            for i in range(6):
+                img.put(c, (3 + i, 3 + i))
+                img.put(c, (size - 4 - i, 3 + i))
+        elif shape == "disk":
+            img.put(c, to=(2, 2, size - 2, size - 2))
+            img.put("white", to=(size - 6, 2, size - 2, 6))
+            img.put("white", to=(3, 3, size - 3, 6))
+        elif shape == "folder":
+            for x in range(1, size - 1):
+                img.put(c, (x, 4))
+                img.put(c, (x, size - 2))
+            for y in range(4, size - 1):
+                img.put(c, (1, y))
+                img.put(c, (size - 2, y))
+            for x in range(3, size - 3):
+                img.put(c, (x, 2))
+            img.put(c, to=(1, 3, size - 2, 4))
+        else:
+            img.put(c, to=(2, 2, size - 2, size - 2))
+        return img
 
 
 class FI2TCWindow(tk.Frame):


### PR DESCRIPTION
## Summary
- Add color-coded icons to reliability analysis toolbox buttons for better visual meaning
- Include internal helper to draw simple 16x16 icons

## Testing
- `pytest tests/test_gui_classes.py tests/test_fmeda_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a069406c6c8327af9446bb32f4e10a