### PR TITLE
Fix duplicate style initialization and toolbox resizing error

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3347,7 +3347,6 @@ class SysMLDiagramWindow(tk.Frame):
         # Shrink the property view to match the button area so it does not force
         # the toolbox wider than needed.
         field_width = button_width // 2
-        self.prop_view.configure(width=button_width)
         self.prop_view.column("field", width=field_width, stretch=False)
         self.prop_view.column("value", width=button_width - field_width, stretch=False)
 

--- a/gui/closable_notebook.py
+++ b/gui/closable_notebook.py
@@ -1,4 +1,10 @@
-"""Custom ttk.Notebook widget with close buttons on the left of each tab."""
+"""Custom ttk.Notebook widget with detachable tabs.
+
+The widget behaves like a regular :class:`ttk.Notebook` but displays a close
+button on the left of each tab. Tabs can also be dragged out of the notebook to
+create a new floating window. Dragging a tab from a floating window back onto a
+notebook re-attaches it to that notebook.
+"""
 
 from __future__ import annotations
 
@@ -9,57 +15,66 @@ from tkinter import ttk
 class ClosableNotebook(ttk.Notebook):
     """Notebook widget with an 'x' button on the left side of each tab."""
 
+    _style_initialized = False
+    _close_img: tk.PhotoImage | None = None
+
     def __init__(self, master: tk.Widget | None = None, **kw):
-        self._close_img = self._create_close_image()
-        style = ttk.Style()
-        style.element_create(
-            "close",
-            "image",
-            self._close_img,
-            border=8,
-            sticky="",
-        )
-        style.layout(
-            "ClosableNotebook.Tab",
-            [
-                (
-                    "Notebook.tab",
-                    {
-                        "sticky": "nswe",
-                        "children": [
-                            (
-                                "Notebook.padding",
-                                {
-                                    "side": "top",
-                                    "sticky": "nswe",
-                                    "children": [
-                                        (
-                                            "Notebook.focus",
-                                            {
-                                                "side": "top",
-                                                "sticky": "nswe",
-                                                "children": [
-                                                    ("close", {"side": "left", "sticky": ""}),
-                                                    ("Notebook.label", {"side": "left", "sticky": ""}),
-                                                ],
-                                            },
-                                        )
-                                    ],
-                                },
-                            )
-                        ],
-                    },
-                )
-            ],
-        )
-        style.layout("ClosableNotebook", style.layout("TNotebook"))
+        if not ClosableNotebook._style_initialized:
+            # Create the close button image and register style elements only once
+            ClosableNotebook._close_img = self._create_close_image()
+            style = ttk.Style()
+            style.element_create(
+                "close",
+                "image",
+                ClosableNotebook._close_img,
+                border=8,
+                sticky="",
+            )
+            style.layout(
+                "ClosableNotebook.Tab",
+                [
+                    (
+                        "Notebook.tab",
+                        {
+                            "sticky": "nswe",
+                            "children": [
+                                (
+                                    "Notebook.padding",
+                                    {
+                                        "side": "top",
+                                        "sticky": "nswe",
+                                        "children": [
+                                            (
+                                                "Notebook.focus",
+                                                {
+                                                    "side": "top",
+                                                    "sticky": "nswe",
+                                                    "children": [
+                                                        ("close", {"side": "left", "sticky": ""}),
+                                                        ("Notebook.label", {"side": "left", "sticky": ""}),
+                                                    ],
+                                                },
+                                            )
+                                        ],
+                                    },
+                                )
+                            ],
+                        },
+                    )
+                ],
+            )
+            style.layout("ClosableNotebook", style.layout("TNotebook"))
+            ClosableNotebook._style_initialized = True
         kw["style"] = "ClosableNotebook"
         super().__init__(master, **kw)
         self._active: int | None = None
         self._closing_tab: str | None = None
         self.protected: set[str] = set()
-        self.bind("<ButtonPress-1>", self._on_close_press, True)
-        self.bind("<ButtonRelease-1>", self._on_close_release)
+        self._drag_data: dict[str, int | None] = {"tab": None, "x": 0, "y": 0}
+        self._dragging = False
+        self.bind("<ButtonPress-1>", self._on_press, True)
+        self.bind("<B1-Motion>", self._on_motion)
+        self.bind("<ButtonRelease-1>", self._on_release, True)
 
     def _create_close_image(self, size: int = 10) -> tk.PhotoImage:
         img = tk.PhotoImage(width=size, height=size)
@@ -69,36 +84,95 @@ class ClosableNotebook(ttk.Notebook):
             img.put("black", (size - 1 - i, i))
         return img
 
