### PR TITLE
Enhance report template editor with visual preview and configurable PDF generation

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -4,6 +4,8 @@ from .config_loader import (
     validate_diagram_rules,
     load_requirement_patterns,
     validate_requirement_patterns,
+    load_report_template,
+    validate_report_template,
 )
 
 __all__ = [
@@ -12,4 +14,6 @@ __all__ = [
     "validate_diagram_rules",
     "load_requirement_patterns",
     "validate_requirement_patterns",
+    "load_report_template",
+    "validate_report_template",
 ]

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -177,6 +177,40 @@ def validate_requirement_patterns(data: Any) -> list[dict[str, Any]]:
     return data
 
 
+def validate_report_template(data: Any) -> dict[str, Any]:
+    """Validate PDF report template structure."""
+
+    if not isinstance(data, dict):
+        raise ValueError("Configuration root must be a JSON object")
+    elements = data.get("elements", {})
+    if not isinstance(elements, dict):
+        raise ValueError("'elements' must be an object")
+    for name, kind in elements.items():
+        if not isinstance(name, str) or not isinstance(kind, str):
+            raise ValueError("elements must map names to string types")
+
+    sections = data.get("sections", [])
+    if not isinstance(sections, list):
+        raise ValueError("'sections' must be a list")
+    for idx, sec in enumerate(sections):
+        if not isinstance(sec, dict):
+            raise ValueError(f"sections[{idx}] must be an object")
+        title = sec.get("title")
+        content = sec.get("content")
+        if not isinstance(title, str):
+            raise ValueError(f"sections[{idx}]['title'] must be a string")
+        if not isinstance(content, str):
+            raise ValueError(f"sections[{idx}]['content'] must be a string")
+
+        for placeholder in re.findall(r"<([^<>]+)>", content):
+            if placeholder not in elements:
+                raise ValueError(
+                    f"sections[{idx}] references unknown element '{placeholder}'"
+                )
+
+    return data
+
+
 def _strip_comments(text: str) -> str:
     """Return *text* with // and /* ... */ comments removed.
 
@@ -242,3 +276,9 @@ def load_requirement_patterns(path: str | Path) -> list[dict[str, Any]]:
     """Load and validate the requirement pattern configuration file."""
     data = load_json_with_comments(path)
     return validate_requirement_patterns(data)
+
+
+def load_report_template(path: str | Path) -> dict[str, Any]:
+    """Load and validate the PDF report template configuration file."""
+    data = load_json_with_comments(path)
+    return validate_report_template(data)

--- a/config/report_template.json
+++ b/config/report_template.json
@@ -1,0 +1,15 @@
+{
+  "elements": {
+    "overview_diagram": "diagram"
+  },
+  "sections": [
+    {
+      "title": "Introduction",
+      "content": "This is the introduction section.\n<overview_diagram>"
+    },
+    {
+      "title": "Conclusion",
+      "content": "This is the conclusion section."
+    }
+  ]
+}

--- a/gui/report_template_toolbox.py
+++ b/gui/report_template_toolbox.py
@@ -1,0 +1,270 @@
+import tkinter as tk
+from tkinter import ttk, simpledialog
+from pathlib import Path
+import json
+import re
+import tkinter.font as tkFont
+from typing import Any
+
+from config import load_report_template, validate_report_template
+from gui import messagebox
+
+
+def layout_report_template(
+    data: dict[str, Any], page_width: int = 595, margin: int = 40, line_height: int = 20
+):
+    """Return layout instructions for *data*.
+
+    The function is intentionally simple: text lines are stacked vertically and
+    element placeholders are represented as boxes of fixed height.  It returns a
+    tuple ``(items, height)`` where *items* is a list of dictionaries describing
+    things to draw (text, title or element) and *height* is the total required
+    canvas height.
+    """
+
+    items: list[dict[str, Any]] = []
+    y = margin
+    elements = data.get("elements", {})
+    for sec in data.get("sections", []):
+        title = sec.get("title", "")
+        items.append({"type": "title", "text": title, "x": margin, "y": y})
+        y += line_height
+        content = sec.get("content", "")
+        tokens = re.split(r"(<[^<>]+>)", content)
+        for tok in tokens:
+            if not tok:
+                continue
+            if tok.startswith("<") and tok.endswith(">"):
+                name = tok[1:-1]
+                kind = elements.get(name, "")
+                items.append(
+                    {"type": "element", "name": name, "kind": kind, "x": margin, "y": y}
+                )
+                y += 100
+            else:
+                lines = tok.split("\n")
+                for line in lines:
+                    items.append({"type": "text", "text": line, "x": margin, "y": y})
+                    y += line_height
+        y += line_height
+    height = y + margin
+    return items, height
+
+
+class ElementDialog(simpledialog.Dialog):
+    """Dialog for adding or editing a single element placeholder."""
+
+    def __init__(self, parent, element: dict[str, str]):
+        self.element = element
+        super().__init__(parent, title="Element")
+
+    def body(self, master):
+        tk.Label(master, text="Name:").grid(row=0, column=0, padx=4, pady=4, sticky="e")
+        self.name_var = tk.StringVar(value=self.element.get("name", ""))
+        ttk.Entry(master, textvariable=self.name_var).grid(row=0, column=1, padx=4, pady=4, sticky="ew")
+        tk.Label(master, text="Type:").grid(row=1, column=0, padx=4, pady=4, sticky="e")
+        self.type_var = tk.StringVar(value=self.element.get("type", ""))
+        ttk.Entry(master, textvariable=self.type_var).grid(row=1, column=1, padx=4, pady=4, sticky="ew")
+        master.columnconfigure(1, weight=1)
+        return master
+
+    def apply(self):
+        self.result = {
+            "name": self.name_var.get().strip(),
+            "type": self.type_var.get().strip(),
+        }
+
+
+class ElementsDialog(simpledialog.Dialog):
+    """Dialog for editing element placeholders."""
+
+    def __init__(self, parent, elements: dict[str, str]):
+        self.elements = dict(elements)
+        super().__init__(parent, title="Edit Elements")
+
+    def body(self, master):
+        self.tree = ttk.Treeview(master, columns=("type",), show="headings")
+        self.tree.heading("type", text="Type")
+        self.tree.grid(row=0, column=0, columnspan=3, sticky="nsew")
+        ybar = ttk.Scrollbar(master, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=ybar.set)
+        ybar.grid(row=0, column=3, sticky="ns")
+
+        btn_add = ttk.Button(master, text="Add", command=self._add)
+        btn_add.grid(row=1, column=0, padx=2, pady=4, sticky="w")
+        btn_edit = ttk.Button(master, text="Edit", command=self._edit)
+        btn_edit.grid(row=1, column=1, padx=2, pady=4, sticky="w")
+        btn_del = ttk.Button(master, text="Delete", command=self._delete)
+        btn_del.grid(row=1, column=2, padx=2, pady=4, sticky="w")
+
+        master.columnconfigure(0, weight=1)
+        master.rowconfigure(0, weight=1)
+        self._populate()
+        return master
+
+    def _populate(self):
+        self.tree.delete(*self.tree.get_children(""))
+        for name, kind in sorted(self.elements.items()):
+            self.tree.insert("", "end", name, values=(kind,))
+
+    def _add(self):
+        dlg = ElementDialog(self, {})
+        if dlg.result:
+            self.elements[dlg.result["name"]] = dlg.result["type"]
+            self._populate()
+
+    def _edit(self):
+        item = self.tree.focus()
+        if not item:
+            return
+        dlg = ElementDialog(
+            self, {"name": item, "type": self.elements.get(item, "")}
+        )
+        if dlg.result:
+            if item in self.elements:
+                del self.elements[item]
+            self.elements[dlg.result["name"]] = dlg.result["type"]
+            self._populate()
+
+    def _delete(self):
+        item = self.tree.focus()
+        if item and item in self.elements:
+            del self.elements[item]
+            self._populate()
+
+    def apply(self):
+        self.result = self.elements
+
+
+class SectionDialog(simpledialog.Dialog):
+    """Dialog for editing a single section."""
+
+    def __init__(self, parent, section: dict[str, str]):
+        self.section = section
+        super().__init__(parent, title="Edit Section")
+
+    def body(self, master):
+        tk.Label(master, text="Title:").grid(row=0, column=0, padx=4, pady=4, sticky="e")
+        self.title_var = tk.StringVar(value=self.section.get("title", ""))
+        ttk.Entry(master, textvariable=self.title_var).grid(row=0, column=1, padx=4, pady=4, sticky="ew")
+        tk.Label(master, text="Content:").grid(row=1, column=0, padx=4, pady=4, sticky="ne")
+        self.content_txt = tk.Text(master, width=40, height=10)
+        self.content_txt.insert("1.0", self.section.get("content", ""))
+        self.content_txt.grid(row=1, column=1, padx=4, pady=4, sticky="nsew")
+        tk.Label(
+            master,
+            text="Use <element_name> to insert configured elements.",
+        ).grid(row=2, column=0, columnspan=2, padx=4, pady=(0, 4), sticky="w")
+        master.columnconfigure(1, weight=1)
+        master.rowconfigure(1, weight=1)
+        return master
+
+    def apply(self):
+        self.result = {
+            "title": self.title_var.get().strip(),
+            "content": self.content_txt.get("1.0", tk.END).strip(),
+        }
+
+
+class ReportTemplateEditor(tk.Frame):
+    """Visual editor for PDF report template configuration."""
+
+    def __init__(self, master, app, config_path: Path | None = None):
+        super().__init__(master)
+        self.app = app
+        self.config_path = Path(
+            config_path or Path(__file__).resolve().parents[1] / "config/report_template.json"
+        )
+        try:
+            self.data = load_report_template(self.config_path)
+        except Exception as exc:  # pragma: no cover - GUI fallback
+            messagebox.showerror(
+                "Report Template", f"Failed to load configuration:\n{exc}"
+            )
+            self.data = {"sections": [], "elements": {}}
+        self.data.setdefault("elements", {})
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        tree_frame = ttk.Frame(self)
+        tree_frame.grid(row=0, column=0, sticky="nsew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        self.tree = ttk.Treeview(tree_frame, columns=("title",), show="headings")
+        self.tree.heading("title", text="Section Title")
+        self.tree.bind("<<TreeviewSelect>>", self._on_select)
+        self.tree.bind("<Double-1>", self._edit_section)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+
+        ybar = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=ybar.set)
+        ybar.grid(row=0, column=1, sticky="ns")
+
+        self.preview = tk.Canvas(self, background="white")
+        self.preview.grid(row=0, column=1, sticky="nsew")
+
+        elem_btn = ttk.Button(self, text="Elements...", command=self._edit_elements)
+        elem_btn.grid(row=1, column=0, sticky="w", padx=4, pady=4)
+        btn = ttk.Button(self, text="Save", command=self.save)
+        btn.grid(row=1, column=1, sticky="e", padx=4, pady=4)
+
+        self._populate_tree()
+        self._render_preview()
+
+    def _populate_tree(self):
+        self.tree.delete(*self.tree.get_children(""))
+        for idx, sec in enumerate(self.data.get("sections", [])):
+            self.tree.insert("", "end", f"sec|{idx}", values=(sec.get("title", ""),))
+        self._render_preview()
+
+    def _on_select(self, _event=None):
+        self._render_preview()
+
+    def _edit_section(self, _event=None):
+        item = self.tree.focus()
+        if not item:
+            return
+        idx = int(item.split("|", 1)[1])
+        section = self.data["sections"][idx]
+        dlg = SectionDialog(self, section)
+        if dlg.result:
+            self.data["sections"][idx] = dlg.result
+            self._populate_tree()
+            self.tree.selection_set(item)
+
+    def _edit_elements(self):
+        dlg = ElementsDialog(self, self.data.get("elements", {}))
+        if dlg.result is not None:
+            self.data["elements"] = dlg.result
+            self._render_preview()
+
+    def save(self):
+        try:
+            validate_report_template(self.data)
+        except Exception as exc:  # pragma: no cover - GUI fallback
+            messagebox.showerror("Report Template", str(exc))
+            return
+        self.config_path.write_text(json.dumps(self.data, indent=2))
+        self._render_preview()
+
+    def _render_preview(self):  # pragma: no cover - requires Tk canvas
+        self.preview.delete("all")
+        items, height = layout_report_template(self.data)
+        page_width = 595
+        self.preview.config(scrollregion=(0, 0, page_width, height))
+        self.preview.create_rectangle(1, 1, page_width - 1, height - 1, outline="#ccc")
+        font = tkFont.Font(family="Arial", size=12)
+        bold = tkFont.Font(family="Arial", size=12, weight="bold")
+        for item in items:
+            if item["type"] == "title":
+                self.preview.create_text(item["x"], item["y"], text=item["text"], anchor="nw", font=bold)
+            elif item["type"] == "text":
+                self.preview.create_text(item["x"], item["y"], text=item["text"], anchor="nw", font=font)
+            elif item["type"] == "element":
+                w, h = 200, 80
+                x, y = item["x"], item["y"]
+                self.preview.create_rectangle(x, y, x + w, y + h, outline="black")
+                self.preview.create_text(x + w / 2, y + h / 2, text=item["name"], font=font)

--- a/tests/test_pdf_template_export.py
+++ b/tests/test_pdf_template_export.py
@@ -1,0 +1,57 @@
+import sys
+import json
+import types
+from pathlib import Path
+
+# Stub required third-party modules before importing application modules
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace(new=lambda *a, **k: None)
+PIL_stub.ImageDraw = types.SimpleNamespace(Draw=lambda *a, **k: types.SimpleNamespace(rectangle=lambda *a, **k: None, text=lambda *a, **k: None))
+PIL_stub.ImageTk = types.SimpleNamespace()
+PIL_stub.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+sys.modules.setdefault("PIL.Image", PIL_stub.Image)
+sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
+sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
+sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
+
+reportlab = types.ModuleType("reportlab")
+reportlab.lib = types.SimpleNamespace()
+reportlab.lib.pagesizes = types.SimpleNamespace(letter=(0, 0), landscape=lambda x: x)
+reportlab.lib.units = types.SimpleNamespace(inch=1)
+reportlab.lib.styles = types.SimpleNamespace(getSampleStyleSheet=lambda: {"Title": "", "Heading2": "", "Normal": ""})
+class DummyDoc:
+    def __init__(self, *a, **k):
+        pass
+    def build(self, story):
+        pass
+reportlab.platypus = types.SimpleNamespace(
+    Paragraph=lambda text, style=None: text,
+    Spacer=lambda w, h: None,
+    SimpleDocTemplate=DummyDoc,
+    Image=lambda buf: None,
+)
+sys.modules.setdefault("reportlab", reportlab)
+sys.modules.setdefault("reportlab.lib", reportlab.lib)
+sys.modules.setdefault("reportlab.lib.pagesizes", reportlab.lib.pagesizes)
+sys.modules.setdefault("reportlab.lib.units", reportlab.lib.units)
+sys.modules.setdefault("reportlab.lib.styles", reportlab.lib.styles)
+sys.modules.setdefault("reportlab.platypus", reportlab.platypus)
+
+from AutoML import FaultTreeApp, filedialog, messagebox
+
+
+def test_generate_pdf_report_exports_template(tmp_path, monkeypatch):
+    pdf_path = tmp_path / "out.pdf"
+    template_path = tmp_path / "template.json"
+    template_path.write_text(json.dumps({"elements": {}, "sections": []}))
+
+    monkeypatch.setattr(filedialog, "asksaveasfilename", lambda **k: str(pdf_path))
+    monkeypatch.setattr(filedialog, "askopenfilename", lambda **k: str(template_path))
+    monkeypatch.setattr(messagebox, "showinfo", lambda *a, **k: None)
+    monkeypatch.setattr(messagebox, "showerror", lambda *a, **k: None)
+
+    app = type("A", (), {"project_properties": {}, "_generate_pdf_report": FaultTreeApp._generate_pdf_report})()
+    app._generate_pdf_report()
+
+    assert pdf_path.with_suffix(".json").exists()

--- a/tests/test_report_template_toolbox.py
+++ b/tests/test_report_template_toolbox.py
@@ -1,0 +1,95 @@
+import sys
+from pathlib import Path
+import types
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub out Pillow dependencies so importing the main app doesn't require Pillow
+PIL_stub = types.ModuleType("PIL")
+PIL_stub.Image = types.SimpleNamespace()
+PIL_stub.ImageTk = types.SimpleNamespace()
+PIL_stub.ImageDraw = types.SimpleNamespace()
+PIL_stub.ImageFont = types.SimpleNamespace()
+sys.modules.setdefault("PIL", PIL_stub)
+sys.modules.setdefault("PIL.Image", PIL_stub.Image)
+sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
+sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
+sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
+
+from AutoML import FaultTreeApp
+from config import validate_report_template
+from gui.report_template_toolbox import layout_report_template
+
+
+def test_report_template_toolbox_single_instance():
+    """Opening report template toolbox twice doesn't duplicate editor."""
+
+    class DummyTab:
+        def winfo_exists(self):
+            return True
+
+    class DummyNotebook:
+        def add(self, tab, text):
+            pass
+
+        def select(self, tab):
+            pass
+
+    class DummyEditor:
+        created = 0
+
+        def __init__(self, master, app, path):
+            DummyEditor.created += 1
+
+        def pack(self, **kwargs):
+            pass
+
+        def winfo_exists(self):
+            return True
+
+    import gui.report_template_toolbox as rtt
+
+    rtt.ReportTemplateEditor = DummyEditor
+
+    class DummyApp:
+        open_report_template_toolbox = FaultTreeApp.open_report_template_toolbox
+
+        def __init__(self):
+            self.doc_nb = DummyNotebook()
+
+        def _new_tab(self, title):
+            return DummyTab()
+
+    app = DummyApp()
+    app.open_report_template_toolbox()
+    app.open_report_template_toolbox()
+    assert DummyEditor.created == 1
+
+
+def test_validate_report_template_with_elements():
+    cfg = {
+        "elements": {"diag": "diagram"},
+        "sections": [{"title": "Intro", "content": "See <diag>"}],
+    }
+    assert validate_report_template(cfg) == cfg
+
+
+def test_validate_report_template_unknown_element():
+    cfg = {
+        "elements": {"diag": "diagram"},
+        "sections": [{"title": "Intro", "content": "<missing>"}],
+    }
+    with pytest.raises(ValueError):
+        validate_report_template(cfg)
+
+
+def test_layout_report_template_basic():
+    data = {
+        "elements": {"img": "diagram"},
+        "sections": [{"title": "Intro", "content": "Hello\n<img>World"}],
+    }
+    items, height = layout_report_template(data)
+    assert height > 0
+    types = [i["type"] for i in items]
+    assert "title" in types and "element" in types and "text" in types


### PR DESCRIPTION
## Summary
- provide layout_report_template utility and canvas-based preview for WYSIWYG editing
- generate PDF reports from configurable JSON templates with placeholder elements
- prompt for a template when saving PDF reports and export the template JSON alongside the PDF
- exercise layout logic with new unit tests

## Testing
- `pytest -q`
- `pytest tests/test_report_template_toolbox.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0901d062483278240091004c16d16