### PR TITLE
Improve arrow icon rendering

### DIFF
--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -94,12 +94,15 @@ def create_icon(
         # Draw a thin horizontal shaft
         for x in range(2, size - 5):
             img.put(c, (x, mid))
-            img.put(outline, (x, mid))
-        # Add a triangular arrow head
+        # Add a filled triangular arrow head on the right
         head = size - 5
         for i in range(5):
-            img.put(outline, (mid + i, mid - 3 - i))
-            img.put(outline, (mid + i, mid + 3 + i))
+            x = head + i
+            for y in range(mid - i, mid + i + 1):
+                img.put(c, (x, y))
+            img.put(outline, (x, mid - i))
+            img.put(outline, (x, mid + i))
+        img.put(outline, (size - 1, mid))
     elif shape == "relation":
         mid = size // 2
         for x in range(2, size - 4):


### PR DESCRIPTION
## Summary
- draw arrow toolbox icons using a filled triangular head so they mirror diagram arrows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a07c31031c8327a44a5d688b1ba9ea