### PR TITLE
feat: add sortable columns to tables

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,6 +1,9 @@
 # Shared GUI helpers
-
 from __future__ import annotations
+
+"""Shared GUI helpers and widget customizations."""
+
+from tkinter import ttk
 
 
 def format_name_with_phase(name: str, phase: str | None) -> str:
@@ -9,3 +12,46 @@ def format_name_with_phase(name: str, phase: str | None) -> str:
     if phase:
         return f"{name} ({phase})" if name else f"({phase})"
     return name
+
+
+# ---------------------------------------------------------------------------
+# Enable clickable column sorting for all ttk.Treeview tables
+# ---------------------------------------------------------------------------
+_orig_heading = ttk.Treeview.heading
+
+
+def _sortable_heading(self, column, option=None, **kw):
+    """Add ascending/descending sort behavior when a column header is clicked."""
+    if option is None and kw and "command" not in kw:
+        def sort_column(col=column):
+            data = [(self.set(k, col), k) for k in self.get_children("")]
+
+            def _is_number(val: str) -> bool:
+                try:
+                    float(val)
+                    return True
+                except Exception:
+                    return False
+
+            numeric = all(_is_number(v) for v, _ in data if v not in ("", None))
+            if numeric:
+                data.sort(
+                    key=lambda t: float(t[0]) if t[0] not in ("", None) else float("-inf")
+                )
+            else:
+                data.sort(key=lambda t: str(t[0]).lower())
+
+            if not hasattr(self, "_sort_reverse"):
+                self._sort_reverse = {}
+            reverse = self._sort_reverse.get(col, False)
+            if reverse:
+                data.reverse()
+            for idx, (_, item) in enumerate(data):
+                self.move(item, "", idx)
+            self._sort_reverse[col] = not reverse
+
+        kw["command"] = sort_column
+    return _orig_heading(self, column, option, **kw)
+
+
+ttk.Treeview.heading = _sortable_heading


### PR DESCRIPTION
## Summary
- add global ttk.Treeview heading hook to enable column sorting
- clicking any table header now toggles ascending/descending numeric or alphabetical order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a06a74ac008327adaad94adf6e5d0c