### PR TITLE
Remove select button from governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -10313,10 +10313,19 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             )
         if not hasattr(self, "tools_frame"):
             self.tools_frame = self.toolbox
-        btn = getattr(self, "tool_buttons", {}).get("Action")
+
+        tool_buttons = getattr(self, "tool_buttons", None)
+        if tool_buttons and "Select" in tool_buttons:
+            btn = tool_buttons.pop("Select")
+            try:
+                btn.destroy()
+            except Exception:  # pragma: no cover - headless tests
+                pass
+
+        btn = tool_buttons.get("Action") if tool_buttons else None
         if btn:
             btn.configure(text="Task")
-            self.tool_buttons["Task"] = self.tool_buttons.pop("Action")
+            tool_buttons["Task"] = tool_buttons.pop("Action")
 
         # ------------------------------------------------------------------
         # Toolbox toggle between Governance and Safety & AI Lifecycle
@@ -10360,13 +10369,6 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         ai_relations = SAFETY_AI_RELATIONS
         if hasattr(self.toolbox, "tk"):
             self.ai_tools_frame = ttk.Frame(self.toolbox)
-            ttk.Button(
-                self.ai_tools_frame,
-                text="Select",
-                image=self._icon_for("Select"),
-                compound=tk.LEFT,
-                command=lambda: self.select_tool("Select"),
-            ).pack(fill=tk.X, padx=2, pady=2)
             for name in ai_nodes:
                 ttk.Button(
                     self.ai_tools_frame,
@@ -10395,13 +10397,6 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         ge_nodes = GOV_ELEMENT_CLASSES
         if hasattr(self.toolbox, "tk"):
             self.gov_elements_frame = ttk.Frame(self.toolbox)
-            ttk.Button(
-                self.gov_elements_frame,
-                text="Select",
-                image=self._icon_for("Select"),
-                compound=tk.LEFT,
-                command=lambda: self.select_tool("Select"),
-            ).pack(fill=tk.X, padx=2, pady=2)
             for group, nodes in ge_nodes.items():
                 frame = ttk.LabelFrame(self.gov_elements_frame, text=group)
                 frame.pack(fill=tk.X, padx=2, pady=2)

--- a/tests/test_governance_no_select_button.py
+++ b/tests/test_governance_no_select_button.py
@@ -1,0 +1,33 @@
+import types
+
+from gui.architecture import GovernanceDiagramWindow
+import gui.architecture as arch
+
+
+def test_governance_diagram_has_no_select_button(monkeypatch):
+    class DummyButton:
+        def __init__(self):
+            self.config = {}
+
+        def configure(self, **kwargs):
+            self.config.update(kwargs)
+
+        def destroy(self):
+            self.destroyed = True
+
+    def fake_sysml_init(self, master, title, tools, diagram_id=None, app=None, history=None, relation_tools=None, tool_groups=None):
+        self.tool_buttons = {"Select": DummyButton(), "Action": DummyButton()}
+        self.toolbox = types.SimpleNamespace()
+        self.tools_frame = None
+        self.rel_frame = None
+        canvas_master = types.SimpleNamespace(pack_forget=lambda: None, pack=lambda **k: None)
+        self.canvas = types.SimpleNamespace(master=canvas_master)
+        self.repo = types.SimpleNamespace(diagrams={})
+        self.diagram_id = "dummy"
+        self.refresh_from_repository = lambda *_: None
+
+    monkeypatch.setattr(arch.SysMLDiagramWindow, "__init__", fake_sysml_init)
+
+    win = GovernanceDiagramWindow(None, None)
+    assert "Select" not in win.tool_buttons
+    assert "Task" in win.tool_buttons


### PR DESCRIPTION
## Summary
- drop the Select tool from governance diagram toolboxes
- cover governance diagrams with a regression test verifying the tool is gone

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a06e004db883278ad1df45190b70cf