### PR TITLE
Generate requirements from SysML diagrams

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -300,7 +300,7 @@ class SafetyManagementWindow(tk.Frame):
         )
 
     def generate_requirements(self) -> None:
-        """Generate requirements for the selected governance diagram."""
+        """Generate requirements for the selected diagram."""
         name = self.diag_var.get()
         if not name:
             return
@@ -308,14 +308,24 @@ class SafetyManagementWindow(tk.Frame):
         if not diag_id:
             return
         repo = SysMLRepository.get_instance()
-        gov = GovernanceDiagram.from_repository(repo, diag_id)
-        try:
-            raw_reqs = gov.generate_requirements()
-        except Exception as exc:  # pragma: no cover - defensive
-            messagebox.showerror(
-                "Requirements", f"Failed to generate requirements: {exc}"
-            )
-            return
+        diag = repo.diagrams.get(diag_id)
+        if diag and diag.diag_type != "Governance Diagram":
+            try:
+                raw_reqs = repo.generate_requirements(diag_id)
+            except Exception as exc:  # pragma: no cover - defensive
+                messagebox.showerror(
+                    "Requirements", f"Failed to generate requirements: {exc}"
+                )
+                return
+        else:
+            gov = GovernanceDiagram.from_repository(repo, diag_id)
+            try:
+                raw_reqs = gov.generate_requirements()
+            except Exception as exc:  # pragma: no cover - defensive
+                messagebox.showerror(
+                    "Requirements", f"Failed to generate requirements: {exc}"
+                )
+                return
         reqs: list[tuple[str, str, list[str]]] = []
         for r in raw_reqs:
             if isinstance(r, tuple):
@@ -396,15 +406,26 @@ class SafetyManagementWindow(tk.Frame):
             diag_id = self.toolbox.diagrams.get(name)
             if not diag_id:
                 continue
-            gov = GovernanceDiagram.from_repository(repo, diag_id)
-            try:
-                raw_reqs = gov.generate_requirements()
-            except Exception as exc:  # pragma: no cover - defensive
-                messagebox.showerror(
-                    "Requirements",
-                    f"Failed to generate requirements for '{name}': {exc}",
-                )
-                continue
+            diag = repo.diagrams.get(diag_id)
+            if diag and diag.diag_type != "Governance Diagram":
+                try:
+                    raw_reqs = repo.generate_requirements(diag_id)
+                except Exception as exc:  # pragma: no cover - defensive
+                    messagebox.showerror(
+                        "Requirements",
+                        f"Failed to generate requirements for '{name}': {exc}",
+                    )
+                    continue
+            else:
+                gov = GovernanceDiagram.from_repository(repo, diag_id)
+                try:
+                    raw_reqs = gov.generate_requirements()
+                except Exception as exc:  # pragma: no cover - defensive
+                    messagebox.showerror(
+                        "Requirements",
+                        f"Failed to generate requirements for '{name}': {exc}",
+                    )
+                    continue
             pairs: list[tuple[str, str, list[str]]] = []
             invalid = False
             for r in raw_reqs:
@@ -486,15 +507,26 @@ class SafetyManagementWindow(tk.Frame):
             diag_id = self.toolbox.diagrams.get(name)
             if not diag_id:
                 continue
-            gov = GovernanceDiagram.from_repository(repo, diag_id)
-            try:
-                raw_reqs = gov.generate_requirements()
-            except Exception as exc:  # pragma: no cover - defensive
-                messagebox.showerror(
-                    "Requirements",
-                    f"Failed to generate requirements for '{name}': {exc}",
-                )
-                continue
+            diag = repo.diagrams.get(diag_id)
+            if diag and diag.diag_type != "Governance Diagram":
+                try:
+                    raw_reqs = repo.generate_requirements(diag_id)
+                except Exception as exc:  # pragma: no cover - defensive
+                    messagebox.showerror(
+                        "Requirements",
+                        f"Failed to generate requirements for '{name}': {exc}",
+                    )
+                    continue
+            else:
+                gov = GovernanceDiagram.from_repository(repo, diag_id)
+                try:
+                    raw_reqs = gov.generate_requirements()
+                except Exception as exc:  # pragma: no cover - defensive
+                    messagebox.showerror(
+                        "Requirements",
+                        f"Failed to generate requirements for '{name}': {exc}",
+                    )
+                    continue
             pairs: list[tuple[str, str, list[str]]] = []
             invalid = False
             for r in raw_reqs:

