### PR TITLE
Enforce Safety & AI relation rules for non-AI targets

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3695,13 +3695,9 @@ class SysMLDiagramWindow(tk.Frame):
                         "Safety & AI relationships must connect Safety & AI and/or Governance elements"
                     )
                 rule = SAFETY_AI_RELATION_RULES.get(conn_type)
-                if (
-                    rule
-                    and src.obj_type in SAFETY_AI_NODE_TYPES
-                    and dst.obj_type in SAFETY_AI_NODE_TYPES
-                ):
-                    targets = rule.get(src.obj_type, set())
-                    if dst.obj_type not in targets:
+                if rule and src.obj_type in SAFETY_AI_NODE_TYPES:
+                    targets = rule.get(src.obj_type)
+                    if not targets or dst.obj_type not in targets:
                         return (
                             False,
                             f"{conn_type} from {src.obj_type} to {dst.obj_type} is not allowed",


### PR DESCRIPTION
## Summary
- Validate Safety & AI relationships based on configuration even when targets are governance elements
- Disallow unsupported relations like Database -> Work Product for Field risk evaluation
- Extend tests to cover allowed and forbidden Safety & AI connections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a121dacaf083279ff4a44d3f8f23b9