### PR TITLE
Render toolbox icons using exact shapes

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -253,6 +253,7 @@ from gui.gsn_config_window import GSNElementConfig
 from gsn import GSNDiagram, GSNModule
 from gsn.nodes import GSNNode
 from gui.closable_notebook import ClosableNotebook
+from gui.icon_factory import create_icon
 from dataclasses import asdict
 from pathlib import Path
 from analysis.mechanisms import (
@@ -2224,7 +2225,7 @@ class FaultTreeApp:
         # application lifecycle.
         self.pkg_icon = self._create_icon("folder", "#b8860b")
         self.diagram_icons = {
-            "Use Case Diagram": self._create_icon("circle", "blue"),
+            "Use Case Diagram": self._create_icon("ellipse", "blue"),
             "Activity Diagram": self._create_icon("arrow", "green"),
             "Governance Diagram": self._create_icon("arrow", "green"),
             "Block Diagram": self._create_icon("rect", "orange"),
@@ -17051,84 +17052,8 @@ class FaultTreeApp:
         return f"\N{LEFT-POINTING DOUBLE ANGLE QUOTATION MARK}{diag.diag_type}\N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK}"
 
     def _create_icon(self, shape: str, color: str) -> tk.PhotoImage:
-        """Return a simple 16x16 PhotoImage for the given shape and color."""
-        size = 16
-        img = tk.PhotoImage(width=size, height=size)
-        img.put("white", to=(0, 0, size - 1, size - 1))
-        c = color
-        if shape == "circle":
-            r = size // 2 - 2
-            cx = cy = size // 2
-            for y in range(size):
-                for x in range(size):
-                    if (x - cx) ** 2 + (y - cy) ** 2 <= r * r:
-                        img.put(c, (x, y))
-        elif shape == "arrow":
-            mid = size // 2
-            for x in range(2, mid + 1):
-                img.put(c, to=(x, mid - 1, x + 1, mid + 1))
-            for i in range(4):
-                img.put(c, to=(mid + i, mid - 2 - i, mid + i + 1, mid - i))
-                img.put(c, to=(mid + i, mid + i, mid + i + 1, mid + 2 + i))
-        elif shape == "diamond":
-            mid = size // 2
-            for y in range(2, size - 2):
-                span = mid - abs(mid - y)
-                img.put(c, to=(mid - span, y, mid + span + 1, y + 1))
-        elif shape == "triangle":
-            mid = size // 2
-            height = size - 4
-            for y in range(height):
-                span = (y * mid) // height
-                img.put(c, to=(mid - span, 2 + y, mid + span + 1, 3 + y))
-        elif shape == "cylinder":
-            img.put(c, to=(2, 4, size - 2, size - 4))
-            for x in range(2, size - 2):
-                img.put(c, (x, 3))
-                img.put(c, (x, size - 4))
-            for x in range(3, size - 3):
-                img.put(c, (x, 2))
-                img.put(c, (x, size - 3))
-        elif shape == "document":
-            img.put(c, to=(2, 2, size - 2, size - 2))
-            fold = "white"
-            for i in range(4):
-                img.put(fold, to=(size - 6 + i, 2, size - 2, 6 - i))
-        elif shape == "bar":
-            img.put(c, to=(2, size // 2 - 2, size - 2, size // 2 + 2))
-        elif shape == "rect":
-            for x in range(3, size - 3):
-                img.put(c, (x, 3))
-                img.put(c, (x, size - 4))
-            for y in range(3, size - 3):
-                img.put(c, (3, y))
-                img.put(c, (size - 4, y))
-        elif shape == "nested":
-            for x in range(1, size - 1):
-                img.put(c, (x, 1))
-                img.put(c, (x, size - 2))
-            for y in range(1, size - 1):
-                img.put(c, (1, y))
-                img.put(c, (size - 2, y))
-            for x in range(5, size - 5):
-                img.put(c, (x, 5))
-                img.put(c, (x, size - 6))
-            for y in range(5, size - 5):
-                img.put(c, (5, y))
-                img.put(c, (size - 6, y))
-        elif shape == "folder":
-            for x in range(1, size - 1):
-                img.put(c, (x, 4))
-                img.put(c, (x, size - 2))
-            for y in range(4, size - 1):
-                img.put(c, (1, y))
-                img.put(c, (size - 2, y))
-            for x in range(3, size - 3):
-                img.put(c, (x, 2))
-            img.put(c, to=(1, 3, size - 2, 4))
-        else:
-            img.put(c, to=(2, 2, size - 2, size - 2))
-        return img
+        """Delegate icon creation to the shared icon factory."""
+        return create_icon(shape, color)
 
     def open_use_case_diagram(self):
         """Prompt for a diagram name then open a new use case diagram."""

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -74,209 +74,6 @@ GOV_ELEMENT_RELATIONS = _CONFIG.get("governance_element_relations", [])
 draw_icon = create_icon
 
 
-def _darken(color: str, factor: float = 0.8) -> str:
-    if color.startswith("#") and len(color) == 7:
-        r = int(color[1:3], 16)
-        g = int(color[3:5], 16)
-        b = int(color[5:7], 16)
-        r = int(r * factor)
-        g = int(g * factor)
-        b = int(b * factor)
-        return f"#{r:02x}{g:02x}{b:02x}"
-    return color
-
-
-def _lighten(color: str, factor: float = 0.3) -> str:
-    if color.startswith("#") and len(color) == 7:
-        r = int(color[1:3], 16)
-        g = int(color[3:5], 16)
-        b = int(color[5:7], 16)
-        r = int(r + (255 - r) * factor)
-        g = int(g + (255 - g) * factor)
-        b = int(b + (255 - b) * factor)
-        return f"#{r:02x}{g:02x}{b:02x}"
-    return color
-
-
-def draw_icon(shape: str, color: str = "black") -> tk.PhotoImage:
-    """Return a 16×16 modern-style icon representing ``shape``."""
-    size = 16
-    img = tk.PhotoImage(width=size, height=size)
-    bg = "white"
-    img.put(bg, to=(0, 0, size - 1, size - 1))
-    fill = _lighten(color, 0.4)
-    stroke = _darken(color, 0.8)
-
-    if shape == "circle":
-        r = size // 2 - 3
-        cx = cy = size // 2
-        for y in range(size):
-            for x in range(size):
-                d = (x - cx) ** 2 + (y - cy) ** 2
-                if d <= r * r:
-                    img.put(fill, (x, y))
-                if r * r - r <= d <= r * r + r:
-                    img.put(stroke, (x, y))
-    elif shape == "arrow":
-        mid = size // 2
-        for x in range(3, size - 5):
-            img.put(stroke, to=(x, mid - 1, x + 1, mid + 2))
-        for i in range(5):
-            img.put(stroke, to=(size - 5 + i, mid - 2 - i, size - 4 + i, mid + 3 + i))
-    elif shape == "diamond":
-        mid = size // 2
-        for y in range(3, size - 3):
-            span = mid - abs(mid - y)
-            img.put(fill, to=(mid - span + 1, y, mid + span, y + 1))
-            img.put(stroke, (mid - span, y))
-            img.put(stroke, (mid + span, y))
-        for i in range(mid - 2):
-            img.put(stroke, (mid - i - 1, 3 + i))
-            img.put(stroke, (mid + i, 3 + i))
-            img.put(stroke, (mid - i - 1, size - 4 - i))
-            img.put(stroke, (mid + i, size - 4 - i))
-    elif shape == "triangle":
-        mid = size // 2
-        height = size - 4
-        for y in range(height):
-            span = (y * (mid - 1)) // height
-            img.put(fill, to=(mid - span + 1, 2 + y, mid + span, 3 + y))
-            img.put(stroke, (mid - span, 2 + y))
-            img.put(stroke, (mid + span, 2 + y))
-        for x in range(2, size - 2):
-            img.put(stroke, (x, size - 2))
-    elif shape == "cylinder":
-        img.put(fill, to=(3, 4, size - 3, size - 4))
-        for x in range(3, size - 3):
-            img.put(stroke, (x, 4))
-            img.put(stroke, (x, size - 4))
-        for x in range(4, size - 4):
-            img.put(stroke, (x, 3))
-            img.put(stroke, (x, size - 3))
-        for y in range(4, size - 4):
-            img.put(stroke, (3, y))
-            img.put(stroke, (size - 4, y))
-    elif shape == "document":
-        img.put(fill, to=(3, 3, size - 3, size - 3))
-        for x in range(3, size - 3):
-            img.put(stroke, (x, 3))
-            img.put(stroke, (x, size - 4))
-        for y in range(3, size - 3):
-            img.put(stroke, (3, y))
-            img.put(stroke, (size - 4, y))
-        fold = _lighten(color, 0.7)
-        img.put(fold, to=(size - 7, 3, size - 3, 7))
-        img.put(stroke, to=(size - 7, 3, size - 3, 7))
-        img.put(stroke, to=(5, 7, size - 5, 8))
-        img.put(stroke, to=(5, 10, size - 5, 11))
-    elif shape == "bar":
-        img.put(stroke, to=(3, size // 2 - 1, size - 3, size // 2 + 2))
-    elif shape == "rect":
-        img.put(fill, to=(3, 3, size - 3, size - 3))
-        for x in range(3, size - 3):
-            img.put(stroke, (x, 3))
-            img.put(stroke, (x, size - 4))
-        for y in range(3, size - 3):
-            img.put(stroke, (3, y))
-            img.put(stroke, (size - 4, y))
-    elif shape == "nested":
-        img.put(fill, to=(1, 1, size - 1, size - 1))
-        for x in range(1, size - 1):
-            img.put(stroke, (x, 1))
-            img.put(stroke, (x, size - 2))
-        for y in range(1, size - 1):
-            img.put(stroke, (1, y))
-            img.put(stroke, (size - 2, y))
-        for x in range(5, size - 5):
-            img.put(stroke, (x, 5))
-            img.put(stroke, (x, size - 6))
-        for y in range(5, size - 5):
-            img.put(stroke, (5, y))
-            img.put(stroke, (size - 6, y))
-    elif shape == "folder":
-        img.put(fill, to=(2, 6, size - 2, size - 2))
-        img.put(fill, to=(2, 4, size // 2, 6))
-        for x in range(2, size - 2):
-            img.put(stroke, (x, 6))
-            img.put(stroke, (x, size - 2))
-        for y in range(6, size - 2):
-            img.put(stroke, (2, y))
-            img.put(stroke, (size - 2, y))
-        for x in range(2, size // 2):
-            img.put(stroke, (x, 4))
-        img.put(stroke, to=(2, 5, size - 2, 6))
-    elif shape == "plus":
-        mid = size // 2
-        for x in range(mid - 1, mid + 2):
-            img.put(stroke, to=(x, 3, x + 1, size - 3))
-        for y in range(mid - 1, mid + 2):
-            img.put(stroke, to=(3, y, size - 3, y + 1))
-    elif shape == "cross":
-        for i in range(3, size - 3):
-            for t in (-1, 0, 1):
-                img.put(stroke, (i + t, i))
-                img.put(stroke, (i + t, size - 1 - i))
-    elif shape == "gear":
-        mid = size // 2
-        r = size // 2 - 4
-        for y in range(size):
-            for x in range(size):
-                d = (x - mid) ** 2 + (y - mid) ** 2
-                if d <= r * r:
-                    img.put(fill, (x, y))
-                if r * r - r <= d <= r * r + r:
-                    img.put(stroke, (x, y))
-        for t in (-r, r):
-            for x in range(mid - 2, mid + 3):
-                img.put(stroke, (x, mid + t))
-            for y in range(mid - 2, mid + 3):
-                img.put(stroke, (mid + t, y))
-    elif shape == "sigma":
-        for x in range(3, size - 3):
-            img.put(stroke, (x, 3))
-            img.put(stroke, (x, size - 4))
-        for i in range(size - 6):
-            img.put(stroke, (3 + i, 3 + i))
-            img.put(stroke, (size - 4 - i, 3 + i))
-    elif shape == "disk":
-        img.put(fill, to=(2, 2, size - 2, size - 2))
-        for x in range(2, size - 2):
-            img.put(stroke, (x, 2))
-            img.put(stroke, (x, size - 3))
-        for y in range(2, size - 2):
-            img.put(stroke, (2, y))
-            img.put(stroke, (size - 3, y))
-        img.put(bg, to=(4, 4, size - 5, 7))
-        img.put(bg, to=(size - 5, 2, size - 2, 5))
-    elif shape == "neural":
-        nodes_left = [(4, 4), (4, 12)]
-        nodes_mid = [(8, 4), (8, 12)]
-        node_out = (12, 8)
-        def draw_node(x: int, y: int) -> None:
-            for dy in (-1, 0, 1):
-                for dx in (-1, 0, 1):
-                    if dx * dx + dy * dy <= 1:
-                        img.put(stroke, (x + dx, y + dy))
-        def draw_line(p1, p2) -> None:
-            x1, y1 = p1
-            x2, y2 = p2
-            steps = max(abs(x2 - x1), abs(y2 - y1))
-            for i in range(steps + 1):
-                x = int(round(x1 + (x2 - x1) * i / steps))
-                y = int(round(y1 + (y2 - y1) * i / steps))
-                img.put(stroke, (x, y))
-        for s in nodes_left:
-            for h in nodes_mid:
-                draw_line(s, h)
-        for h in nodes_mid:
-            draw_line(h, node_out)
-        for p in nodes_left + nodes_mid + [node_out]:
-            draw_node(*p)
-    else:
-        img.put(stroke, to=(2, 2, size - 2, size - 2))
-    return img
-
-
 def _make_gov_element_classes(nodes: list[str]) -> dict[str, list[str]]:
     base = {
         "Entities": [n for n in ["Organization", "Business Unit", "Role"] if n in nodes],
@@ -3627,8 +3424,8 @@ class SysMLDiagramWindow(tk.Frame):
     def _shape_for_tool(self, name: str) -> str:
         mapping = {
             "Select": "arrow",
-            "Actor": "circle",
-            "Use Case": "circle",
+            "Actor": "human",
+            "Use Case": "ellipse",
             "Block": "rect",
             "Part": "rect",
             "Port": "circle",
@@ -3657,11 +3454,24 @@ class SysMLDiagramWindow(tk.Frame):
         }
         if name in mapping:
             return mapping[name]
-        if name in {"Flow"} or any(
-            k in name
-            for k in ["Propagate", "Used", "Trace", "Satisfied", "Derived", "Re-use"]
+        relation_names = {
+            "Flow",
+            "Association",
+            "Communication Path",
+            "Generalize",
+            "Include",
+            "Extend",
+            "Generalization",
+            "Aggregation",
+            "Composite Aggregation",
+            "Connector",
+            "Control Action",
+            "Feedback",
+        }
+        if name in relation_names or any(
+            k in name for k in ["Propagate", "Used", "Trace", "Satisfied", "Derived", "Re-use"]
         ):
-            return "arrow"
+            return "relation"
         return "rect"
 
         # ------------------------------------------------------------
@@ -11688,15 +11498,15 @@ class ArchitectureManagerDialog(tk.Frame):
         style = StyleManager.get_instance()
         self.pkg_icon = self._create_icon("folder", "#b8860b")
         self.diagram_icons = {
-            "Use Case Diagram": self._create_icon("circle", "blue"),
+            "Use Case Diagram": self._create_icon("ellipse", "blue"),
             "Activity Diagram": self._create_icon("arrow", "green"),
             "Governance Diagram": self._create_icon("arrow", "green"),
             "Block Diagram": self._create_icon("rect", "orange"),
             "Internal Block Diagram": self._create_icon("nested", "purple"),
         }
         self.elem_icons = {
-            "Actor": self._create_icon("circle", style.get_color("Actor")),
-            "Use Case": self._create_icon("circle", style.get_color("Use Case")),
+            "Actor": self._create_icon("human", style.get_color("Actor")),
+            "Use Case": self._create_icon("ellipse", style.get_color("Use Case")),
             "Block": self._create_icon("rect", style.get_color("Block")),
             "Part": self._create_icon("rect", style.get_color("Part")),
             "Port": self._create_icon("circle", style.get_color("Port")),

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -493,6 +493,5 @@ class GSNExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def _create_icon(self, shape: str, color: str = "black") -> tk.PhotoImage:
-        """Proxy to the shared icon factory with the canvas background."""
-        bg = StyleManager.get_instance().canvas_bg
-        return create_icon(shape, color, bg)
+        """Proxy to the shared icon factory."""
+        return create_icon(shape, color)

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -1,17 +1,23 @@
 import tkinter as tk
+from typing import Optional
 
-def create_icon(shape: str, color: str = "black", bg: str = "white") -> tk.PhotoImage:
+
+def create_icon(
+    shape: str, color: str = "black", bg: Optional[str] = None
+) -> tk.PhotoImage:
     """Return a small 16x16 PhotoImage for *shape* using *color*.
 
     Icons now have filled interiors and simple outlines so they look like
-    miniature versions of the objects they represent.  The implementation is
-    deliberately lightweight and only uses ``tk.PhotoImage`` drawing
-    primitives so it works in the same environments as the previous icon
-    helpers.
+    miniature versions of the objects they represent. By default the returned
+    image has a transparent background so the icons blend with any widget.
+    The implementation is deliberately lightweight and only uses
+    ``tk.PhotoImage`` drawing primitives so it works in the same environments
+    as the previous icon helpers.
     """
     size = 16
     img = tk.PhotoImage(width=size, height=size)
-    img.put(bg, to=(0, 0, size - 1, size - 1))
+    if bg:
+        img.put(bg, to=(0, 0, size - 1, size - 1))
     c = color
     outline = "black"
     if shape == "circle":
@@ -24,6 +30,37 @@ def create_icon(shape: str, color: str = "black", bg: str = "white") -> tk.Photo
                     img.put(c, (x, y))
                 if r * r <= dist <= (r + 1) * (r + 1):
                     img.put(outline, (x, y))
+    elif shape == "ellipse":
+        rx = size // 2 - 2
+        ry = size // 2 - 4
+        cx = cy = size // 2
+        for y in range(size):
+            for x in range(size):
+                norm = ((x - cx) ** 2) / (rx * rx) + ((y - cy) ** 2) / (ry * ry)
+                if norm <= 1:
+                    img.put(c, (x, y))
+                if 1 <= norm <= 1.2:
+                    img.put(outline, (x, y))
+    elif shape == "human":
+        cx = size // 2
+        head_r = 3
+        head_cy = 4
+        for y in range(head_cy - head_r, head_cy + head_r + 1):
+            for x in range(cx - head_r, cx + head_r + 1):
+                dist = (x - cx) ** 2 + (y - head_cy) ** 2
+                if dist <= head_r * head_r:
+                    img.put(c, (x, y))
+                if head_r * head_r <= dist <= (head_r + 1) * (head_r + 1):
+                    img.put(outline, (x, y))
+        for y in range(head_cy + head_r, size - 3):
+            img.put(c, (cx, y))
+        arm_y = head_cy + head_r + 2
+        for x in range(cx - 4, cx + 5):
+            img.put(c, (x, arm_y))
+        leg_start = size - 4
+        for i in range(4):
+            img.put(c, (cx - i, leg_start + i))
+            img.put(c, (cx + i, leg_start + i))
     elif shape == "diamond":
         mid = size // 2
         for y in range(2, size - 2):
@@ -62,6 +99,13 @@ def create_icon(shape: str, color: str = "black", bg: str = "white") -> tk.Photo
         for i in range(5):
             img.put(outline, (mid + i, mid - 3 - i))
             img.put(outline, (mid + i, mid + 3 + i))
+    elif shape == "relation":
+        mid = size // 2
+        for x in range(2, size - 4):
+            img.put(c, (x, mid))
+        for i in range(4):
+            img.put(c, (size - 4 + i, mid - i))
+            img.put(c, (size - 4 + i, mid + i))
     elif shape == "triangle":
         mid = size // 2
         height = size - 4
@@ -82,7 +126,7 @@ def create_icon(shape: str, color: str = "black", bg: str = "white") -> tk.Photo
             img.put(outline, (x, size - 3))
     elif shape == "document":
         img.put(c, to=(2, 2, size - 2, size - 2))
-        fold = bg
+        fold = bg or "white"
         for i in range(4):
             img.put(fold, to=(size - 6 + i, 2, size - 2, 6 - i))
         for x in range(2, size - 2):
@@ -158,14 +202,42 @@ def create_icon(shape: str, color: str = "black", bg: str = "white") -> tk.Photo
             img.put(outline, (size - 4 - i, 3 + i))
     elif shape == "disk":
         img.put(c, to=(2, 2, size - 2, size - 2))
-        img.put(bg, to=(size - 6, 2, size - 2, 6))
-        img.put(bg, to=(3, 3, size - 3, 6))
+        if bg:
+            img.put(bg, to=(size - 6, 2, size - 2, 6))
+            img.put(bg, to=(3, 3, size - 3, 6))
         for x in range(2, size - 2):
             img.put(outline, (x, 2))
             img.put(outline, (x, size - 2))
         for y in range(2, size - 2):
             img.put(outline, (2, y))
             img.put(outline, (size - 2, y))
+    elif shape == "neural":
+        nodes_left = [(4, 4), (4, 12)]
+        nodes_mid = [(8, 4), (8, 12)]
+        node_out = (12, 8)
+
+        def draw_node(x: int, y: int) -> None:
+            for dy in (-1, 0, 1):
+                for dx in (-1, 0, 1):
+                    if dx * dx + dy * dy <= 1:
+                        img.put(outline, (x + dx, y + dy))
+
+        def draw_line(p1, p2) -> None:
+            x1, y1 = p1
+            x2, y2 = p2
+            steps = max(abs(x2 - x1), abs(y2 - y1))
+            for i in range(steps + 1):
+                x = int(round(x1 + (x2 - x1) * i / steps))
+                y = int(round(y1 + (y2 - y1) * i / steps))
+                img.put(outline, (x, y))
+
+        for s in nodes_left:
+            for h in nodes_mid:
+                draw_line(s, h)
+        for h in nodes_mid:
+            draw_line(h, node_out)
+        for p in nodes_left + nodes_mid + [node_out]:
+            draw_node(*p)
     else:
         img.put(c, to=(2, 2, size - 2, size - 2))
         for x in range(2, size - 2):


### PR DESCRIPTION
## Summary
- Use shared icon factory for architecture toolboxes
- Add ellipse, human, relation and neural shapes to icon factory
- Update toolbox mappings so icons mirror diagram shapes
- Map common relationship tools to the line icon so connectors render correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a074e33fcc83279a67f3db771ab41d