### PR TITLE
Make governance element names read-only

### DIFF
--- a/tests/test_work_product_name_read_only.py
+++ b/tests/test_work_product_name_read_only.py
@@ -28,3 +28,56 @@ def test_work_product_name_read_only():
     dlg._behaviors = []
     dlg.apply()
     assert obj.properties["name"] == "Risk Assessment"
+
+
+def _make_master(diag_id):
+    class DummyMaster:
+        pass
+
+    m = DummyMaster()
+    m.diagram_id = diag_id
+    return m
+
+
+def test_process_area_name_read_only():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    obj = SysMLObject(
+        1,
+        "System Boundary",
+        0.0,
+        0.0,
+        properties={"name": "Hazard & Threat Analysis"},
+    )
+    dlg = SysMLObjectDialog.__new__(SysMLObjectDialog)
+    dlg.obj = obj
+    dlg.master = _make_master(diag.diag_id)
+    dlg.name_var = DummyVar("Renamed")
+    dlg.width_var = DummyVar(str(obj.width))
+    dlg.height_var = DummyVar(str(obj.height))
+    dlg.entries = {}
+    dlg.listboxes = {}
+    dlg._operations = []
+    dlg._behaviors = []
+    dlg.apply()
+    assert obj.properties["name"] == "Hazard & Threat Analysis"
+
+
+def test_lifecycle_phase_name_read_only():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    obj = SysMLObject(1, "Lifecycle Phase", 0.0, 0.0, properties={"name": "Concept"})
+    dlg = SysMLObjectDialog.__new__(SysMLObjectDialog)
+    dlg.obj = obj
+    dlg.master = _make_master(diag.diag_id)
+    dlg.name_var = DummyVar("Renamed")
+    dlg.width_var = DummyVar(str(obj.width))
+    dlg.height_var = DummyVar(str(obj.height))
+    dlg.entries = {}
+    dlg.listboxes = {}
+    dlg._operations = []
+    dlg._behaviors = []
+    dlg.apply()
+    assert obj.properties["name"] == "Concept"


### PR DESCRIPTION
## Summary
- Ensure Work Product, Process Area, and Lifecycle Phase names are read-only
- Add tests verifying governance element name immutability

## Testing
- `PYTHONPATH=. pytest tests/test_work_product_name_read_only.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a08998e0bc8327b00e8d62aeec3688