### PR TITLE
Add button to prune obsolete requirements

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -71,6 +71,11 @@ class SafetyManagementWindow(tk.Frame):
             text="Lifecycle Requirements",
             command=self.generate_lifecycle_requirements,
         ).pack(side=tk.LEFT)
+        ttk.Button(
+            top,
+            text="Delete Obsolete",
+            command=self.delete_obsolete_requirements,
+        ).pack(side=tk.LEFT)
 
         self.diagram_frame = ttk.Frame(self)
         self.diagram_frame.pack(fill=tk.BOTH, expand=True)
@@ -516,6 +521,18 @@ class SafetyManagementWindow(tk.Frame):
                 ids.append(self._add_requirement(text, rtype, diagram=name))
         ids = [rid for rid, req in global_requirements.items() if req.get("phase") is None]
         self._display_requirements("Lifecycle Requirements", ids)
+
+    def delete_obsolete_requirements(self) -> None:
+        """Remove all requirements marked as obsolete."""
+        obsolete = [rid for rid, req in global_requirements.items() if req.get("status") == "obsolete"]
+        if not obsolete:
+            messagebox.showinfo("Requirements", "No obsolete requirements to delete.")
+            return
+        for rid in obsolete:
+            del global_requirements[rid]
+        messagebox.showinfo(
+            "Requirements", f"Deleted {len(obsolete)} obsolete requirements."
+        )
 
     @staticmethod
     def _collect_requirements(gov: GovernanceDiagram) -> list[str]:

--- a/tests/test_phase_requirement_updates.py
+++ b/tests/test_phase_requirement_updates.py
@@ -110,3 +110,26 @@ def test_lifecycle_requirements_visible_in_phases(monkeypatch):
     win.generate_phase_requirements("Phase1")
     ids = captured.get("Phase1 Requirements", [])
     assert life_rid in ids
+
+
+def test_delete_obsolete(monkeypatch):
+    win = _setup_window(monkeypatch)
+    global_requirements.clear()
+    global_requirements.update(
+        {
+            "obs": {"status": "obsolete"},
+            "keep": {"status": "draft"},
+        }
+    )
+
+    shown = []
+
+    def _info(*args, **kwargs):
+        shown.append(args)
+
+    monkeypatch.setattr(smt, "messagebox", types.SimpleNamespace(showinfo=_info))
+
+    win.delete_obsolete_requirements()
+    assert "obs" not in global_requirements
+    assert "keep" in global_requirements
+    assert shown  # ensure message displayed


### PR DESCRIPTION
## Summary
- Add GUI button to remove obsolete requirements
- Implement requirement cleanup logic
- Cover obsolete removal with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a06a8554348327bee55d319c363069