### PR TITLE
Add section management buttons to report template tool

### DIFF
--- a/gui/report_template_toolbox.py
+++ b/gui/report_template_toolbox.py
@@ -211,6 +211,18 @@ class ReportTemplateEditor(tk.Frame):
         ybar.grid(row=0, column=1, sticky="ns")
         xbar.grid(row=1, column=0, sticky="ew")
 
+        btn_frame = ttk.Frame(tree_frame)
+        btn_frame.grid(row=2, column=0, columnspan=2, sticky="w", padx=2, pady=(4, 0))
+        ttk.Button(btn_frame, text="Add", command=self._add_section).pack(
+            side="left", padx=2
+        )
+        ttk.Button(btn_frame, text="Edit", command=self._edit_section).pack(
+            side="left", padx=2
+        )
+        ttk.Button(btn_frame, text="Delete", command=self._delete_section).pack(
+            side="left", padx=2
+        )
+
         preview_frame = ttk.Frame(self)
         preview_frame.grid(row=0, column=1, sticky="nsew")
         preview_frame.rowconfigure(0, weight=1)
@@ -241,6 +253,14 @@ class ReportTemplateEditor(tk.Frame):
     def _on_select(self, _event=None):
         self._render_preview()
 
+    def _add_section(self):
+        dlg = SectionDialog(self, {"title": "", "content": ""})
+        if dlg.result:
+            self.data.setdefault("sections", []).append(dlg.result)
+            self._populate_tree()
+            new_idx = len(self.data["sections"]) - 1
+            self.tree.selection_set(f"sec|{new_idx}")
+
     def _edit_section(self, _event=None):
         item = self.tree.focus()
         if not item:
@@ -252,6 +272,14 @@ class ReportTemplateEditor(tk.Frame):
             self.data["sections"][idx] = dlg.result
             self._populate_tree()
             self.tree.selection_set(item)
+
+    def _delete_section(self):
+        item = self.tree.focus()
+        if not item:
+            return
+        idx = int(item.split("|", 1)[1])
+        del self.data["sections"][idx]
+        self._populate_tree()
 
     def _edit_elements(self):
         dlg = ElementsDialog(self, self.data.get("elements", {}))

--- a/tests/test_report_template_toolbox.py
+++ b/tests/test_report_template_toolbox.py
@@ -142,3 +142,41 @@ def test_validate_report_template_requirement_elements():
         "sections": [{"title": "Vehicle Reqs", "content": "<req_vehicle>"}],
     }
     assert validate_report_template(cfg) == cfg
+
+
+def test_report_template_editor_section_crud(tmp_path, monkeypatch):
+    import tkinter as tk
+    try:
+        root = tk.Tk()
+        root.withdraw()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    import gui.report_template_toolbox as rtt
+
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text("{\n  \"elements\": {},\n  \"sections\": []\n}")
+    editor = rtt.ReportTemplateEditor(root, None, cfg_path)
+
+    class AddDlg:
+        def __init__(self, parent, section):
+            self.result = {"title": "New", "content": "C"}
+
+    monkeypatch.setattr(rtt, "SectionDialog", AddDlg)
+    editor._add_section()
+    assert [s["title"] for s in editor.data["sections"]] == ["New"]
+
+    class EditDlg:
+        def __init__(self, parent, section):
+            self.result = {"title": "Updated", "content": section["content"]}
+
+    monkeypatch.setattr(rtt, "SectionDialog", EditDlg)
+    editor.tree.selection_set("sec|0")
+    editor._edit_section()
+    assert editor.data["sections"][0]["title"] == "Updated"
+
+    editor.tree.selection_set("sec|0")
+    editor._delete_section()
+    assert editor.data["sections"] == []
+
+    root.destroy()


### PR DESCRIPTION
## Summary
- Add dedicated buttons for adding, editing, and deleting report sections in the Report Template editor
- Implement internal CRUD helpers for section management
- Test section add/edit/remove behaviors

## Testing
- `pytest tests/test_report_template_toolbox.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0ab1dc6108327b7c5f6bd96280a1b