### PR TITLE
Reload diagram rules across modules

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -17018,14 +17018,24 @@ class FaultTreeApp:
         self.report_template_manager.pack(fill=tk.BOTH, expand=True)
 
     def reload_config(self) -> None:
-        """Reload diagram rule configuration across modules."""
-        _reload_local_config()
-        from gui import architecture, review_toolbox
-        from analysis import fmeda_utils, governance
+        """Reload diagram rule configuration across all interested modules."""
 
-        for mod in (architecture, review_toolbox, fmeda_utils, governance):
+        import sys
+
+        _reload_local_config()
+
+        for mod in list(sys.modules.values()):
             if hasattr(mod, "reload_config"):
-                mod.reload_config()
+                try:  # pragma: no cover - defensive programming
+                    mod.reload_config()
+                except Exception:
+                    pass
+
+        if hasattr(self, "canvas") and getattr(self.canvas, "winfo_exists", lambda: False)():
+            self.redraw_canvas()
+        pd = getattr(self, "page_diagram", None)
+        if pd and getattr(pd.canvas, "winfo_exists", lambda: False)():
+            pd.redraw_canvas()
 
     def open_style_editor(self):
         """Open the diagram style editor window."""

--- a/tests/test_diagram_rules_reload.py
+++ b/tests/test_diagram_rules_reload.py
@@ -1,0 +1,25 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui import architecture
+from config import load_json_with_comments
+
+
+def test_connection_rules_reload(tmp_path, monkeypatch):
+    orig_path = architecture._CONFIG_PATH
+    cfg = load_json_with_comments(orig_path)
+    assert "Action" not in cfg["connection_rules"]["Governance Diagram"]["Produces"]
+    new_cfg = json.loads(json.dumps(cfg))  # deep copy
+    new_cfg["connection_rules"]["Governance Diagram"]["Produces"]["Action"] = ["Work Product"]
+    tmp_file = tmp_path / "diagram_rules.json"
+    tmp_file.write_text(json.dumps(new_cfg))
+    try:
+        monkeypatch.setattr(architecture, "_CONFIG_PATH", tmp_file)
+        architecture.reload_config()
+        assert "Work Product" in architecture.CONNECTION_RULES["Governance Diagram"]["Produces"]["Action"]
+    finally:
+        monkeypatch.setattr(architecture, "_CONFIG_PATH", orig_path)
+        architecture.reload_config()


### PR DESCRIPTION
## Summary
- ensure updated diagram rules are reloaded across all modules using them
- refresh open diagrams when rules are reloaded
- add regression test for connection rule reloads

## Testing
- `pytest tests/test_diagram_rules_reload.py tests/test_governance_element_connection_rules.py tests/test_diagram_rules_toolbox.py`

------
https://chatgpt.com/codex/tasks/task_b_68a11830be588327814fb8bd85278029