### PR TITLE
Handle missing config files in bundled executables

### DIFF
--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 import json
 import re
+import importlib.resources as resources
 
 
 def _ensure_list_of_strings(val: Any, name: str) -> None:
@@ -279,7 +280,15 @@ def _strip_comments(text: str) -> str:
 def load_json_with_comments(path: str | Path) -> Any:
     """Load a JSON file allowing // and /* */ comments and trailing commas."""
     p = Path(path)
-    text = _strip_comments(p.read_text())
+    try:
+        text = _strip_comments(p.read_text())
+    except FileNotFoundError:
+        # When running from a bundled executable the configuration files may be
+        # packaged as importlib resources.  Attempt to load the file from the
+        # corresponding package if it is not found on disk.
+        pkg = p.parent.name
+        with resources.as_file(resources.files(pkg) / p.name) as res:
+            text = _strip_comments(res.read_text())
     # Remove trailing commas left after comment stripping
     text = re.sub(r",\s*(?=[}\]])", "", text)
     return json.loads(text)


### PR DESCRIPTION
## Summary
- Add fallback to load JSON config files from package resources when not found on disk
- Import `importlib.resources` in `config_loader` to support PyInstaller bundles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a14076a2a48327a98ea48d66475332