-    def _on_close_press(self, event: tk.Event) -> str | None:
+    def _on_press(self, event: tk.Event) -> str | None:
         element = self.identify(event.x, event.y)
-        if "close" in element:
+        try:
             index = self.index(f"@{event.x},{event.y}")
+        except tk.TclError:
+            index = None
+        if "close" in element and index is not None:
             tab_id = self.tabs()[index]
             if tab_id in self.protected:
                 return "break"
             self.state(["pressed"])
             self._active = index
             return "break"
+        self._drag_data = {"tab": index, "x": event.x_root, "y": event.y_root}
         return None
 
-    def _on_close_release(self, event: tk.Event) -> None:
-        if not self.instate(["pressed"]):
+    def _on_motion(self, event: tk.Event) -> None:
+        if self._drag_data["tab"] is None:
             return
-        element = self.identify(event.x, event.y)
-        index = self.index(f"@{event.x},{event.y}")
-        if "close" in element and self._active == index:
-            tab_id = self.tabs()[index]
-            if tab_id in self.protected:
-                self.state(["!pressed"])
-                self._active = None
+        dx = abs(event.x_root - self._drag_data["x"])
+        dy = abs(event.y_root - self._drag_data["y"])
+        if dx > 5 or dy > 5:
+            self._dragging = True
+
+    def _on_release(self, event: tk.Event) -> None:
+        if self.instate(["pressed"]):
+            element = self.identify(event.x, event.y)
+            index = self.index(f"@{event.x},{event.y}")
+            if "close" in element and self._active == index:
+                tab_id = self.tabs()[index]
+                if tab_id in self.protected:
+                    self.state(["!pressed"])
+                    self._active = None
+                    self._reset_drag()
+                    return
+                self._closing_tab = tab_id
+                self.event_generate("<<NotebookTabClosed>>")
+                if tab_id in self.tabs():
+                    try:
+                        self.forget(tab_id)
+                    except tk.TclError:
+                        pass
+            self.state(["!pressed"])
+            self._active = None
+            self._reset_drag()
+            return
+
+        tab_index = self._drag_data["tab"]
+        if tab_index is not None and self._dragging:
+            try:
+                tab_id = self.tabs()[tab_index]
+            except IndexError:
+                self._reset_drag()
                 return
-            self._closing_tab = tab_id
-            self.event_generate("<<NotebookTabClosed>>")
-            if tab_id in self.tabs():
-                try:
-                    self.forget(tab_id)
-                except tk.TclError:
-                    pass
-        self.state(["!pressed"])
-        self._active = None
+            widget = self.winfo_containing(event.x_root, event.y_root)
+            while widget is not None and not isinstance(widget, ClosableNotebook):
+                widget = widget.master
+            if isinstance(widget, ClosableNotebook) and widget is not self:
+                self._move_tab(tab_id, widget)
+            else:
+                self._detach_tab(tab_id, event.x_root, event.y_root)
+        self._reset_drag()
+
+    def _move_tab(self, tab_id: str, target: "ClosableNotebook") -> None:
+        text = self.tab(tab_id, "text")
+        child = self.nametowidget(tab_id)
+        self.forget(tab_id)
+        # Reparent the tab's child widget to the target notebook before adding
+        try:
+            child.tk.call("tk", "unsupported", "reparent", child._w, target._w)
+        except tk.TclError:
+            pass
+        child.master = target  # keep Python's widget hierarchy in sync
+        target.add(child, text=text)
+        target.select(child)
+        if isinstance(self.master, tk.Toplevel) and not self.tabs():
+            self.master.destroy()
+
+    def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
+        self.update_idletasks()
+        width = self.winfo_width() or 200
+        height = self.winfo_height() or 200
+        win = tk.Toplevel(self)
+        win.geometry(f"{width}x{height}+{x}+{y}")
+        nb = ClosableNotebook(win)
+        nb.pack(expand=True, fill="both")
+        self._move_tab(tab_id, nb)
+
+    def _reset_drag(self) -> None:
+        self._drag_data = {"tab": None, "x": 0, "y": 0}
+        self._dragging = False
 


### PR DESCRIPTION
## Summary
- Prevent duplicate style creation in `ClosableNotebook` to allow multiple detachable tab windows
- Remove invalid width configuration in `_fit_toolbox` to avoid Tk errors
- Reparent tab widgets and size new windows when detaching so tabs can be reattached and windows aren't tiny

## Testing
- `pytest tests/test_gui_classes.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1193f9184832793048dba2fa60ab9