### PR TITLE
Add report template editor tool

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -528,6 +528,9 @@ _CONFIG_PATH = Path(__file__).resolve().parent / "config/diagram_rules.json"
 _CONFIG = load_diagram_rules(_CONFIG_PATH)
 GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
 _PATTERN_PATH = Path(__file__).resolve().parent / "config/requirement_patterns.json"
+_REPORT_TEMPLATE_PATH = (
+    Path(__file__).resolve().parent / "config/report_template.json"
+)
 
 
 def _reload_local_config() -> None:
@@ -2740,6 +2743,7 @@ class FaultTreeApp:
             "Cause & Effect Diagram": self.show_cause_effect_chain,
             "Diagram Rule Editor": self.open_diagram_rules_toolbox,
             "Requirement Pattern Editor": self.open_requirement_patterns_toolbox,
+            "Report Template Editor": self.open_report_template_toolbox,
         }
 
         self.tool_categories: dict[str, list[str]] = {
@@ -2754,8 +2758,9 @@ class FaultTreeApp:
                 "Cause & Effect Diagram",
             ],
             "Configuration": [
-                "Diagram Rule Editor",
+                "Diagram Rule Editor", 
                 "Requirement Pattern Editor",
+                "Report Template Editor",
             ],
         }
         self.tool_to_work_product = {}
@@ -16864,6 +16869,30 @@ class FaultTreeApp:
             parent, self, _PATTERN_PATH
         )
         self.requirement_patterns_editor.pack(fill=tk.BOTH, expand=True)
