### PR TITLE
Place test suite labels below shape

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6841,6 +6841,10 @@ class SysMLDiagramWindow(tk.Frame):
             )
             self.canvas.create_line(x - w, y, x + w, y, fill=outline)
             self.canvas.create_line(x, y - h, x, y + h, fill=outline)
+            label = obj.properties.get("name", obj.obj_type)
+            self.canvas.create_text(
+                x, y + h + 10 * self.zoom, text=label, font=self.font
+            )
         elif obj.obj_type == "System":
             self.canvas.create_rectangle(
                 x - w,
@@ -7593,6 +7597,7 @@ class SysMLDiagramWindow(tk.Frame):
             "Database",
             "ANN",
             "Data acquisition",
+            "Test Suite",
         ):
             if hasattr(self, "_object_label_lines"):
                 label_lines = self._object_label_lines(obj)

--- a/tests/test_testsuite_label_position.py
+++ b/tests/test_testsuite_label_position.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from gui.architecture import SysMLObject, SysMLDiagramWindow
+
+
+class DummyCanvas:
+    def __init__(self):
+        self.text_calls = []
+
+    def create_rectangle(self, *args, **kwargs):
+        pass
+
+    def create_line(self, *args, **kwargs):
+        pass
+
+    def create_text(self, x, y, *args, **kwargs):
+        self.text_calls.append((x, y, kwargs))
+
+
+def test_testsuite_label_position():
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.canvas = DummyCanvas()
+    win.zoom = 1.0
+    win.font = ("Arial", 12)
+    win.selected_objs = []
+    win._object_label_lines = lambda obj: [obj.properties.get("name", "")]
+
+    obj = SysMLObject(
+        1,
+        "Test Suite",
+        100,
+        100,
+        width=80,
+        height=40,
+        properties={"name": "TS"},
+    )
+    win.draw_object(obj)
+
+    assert win.canvas.text_calls, "No text drawn for test suite label"
+    x, y, kw = win.canvas.text_calls[-1]
+    assert kw.get("text") == "TS"
+    expected_y = obj.y * win.zoom + obj.height * win.zoom / 2 + 10 * win.zoom
+    assert x == obj.x * win.zoom
+    assert y == pytest.approx(expected_y)


### PR DESCRIPTION
## Summary
- Position Test Suite object labels underneath the icon
- Exclude Test Suite from center label rendering
- Add regression test for Test Suite label position

## Testing
- `pytest tests/test_testsuite_label_position.py tests/test_role_label_position.py`


------
https://chatgpt.com/codex/tasks/task_b_68a08ba224188327bc3a7a57ba9dbe6a