### PR TITLE
feat: add search toolbox and menu

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -243,6 +243,7 @@ from gui.review_toolbox import (
     ReviewDocumentDialog,
     VersionCompareDialog,
 )
+from gui.search_toolbox import SearchToolbox
 from functools import partial
 from gui.safety_management_toolbox import SafetyManagementToolbox
 from gui.gsn_explorer import GSNExplorer
@@ -2383,6 +2384,12 @@ class FaultTreeApp:
         edit_menu.add_command(label="Edit Severity", command=self.edit_severity, accelerator="Ctrl+E")
         edit_menu.add_command(label="Edit Controllability", command=self.edit_controllability)
         edit_menu.add_command(label="Edit Page Flag", command=self.edit_page_flag)
+        search_menu = tk.Menu(menubar, tearoff=0)
+        search_menu.add_command(
+            label="Find...",
+            command=self.open_search_toolbox,
+            accelerator="Ctrl+F",
+        )
         process_menu = tk.Menu(menubar, tearoff=0)
         process_menu.add_command(label="Calc Prototype Assurance Level (PAL)", command=self.calculate_overall, accelerator="Ctrl+R")
         process_menu.add_command(label="Calc PMHF", command=self.calculate_pmfh, accelerator="Ctrl+M")
@@ -2619,6 +2626,7 @@ class FaultTreeApp:
         # Add menus to the bar in the desired order
         menubar.add_cascade(label="File", menu=file_menu)
         menubar.add_cascade(label="Edit", menu=edit_menu)
+        menubar.add_cascade(label="Search", menu=search_menu)
         menubar.add_cascade(label="View", menu=view_menu)
         menubar.add_cascade(label="Requirements", menu=requirements_menu)
         menubar.add_cascade(label="Architecture", menu=architecture_menu)
@@ -2664,6 +2672,7 @@ class FaultTreeApp:
         root.bind("<Control-m>", lambda event: self.calculate_pmfh())
         root.bind("<Control-=>", lambda event: self.zoom_in())
         root.bind("<Control-minus>", lambda event: self.zoom_out())
+        root.bind("<Control-f>", lambda event: self.open_search_toolbox())
         root.bind("<Control-u>", lambda event: self.edit_user_name())
         root.bind("<Control-d>", lambda event: self.edit_description())
         root.bind("<Control-l>", lambda event: self.edit_rationale())
@@ -19816,6 +19825,16 @@ class FaultTreeApp:
             self.review_window.pack(fill=tk.BOTH, expand=True)
         self.refresh_all()
         self.set_current_user()
+
+    def open_search_toolbox(self):
+        """Open the search toolbox in a new tab or focus existing one."""
+        if hasattr(self, "_search_tab") and getattr(self._search_tab, "winfo_exists", lambda: 0)():
+            self.doc_nb.select(self._search_tab)
+            return
+        self._search_tab = self._new_tab("Search")
+        self.search_window = SearchToolbox(self._search_tab, self)
+        self.search_window.pack(fill=tk.BOTH, expand=True)
+        self.doc_nb.select(self._search_tab)
 
     def send_review_email(self, review):
         """Send the review summary to all reviewers via configured SMTP."""