+
+    def open_report_template_toolbox(self):
+        """Open editor for PDF report template configuration."""
+        tab_exists = (
+            hasattr(self, "_report_template_tab") and self._report_template_tab.winfo_exists()
+        )
+        editor_exists = (
+            hasattr(self, "report_template_editor")
+            and self.report_template_editor.winfo_exists()
+        )
+        if tab_exists:
+            self.doc_nb.select(self._report_template_tab)
+            if editor_exists:
+                return
+            parent = self._report_template_tab
+        else:
+            parent = self._report_template_tab = self._new_tab("Report Template")
+
+        from gui.report_template_toolbox import ReportTemplateEditor
+
+        self.report_template_editor = ReportTemplateEditor(
+            parent, self, _REPORT_TEMPLATE_PATH
+        )
+        self.report_template_editor.pack(fill=tk.BOTH, expand=True)
 
     def reload_config(self) -> None:
         """Reload diagram rule configuration across modules."""

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -4,6 +4,8 @@ from .config_loader import (
     validate_diagram_rules,
     load_requirement_patterns,
     validate_requirement_patterns,
+    load_report_template,
+    validate_report_template,
 )
 
 __all__ = [
@@ -12,4 +14,6 @@ __all__ = [
     "validate_diagram_rules",
     "load_requirement_patterns",
     "validate_requirement_patterns",
+    "load_report_template",
+    "validate_report_template",
 ]

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -177,6 +177,28 @@ def validate_requirement_patterns(data: Any) -> list[dict[str, Any]]:
     return data
 
 
+def validate_report_template(data: Any) -> dict[str, Any]:
+    """Validate PDF report template structure."""
+
+    if not isinstance(data, dict):
+        raise ValueError("Configuration root must be a JSON object")
+
+    sections = data.get("sections", [])
+    if not isinstance(sections, list):
+        raise ValueError("'sections' must be a list")
+    for idx, sec in enumerate(sections):
+        if not isinstance(sec, dict):
+            raise ValueError(f"sections[{idx}] must be an object")
+        title = sec.get("title")
+        content = sec.get("content")
+        if not isinstance(title, str):
+            raise ValueError(f"sections[{idx}]['title'] must be a string")
+        if not isinstance(content, str):
+            raise ValueError(f"sections[{idx}]['content'] must be a string")
+
+    return data
+
+
 def _strip_comments(text: str) -> str:
     """Return *text* with // and /* ... */ comments removed.
 
@@ -242,3 +264,9 @@ def load_requirement_patterns(path: str | Path) -> list[dict[str, Any]]:
     """Load and validate the requirement pattern configuration file."""
     data = load_json_with_comments(path)
     return validate_requirement_patterns(data)
+
+
+def load_report_template(path: str | Path) -> dict[str, Any]:
+    """Load and validate the PDF report template configuration file."""
+    data = load_json_with_comments(path)
+    return validate_report_template(data)

--- a/config/report_template.json
+++ b/config/report_template.json
@@ -1,0 +1,12 @@
+{
+  "sections": [
+    {
+      "title": "Introduction",
+      "content": "This is the introduction section."
+    },
+    {
+      "title": "Conclusion",
+      "content": "This is the conclusion section."
+    }
+  ]
+}

--- a/gui/report_template_toolbox.py
+++ b/gui/report_template_toolbox.py
@@ -1,0 +1,112 @@
+import tkinter as tk
+from tkinter import ttk, simpledialog
+from pathlib import Path
+import json
+from config import load_report_template, validate_report_template
+from gui import messagebox
+
+
+class SectionDialog(simpledialog.Dialog):
+    """Dialog for editing a single section."""
+
+    def __init__(self, parent, section: dict[str, str]):
+        self.section = section
+        super().__init__(parent, title="Edit Section")
+
+    def body(self, master):
+        tk.Label(master, text="Title:").grid(row=0, column=0, padx=4, pady=4, sticky="e")
+        self.title_var = tk.StringVar(value=self.section.get("title", ""))
+        ttk.Entry(master, textvariable=self.title_var).grid(row=0, column=1, padx=4, pady=4, sticky="ew")
+        tk.Label(master, text="Content:").grid(row=1, column=0, padx=4, pady=4, sticky="ne")
+        self.content_var = tk.StringVar(value=self.section.get("content", ""))
+        ttk.Entry(master, textvariable=self.content_var).grid(row=1, column=1, padx=4, pady=4, sticky="ew")
+        master.columnconfigure(1, weight=1)
+        return master
+
+    def apply(self):
+        self.result = {
+            "title": self.title_var.get().strip(),
+            "content": self.content_var.get().strip(),
+        }
+
+
+class ReportTemplateEditor(tk.Frame):
+    """Visual editor for PDF report template configuration."""
+
+    def __init__(self, master, app, config_path: Path | None = None):
+        super().__init__(master)
+        self.app = app
+        self.config_path = Path(
+            config_path or Path(__file__).resolve().parents[1] / "config/report_template.json"
+        )
+        try:
+            self.data = load_report_template(self.config_path)
+        except Exception as exc:  # pragma: no cover - GUI fallback
+            messagebox.showerror(
+                "Report Template", f"Failed to load configuration:\n{exc}"
+            )
+            self.data = {"sections": []}
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        tree_frame = ttk.Frame(self)
+        tree_frame.grid(row=0, column=0, sticky="nsew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        self.tree = ttk.Treeview(tree_frame, columns=("title",), show="headings")
+        self.tree.heading("title", text="Section Title")
+        self.tree.bind("<<TreeviewSelect>>", self._on_select)
+        self.tree.bind("<Double-1>", self._edit_section)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+
+        ybar = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=ybar.set)
+        ybar.grid(row=0, column=1, sticky="ns")
+
+        self.preview = tk.Text(self, state="disabled", wrap="word")
+        self.preview.grid(row=0, column=1, sticky="nsew")
+
+        btn = ttk.Button(self, text="Save", command=self.save)
+        btn.grid(row=1, column=1, sticky="e", padx=4, pady=4)
+
+        self._populate_tree()
+
+    def _populate_tree(self):
+        self.tree.delete(*self.tree.get_children(""))
+        for idx, sec in enumerate(self.data.get("sections", [])):
+            self.tree.insert("", "end", f"sec|{idx}", values=(sec.get("title", ""),))
+
+    def _on_select(self, _event=None):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        idx = int(sel[0].split("|", 1)[1])
+        section = self.data["sections"][idx]
+        self.preview.configure(state="normal")
+        self.preview.delete("1.0", tk.END)
+        self.preview.insert("1.0", section.get("content", ""))
+        self.preview.configure(state="disabled")
+
+    def _edit_section(self, _event=None):
+        item = self.tree.focus()
+        if not item:
+            return
+        idx = int(item.split("|", 1)[1])
+        section = self.data["sections"][idx]
+        dlg = SectionDialog(self, section)
+        if dlg.result:
+            self.data["sections"][idx] = dlg.result
+            self._populate_tree()
+            self.tree.selection_set(item)
+            self._on_select()
+
+    def save(self):
+        try:
+            validate_report_template(self.data)
+        except Exception as exc:  # pragma: no cover - GUI fallback
+            messagebox.showerror("Report Template", str(exc))
+            return
+        self.config_path.write_text(json.dumps(self.data, indent=2))

--- a/tests/test_report_template_toolbox.py
+++ b/tests/test_report_template_toolbox.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub out Pillow dependencies so importing the main app doesn't require Pillow
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace()
+PIL_stub.ImageTk = types.SimpleNamespace()
+PIL_stub.ImageDraw = types.SimpleNamespace()
+PIL_stub.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+sys.modules.setdefault("PIL.Image", PIL_stub.Image)
+sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
+sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
+sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
+
+from AutoML import FaultTreeApp
+
+
+def test_report_template_toolbox_single_instance():
+    """Opening report template toolbox twice doesn't duplicate editor."""
+
+    class DummyTab:
+        def winfo_exists(self):
+            return True
+
+    class DummyNotebook:
+        def add(self, tab, text):
+            pass
+
+        def select(self, tab):
+            pass
+
+    class DummyEditor:
+        created = 0
+
+        def __init__(self, master, app, path):
+            DummyEditor.created += 1
+
+        def pack(self, **kwargs):
+            pass
+
+        def winfo_exists(self):
+            return True
+
+    import gui.report_template_toolbox as rtt
+
+    rtt.ReportTemplateEditor = DummyEditor
+
+    class DummyApp:
+        open_report_template_toolbox = FaultTreeApp.open_report_template_toolbox
+
+        def __init__(self):
+            self.doc_nb = DummyNotebook()
+
+        def _new_tab(self, title):
+            return DummyTab()
+
+    app = DummyApp()
+    app.open_report_template_toolbox()
+    app.open_report_template_toolbox()
+    assert DummyEditor.created == 1


### PR DESCRIPTION
## Summary
- add JSON-backed PDF report template configuration and loader helpers
- introduce ReportTemplateEditor GUI for visual template editing with preview
- wire tool into application menu and include tests

## Testing
- `pytest -q`
- `pytest tests/test_report_template_toolbox.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0901d062483278240091004c16d16