### PR TITLE
Add report template manager

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2744,6 +2744,7 @@ class FaultTreeApp:
             "Diagram Rule Editor": self.open_diagram_rules_toolbox,
             "Requirement Pattern Editor": self.open_requirement_patterns_toolbox,
             "Report Template Editor": self.open_report_template_toolbox,
+            "Report Template Manager": self.open_report_template_manager,
         }
 
         self.tool_categories: dict[str, list[str]] = {
@@ -2761,6 +2762,7 @@ class FaultTreeApp:
                 "Diagram Rule Editor", 
                 "Requirement Pattern Editor",
                 "Report Template Editor",
+                "Report Template Manager",
             ],
         }
         self.tool_to_work_product = {}
@@ -16984,6 +16986,31 @@ class FaultTreeApp:
             parent, self, _REPORT_TEMPLATE_PATH
         )
         self.report_template_editor.pack(fill=tk.BOTH, expand=True)
+
+    def open_report_template_manager(self):
+        """Open manager for multiple report templates."""
+        tab_exists = (
+            hasattr(self, "_report_template_mgr_tab")
+            and self._report_template_mgr_tab.winfo_exists()
+        )
+        manager_exists = (
+            hasattr(self, "report_template_manager")
+            and self.report_template_manager.winfo_exists()
+        )
+        if tab_exists:
+            self.doc_nb.select(self._report_template_mgr_tab)
+            if manager_exists:
+                return
+            parent = self._report_template_mgr_tab
+        else:
+            parent = self._report_template_mgr_tab = self._new_tab("Report Templates")
+
+        from gui.report_template_manager import ReportTemplateManager
+
+        self.report_template_manager = ReportTemplateManager(
+            parent, self, _REPORT_TEMPLATE_PATH.parent
+        )
+        self.report_template_manager.pack(fill=tk.BOTH, expand=True)
 
     def reload_config(self) -> None:
         """Reload diagram rule configuration across modules."""

--- a/gui/report_template_manager.py
+++ b/gui/report_template_manager.py
@@ -1,0 +1,99 @@
+import tkinter as tk
+from tkinter import ttk, simpledialog
+from pathlib import Path
+import json
+
+from gui import messagebox
+
+
+class ReportTemplateManager(tk.Frame):
+    """Manage multiple PDF report templates.
+
+    Allows listing, creating, editing and deleting template files stored
+    in ``templates_dir``.  A template is any ``*.json`` file whose name
+    contains ``"template"``.
+    """
+
+    def __init__(self, master, app, templates_dir: Path | None = None):
+        super().__init__(master)
+        self.app = app
+        self.templates_dir = Path(
+            templates_dir or Path(__file__).resolve().parents[1] / "config"
+        )
+
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        self.listbox = tk.Listbox(self)
+        self.listbox.grid(row=0, column=0, sticky="nsew")
+
+        btn_frame = ttk.Frame(self)
+        btn_frame.grid(row=0, column=1, sticky="ns")
+        ttk.Button(btn_frame, text="Add", command=self._add_template).pack(
+            fill=tk.X, padx=2, pady=2
+        )
+        ttk.Button(btn_frame, text="Edit", command=self._edit_template).pack(
+            fill=tk.X, padx=2, pady=2
+        )
+        ttk.Button(btn_frame, text="Delete", command=self._delete_template).pack(
+            fill=tk.X, padx=2, pady=2
+        )
+
+        self._refresh_list()
+
+    # ------------------------------------------------------------------
+    def _template_files(self) -> list[Path]:
+        return sorted(
+            p
+            for p in self.templates_dir.glob("*.json")
+            if "template" in p.name.lower()
+        )
+
+    def _refresh_list(self):
+        self.listbox.delete(0, tk.END)
+        for p in self._template_files():
+            self.listbox.insert(tk.END, p.name)
+
+    # ------------------------------------------------------------------
+    def _add_template(self):  # pragma: no cover - GUI dialog interaction
+        name = simpledialog.askstring("Template", "Template name:")
+        if not name:
+            return
+        if not name.lower().endswith("_template"):
+            name = f"{name}_template"
+        path = self.templates_dir / f"{name}.json"
+        if path.exists():
+            messagebox.showerror("Template", "Template already exists")
+            return
+        data = {"elements": {}, "sections": []}
+        path.write_text(json.dumps(data, indent=2))
+        self._refresh_list()
+
+    def _selected_path(self) -> Path | None:
+        sel = self.listbox.curselection()
+        if not sel:
+            return None
+        return self.templates_dir / self.listbox.get(sel[0])
+
+    def _edit_template(self):  # pragma: no cover - GUI dialog interaction
+        path = self._selected_path()
+        if not path:
+            return
+        from gui.report_template_toolbox import ReportTemplateEditor
+
+        top = tk.Toplevel(self)
+        editor = ReportTemplateEditor(top, self.app, path)
+        editor.pack(fill=tk.BOTH, expand=True)
+
+    def _delete_template(self):  # pragma: no cover - GUI dialog interaction
+        path = self._selected_path()
+        if not path:
+            return
+        if not messagebox.askyesno("Template", f"Delete {path.name}?"):
+            return
+        try:
+            path.unlink()
+        except Exception:
+            messagebox.showerror("Template", "Failed to delete template")
+            return
+        self._refresh_list()

