### PR TITLE
Allow governance task connection rules

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -463,45 +463,50 @@ class GovernanceDiagram:
                 if s_role != "subject" and d_role == "subject":
                     subject, obj = obj, subject
             text_override: str | None = None
+            pattern_vars: list[str] = []
             src_type = self.node_types.get(src, "")
             dst_type = self.node_types.get(dst, "")
-            patterns = _PATTERN_MAP.get(
-                (src_type.lower(), (label or conn_type or "").lower(), dst_type.lower()),
-                [],
-            )
-            base = cond_pat = cond_const_pat = const_pat = None
-            for pat in patterns:
-                tmpl = pat.get("Template", "")
-                has_cond = "<condition>" in tmpl or "<acceptance_criteria>" in tmpl
-                has_const = "<constraint>" in tmpl
-                if has_cond and has_const and not cond_const_pat:
-                    cond_const_pat = pat
-                elif has_const and not has_cond and not const_pat:
-                    const_pat = pat
-                elif has_cond and not has_const and not cond_pat:
-                    cond_pat = pat
-                elif not has_cond and not has_const and not base:
-                    base = pat
-            pattern = None
-            if cond and constraint and cond_const_pat:
-                pattern = cond_const_pat
-            elif constraint and const_pat:
-                pattern = const_pat
-            elif cond and cond_pat and not base:
-                pattern = cond_pat
-            else:
-                pattern = base or cond_pat or const_pat or cond_const_pat
-            pattern_vars: list[str] = []
-            if pattern:
-                text_override, pattern_vars = _apply_pattern(
-                    pattern, src, dst, src_type, dst_type, cond, constraint
+            if kind != "flow":
+                patterns = _PATTERN_MAP.get(
+                    (
+                        src_type.lower(),
+                        (label or conn_type or "").lower(),
+                        dst_type.lower(),
+                    ),
+                    [],
                 )
-                if (
-                    cond
-                    and "<condition>" not in pattern.get("Template", "")
-                    and "<acceptance_criteria>" not in pattern.get("Template", "")
-                ):
-                    text_override = f"If {cond}, {text_override}"
+                base = cond_pat = cond_const_pat = const_pat = None
+                for pat in patterns:
+                    tmpl = pat.get("Template", "")
+                    has_cond = "<condition>" in tmpl or "<acceptance_criteria>" in tmpl
+                    has_const = "<constraint>" in tmpl
+                    if has_cond and has_const and not cond_const_pat:
+                        cond_const_pat = pat
+                    elif has_const and not has_cond and not const_pat:
+                        const_pat = pat
+                    elif has_cond and not has_const and not cond_pat:
+                        cond_pat = pat
+                    elif not has_cond and not has_const and not base:
+                        base = pat
+                pattern = None
+                if cond and constraint and cond_const_pat:
+                    pattern = cond_const_pat
+                elif constraint and const_pat:
+                    pattern = const_pat
+                elif cond and cond_pat and not base:
+                    pattern = cond_pat
+                else:
+                    pattern = base or cond_pat or const_pat or cond_const_pat
+                if pattern:
+                    text_override, pattern_vars = _apply_pattern(
+                        pattern, src, dst, src_type, dst_type, cond, constraint
+                    )
+                    if (
+                        cond
+                        and "<condition>" not in pattern.get("Template", "")
+                        and "<acceptance_criteria>" not in pattern.get("Template", "")
+                    ):
+                        text_override = f"If {cond}, {text_override}"
 
             requirements.append(
                 GeneratedRequirement(

--- a/analysis/requirement_rule_generator.py
+++ b/analysis/requirement_rule_generator.py
@@ -206,8 +206,8 @@ def gov_template_for_relation(relation_label: str) -> str:
         "constrained by": "shall comply with the <target_id> (<target_class>).",
         "used after review": "shall be used after review the <target_id> (<target_class>).",
         "used after approval": "shall be used after approval the <target_id> (<target_class>).",
-        "propagate by review": "shall propagate by review the <target_id> (<target_class}).",
-        "propagate by approval": "shall propagate by approval the <target_id> (<target_class}).",
+        "propagate by review": "shall propagate by review the <target_id> (<target_class>).",
+        "propagate by approval": "shall propagate by approval the <target_id> (<target_class>).",
     }
     if r in with_prep:
         return tidy_sentence(f"<source_id> (<source_class>) {with_prep[r]}")

--- a/config/requirement_patterns.json
+++ b/config/requirement_patterns.json
@@ -3746,7 +3746,7 @@
   {
     "Pattern ID": "GOV-propagate_by_approval-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Propagate by Approval]--> Work Product",
-    "Template": "<source_id> (<source_class>) shall propagate by approval the <target_id> (<target_class}).",
+    "Template": "<source_id> (<source_class>) shall propagate by approval the <target_id> (<target_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3757,7 +3757,7 @@
   {
     "Pattern ID": "GOV-propagate_by_approval-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Propagate by Approval]--> Work Product",
-    "Template": "When <condition>, <source_id> (<source_class>) shall propagate by approval the <target_id> (<target_class}).",
+    "Template": "When <condition>, <source_id> (<source_class>) shall propagate by approval the <target_id> (<target_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3769,7 +3769,7 @@
   {
     "Pattern ID": "GOV-propagate_by_approval-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Propagate by Approval]--> Work Product",
-    "Template": "When <condition>, <source_id> (<source_class>) shall propagate by approval the <target_id> (<target_class}) constrained by <constraint>.",
+    "Template": "When <condition>, <source_id> (<source_class>) shall propagate by approval the <target_id> (<target_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3782,7 +3782,7 @@
   {
     "Pattern ID": "GOV-propagate_by_approval-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Propagate by Approval]--> Work Product",
-    "Template": "<source_id> (<source_class>) shall propagate by approval the <target_id> (<target_class}) constrained by <constraint>.",
+    "Template": "<source_id> (<source_class>) shall propagate by approval the <target_id> (<target_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3794,7 +3794,7 @@
   {
     "Pattern ID": "GOV-propagate_by_review-Work_Product-Work_Product",
     "Trigger": "Gov: Work Product --[Propagate by Review]--> Work Product",
-    "Template": "<source_id> (<source_class>) shall propagate by review the <target_id> (<target_class}).",
+    "Template": "<source_id> (<source_class>) shall propagate by review the <target_id> (<target_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3805,7 +3805,7 @@
   {
     "Pattern ID": "GOV-propagate_by_review-Work_Product-Work_Product-COND",
     "Trigger": "Gov: Work Product --[Propagate by Review]--> Work Product",
-    "Template": "When <condition>, <source_id> (<source_class>) shall propagate by review the <target_id> (<target_class}).",
+    "Template": "When <condition>, <source_id> (<source_class>) shall propagate by review the <target_id> (<target_class>).",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3817,7 +3817,7 @@
   {
     "Pattern ID": "GOV-propagate_by_review-Work_Product-Work_Product-COND-CONST",
     "Trigger": "Gov: Work Product --[Propagate by Review]--> Work Product",
-    "Template": "When <condition>, <source_id> (<source_class>) shall propagate by review the <target_id> (<target_class}) constrained by <constraint>.",
+    "Template": "When <condition>, <source_id> (<source_class>) shall propagate by review the <target_id> (<target_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",
@@ -3830,7 +3830,7 @@
   {
     "Pattern ID": "GOV-propagate_by_review-Work_Product-Work_Product-CONST",
     "Trigger": "Gov: Work Product --[Propagate by Review]--> Work Product",
-    "Template": "<source_id> (<source_class>) shall propagate by review the <target_id> (<target_class}) constrained by <constraint>.",
+    "Template": "<source_id> (<source_class>) shall propagate by review the <target_id> (<target_class>) constrained by <constraint>.",
     "Variables": [
       "<owner>",
       "<due_date>",

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -193,6 +193,13 @@ NODE_CONNECTION_LIMITS: dict[str, int] = _CONFIG.get("node_connection_limits", {
 # Node types that require guards on outgoing flows
 GUARD_NODES = set(_CONFIG.get("guard_nodes", []))
 
+# Node type aliases used when validating governance diagram connections.
+# Governance tasks are implemented using SysML ``Action`` elements but are
+# presented as "Task" to users.  Mapping aliases before applying connection
+# rules ensures that configuration updates targeting "Task" also affect these
+# underlying "Action" nodes.
+_GOV_TYPE_ALIASES = {"Action": "Task"}
+
 
 # Connection types excluding Safety & AI relations used for membership checks
 _BASE_CONN_TYPES = {
@@ -3555,10 +3562,15 @@ class SysMLDiagramWindow(tk.Frame):
         diag_rules = CONNECTION_RULES.get(diag_type, {})
         conn_rules = diag_rules.get(conn_type)
         if conn_rules:
-            targets = conn_rules.get(src.obj_type, set())
-            if dst.obj_type not in targets:
+            src_type = src.obj_type
+            dst_type = dst.obj_type
+            if diag_type == "Governance Diagram" and conn_type != "Flow":
+                src_type = _GOV_TYPE_ALIASES.get(src_type, src_type)
+                dst_type = _GOV_TYPE_ALIASES.get(dst_type, dst_type)
+            targets = conn_rules.get(src_type, set())
+            if dst_type not in targets:
                 return False, (
-                    f"{conn_type} from {src.obj_type} to {dst.obj_type} is not allowed"
+                    f"{conn_type} from {src_type} to {dst_type} is not allowed"
                 )
 
         if diag_type == "Block Diagram":

--- a/tests/test_governance_task_connection_rule.py
+++ b/tests/test_governance_task_connection_rule.py
@@ -1,0 +1,28 @@
+import json
+import types
+from pathlib import Path
+
+from gui import architecture
+
+
+def test_governance_task_rule_allows_action(tmp_path, monkeypatch):
+    cfg = {
+        "connection_rules": {
+            "Governance Diagram": {"Produces": {"Task": ["Work Product"]}}
+        }
+    }
+    path = tmp_path / "diagram_rules.json"
+    path.write_text(json.dumps(cfg))
+    orig_path = architecture._CONFIG_PATH
+    monkeypatch.setattr(architecture, "_CONFIG_PATH", path)
+    architecture.reload_config()
+    win = architecture.GovernanceDiagramWindow.__new__(architecture.GovernanceDiagramWindow)
+    win.repo = types.SimpleNamespace(diagrams={})
+    win.diagram_id = "d"
+    win.repo.diagrams["d"] = types.SimpleNamespace(diag_type="Governance Diagram")
+    src = architecture.SysMLObject(1, "Action", 0, 0)
+    dst = architecture.SysMLObject(2, "Work Product", 0, 0)
+    valid, _ = architecture.GovernanceDiagramWindow.validate_connection(win, src, dst, "Produces")
+    assert valid
+    monkeypatch.setattr(architecture, "_CONFIG_PATH", orig_path)
+    architecture.reload_config()


### PR DESCRIPTION
## Summary
- map governance Action nodes to Task so edited connection rules take effect
- avoid applying requirement patterns to Flow edges and fix propagate-by templates
- add regression test for Task→Work Product Produces connection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a117e7b85083278423175a8b8aa01d