### PR TITLE
Ensure detached tabs stay within screen bounds

### DIFF
--- a/gui/closable_notebook.py
+++ b/gui/closable_notebook.py
@@ -201,6 +201,10 @@ class ClosableNotebook(ttk.Notebook):
         width = self.winfo_width() or 200
         height = self.winfo_height() or 200
         win = tk.Toplevel(self)
+        screen_w = win.winfo_screenwidth()
+        screen_h = win.winfo_screenheight()
+        x = max(min(x, screen_w - width), 0)
+        y = max(min(y, screen_h - height), 0)
         win.geometry(f"{width}x{height}+{x}+{y}")
         nb = ClosableNotebook(win)
         nb.pack(expand=True, fill="both")

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -24,13 +24,19 @@ def test_tab_detach_and_reattach():
     nb._on_tab_press(press)
     nb._dragging = True
     release = Event()
-    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
-    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+    release.x_root = 10000
+    release.y_root = 10000
     nb._on_tab_release(release)
 
     assert len(nb.tabs()) == 0
     new_nb = frame.master
     assert isinstance(new_nb, ClosableNotebook)
+    new_win = new_nb.winfo_toplevel()
+    new_win.update_idletasks()
+    screen_w = new_win.winfo_screenwidth()
+    screen_h = new_win.winfo_screenheight()
+    assert 0 <= new_win.winfo_x() <= screen_w - new_win.winfo_width()
+    assert 0 <= new_win.winfo_y() <= screen_h - new_win.winfo_height()
 
     press2 = Event(); press2.x = 5; press2.y = 5
     new_nb._on_tab_press(press2)


### PR DESCRIPTION
## Summary
- Keep detached notebook tabs fully visible by constraining the new window to screen bounds
- Test that detached tab windows open within the visible screen area

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a12708f4f8832797ab460959928990