### PR TITLE
Generate vehicle requirements from activity diagrams

### DIFF
--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -401,13 +401,14 @@ class SafetyManagementWindow(tk.Frame):
             messagebox.showinfo("Requirements", f"No governance diagrams for phase '{phase}'.")
             return
         repo = SysMLRepository.get_instance()
+        repo_diagrams = getattr(repo, "diagrams", {})
         diag_pairs: dict[str, list[tuple[str, str, list[str]]]] = {}
         for name in diag_names:
             diag_id = self.toolbox.diagrams.get(name)
             if not diag_id:
                 continue
-            diag = repo.diagrams.get(diag_id)
-            if diag and diag.diag_type != "Governance Diagram":
+            diag = repo_diagrams.get(diag_id) if isinstance(repo_diagrams, dict) else None
+            if diag and diag.diag_type != "Governance Diagram" and hasattr(repo, "generate_requirements"):
                 try:
                     raw_reqs = repo.generate_requirements(diag_id)
                 except Exception as exc:  # pragma: no cover - defensive
@@ -502,13 +503,14 @@ class SafetyManagementWindow(tk.Frame):
                 "Requirements", "No lifecycle governance diagrams.")
             return
         repo = SysMLRepository.get_instance()
+        repo_diagrams = getattr(repo, "diagrams", {})
         diag_pairs: dict[str, list[tuple[str, str, list[str]]]] = {}
         for name in diag_names:
             diag_id = self.toolbox.diagrams.get(name)
             if not diag_id:
                 continue
-            diag = repo.diagrams.get(diag_id)
-            if diag and diag.diag_type != "Governance Diagram":
+            diag = repo_diagrams.get(diag_id) if isinstance(repo_diagrams, dict) else None
+            if diag and diag.diag_type != "Governance Diagram" and hasattr(repo, "generate_requirements"):
                 try:
                     raw_reqs = repo.generate_requirements(diag_id)
                 except Exception as exc:  # pragma: no cover - defensive

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -765,12 +765,11 @@ class SysMLRepository:
         Returns
         -------
         list[tuple[str, str]]
-            Generated requirement texts paired with their types.  The function
-            currently emits "functional" requirements describing the
-            predecessor relationship between connected actions in activity
-            diagrams.  For other SysML diagrams a generic "functional"
-            requirement expressing that two elements are connected is
-            produced.
+            Generated requirement texts paired with their types.  Activity
+            diagrams yield "vehicle" requirements describing the predecessor
+            relationship between connected actions.  For other SysML diagrams a
+            generic "functional" requirement expressing that two elements are
+            connected is produced.
         """
 
         if _visited is None:
@@ -813,9 +812,11 @@ class SysMLRepository:
                 continue
             if diag.diag_type == "Activity Diagram":
                 text = f"{src} shall precede {dst}."
+                req_type = "vehicle"
             else:
                 text = f"{src} shall be connected to {dst}."
-            reqs.append((text, "functional"))
+                req_type = "functional"
+            reqs.append((text, req_type))
 
         return reqs
 

--- a/tests/test_sysml_requirements.py
+++ b/tests/test_sysml_requirements.py
@@ -22,6 +22,7 @@ def test_activity_diagram_requirements():
     reqs = repo.generate_requirements(ad.diag_id)
     texts = [r[0] for r in reqs]
     assert "Start shall precede End." in texts
+    assert {r[1] for r in reqs} == {"vehicle"}
 
 
 def test_call_behavior_action_dependencies():
@@ -58,3 +59,18 @@ def test_call_behavior_action_dependencies():
     assert "Start shall precede CallSub." in texts
     assert "CallSub shall precede End." in texts
     assert "S1 shall precede S2." in texts
+    assert {r[1] for r in reqs} == {"vehicle"}
+
+
+def test_non_activity_diagram_requirement_type():
+    repo = setup_repo()
+    bdd = repo.create_diagram("Block Definition Diagram", name="Struct")
+    b1 = repo.create_element("Block", name="A")
+    b2 = repo.create_element("Block", name="B")
+    bdd.objects = [
+        {"obj_id": 1, "obj_type": "Block", "element_id": b1.elem_id, "properties": {"name": "A"}},
+        {"obj_id": 2, "obj_type": "Block", "element_id": b2.elem_id, "properties": {"name": "B"}},
+    ]
+    bdd.connections = [{"src": 1, "dst": 2, "conn_type": "Association"}]
+    reqs = repo.generate_requirements(bdd.diag_id)
+    assert reqs == [("A shall be connected to B.", "functional")]


### PR DESCRIPTION
## Summary
- Produce `vehicle` requirements when generating from SysML activity diagrams
- Harden phase and lifecycle requirement generation against minimal repository stubs
- Test SysML requirement typing and non-activity diagram behavior

## Testing
- `pytest tests/test_sysml_requirements.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1241f6c30832785822facc6349c8a