--- a/gui/search_toolbox.py
+++ b/gui/search_toolbox.py
@@ -1,0 +1,104 @@
+import tkinter as tk
+from tkinter import ttk
+import re
+from sysml.sysml_repository import SysMLRepository
+
+
+def search_repository(repo: SysMLRepository, pattern: str, *, case_sensitive: bool = False,
+                      use_regex: bool = False, in_names: bool = True,
+                      in_descriptions: bool = True):
+    """Return list of repo items matching *pattern*.
+
+    Parameters
+    ----------
+    repo: SysMLRepository
+        Repository to search.
+    pattern: str
+        Text or regular expression to look for.
+    case_sensitive: bool
+        Whether matching should be case sensitive.
+    use_regex: bool
+        Interpret *pattern* as a regular expression.
+    in_names: bool
+        Search element and diagram names.
+    in_descriptions: bool
+        Search element properties["description"] and diagram descriptions.
+    """
+    results = []
+    if not pattern:
+        return results
+    flags = 0 if case_sensitive else re.IGNORECASE
+    if use_regex:
+        try:
+            regex = re.compile(pattern, flags)
+        except re.error:
+            return results
+        matcher = lambda text: bool(regex.search(text))
+    else:
+        comp = pattern if case_sensitive else pattern.lower()
+        def matcher(text):
+            target = text if case_sensitive else text.lower()
+            return comp in target
+    for elem_id, elem in repo.elements.items():
+        texts = []
+        if in_names:
+            texts.append(elem.name or "")
+        if in_descriptions:
+            texts.append(elem.properties.get("description", ""))
+        if any(matcher(t) for t in texts if t):
+            results.append(("element", elem_id, elem.display_name()))
+    for diag_id, diag in repo.diagrams.items():
+        texts = []
+        if in_names:
+            texts.append(diag.name or "")
+        if in_descriptions:
+            texts.append(diag.description or "")
+        if any(matcher(t) for t in texts if t):
+            results.append(("diagram", diag_id, diag.display_name()))
+    return results
+
+
+class SearchToolbox(tk.Frame):
+    """Simple toolbox providing repository search similar to IDE search."""
+
+    def __init__(self, master=None, app=None):
+        super().__init__(master)
+        self.app = app
+        self.repo = SysMLRepository.get_instance()
+
+        opts = tk.Frame(self)
+        opts.pack(fill=tk.X, padx=4, pady=4)
+
+        tk.Label(opts, text="Find:").pack(side=tk.LEFT)
+        self.pattern_var = tk.StringVar()
+        tk.Entry(opts, textvariable=self.pattern_var, width=30).pack(side=tk.LEFT, padx=4)
+        tk.Button(opts, text="Search", command=self.perform_search).pack(side=tk.LEFT)
+
+        self.case_var = tk.BooleanVar()
+        self.regex_var = tk.BooleanVar()
+        self.names_var = tk.BooleanVar(value=True)
+        self.desc_var = tk.BooleanVar(value=True)
+
+        tk.Checkbutton(opts, text="Match case", variable=self.case_var).pack(side=tk.LEFT, padx=4)
+        tk.Checkbutton(opts, text="Regex", variable=self.regex_var).pack(side=tk.LEFT)
+        tk.Checkbutton(opts, text="Names", variable=self.names_var).pack(side=tk.LEFT, padx=4)
+        tk.Checkbutton(opts, text="Descriptions", variable=self.desc_var).pack(side=tk.LEFT)
+
+        self.tree = ttk.Treeview(self, columns=("type", "name"), show="headings")
+        self.tree.heading("type", text="Type")
+        self.tree.heading("name", text="Name")
+        self.tree.pack(fill=tk.BOTH, expand=True, padx=4, pady=4)
+
+    def perform_search(self):
+        pattern = self.pattern_var.get()
+        results = search_repository(
+            self.repo,
+            pattern,
+            case_sensitive=self.case_var.get(),
+            use_regex=self.regex_var.get(),
+            in_names=self.names_var.get(),
+            in_descriptions=self.desc_var.get(),
+        )
+        self.tree.delete(*self.tree.get_children())
+        for typ, _id, name in results:
+            self.tree.insert("", tk.END, values=(typ, name))

--- a/tests/test_search_toolbox.py
+++ b/tests/test_search_toolbox.py
@@ -1,0 +1,27 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.search_toolbox import search_repository
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_search_repository_matches_names_and_descriptions():
+    repo = SysMLRepository.reset_instance()
+    e1 = repo.create_element("Block", name="Controller", properties={"description": "controls things"})
+    e2 = repo.create_element("Block", name="sensor", properties={"description": "temperature sensor"})
+    d1 = repo.create_diagram("UseCase", name="Main", description="main scenario")
+
+    res = search_repository(repo, "controller")
+    assert ("element", e1.elem_id, e1.display_name()) in res
+
+    res = search_repository(repo, "scenario")
+    assert ("diagram", d1.diag_id, d1.display_name()) in res
+
+    res = search_repository(repo, "Sensor", case_sensitive=True)
+    assert ("element", e2.elem_id, e2.display_name()) not in res
+
+    res = search_repository(repo, "sens[oa]r", use_regex=True)
+    assert ("element", e2.elem_id, e2.display_name()) in res


### PR DESCRIPTION
## Summary
- add a searchable toolbox with regex and case-sensitive options
- expose search via new Search menu and Ctrl+F shortcut

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a13a45364c8327ba6bbcd0534ab89d