### PR TITLE
feat: add detailed icon factory

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -20,6 +20,7 @@ from gui.style_manager import StyleManager
 from gui.drawing_helper import fta_drawing_helper
 from config import load_diagram_rules
 import json
+from gui.icon_factory import create_icon
 
 from sysml.sysml_spec import SYSML_PROPERTIES
 from analysis.models import (
@@ -69,86 +70,8 @@ SAFETY_AI_RELATION_SET = set(SAFETY_AI_RELATIONS)
 GOV_ELEMENT_NODES = _CONFIG.get("governance_element_nodes", [])
 GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", [])
 
-
-def draw_icon(shape: str, color: str = "black") -> tk.PhotoImage:
-    """Return a simple 16x16 PhotoImage representing the given *shape*."""
-    size = 16
-    img = tk.PhotoImage(width=size, height=size)
-    img.put("white", to=(0, 0, size - 1, size - 1))
-    c = color
-    if shape == "circle":
-        r = size // 2 - 2
-        cx = cy = size // 2
-        for y in range(size):
-            for x in range(size):
-                if (x - cx) ** 2 + (y - cy) ** 2 <= r * r:
-                    img.put(c, (x, y))
-    elif shape == "arrow":
-        mid = size // 2
-        for x in range(2, mid + 1):
-            img.put(c, to=(x, mid - 1, x + 1, mid + 1))
-        for i in range(4):
-            img.put(c, to=(mid + i, mid - 2 - i, mid + i + 1, mid - i))
-            img.put(c, to=(mid + i, mid + i, mid + i + 1, mid + 2 + i))
-    elif shape == "diamond":
-        mid = size // 2
-        for y in range(2, size - 2):
-            span = mid - abs(mid - y)
-            img.put(c, to=(mid - span, y, mid + span + 1, y + 1))
-    elif shape == "triangle":
-        mid = size // 2
-        height = size - 4
-        for y in range(height):
-            span = (y * mid) // height
-            img.put(c, to=(mid - span, 2 + y, mid + span + 1, 3 + y))
-    elif shape == "cylinder":
-        img.put(c, to=(2, 4, size - 2, size - 4))
-        for x in range(2, size - 2):
-            img.put(c, (x, 3))
-            img.put(c, (x, size - 4))
-        for x in range(3, size - 3):
-            img.put(c, (x, 2))
-            img.put(c, (x, size - 3))
-    elif shape == "document":
-        img.put(c, to=(2, 2, size - 2, size - 2))
-        fold = "white"
-        for i in range(4):
-            img.put(fold, to=(size - 6 + i, 2, size - 2, 6 - i))
-    elif shape == "bar":
-        img.put(c, to=(2, size // 2 - 2, size - 2, size // 2 + 2))
-    elif shape == "rect":
-        for x in range(3, size - 3):
-            img.put(c, (x, 3))
-            img.put(c, (x, size - 4))
-        for y in range(3, size - 3):
-            img.put(c, (3, y))
-            img.put(c, (size - 4, y))
-    elif shape == "nested":
-        for x in range(1, size - 1):
-            img.put(c, (x, 1))
-            img.put(c, (x, size - 2))
-        for y in range(1, size - 1):
-            img.put(c, (1, y))
-            img.put(c, (size - 2, y))
-        for x in range(5, size - 5):
-            img.put(c, (x, 5))
-            img.put(c, (x, size - 6))
-        for y in range(5, size - 5):
-            img.put(c, (5, y))
-            img.put(c, (size - 6, y))
-    elif shape == "folder":
-        for x in range(1, size - 1):
-            img.put(c, (x, 4))
-            img.put(c, (x, size - 2))
-        for y in range(4, size - 1):
-            img.put(c, (1, y))
-            img.put(c, (size - 2, y))
-        for x in range(3, size - 3):
-            img.put(c, (x, 2))
-        img.put(c, to=(1, 3, size - 2, 4))
-    else:
-        img.put(c, to=(2, 2, size - 2, size - 2))
-    return img
+# expose the icon factory under the old name used throughout the module
+draw_icon = create_icon
 
 
 def _make_gov_element_classes(nodes: list[str]) -> dict[str, list[str]]:

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -7,6 +7,7 @@ from tkinter import ttk, simpledialog
 from gsn import GSNNode, GSNDiagram, GSNModule
 from gui import format_name_with_phase
 from gui.style_manager import StyleManager
+from gui.icon_factory import create_icon
 
 
 class GSNExplorer(tk.Frame):
@@ -36,7 +37,7 @@ class GSNExplorer(tk.Frame):
         tree_frame.rowconfigure(0, weight=1)
         tree_frame.columnconfigure(0, weight=1)
 
-        # simple icons so different elements are visually distinct
+        # detailed icons to visually distinguish elements
         self.module_icon = self._create_icon("folder", "#b8860b")
         self.diagram_icon = self._create_icon("rect", "#4682b4")
         self.node_icons = {
@@ -492,40 +493,6 @@ class GSNExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def _create_icon(self, shape: str, color: str = "black") -> tk.PhotoImage:
-        """Return a simple 16x16 icon for treeview items."""
-        size = 16
-        img = tk.PhotoImage(width=size, height=size)
-        img.put(StyleManager.get_instance().canvas_bg, to=(0, 0, size - 1, size - 1))
-        c = color
-        if shape == "circle":
-            r = size // 2 - 2
-            cx = cy = size // 2
-            for y in range(size):
-                for x in range(size):
-                    if (x - cx) ** 2 + (y - cy) ** 2 <= r * r:
-                        img.put(c, (x, y))
-        elif shape == "diamond":
-            mid = size // 2
-            for y in range(2, size - 2):
-                span = mid - abs(mid - y)
-                img.put(c, to=(mid - span, y, mid + span + 1, y + 1))
-        elif shape == "rect":
-            for x in range(3, size - 3):
-                img.put(c, (x, 3))
-                img.put(c, (x, size - 4))
-            for y in range(3, size - 3):
-                img.put(c, (3, y))
-                img.put(c, (size - 4, y))
-        elif shape == "folder":
-            for x in range(1, size - 1):
-                img.put(c, (x, 4))
-                img.put(c, (x, size - 2))
-            for y in range(4, size - 1):
-                img.put(c, (1, y))
-                img.put(c, (size - 2, y))
-            for x in range(3, size - 3):
-                img.put(c, (x, 2))
-            img.put(c, to=(1, 3, size - 2, 4))
-        else:
-            img.put(c, to=(2, 2, size - 2, size - 2))
-        return img
+        """Proxy to the shared icon factory with the canvas background."""
+        bg = StyleManager.get_instance().canvas_bg
+        return create_icon(shape, color, bg)

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -1,0 +1,177 @@
+import tkinter as tk
+
+def create_icon(shape: str, color: str = "black", bg: str = "white") -> tk.PhotoImage:
+    """Return a small 16x16 PhotoImage for *shape* using *color*.
+
+    Icons now have filled interiors and simple outlines so they look like
+    miniature versions of the objects they represent.  The implementation is
+    deliberately lightweight and only uses ``tk.PhotoImage`` drawing
+    primitives so it works in the same environments as the previous icon
+    helpers.
+    """
+    size = 16
+    img = tk.PhotoImage(width=size, height=size)
+    img.put(bg, to=(0, 0, size - 1, size - 1))
+    c = color
+    outline = "black"
+    if shape == "circle":
+        r = size // 2 - 3
+        cx = cy = size // 2
+        for y in range(size):
+            for x in range(size):
+                dist = (x - cx) ** 2 + (y - cy) ** 2
+                if dist <= r * r:
+                    img.put(c, (x, y))
+                if r * r <= dist <= (r + 1) * (r + 1):
+                    img.put(outline, (x, y))
+    elif shape == "diamond":
+        mid = size // 2
+        for y in range(2, size - 2):
+            span = mid - abs(mid - y)
+            img.put(c, to=(mid - span, y, mid + span + 1, y + 1))
+            img.put(outline, (mid - span, y))
+            img.put(outline, (mid + span, y))
+    elif shape == "rect":
+        img.put(c, to=(3, 3, size - 3, size - 3))
+        for x in range(3, size - 3):
+            img.put(outline, (x, 3))
+            img.put(outline, (x, size - 4))
+        for y in range(3, size - 3):
+            img.put(outline, (3, y))
+            img.put(outline, (size - 4, y))
+    elif shape == "folder":
+        img.put(c, to=(1, 5, size - 2, size - 2))
+        img.put(c, to=(1, 3, size // 2, 5))
+        for x in range(1, size - 1):
+            img.put(outline, (x, 5))
+            img.put(outline, (x, size - 2))
+        for y in range(5, size - 1):
+            img.put(outline, (1, y))
+            img.put(outline, (size - 2, y))
+        for x in range(1, size // 2):
+            img.put(outline, (x, 3))
+        for y in range(3, 5):
+            img.put(outline, (1, y))
+    elif shape == "arrow":
+        mid = size // 2
+        for x in range(2, mid + 2):
+            img.put(c, to=(x, mid - 2, x + 1, mid + 2))
+        for i in range(4):
+            img.put(c, to=(mid + i, mid - 3 - i, mid + i + 1, mid - i))
+            img.put(c, to=(mid + i, mid + i, mid + i + 1, mid + 3 + i))
+        for i in range(5):
+            img.put(outline, (mid + i, mid - 3 - i))
+            img.put(outline, (mid + i, mid + 3 + i))
+    elif shape == "triangle":
+        mid = size // 2
+        height = size - 4
+        for y in range(height):
+            span = (y * mid) // height
+            img.put(c, to=(mid - span, 2 + y, mid + span + 1, 3 + y))
+            img.put(outline, (mid - span, 2 + y))
+            img.put(outline, (mid + span, 2 + y))
+        for x in range(2, size - 2):
+            img.put(outline, (x, height + 2))
+    elif shape == "cylinder":
+        img.put(c, to=(2, 4, size - 2, size - 4))
+        for x in range(2, size - 2):
+            img.put(outline, (x, 4))
+            img.put(outline, (x, size - 4))
+        for x in range(3, size - 3):
+            img.put(outline, (x, 3))
+            img.put(outline, (x, size - 3))
+    elif shape == "document":
+        img.put(c, to=(2, 2, size - 2, size - 2))
+        fold = bg
+        for i in range(4):
+            img.put(fold, to=(size - 6 + i, 2, size - 2, 6 - i))
+        for x in range(2, size - 2):
+            img.put(outline, (x, 2))
+            img.put(outline, (x, size - 2))
+        for y in range(2, size - 2):
+            img.put(outline, (2, y))
+            img.put(outline, (size - 2, y))
+    elif shape == "bar":
+        top = size // 2 - 2
+        img.put(c, to=(2, top, size - 2, top + 4))
+        for x in range(2, size - 2):
+            img.put(outline, (x, top))
+            img.put(outline, (x, top + 3))
+    elif shape == "nested":
+        for x in range(1, size - 1):
+            img.put(outline, (x, 1))
+            img.put(outline, (x, size - 2))
+        for y in range(1, size - 1):
+            img.put(outline, (1, y))
+            img.put(outline, (size - 2, y))
+        for x in range(4, size - 4):
+            img.put(outline, (x, 4))
+            img.put(outline, (x, size - 5))
+        for y in range(4, size - 4):
+            img.put(outline, (4, y))
+            img.put(outline, (size - 5, y))
+    elif shape == "plus":
+        mid = size // 2
+        for x in range(3, size - 3):
+            img.put(c, (x, mid))
+        for y in range(3, size - 3):
+            img.put(c, (mid, y))
+        for x in range(3, size - 3):
+            img.put(outline, (x, mid - 1))
+            img.put(outline, (x, mid + 1))
+        for y in range(3, size - 3):
+            img.put(outline, (mid - 1, y))
+            img.put(outline, (mid + 1, y))
+    elif shape == "cross":
+        for i in range(3, size - 3):
+            img.put(c, (i, i))
+            img.put(c, (i, size - i - 1))
+            img.put(outline, (i, i))
+            img.put(outline, (i, size - i - 1))
+    elif shape == "gear":
+        mid = size // 2
+        r = size // 2 - 4
+        for y in range(size):
+            for x in range(size):
+                dist = (x - mid) ** 2 + (y - mid) ** 2
+                if dist <= r * r:
+                    img.put(c, (x, y))
+                if r * r <= dist <= (r + 1) * (r + 1):
+                    img.put(outline, (x, y))
+        for t in (-r, r):
+            for x in range(mid - 1, mid + 2):
+                img.put(c, (x, mid + t))
+                img.put(outline, (x, mid + t))
+            for y in range(mid - 1, mid + 2):
+                img.put(c, (mid + t, y))
+                img.put(outline, (mid + t, y))
+    elif shape == "sigma":
+        for x in range(3, size - 3):
+            img.put(c, (x, 3))
+            img.put(c, (x, size - 4))
+            img.put(outline, (x, 3))
+            img.put(outline, (x, size - 4))
+        for i in range(6):
+            img.put(c, (3 + i, 3 + i))
+            img.put(c, (size - 4 - i, 3 + i))
+            img.put(outline, (3 + i, 3 + i))
+            img.put(outline, (size - 4 - i, 3 + i))
+    elif shape == "disk":
+        img.put(c, to=(2, 2, size - 2, size - 2))
+        img.put(bg, to=(size - 6, 2, size - 2, 6))
+        img.put(bg, to=(3, 3, size - 3, 6))
+        for x in range(2, size - 2):
+            img.put(outline, (x, 2))
+            img.put(outline, (x, size - 2))
+        for y in range(2, size - 2):
+            img.put(outline, (2, y))
+            img.put(outline, (size - 2, y))
+    else:
+        img.put(c, to=(2, 2, size - 2, size - 2))
+        for x in range(2, size - 2):
+            img.put(outline, (x, 2))
+            img.put(outline, (x, size - 2))
+        for y in range(2, size - 2):
+            img.put(outline, (2, y))
+            img.put(outline, (size - 2, y))
+    return img

--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -35,6 +35,7 @@ class DiagramSelectDialog(simpledialog.Dialog):  # pragma: no cover - requires t
 from analysis.safety_case import SafetyCaseLibrary, SafetyCase
 from gui import messagebox, format_name_with_phase
 from gui.safety_case_table import SafetyCaseTable
+from gui.icon_factory import create_icon
 
 
 class SafetyCaseExplorer(tk.Frame):
@@ -210,38 +211,5 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def _create_icon(self, shape: str, color: str = "black") -> tk.PhotoImage:
-        """Return a simple 16x16 icon for treeview items."""
-        size = 16
-        img = tk.PhotoImage(width=size, height=size)
-        img.put("white", to=(0, 0, size - 1, size - 1))
-        c = color
-        if shape == "circle":
-            r = size // 2 - 2
-            cx = cy = size // 2
-            for y in range(size):
-                for x in range(size):
-                    if (x - cx) ** 2 + (y - cy) ** 2 <= r * r:
-                        img.put(c, (x, y))
-        elif shape == "diamond":
-            mid = size // 2
-            for y in range(2, size - 2):
-                span = mid - abs(mid - y)
-                img.put(c, to=(mid - span, y, mid + span + 1, y + 1))
-        elif shape == "rect":
-            for x in range(3, size - 3):
-                img.put(c, (x, 3))
-                img.put(c, (x, size - 4))
-            for y in range(3, size - 3):
-                img.put(c, (3, y))
-                img.put(c, (size - 4, y))
-        elif shape == "folder":
-            for x in range(1, size - 1):
-                img.put(c, (x, 4))
-                img.put(c, (x, size - 2))
-            for y in range(4, size - 1):
-                img.put(c, (1, y))
-                img.put(c, (size - 2, y))
-            for x in range(3, size - 3):
-                img.put(c, (x, 2))
-            img.put(c, to=(1, 3, size - 2, 4))
-        return img
+        """Proxy to the shared icon factory."""
+        return create_icon(shape, color)

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -10,6 +10,7 @@ from typing import List, Dict
 import re
 
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from gui.icon_factory import create_icon
 
 
 def _strip_phase_suffix(name: str) -> str:
@@ -297,13 +298,5 @@ class SafetyManagementExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def _create_icon(self, shape: str, color: str = "black"):
-        """Create a tiny tkinter drawing for treeview icons."""
-        img = tk.PhotoImage(width=16, height=16)
-        if shape == "folder":
-            img.put(color, to=(0, 4, 15, 15))
-            img.put("white", to=(3, 0, 15, 5))
-        elif shape == "rect":
-            img.put(color, to=(1, 1, 15, 15))
-        else:
-            img.put(color, to=(1, 1, 15, 15))
-        return img
+        """Proxy to the shared icon factory."""
+        return create_icon(shape, color)

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -38,6 +38,7 @@ from analysis.models import (
 from analysis.safety_management import ACTIVE_TOOLBOX, SAFETY_ANALYSIS_WORK_PRODUCTS
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.constants import CHECK_MARK, CROSS_MARK
+from gui.icon_factory import create_icon
 from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
 from gui.architecture import (
     _work_product_name,
@@ -1212,57 +1213,8 @@ class ReliabilityWindow(tk.Frame):
         )
 
     def _create_icon(self, shape: str, color: str = "black") -> tk.PhotoImage:
-        """Return a simple 16x16 icon for toolbox buttons."""
-        size = 16
-        img = tk.PhotoImage(width=size, height=size)
-        img.put("white", to=(0, 0, size - 1, size - 1))
-        c = color
-        if shape == "plus":
-            mid = size // 2
-            for x in range(3, size - 3):
-                img.put(c, (x, mid))
-            for y in range(3, size - 3):
-                img.put(c, (mid, y))
-        elif shape == "cross":
-            for i in range(3, size - 3):
-                img.put(c, (i, i))
-                img.put(c, (i, size - i - 1))
-        elif shape == "gear":
-            mid = size // 2
-            r = size // 2 - 4
-            for y in range(size):
-                for x in range(size):
-                    if (x - mid) ** 2 + (y - mid) ** 2 <= r * r:
-                        img.put(c, (x, y))
-            for t in (-r, r):
-                for x in range(mid - 1, mid + 2):
-                    img.put(c, (x, mid + t))
-                for y in range(mid - 1, mid + 2):
-                    img.put(c, (mid + t, y))
-        elif shape == "sigma":
-            for x in range(3, size - 3):
-                img.put(c, (x, 3))
-                img.put(c, (x, size - 4))
-            for i in range(6):
-                img.put(c, (3 + i, 3 + i))
-                img.put(c, (size - 4 - i, 3 + i))
-        elif shape == "disk":
-            img.put(c, to=(2, 2, size - 2, size - 2))
-            img.put("white", to=(size - 6, 2, size - 2, 6))
-            img.put("white", to=(3, 3, size - 3, 6))
-        elif shape == "folder":
-            for x in range(1, size - 1):
-                img.put(c, (x, 4))
-                img.put(c, (x, size - 2))
-            for y in range(4, size - 1):
-                img.put(c, (1, y))
-                img.put(c, (size - 2, y))
-            for x in range(3, size - 3):
-                img.put(c, (x, 2))
-            img.put(c, to=(1, 3, size - 2, 4))
-        else:
-            img.put(c, to=(2, 2, size - 2, size - 2))
-        return img
+        """Proxy to the shared icon factory."""
+        return create_icon(shape, color)
 
 
 class FI2TCWindow(tk.Frame):


### PR DESCRIPTION
## Summary
- add reusable `create_icon` helper that draws detailed miniature icons
- update GUI modules to use the shared icon factory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a06dc509ec8327b5e72ded5c3328af