### PR TITLE
Ensure tabs refresh when focused

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16972,11 +16972,16 @@ class FaultTreeApp:
             if hasattr(event.widget, "nametowidget")
             else tab_id
         )
+        # Propagate recent changes and ensure the active tab reflects them
+        self.refresh_all()
         if tab is getattr(self, "_safety_case_tab", None):
             self.refresh_safety_case_table()
-        for child in tab.winfo_children():
+        widgets = [tab, *tab.winfo_children()]
+        for child in widgets:
             if hasattr(child, "refresh_from_repository"):
                 child.refresh_from_repository()
+            elif hasattr(child, "refresh"):
+                child.refresh()
 
         toolbox = getattr(self, "safety_mgmt_toolbox", None)
         if toolbox and getattr(self, "diagram_tabs", None):

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -2512,6 +2512,45 @@ def test_focus_governance_diagram_sets_phase_and_hides_functions():
     assert len(changes) == 3
 
 
+def test_tab_focus_triggers_refresh():
+    class DummyChild:
+        def __init__(self):
+            self.called = False
+
+        def refresh_from_repository(self):
+            self.called = True
+
+    class DummyTab:
+        def __init__(self):
+            self.refreshed = False
+            self.child = DummyChild()
+
+        def winfo_children(self):
+            return [self.child]
+
+        def refresh(self):
+            self.refreshed = True
+
+    class DummyNotebook:
+        def __init__(self, tab):
+            self.tab = tab
+
+        def select(self):
+            return self.tab
+
+        def nametowidget(self, widget):
+            return widget
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    tab = DummyTab()
+    nb = DummyNotebook(tab)
+    app.refresh_all = types.MethodType(lambda self: None, app)
+    app._safety_case_tab = None
+    app._on_tab_change(types.SimpleNamespace(widget=nb))
+    assert tab.refreshed
+    assert tab.child.called
+
+
 def test_requirement_trace_lookup():
     toolbox = SafetyManagementToolbox()
 


### PR DESCRIPTION
## Summary
- Refresh entire application and tab contents when switching tabs to keep data current
- Test that tab focus triggers refresh functions on the tab and its children

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a06f12986883278f9eb51ad584e7fc