### PR TITLE
Enable multiline cells in table views

### DIFF
--- a/gui/safety_case_table.py
+++ b/gui/safety_case_table.py
@@ -8,6 +8,7 @@ from tkinter import ttk, simpledialog
 from analysis.constants import CHECK_MARK
 from analysis.safety_case import SafetyCase
 from gui import messagebox
+from gui.toolboxes import configure_table_style, _wrap_val
 
 
 try:  # pragma: no cover - fallback if AutoML isn't fully imported yet
@@ -45,7 +46,14 @@ class SafetyCaseTable(tk.Frame):
             "notes",
         )
         self.columns = columns
-        self.tree = ttk.Treeview(self, columns=columns, show="headings")
+        style_name = "SafetyCase.Treeview"
+        try:
+            configure_table_style(style_name, rowheight=80)
+            self.tree = ttk.Treeview(
+                self, columns=columns, show="headings", style=style_name
+            )
+        except Exception:
+            self.tree = ttk.Treeview(self, columns=columns, show="headings")
         headers = {
             "solution": "Solution",
             "description": "Description",
@@ -138,15 +146,17 @@ class SafetyCaseTable(tk.Frame):
                 "",
                 "end",
                 values=(
-                    sol.user_name,
-                    getattr(sol, "description", ""),
-                    getattr(sol, "work_product", ""),
-                    getattr(sol, "evidence_link", ""),
-                    v_target,
-                    prob,
-                    spi_val,
-                    CHECK_MARK if getattr(sol, "evidence_sufficient", False) else "",
-                    getattr(sol, "manager_notes", ""),
+                    _wrap_val(sol.user_name),
+                    _wrap_val(getattr(sol, "description", ""), 40),
+                    _wrap_val(getattr(sol, "work_product", "")),
+                    _wrap_val(getattr(sol, "evidence_link", ""), 40),
+                    _wrap_val(v_target),
+                    _wrap_val(prob),
+                    _wrap_val(spi_val),
+                    _wrap_val(
+                        CHECK_MARK if getattr(sol, "evidence_sufficient", False) else ""
+                    ),
+                    _wrap_val(getattr(sol, "manager_notes", ""), 40),
                 ),
                 tags=(sol.unique_id,),
             )

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -13,6 +13,7 @@ from analysis.models import (
 from gui.architecture import GovernanceDiagramWindow
 from gui import messagebox
 from sysml.sysml_repository import SysMLRepository
+from gui.toolboxes import configure_table_style, _wrap_val
 
 
 class SafetyManagementWindow(tk.Frame):
@@ -245,7 +246,14 @@ class SafetyManagementWindow(tk.Frame):
             child.destroy()
         columns = ("ID", "Type", "Text", "Phase", "Status")
         tree_frame = ttk.Frame(frame)
-        tree = ttk.Treeview(tree_frame, columns=columns, show="headings")
+        style_name = "Requirements.Treeview"
+        try:
+            configure_table_style(style_name, rowheight=80)
+            tree = ttk.Treeview(
+                tree_frame, columns=columns, show="headings", style=style_name
+            )
+        except Exception:
+            tree = ttk.Treeview(tree_frame, columns=columns, show="headings")
         for c in columns:
             tree.heading(c, text=c)
 
@@ -257,11 +265,11 @@ class SafetyManagementWindow(tk.Frame):
                     "",
                     "end",
                     values=(
-                        rid,
-                        req.get("req_type", ""),
-                        req.get("text", ""),
-                        req.get("phase") or "",
-                        req.get("status", ""),
+                        _wrap_val(rid),
+                        _wrap_val(req.get("req_type", "")),
+                        _wrap_val(req.get("text", ""), 60),
+                        _wrap_val(req.get("phase") or ""),
+                        _wrap_val(req.get("status", "")),
                     ),
                 )
 


### PR DESCRIPTION
## Summary
- allow requirement tables to wrap cell content and use taller rows
- make safety case table display multiline values in all columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1341129788327bca522a872872c6e