### PR TITLE
Improve governance and Safety & AI toolbox icons

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3415,15 +3415,31 @@ class SysMLDiagramWindow(tk.Frame):
         icon = self._icons.get(name)
         if icon is None:
             style = StyleManager.get_instance()
-            color = style.get_color(name)
-            if color == "#FFFFFF":
-                color = "black"
             shape = self._shape_for_tool(name)
+            if shape == "relation":
+                color = "black"
+            else:
+                color = style.get_color(name)
+                if color == "#FFFFFF" and name.startswith("Add "):
+                    base = name[4:]
+                    if base.startswith("Generic "):
+                        base = base[8:]
+                    if base == "Process Area":
+                        base = "Process"
+                    color = style.get_color(base)
+                if color == "#FFFFFF":
+                    color = "black"
             icon = draw_icon(shape, color)
             self._icons[name] = icon
         return icon
 
     def _shape_for_tool(self, name: str) -> str:
+        if name.startswith("Add "):
+            name = name[4:]
+            if name.startswith("Generic "):
+                name = name[8:]
+            if name == "Process Area":
+                name = "System Boundary"
         mapping = {
             "Select": "arrow",
             "Actor": "human",
@@ -3453,6 +3469,26 @@ class SysMLDiagramWindow(tk.Frame):
             "Record": "circle",
             "Role": "circle",
             "Standard": "document",
+            "Process": "hexagon",
+            "Activity": "rect",
+            "Task": "rect",
+            "Operation": "ellipse",
+            "Driving Function": "triangle",
+            "Software Component": "rect",
+            "Test Suite": "test",
+            "System": "nested",
+            "Verification Plan": "document",
+            "Component": "rect",
+            "Manufacturing Process": "hexagon",
+            "Vehicle": "vehicle",
+            "Fleet": "vehicle",
+            "Safety Compliance": "diamond",
+            "Incident": "star",
+            "Safety Issue": "triangle",
+            "Field Data": "cylinder",
+            "Model": "document",
+            "Lifecycle Phase": "folder",
+            "Work Product": "rect",
         }
         if name in mapping:
             return mapping[name]
@@ -3470,6 +3506,8 @@ class SysMLDiagramWindow(tk.Frame):
             "Control Action",
             "Feedback",
         }
