### PR TITLE
Fix relation icon arrowhead shape

### DIFF
--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -105,11 +105,14 @@ def create_icon(
         img.put(outline, (size - 1, mid))
     elif shape == "relation":
         mid = size // 2
-        for x in range(2, size - 4):
+        # Draw a line with an open arrow head on the left. A previous revision
+        # inadvertently inverted the arrow head so the tip appeared wide instead
+        # of pointed. Draw the head with its tip at x=0.
+        for x in range(4, size - 2):
             img.put(c, (x, mid))
         for i in range(4):
-            img.put(c, (size - 4 + i, mid - i))
-            img.put(c, (size - 4 + i, mid + i))
+            img.put(c, (i, mid - i))
+            img.put(c, (i, mid + i))
     elif shape == "triangle":
         mid = size // 2
         height = size - 4

--- a/tests/test_relation_icon_orientation.py
+++ b/tests/test_relation_icon_orientation.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import gui.icon_factory as icons
+
+
+def test_relation_icon_arrowhead_shape(monkeypatch):
+    class DummyImage:
+        def __init__(self, *args, **kwargs):
+            self.coords = set()
+        def put(self, color, pos=None, to=None):
+            if pos is not None:
+                self.coords.add(pos)
+            else:
+                x1, y1, x2, y2 = to
+                for x in range(x1, x2):
+                    for y in range(y1, y2):
+                        self.coords.add((x, y))
+    monkeypatch.setattr(icons.tk, "PhotoImage", DummyImage)
+    img = icons.create_icon("relation", "black")
+    mid = 16 // 2
+    left_head = {(i, mid - i) for i in range(4)} | {(i, mid + i) for i in range(4)}
+    inverted_head = {(3 - i, mid - i) for i in range(4)} | {(3 - i, mid + i) for i in range(4)}
+    right_head = {(16 - 4 + i, mid - i) for i in range(1, 4)} | {(16 - 4 + i, mid + i) for i in range(1, 4)}
+    assert left_head <= img.coords
+    assert not any(pt in img.coords for pt in inverted_head | right_head)


### PR DESCRIPTION
## Summary
- Draw relation icons with a correctly pointed arrowhead on the left side
- Add regression test ensuring the arrowhead tip is not inverted

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a126bef8e483279ca7c5b6d0ec084d