### PR TITLE
Add scrollbar and fixed window size to allowed targets dialog

### DIFF
--- a/gui/diagram_rules_toolbox.py
+++ b/gui/diagram_rules_toolbox.py
@@ -16,12 +16,26 @@ class MultiSelectDialog(simpledialog.Dialog):
         super().__init__(parent, title=title)
 
     def body(self, master):
+        """Create dialog body with a listbox and scrollbar."""
+        # Ensure the dialog window is a fixed size
+        self.resizable(False, False)
+
+        # Use a frame so the listbox and scrollbar can be arranged side-by-side
+        master.grid_columnconfigure(0, weight=1)
+        master.grid_rowconfigure(0, weight=1)
+
         self.listbox = tk.Listbox(master, selectmode=tk.MULTIPLE, height=10)
         for idx, opt in enumerate(self.options):
             self.listbox.insert(tk.END, opt)
             if opt in self.initial:
                 self.listbox.selection_set(idx)
-        self.listbox.grid(row=0, column=0, padx=5, pady=5)
+
+        # Add a vertical scrollbar for long option lists
+        scrollbar = ttk.Scrollbar(master, orient="vertical", command=self.listbox.yview)
+        self.listbox.configure(yscrollcommand=scrollbar.set)
+
+        self.listbox.grid(row=0, column=0, padx=5, pady=5, sticky="nsew")
+        scrollbar.grid(row=0, column=1, sticky="ns")
         return self.listbox
 
     def apply(self):


### PR DESCRIPTION
## Summary
- Add vertical scrollbar to allowed targets multi-selection dialog
- Make dialog window non-resizable for consistent sizing

## Testing
- `pytest` (5 failed, 691 passed, 5 skipped)

------
https://chatgpt.com/codex/tasks/task_b_68a11731835483279a6c76750f266201