### PR TITLE
Render relationship icons as line arrows

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -17056,6 +17056,7 @@ class FaultTreeApp:
         img = tk.PhotoImage(width=size, height=size)
         img.put("white", to=(0, 0, size - 1, size - 1))
         c = color
+        outline = "black"
         if shape == "circle":
             r = size // 2 - 2
             cx = cy = size // 2
@@ -17065,11 +17066,15 @@ class FaultTreeApp:
                         img.put(c, (x, y))
         elif shape == "arrow":
             mid = size // 2
-            for x in range(2, mid + 1):
-                img.put(c, to=(x, mid - 1, x + 1, mid + 1))
-            for i in range(4):
-                img.put(c, to=(mid + i, mid - 2 - i, mid + i + 1, mid - i))
-                img.put(c, to=(mid + i, mid + i, mid + i + 1, mid + 2 + i))
+            for x in range(2, size - 5):
+                img.put(c, (x, mid))
+                img.put(outline, (x, mid))
+            head = size - 5
+            for i in range(5):
+                for y in range(mid - i, mid + i + 1):
+                    img.put(c, (head + i, y))
+                img.put(outline, (head + i, mid - i))
+                img.put(outline, (head + i, mid + i))
         elif shape == "diamond":
             mid = size // 2
             for y in range(2, size - 2):

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -54,14 +54,17 @@ def create_icon(shape: str, color: str = "black", bg: str = "white") -> tk.Photo
             img.put(outline, (1, y))
     elif shape == "arrow":
         mid = size // 2
-        for x in range(2, mid + 2):
-            img.put(c, to=(x, mid - 2, x + 1, mid + 2))
-        for i in range(4):
-            img.put(c, to=(mid + i, mid - 3 - i, mid + i + 1, mid - i))
-            img.put(c, to=(mid + i, mid + i, mid + i + 1, mid + 3 + i))
+        # Draw a thin horizontal shaft
+        for x in range(2, size - 5):
+            img.put(c, (x, mid))
+            img.put(outline, (x, mid))
+        # Add a triangular arrow head
+        head = size - 5
         for i in range(5):
-            img.put(outline, (mid + i, mid - 3 - i))
-            img.put(outline, (mid + i, mid + 3 + i))
+            for y in range(mid - i, mid + i + 1):
+                img.put(c, (head + i, y))
+            img.put(outline, (head + i, mid - i))
+            img.put(outline, (head + i, mid + i))
     elif shape == "triangle":
         mid = size // 2
         height = size - 4


### PR DESCRIPTION
## Summary
- Make arrow icons appear as a thin line with a triangular head so relationship icons show an arrowed link
- Apply the updated arrow rendering in AutoML's internal icon creation helper

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_explorer.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a074c2f7008327b452bff86d704948