### PR TITLE
Ensure tabs refresh when focused

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -16972,11 +16972,16 @@ class FaultTreeApp:
             if hasattr(event.widget, "nametowidget")
             else tab_id
         )
+        # Propagate recent changes and ensure the active tab reflects them
+        self.refresh_all()
         if tab is getattr(self, "_safety_case_tab", None):
             self.refresh_safety_case_table()
-        for child in tab.winfo_children():
+        widgets = [tab, *tab.winfo_children()]
+        for child in widgets:
             if hasattr(child, "refresh_from_repository"):
                 child.refresh_from_repository()
+            elif hasattr(child, "refresh"):
+                child.refresh()
 
         toolbox = getattr(self, "safety_mgmt_toolbox", None)
         if toolbox and getattr(self, "diagram_tabs", None):

--- a/tests/test_display_requirements_phase_column.py
+++ b/tests/test_display_requirements_phase_column.py
@@ -62,12 +62,14 @@ def test_display_requirements_includes_phase(monkeypatch):
         def __init__(self, master, columns, show="headings"):
             columns_captured.append(columns)
             master.children.append(self)
+            self.rows = []
 
         def heading(self, col, text=""):
             pass
 
         def insert(self, parent, idx, values):
             inserted.append(values)
+            self.rows.append(values)
 
         def configure(self, **kwargs):
             pass
@@ -80,6 +82,12 @@ def test_display_requirements_includes_phase(monkeypatch):
 
         def grid(self, *args, **kwargs):
             pass
+
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def delete(self, *items):
+            self.rows = []
 
     monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
     monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)

--- a/tests/test_governance_ai_requirement_type.py
+++ b/tests/test_governance_ai_requirement_type.py
@@ -101,6 +101,12 @@ def test_ai_elements_generate_ai_safety_requirements(monkeypatch):
         def grid(self, *args, **kwargs):
             pass
 
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def delete(self, *items):
+            self.rows = []
+
     monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
     monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)

--- a/tests/test_governance_lifecycle_requirements_menu.py
+++ b/tests/test_governance_lifecycle_requirements_menu.py
@@ -116,6 +116,12 @@ def test_lifecycle_requirements_menu(monkeypatch):
         def grid(self, *args, **kwargs):
             pass
 
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def delete(self, *items):
+            self.rows = []
+
     monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
     monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)

--- a/tests/test_governance_phase_requirements_error.py
+++ b/tests/test_governance_phase_requirements_error.py
@@ -33,7 +33,10 @@ def test_generate_phase_requirements_handles_errors(monkeypatch):
     win.app = types.SimpleNamespace(_new_tab=lambda title: None)
 
     displayed = []
-    win._display_requirements = lambda title, ids: displayed.append((title, ids))
+    def display_stub(title, ids):
+        displayed.append((title, ids))
+        return types.SimpleNamespace(refresh_table=lambda ids: None)
+    win._display_requirements = display_stub
 
     errors = []
     monkeypatch.setattr(smt.messagebox, "showerror", lambda t, m: errors.append((t, m)))

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -115,6 +115,12 @@ def test_phase_requirements_menu(monkeypatch):
         def grid(self, *args, **kwargs):
             pass
 
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def delete(self, *items):
+            self.rows = []
+
     monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
     monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)

--- a/tests/test_governance_phase_requirements_type_error.py
+++ b/tests/test_governance_phase_requirements_type_error.py
@@ -28,7 +28,10 @@ def test_generate_phase_requirements_non_string(monkeypatch):
     win.app = types.SimpleNamespace(_new_tab=lambda title: None)
 
     displayed = []
-    win._display_requirements = lambda title, ids: displayed.append((title, ids))
+    def display_stub(title, ids):
+        displayed.append((title, ids))
+        return types.SimpleNamespace(refresh_table=lambda ids: None)
+    win._display_requirements = display_stub
 
     errors = []
     monkeypatch.setattr(smt.messagebox, "showerror", lambda t, m: errors.append((t, m)))

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -101,6 +101,12 @@ def test_requirements_button_opens_tab(monkeypatch):
         def grid(self, *args, **kwargs):
             pass
 
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def delete(self, *items):
+            self.rows = []
+
     monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
     monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
     monkeypatch.setattr(smt.ttk, "Treeview", DummyTree)
@@ -190,13 +196,14 @@ def test_requirements_button_no_change(monkeypatch):
 
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
+            self.rows = []
             master.children.append(self)
 
         def heading(self, col, text=""):
             pass
 
         def insert(self, parent, idx, values):