+        relation_names.update(GOV_ELEMENT_RELATIONS)
+        relation_names.update(SAFETY_AI_RELATIONS)
         if name in relation_names or any(
             k in name for k in ["Propagate", "Used", "Trace", "Satisfied", "Derived", "Re-use"]
         ):

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -242,6 +242,77 @@ def create_icon(
             draw_line(h, node_out)
         for p in nodes_left + nodes_mid + [node_out]:
             draw_node(*p)
+    elif shape == "hexagon":
+        mid = size // 2
+        for y in range(3, size - 3):
+            offset = abs(mid - y) // 2
+            start = 3 + offset
+            end = size - 3 - offset
+            img.put(c, to=(start, y, end, y + 1))
+            img.put(outline, (start, y))
+            img.put(outline, (end - 1, y))
+        for x in range(4, size - 4):
+            img.put(outline, (x, 3))
+            img.put(outline, (x, size - 4))
+    elif shape == "test":
+        img.put(c, to=(3, 3, size - 3, size - 3))
+        for x in range(3, size - 3):
+            img.put(outline, (x, 3))
+            img.put(outline, (x, size - 4))
+        for y in range(3, size - 3):
+            img.put(outline, (3, y))
+            img.put(outline, (size - 4, y))
+        mid = size // 2
+        for x in range(4, size - 4):
+            img.put(outline, (x, mid))
+        for y in range(4, size - 4):
+            img.put(outline, (mid, y))
+    elif shape == "vehicle":
+        top = 4
+        bottom = size - 5
+        img.put(c, to=(3, top, size - 3, bottom))
+        for x in range(3, size - 3):
+            img.put(outline, (x, top))
+            img.put(outline, (x, bottom - 1))
+        for y in range(top, bottom):
+            img.put(outline, (3, y))
+            img.put(outline, (size - 4, y))
+        wheel_y = bottom - 1
+        for cx in (5, size - 6):
+            for dx in (-1, 0, 1):
+                for dy in (0, 1):
+                    img.put(outline, (cx + dx, wheel_y + dy))
+    elif shape == "star":
+        points = [
+            (8, 3),
+            (10, 5),
+            (13, 5),
+            (11, 8),
+            (13, 11),
+            (10, 11),
+            (8, 13),
+            (6, 11),
+            (3, 11),
+            (5, 8),
+            (3, 5),
+            (6, 5),
+        ]
+        for y in range(3, 13):
+            xs = []
+            for i in range(len(points)):
+                x1, y1 = points[i]
+                x2, y2 = points[(i + 1) % len(points)]
+                if y1 == y2:
+                    continue
+                if y < min(y1, y2) or y >= max(y1, y2):
+                    continue
+                x = x1 + (y - y1) * (x2 - x1) / (y2 - y1)
+                xs.append(int(x))
+            xs.sort()
+            for j in range(0, len(xs), 2):
+                img.put(c, to=(xs[j], y, xs[j + 1] + 1, y + 1))
+        for x, y in points:
+            img.put(outline, (x, y))
     else:
         img.put(c, to=(2, 2, size - 2, size - 2))
         for x in range(2, size - 2):

--- a/styles/pastel.xml
+++ b/styles/pastel.xml
@@ -28,4 +28,66 @@
   <object type="Record" color="#fce5cd" />
   <object type="Role" color="#F4D698" />
   <object type="Standard" color="#a2c4c9" />
+  <object type="Work Product" color="#fff2cc" />
+  <object type="Process" color="#e6f2ff" />
+  <object type="Activity" color="#fff2cc" />
+  <object type="Task" color="#d9ead3" />
+  <object type="Operation" color="#ead1dc" />
+  <object type="Driving Function" color="#d0e0e3" />
+  <object type="Software Component" color="#fff2cc" />
+  <object type="Test Suite" color="#f4cccc" />
+  <object type="System" color="#c9daf8" />
+  <object type="Verification Plan" color="#f9cb9c" />
+  <object type="Component" color="#fff2cc" />
+  <object type="Manufacturing Process" color="#b4a7d6" />
+  <object type="Vehicle" color="#a2c4c9" />
+  <object type="Fleet" color="#a4c2f4" />
+  <object type="Safety Compliance" color="#cfe2f3" />
+  <object type="Incident" color="#f4cccc" />
+  <object type="Safety Issue" color="#fce5cd" />
+  <object type="Field Data" color="#e2f0d9" />
+  <object type="Model" color="#d9d2e9" />
+  <object type="Lifecycle Phase" color="#F4D698" />
+  <object type="Annotation" color="#cfe2f3" />
+  <object type="Synthesis" color="#d9ead3" />
+  <object type="Augmentation" color="#fce5cd" />
+  <object type="Acquisition" color="#fff2cc" />
+  <object type="Labeling" color="#e6f2ff" />
+  <object type="Field risk evaluation" color="#f4cccc" />
+  <object type="Field data collection" color="#e2f0d9" />
+  <object type="AI training" color="#f9cb9c" />
+  <object type="AI re-training" color="#c9daf8" />
+  <object type="Curation" color="#b6d7a8" />
+  <object type="Ingestion" color="#ead1dc" />
+  <object type="Model evaluation" color="#a4c2f4" />
+  <object type="Tune" color="#a2c4c9" />
+  <object type="Hyperparameter Validation" color="#d9d2e9" />
+  <object type="Monitoring" color="#cfe2f3" />
+  <object type="Complies with" color="#d9ead3" />
+  <object type="Approves" color="#b6d7a8" />
+  <object type="Audits" color="#f9cb9c" />
+  <object type="Authorizes" color="#cfe2f3" />
+  <object type="Communication Path" color="#a4c2f4" />
+  <object type="Constrained by" color="#ead1dc" />
+  <object type="Consumes" color="#fce5cd" />
+  <object type="Curation" color="#d9d2e9" />
+  <object type="Delivers" color="#fff2cc" />
+  <object type="Executes" color="#c9daf8" />
+  <object type="Extend" color="#e6f2ff" />
+  <object type="Generalize" color="#d9ead3" />
+  <object type="Monitors" color="#f4cccc" />
+  <object type="Performs" color="#e2f0d9" />
+  <object type="Produces" color="#b4a7d6" />
+  <object type="Responsible for" color="#a2c4c9" />
+  <object type="Uses" color="#cfe2f3" />
+  <object type="Constrains" color="#b6d7a8" />
+  <object type="Establish" color="#f9cb9c" />
+  <object type="Implement" color="#cfe2f3" />
+  <object type="Validate" color="#d9ead3" />
+  <object type="Verify" color="#a4c2f4" />
+  <object type="Manufacture" color="#ead1dc" />
+  <object type="Operate" color="#c9daf8" />
+  <object type="Inspect" color="#fce5cd" />
+  <object type="Triage" color="#d9d2e9" />
+  <object type="Improve" color="#fff2cc" />
 </style>

--- a/tests/test_safety_ai_relation_icons.py
+++ b/tests/test_safety_ai_relation_icons.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import (
+    SAFETY_AI_RELATIONS,
+    GOV_ELEMENT_RELATIONS,
+    GovernanceDiagramWindow,
+)
+from unittest.mock import patch
+
+
+def test_relation_icons_are_black():
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    with patch("gui.architecture.draw_icon") as draw:
+        draw.return_value = object()
+        for rel in set(SAFETY_AI_RELATIONS + GOV_ELEMENT_RELATIONS):
+            assert win._shape_for_tool(rel) == "relation"
+            win._icon_for(rel)
+            draw.assert_called_with("relation", "black")
+            draw.reset_mock()


### PR DESCRIPTION
## Summary
- force all relationship toolbox icons to render in black
- add colored icons for Add Work Product, Add Generic Work Product, Add Process Area, and Add Lifecycle Phase buttons
- extend regression test to ensure relationship icons default to black

## Testing
- `pytest tests/test_governance_elements_toolbox_no_select.py -q`
- `pytest tests/test_safety_toolbox_no_select.py -q`
- `PYTHONPATH=. pytest tests/test_governance_relationship_stereotype.py -q`
- `pytest tests/test_safety_ai_relation_icons.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a07ece8900832797be38b3c1afed84