### PR TITLE
Use 'from' in field data collection requirement templates

### DIFF
--- a/analysis/requirement_rule_generator.py
+++ b/analysis/requirement_rule_generator.py
@@ -166,9 +166,18 @@ def make_trigger(prefix: str, src: str, rel: str, tgt: str) -> str:
 
 
 def make_sa_template(subject: str, action: str) -> str:
-    return tidy_sentence(
-        f"{subject} shall {action} the <target_id> (<target_class>) using the <source_id> (<source_class>)."
-    )
+    action_clean = (action or "").strip()
+    if action_clean.lower() == "collect field data":
+        tmpl = (
+            f"{subject} shall {action_clean} from the <target_id> (<target_class>) "
+            f"using the <source_id> (<source_class>)."
+        )
+    else:
+        tmpl = (
+            f"{subject} shall {action_clean} the <target_id> (<target_class>) "
+            f"using the <source_id> (<source_class>)."
+        )
+    return tidy_sentence(tmpl)
 
 
 def make_sa_variables_base() -> List[str]:

--- a/config/requirement_patterns.json
+++ b/config/requirement_patterns.json
@@ -4914,7 +4914,7 @@
   {
     "Pattern ID": "SA-field_data_collection-Database-Data_acquisition",
     "Trigger": "Safety&AI: Database --[Field data collection]--> Data acquisition",
-    "Template": "Engineering team shall collect field data the <target_id> (<target_class>) using the <source_id> (<source_class>).",
+    "Template": "Engineering team shall collect field data from the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
       "<source_class>",
@@ -4927,7 +4927,7 @@
   {
     "Pattern ID": "SA-field_data_collection-Database-Data_acquisition-COND",
     "Trigger": "Safety&AI: Database --[Field data collection]--> Data acquisition",
-    "Template": "When <condition>, Engineering team shall collect field data the <target_id> (<target_class>) using the <source_id> (<source_class>).",
+    "Template": "When <condition>, Engineering team shall collect field data from the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
       "<source_class>",
@@ -4941,7 +4941,7 @@
   {
     "Pattern ID": "SA-field_data_collection-Database-Data_acquisition-COND-CONST",
     "Trigger": "Safety&AI: Database --[Field data collection]--> Data acquisition",
-    "Template": "When <condition>, Engineering team shall collect field data the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
+    "Template": "When <condition>, Engineering team shall collect field data from the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
       "<source_class>",
@@ -4956,7 +4956,7 @@
   {
     "Pattern ID": "SA-field_data_collection-Database-Data_acquisition-CONST",
     "Trigger": "Safety&AI: Database --[Field data collection]--> Data acquisition",
-    "Template": "Engineering team shall collect field data the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
+    "Template": "Engineering team shall collect field data from the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
       "<source_class>",
@@ -4970,7 +4970,7 @@
   {
     "Pattern ID": "SA-field_data_collection-Database-Task",
     "Trigger": "Safety&AI: Database --[Field data collection]--> Task",
-    "Template": "Engineering team shall collect field data the <target_id> (<target_class>) using the <source_id> (<source_class>).",
+    "Template": "Engineering team shall collect field data from the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
       "<source_class>",
@@ -4983,7 +4983,7 @@
   {
     "Pattern ID": "SA-field_data_collection-Database-Task-COND",
     "Trigger": "Safety&AI: Database --[Field data collection]--> Task",
-    "Template": "When <condition>, Engineering team shall collect field data the <target_id> (<target_class>) using the <source_id> (<source_class>).",
+    "Template": "When <condition>, Engineering team shall collect field data from the <target_id> (<target_class>) using the <source_id> (<source_class>).",
     "Variables": [
       "<source_id>",
       "<source_class>",
@@ -4997,7 +4997,7 @@
   {
     "Pattern ID": "SA-field_data_collection-Database-Task-COND-CONST",
     "Trigger": "Safety&AI: Database --[Field data collection]--> Task",
-    "Template": "When <condition>, Engineering team shall collect field data the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
+    "Template": "When <condition>, Engineering team shall collect field data from the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
       "<source_class>",
@@ -5012,7 +5012,7 @@
   {
     "Pattern ID": "SA-field_data_collection-Database-Task-CONST",
     "Trigger": "Safety&AI: Database --[Field data collection]--> Task",
-    "Template": "Engineering team shall collect field data the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
+    "Template": "Engineering team shall collect field data from the <target_id> (<target_class>) using the <source_id> (<source_class>) constrained by <constraint>.",
     "Variables": [
       "<source_id>",
       "<source_class>",

--- a/tests/test_requirement_rule_generator.py
+++ b/tests/test_requirement_rule_generator.py
@@ -41,3 +41,24 @@ def test_reload_config_updates_patterns(tmp_path: Path, monkeypatch) -> None:
     governance.reload_config()
     ids = {p["Pattern ID"] for p in governance._PATTERN_DEFS}
     assert "SA-augmentation-ANN-Database" in ids
+
+
+def test_field_data_collection_uses_from() -> None:
+    cfg = {
+        "requirement_rules": {
+            "field data collection": {
+                "action": "collect field data",
+                "subject": "Engineering team",
+            }
+        },
+        "safety_ai_relation_rules": {
+            "Field data collection": {"Database": ["Data acquisition"]}
+        },
+    }
+    patterns = generate_patterns_from_config(cfg)
+    tmpl = next(
+        p["Template"]
+        for p in patterns
+        if p["Pattern ID"] == "SA-field_data_collection-Database-Data_acquisition"
+    )
+    assert "collect field data from the <target_id>" in tmpl


### PR DESCRIPTION
## Summary
- ensure Safety & AI rule generator uses "from" for field data collection targets
- regenerate requirement pattern templates to reflect updated wording
- add regression test for field data collection template

## Testing
- `pytest tests/test_requirement_rule_generator.py tests/test_relation_direction.py tests/test_diagram_rules_requirement_mappings.py`

------
https://chatgpt.com/codex/tasks/task_b_68a130eb70fc8327a156a7c7e0914a2d