-            pass
+            self.rows.append(values)
 
         def configure(self, **kwargs):
             pass
@@ -209,6 +216,12 @@ def test_requirements_button_no_change(monkeypatch):
 
         def grid(self, *args, **kwargs):
             pass
+
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def delete(self, *items):
+            self.rows = []
 
     monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
     monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)
@@ -299,13 +312,14 @@ def test_other_diagram_requirements_preserved(monkeypatch):
 
     class DummyTree:
         def __init__(self, master, columns, show="headings"):
+            self.rows = []
             master.children.append(self)
 
         def heading(self, col, text=""):
             pass
 
         def insert(self, parent, idx, values):
-            pass
+            self.rows.append(values)
 
         def configure(self, **kwargs):
             pass
@@ -318,6 +332,12 @@ def test_other_diagram_requirements_preserved(monkeypatch):
 
         def grid(self, *args, **kwargs):
             pass
+
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def delete(self, *items):
+            self.rows = []
 
     monkeypatch.setattr(smt.ttk, "Frame", DummyFrame)
     monkeypatch.setattr(smt.ttk, "Scrollbar", DummyScrollbar)

--- a/tests/test_governance_requirements_error.py
+++ b/tests/test_governance_requirements_error.py
@@ -21,7 +21,10 @@ def test_generate_requirements_error(monkeypatch):
     errors: list[tuple[str, str]] = []
     monkeypatch.setattr(smt.messagebox, "showerror", lambda t, m: errors.append((t, m)))
     called: list[str] = []
-    monkeypatch.setattr(SafetyManagementWindow, "_display_requirements", lambda self, title, ids: called.append(title))
+    def display_stub(self, title, ids):
+        called.append(title)
+        return types.SimpleNamespace(refresh_table=lambda ids: None)
+    monkeypatch.setattr(SafetyManagementWindow, "_display_requirements", display_stub)
 
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)
     win.toolbox = toolbox
@@ -45,7 +48,10 @@ def test_generate_phase_requirements_error(monkeypatch):
     errors: list[tuple[str, str]] = []
     monkeypatch.setattr(smt.messagebox, "showerror", lambda t, m: errors.append((t, m)))
     called: list[str] = []
-    monkeypatch.setattr(SafetyManagementWindow, "_display_requirements", lambda self, title, ids: called.append(title))
+    def display_stub(self, title, ids):
+        called.append(title)
+        return types.SimpleNamespace(refresh_table=lambda ids: None)
+    monkeypatch.setattr(SafetyManagementWindow, "_display_requirements", display_stub)
 
     win = SafetyManagementWindow.__new__(SafetyManagementWindow)
     win.toolbox = toolbox

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -2512,6 +2512,45 @@ def test_focus_governance_diagram_sets_phase_and_hides_functions():
     assert len(changes) == 3
 
 
+def test_tab_focus_triggers_refresh():
+    class DummyChild:
+        def __init__(self):
+            self.called = False
+
+        def refresh_from_repository(self):
+            self.called = True
+
+    class DummyTab:
+        def __init__(self):
+            self.refreshed = False
+            self.child = DummyChild()
+
+        def winfo_children(self):
+            return [self.child]
+
+        def refresh(self):
+            self.refreshed = True
+
+    class DummyNotebook:
+        def __init__(self, tab):
+            self.tab = tab
+
+        def select(self):
+            return self.tab
+
+        def nametowidget(self, widget):
+            return widget
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+    tab = DummyTab()
+    nb = DummyNotebook(tab)
+    app.refresh_all = types.MethodType(lambda self: None, app)
+    app._safety_case_tab = None
+    app._on_tab_change(types.SimpleNamespace(widget=nb))
+    assert tab.refreshed
+    assert tab.child.called
+
+
 def test_requirement_trace_lookup():
     toolbox = SafetyManagementToolbox()
 

--- a/tests/test_safety_management_dedup.py
+++ b/tests/test_safety_management_dedup.py
@@ -149,6 +149,12 @@ def test_display_requirements_clears_existing(monkeypatch):
         def grid(self, *args, **kwargs):
             pass
 
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def delete(self, *items):
+            self.rows = []
+
         def destroy(self):
             self.master.children.remove(self)
 


### PR DESCRIPTION
## Summary
- Rebuild requirement table widgets via a reusable populate function and expose a `refresh_table` hook
- Attach `refresh_from_repository` callbacks when generating requirement tabs so focusing them reflects latest data
- Add regression test confirming lifecycle requirement tabs update after deletions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a06f12986883278f9eb51ad584e7fc