--- a/tests/test_report_template_manager.py
+++ b/tests/test_report_template_manager.py
@@ -1,0 +1,94 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.report_template_manager import ReportTemplateManager
+from gui import report_template_manager as rtm
+import gui.report_template_toolbox as rtt
+
+
+class DummyListbox:
+    def __init__(self):
+        self.items: list[str] = []
+        self._sel: tuple[int, ...] = ()
+
+    def delete(self, *args):
+        self.items.clear()
+
+    def insert(self, index, value):
+        self.items.append(value)
+
+    def size(self):
+        return len(self.items)
+
+    def get(self, index):
+        return self.items[index]
+
+    def curselection(self):
+        return self._sel
+
+    def selection_set(self, index):
+        self._sel = (index,)
+
+
+def test_report_template_manager_lists_templates(tmp_path):
+    (tmp_path / "report_template.json").write_text("{}")
+    (tmp_path / "custom_template.json").write_text("{}")
+    (tmp_path / "diagram_rules.json").write_text("{}")
+    mgr = object.__new__(ReportTemplateManager)
+    mgr.templates_dir = tmp_path
+    mgr.listbox = DummyListbox()
+    ReportTemplateManager._refresh_list(mgr)
+    names = [mgr.listbox.get(i) for i in range(mgr.listbox.size())]
+    assert "report_template.json" in names
+    assert "custom_template.json" in names
+    assert "diagram_rules.json" not in names
+
+
+def test_report_template_manager_add_delete(tmp_path, monkeypatch):
+    mgr = object.__new__(ReportTemplateManager)
+    mgr.templates_dir = tmp_path
+    mgr.listbox = DummyListbox()
+    ReportTemplateManager._refresh_list(mgr)
+    monkeypatch.setattr(rtm.simpledialog, "askstring", lambda *a, **k: "new")
+    mgr._add_template()
+    new_path = tmp_path / "new_template.json"
+    assert new_path.exists()
+    idx = list(mgr.listbox.get(i) for i in range(mgr.listbox.size())).index("new_template.json")
+    mgr.listbox.selection_set(idx)
+    monkeypatch.setattr(rtm.messagebox, "askyesno", lambda *a, **k: True)
+    mgr._delete_template()
+    assert not new_path.exists()
+
+
+def test_report_template_manager_edit_uses_editor(tmp_path, monkeypatch):
+    file = tmp_path / "a_template.json"
+    file.write_text("{}")
+
+    class DummyEditor:
+        called = False
+
+        def __init__(self, master, app, path):
+            DummyEditor.called = True
+            self.master = master
+            self.app = app
+            self.path = path
+
+        def pack(self, **kw):
+            pass
+
+        def winfo_exists(self):
+            return True
+
+    monkeypatch.setattr(rtt, "ReportTemplateEditor", DummyEditor)
+    monkeypatch.setattr(rtm.tk, "Toplevel", lambda _m: object())
+    mgr = object.__new__(ReportTemplateManager)
+    mgr.templates_dir = tmp_path
+    mgr.listbox = DummyListbox()
+    mgr.app = None
+    ReportTemplateManager._refresh_list(mgr)
+    idx = list(mgr.listbox.get(i) for i in range(mgr.listbox.size())).index("a_template.json")
+    mgr.listbox.selection_set(idx)
+    mgr._edit_template()
+    assert DummyEditor.called


### PR DESCRIPTION
## Summary
- Introduce ReportTemplateManager to list, create, edit, and delete report templates.
- Integrate manager with FaultTreeApp tools.
- Test template management operations.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0c04283c88327b1710130cc302e6a