### PR TITLE
Fix Tkinter Treeview width configuration error

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3347,7 +3347,12 @@ class SysMLDiagramWindow(tk.Frame):
         # Shrink the property view to match the button area so it does not force
         # the toolbox wider than needed.
         field_width = button_width // 2
-        self.prop_view.configure(width=button_width)
+        # ``ttk.Treeview`` widgets do not accept a ``width`` configuration
+        # option.  Attempting to set it raises a ``TclError``.  The desired
+        # effect here is to limit the property view so it matches the width of
+        # the toolbox buttons.  Configure the surrounding frame instead and set
+        # the column widths explicitly to control the overall size.
+        self.prop_frame.configure(width=button_width)
         self.prop_view.column("field", width=field_width, stretch=False)
         self.prop_view.column("value", width=button_width - field_width, stretch=False)
 


### PR DESCRIPTION
## Summary
- Prevent TclError by configuring width on property frame instead of Treeview
- Add explanatory comments and preserve column width adjustments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a092ff26008327bd9e9c354a529069