### PR TITLE
Expand product goals matrix with full attributes

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -14062,21 +14062,60 @@ class FaultTreeApp:
             return
         self._sg_matrix_tab = self._new_tab("Product Goals Matrix")
         win = self._sg_matrix_tab
-        columns = ["ID", "ASIL", "Target PMHF", "CAL", "SafeState", "Text"]
+        columns = [
+            "ID",
+            "ASIL",
+            "Target PMHF",
+            "CAL",
+            "SafeState",
+            "FTTI",
+            "Acc Rate",
+            "On Hours",
+            "Val Target",
+            "Profile",
+            "Val Desc",
+            "Acceptance",
+            "Description",
+            "Text",
+        ]
         tree = ttk.Treeview(win, columns=columns, show="tree headings")
         tree.heading("ID", text="Requirement ID")
         tree.heading("ASIL", text="ASIL")
         tree.heading("Target PMHF", text="Target PMHF (1/h)")
         tree.heading("CAL", text="CAL")
         tree.heading("SafeState", text="Safe State")
+        tree.heading("FTTI", text="FTTI")
+        tree.heading("Acc Rate", text="Acc Rate (1/h)")
+        tree.heading("On Hours", text="On Hours")
+        tree.heading("Val Target", text="Val Target")
+        tree.heading("Profile", text="Profile")
+        tree.heading("Val Desc", text="Val Desc")
+        tree.heading("Acceptance", text="Acceptance")
+        tree.heading("Description", text="Description")
         tree.heading("Text", text="Text")
         tree.column("ID", width=120)
         tree.column("ASIL", width=60)
         tree.column("Target PMHF", width=120)
         tree.column("CAL", width=60)
         tree.column("SafeState", width=100)
+        tree.column("FTTI", width=80)
+        tree.column("Acc Rate", width=100)
+        tree.column("On Hours", width=100)
+        tree.column("Val Target", width=120)
+        tree.column("Profile", width=120)
+        tree.column("Val Desc", width=200)
+        tree.column("Acceptance", width=200)
+        tree.column("Description", width=200)
         tree.column("Text", width=300)
-        tree.pack(fill=tk.BOTH, expand=True)
+
+        vsb = ttk.Scrollbar(win, orient="vertical", command=tree.yview)
+        hsb = ttk.Scrollbar(win, orient="horizontal", command=tree.xview)
+        tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        win.columnconfigure(0, weight=1)
+        win.rowconfigure(0, weight=1)
 
         for te in self.top_events:
             sg_text = te.safety_goal_description or (te.user_name or f"SG {te.unique_id}")
@@ -14085,14 +14124,24 @@ class FaultTreeApp:
             asil = te.safety_goal_asil or "QM"
             target = PMHF_TARGETS.get(asil, 1.0)
             parent_iid = tree.insert(
-                "", "end", text=sg_text,
+                "",
+                "end",
+                text=sg_text,
                 values=[
                     sg_id,
                     te.safety_goal_asil,
                     f"{target:.1e}",
                     cal,
                     te.safe_state,
+                    getattr(te, "ftti", ""),
+                    str(getattr(te, "acceptance_rate", "")),
+                    getattr(te, "operational_hours_on", ""),
+                    getattr(te, "validation_target", ""),
+                    getattr(te, "mission_profile", ""),
+                    getattr(te, "validation_desc", ""),
+                    getattr(te, "acceptance_criteria", ""),
                     sg_text,
+                    "",
                 ],
             )
             reqs = self.collect_requirements_recursive(te)
@@ -14109,6 +14158,14 @@ class FaultTreeApp:
                     values=[
                         req_id,
                         req.get("asil", ""),
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
                         "",
                         "",
                         "",

--- a/tests/test_gui_classes.py
+++ b/tests/test_gui_classes.py
@@ -30,5 +30,23 @@ class DoubleClickBindingTests(unittest.TestCase):
         src = inspect.getsource(FaultTreeApp.show_product_goals_editor)
         self.assertIn('bind("<Double-1>"', src)
 
+
+class ProductGoalsMatrixTests(unittest.TestCase):
+    def test_matrix_has_all_columns_and_scrollbars(self):
+        src = inspect.getsource(FaultTreeApp.show_safety_goals_matrix)
+        for col in [
+            'FTTI',
+            'Acc Rate',
+            'On Hours',
+            'Val Target',
+            'Profile',
+            'Val Desc',
+            'Acceptance',
+            'Description',
+        ]:
+            self.assertIn(col, src)
+        self.assertIn('xscrollcommand', src)
+        self.assertIn('yscrollcommand', src)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Extend Product Goals Matrix to display all product goal attributes.
- Add horizontal and vertical scrollbars for easier navigation with many goals.
- Test coverage ensures matrix code includes new columns and scrollbars.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1353584348327a577b00d7ee5d7e2