### PR TITLE
Fix tab detachment in notebook widget

### DIFF
--- a/gui/closable_notebook.py
+++ b/gui/closable_notebook.py
@@ -76,6 +76,28 @@ class ClosableNotebook(ttk.Notebook):
         self.bind("<B1-Motion>", self._on_motion)
         self.bind("<ButtonRelease-1>", self._on_release, True)
 
+    # ------------------------------------------------------------------
+    # Backwards compatible helpers
+    # ------------------------------------------------------------------
+    #
+    # Older code as well as the unit tests in this repository expect the
+    # notebook to expose ``_on_tab_press`` and ``_on_tab_release`` methods
+    # that behave like the bound event handlers above.  The original file
+    # was refactored to use the shorter ``_on_press``/``_on_release`` names
+    # but the helper methods were accidentally dropped.  Without them the
+    # tests fail with ``AttributeError`` and dragging a tab programmatically
+    # is impossible.  Provide tiny wrappers so the old API continues to
+    # work.
+
+    def _on_tab_press(self, event: tk.Event) -> str | None:  # pragma: no cover - thin wrapper
+        return self._on_press(event)
+
+    def _on_tab_release(self, event: tk.Event) -> None:  # pragma: no cover - thin wrapper
+        self._on_release(event)
+
+    def _on_tab_motion(self, event: tk.Event) -> None:  # pragma: no cover - thin wrapper
+        self._on_motion(event)
+
     def _create_close_image(self, size: int = 10) -> tk.PhotoImage:
         img = tk.PhotoImage(width=size, height=size)
         img.put("white", to=(0, 0, size - 1, size - 1))
@@ -182,11 +204,13 @@ class ClosableNotebook(ttk.Notebook):
         win.geometry(f"{width}x{height}+{x}+{y}")
         nb = ClosableNotebook(win)
         nb.pack(expand=True, fill="both")
+        # ``tk::unsupported::reparent`` requires the target widget to be
+        # realised.  Without updating the new notebook window here the tab
+        # ends up detached into an empty toplevel and cannot be re-attached
+        # later.  Ensuring the window exists before moving the tab fixes the
+        # behaviour and mirrors how Tk handles normal drag operations.
+        nb.update_idletasks()
         self._move_tab(tab_id, nb)
-
-    def _reset_drag(self) -> None:
-        self._drag_data = {"tab": None, "x": 0, "y": 0}
-        self._dragging = False
 
     def _reset_drag(self) -> None:
         self._drag_data = {"tab": None, "x": 0, "y": 0}


### PR DESCRIPTION
## Summary
- restore compatibility wrappers for `_on_tab_*` methods
- ensure detached notebooks are realised before moving tabs
- clean up duplicate drag reset logic

## Testing
- `pytest tests/test_tab_detach.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a124430e688327a764c83480b3e7e6