--- a/tests/test_sysml_requirements.py
+++ b/tests/test_sysml_requirements.py
@@ -1,0 +1,60 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from sysml.sysml_repository import SysMLRepository
+
+
+def setup_repo():
+    SysMLRepository._instance = None
+    return SysMLRepository.get_instance()
+
+
+def test_activity_diagram_requirements():
+    repo = setup_repo()
+    ad = repo.create_diagram("Activity Diagram", name="Main")
+    a1 = repo.create_element("Action", name="Start")
+    a2 = repo.create_element("Action", name="End")
+    ad.objects = [
+        {"obj_id": 1, "obj_type": "Action", "element_id": a1.elem_id, "properties": {"name": "Start"}},
+        {"obj_id": 2, "obj_type": "Action", "element_id": a2.elem_id, "properties": {"name": "End"}},
+    ]
+    ad.connections = [{"src": 1, "dst": 2, "conn_type": "Control Flow"}]
+    reqs = repo.generate_requirements(ad.diag_id)
+    texts = [r[0] for r in reqs]
+    assert "Start shall precede End." in texts
+
+
+def test_call_behavior_action_dependencies():
+    repo = setup_repo()
+    sub = repo.create_diagram("Activity Diagram", name="Sub")
+    s1 = repo.create_element("Action", name="S1")
+    s2 = repo.create_element("Action", name="S2")
+    sub.objects = [
+        {"obj_id": 1, "obj_type": "Action", "element_id": s1.elem_id, "properties": {"name": "S1"}},
+        {"obj_id": 2, "obj_type": "Action", "element_id": s2.elem_id, "properties": {"name": "S2"}},
+    ]
+    sub.connections = [{"src": 1, "dst": 2, "conn_type": "Control Flow"}]
+
+    main = repo.create_diagram("Activity Diagram", name="Main")
+    start = repo.create_element("Action", name="Start")
+    call_elem = repo.create_element("CallBehaviorAction", name="CallSub")
+    end = repo.create_element("Action", name="End")
+    main.objects = [
+        {"obj_id": 1, "obj_type": "Action", "element_id": start.elem_id, "properties": {"name": "Start"}},
+        {
+            "obj_id": 2,
+            "obj_type": "CallBehaviorAction",
+            "element_id": call_elem.elem_id,
+            "properties": {"name": "CallSub", "behavior": sub.diag_id},
+        },
+        {"obj_id": 3, "obj_type": "Action", "element_id": end.elem_id, "properties": {"name": "End"}},
+    ]
+    main.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Control Flow"},
+        {"src": 2, "dst": 3, "conn_type": "Control Flow"},
+    ]
+    reqs = repo.generate_requirements(main.diag_id)
+    texts = [r[0] for r in reqs]
+    assert "Start shall precede CallSub." in texts
+    assert "CallSub shall precede End." in texts
+    assert "S1 shall precede S2." in texts


### PR DESCRIPTION
## Summary
- add requirement generation in `SysMLRepository` with support for activity diagrams and called behaviors
- allow Safety Management toolbox to generate requirements from SysML diagrams, phases, and lifecycle views
- cover SysML requirement generation with new tests

## Testing
- `pytest tests/test_sysml_requirements.py tests/test_actions.py`
- `pytest tests/test_governance_phase_requirements_menu.py tests/test_governance_lifecycle_requirements_menu.py`
- `pytest tests/test_governance_requirements_button.py`


------
https://chatgpt.com/codex/tasks/task_b_68a120ae0b0c8327883e1dc2a9c44d2b