### PR TITLE
Display element class names in generated requirements

### DIFF
--- a/tests/test_governance_decision_guard.py
+++ b/tests/test_governance_decision_guard.py
@@ -36,7 +36,7 @@ class GovernanceDecisionGuardTests(unittest.TestCase):
         self.assertEqual(gdiag.edge_data[("A", "B")]["condition"], "g1")
         reqs = gdiag.generate_requirements()
         texts = [r.text for r in reqs]
-        self.assertIn("If g1, A shall precede 'B'.", texts)
+        self.assertIn("If g1, A (Action) shall precede 'B (Action)'.", texts)
 
 
 if __name__ == "__main__":

--- a/tests/test_governance_decision_transition_requirement.py
+++ b/tests/test_governance_decision_transition_requirement.py
@@ -23,5 +23,5 @@ def test_decision_transition_requirement_mentions_source():
 
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
-    assert "If completion >= 0.98, after 'Collect Data', Engineering team shall train 'ANN1'." in texts
+    assert "If completion >= 0.98, after 'Collect Data (Activity)', Engineering team shall train 'ANN1 (ANN)'." in texts
     assert all("Decision1" not in t for t in texts)

--- a/tests/test_governance_lifecycle_requirements_menu.py
+++ b/tests/test_governance_lifecycle_requirements_menu.py
@@ -138,8 +138,8 @@ def test_lifecycle_requirements_menu(monkeypatch):
     assert "Lifecycle Requirements" in title
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
-    assert any("Alpha shall precede 'Beta'." in t for t in texts)
-    assert not any("Start shall precede 'Finish'." in t for t in texts)
+    assert any("Alpha (Action) shall precede 'Beta (Action)'." in t for t in texts)
+    assert not any("Start (Action) shall precede 'Finish (Action)'." in t for t in texts)
     assert all(row[1] == "organizational" for row in trees[0].rows)
     assert all(row[4] == "draft" for row in trees[0].rows)
     assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_governance_phase_requirements_menu.py
+++ b/tests/test_governance_phase_requirements_menu.py
@@ -137,8 +137,8 @@ def test_phase_requirements_menu(monkeypatch):
     assert "Phase1 Requirements" in title
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
-    assert any("Start shall precede 'Finish'." in t for t in texts)
-    assert any("Check shall precede 'Complete'." in t for t in texts)
+    assert any("Start (Action) shall precede 'Finish (Action)'." in t for t in texts)
+    assert any("Check (Action) shall precede 'Complete (Action)'." in t for t in texts)
     assert all(row[1] == "organizational" for row in trees[0].rows)
     assert all(row[4] == "draft" for row in trees[0].rows)
     assert len(global_requirements) == len(trees[0].rows)

--- a/tests/test_governance_phase_transition_requirements.py
+++ b/tests/test_governance_phase_transition_requirements.py
@@ -26,7 +26,7 @@ def test_phase_transition_requirement_direct_flow():
 
     reqs = diagram.generate_requirements()
     texts = _texts(reqs)
-    assert "P1 shall transition to 'P2'." in texts
+    assert "P1 (Lifecycle Phase) shall transition to 'P2 (Lifecycle Phase)'." in texts
 
 
 def test_phase_transition_requirement_with_reuse_and_condition():
@@ -39,5 +39,5 @@ def test_phase_transition_requirement_with_reuse_and_condition():
     reqs = diagram.generate_requirements()
     texts = _texts(reqs)
     assert (
-        "P1 shall transition to 'P2' reusing outputs from 'P1' only after design approved." in texts
+        "P1 (Lifecycle Phase) shall transition to 'P2 (Lifecycle Phase)' reusing outputs from 'P1 (Lifecycle Phase)' only after design approved." in texts
     )

--- a/tests/test_governance_relationship_label.py
+++ b/tests/test_governance_relationship_label.py
@@ -18,4 +18,5 @@ def test_label_relationship_between_database_nodes():
 
     reqs = diagram.generate_requirements()
     texts = [r.text for r in reqs]
-    assert "User DB shall sync with 'Analytics DB'." in texts
+    assert "User DB (Action) shall sync with 'Analytics DB (Action)'." in texts
+

--- a/tests/test_governance_requirements_button.py
+++ b/tests/test_governance_requirements_button.py
@@ -124,7 +124,7 @@ def test_requirements_button_opens_tab(monkeypatch):
     assert "Gov Requirements" in title
     assert trees and trees[0].rows
     texts = [row[2] for row in trees[0].rows]
-    assert any("Start shall precede 'Finish'." in t for t in texts)
+    assert any("Start (Action) shall precede 'Finish (Action)'." in t for t in texts)
     # Ensure requirement types are organizational
     assert all(row[1] == "organizational" for row in trees[0].rows)
     assert all(row[4] == "draft" for row in trees[0].rows)

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -25,9 +25,9 @@ def test_generate_requirements_from_governance_diagram():
     texts = [r.text for r in reqs]
 
     assert "Data Steward (Role) shall perform 'Review Data (Activity)'." in texts
-    assert "Review Data shall produce 'Report'." in texts
+    assert "Review Data (Activity) shall produce 'Report (Document)'." in texts
     assert "If data validated, Data Steward (Role) shall approve 'Report (Document)'." in texts
-    assert "Review Data shall comply with 'Policy DP-001'." in texts
+    assert "Review Data (Activity) shall comply with 'Policy DP-001 (Policy)'." in texts
     assert "Organization shall review data." in texts
 
     perf_req = next(r for r in reqs if r.action == "perform")
@@ -65,7 +65,7 @@ def test_ai_training_and_curation_requirements():
         "If completion >= 0.98, Engineering team shall train the ANN1 (ANN) using the Database1 (Database)."
         in texts
     )
-    assert "If completion < 0.98, Engineering team shall curate 'Database1'." in texts
+    assert "If completion < 0.98, Engineering team shall curate 'Database1 (Database)'." in texts
 
     train_req = next(r for r in reqs if r.action == "train")
     assert train_req.subject == "Engineering team"


### PR DESCRIPTION
## Summary
- include subject, object, constraint, and origin classes in requirement text
- adjust lifecycle phase transition wording to show element classes
- update tests for class-qualified requirement text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1223fc4c0832794ede36112e81c73