### PR TITLE
Search across nodes, connections, and hazards

### DIFF
--- a/gui/search_toolbox.py
+++ b/gui/search_toolbox.py
@@ -23,6 +23,10 @@ class SearchToolbox(tk.Toplevel):
         self.search_var = tk.StringVar()
         self.case_var = tk.BooleanVar(value=False)
         self.regex_var = tk.BooleanVar(value=False)
+        self.nodes_var = tk.BooleanVar(value=True)
+        self.connections_var = tk.BooleanVar(value=True)
+        self.failures_var = tk.BooleanVar(value=True)
+        self.hazards_var = tk.BooleanVar(value=True)
         # each result is a mapping with keys: 'label' and 'open'
         self.results: list[dict[str, object]] = []
         self.current_index: int = -1
@@ -54,12 +58,19 @@ class SearchToolbox(tk.Toplevel):
             side=tk.LEFT
         )
 
+        sources = ttk.Frame(frame)
+        sources.grid(row=2, column=0, columnspan=5, sticky="w", pady=(4, 0))
+        ttk.Checkbutton(sources, text="Nodes", variable=self.nodes_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Connections", variable=self.connections_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Failures", variable=self.failures_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Hazards", variable=self.hazards_var).pack(side=tk.LEFT)
+
         self.results_box = tk.Listbox(frame, height=10)
-        self.results_box.grid(row=2, column=0, columnspan=5, sticky="nsew", pady=(8, 0))
+        self.results_box.grid(row=3, column=0, columnspan=5, sticky="nsew", pady=(8, 0))
         self.results_box.bind("<Double-1>", self._open_selected)
 
         frame.columnconfigure(1, weight=1)
-        frame.rowconfigure(2, weight=1)
+        frame.rowconfigure(3, weight=1)
 
         self.transient(master)
         self.grab_set()
@@ -94,71 +105,109 @@ class SearchToolbox(tk.Toplevel):
         self.results.clear()
         self.current_index = -1
 
-        # --- search fault tree / GSN nodes
-        for node in getattr(self.app, "get_all_nodes_in_model", lambda: [])():
-            text = f"{node.user_name}\n{getattr(node, 'description', '')}"
-            if regex.search(text):
-                label = (
-                    f"{type(node).__name__} ({getattr(node, 'node_type', '')}) - "
-                    f"{node.user_name} [{self._node_path(node)}]"
-                )
-                self.results_box.insert(tk.END, label)
-                self.results.append(
-                    {
-                        "label": label,
-                        "open": lambda n=node: self.app.open_page_diagram(
-                            getattr(n, "original", n)
-                        ),
-                    }
-                )
+        if self.nodes_var.get():
+            nodes = getattr(self.app, "get_all_nodes_in_model", lambda: [])()
+            for node in nodes:
+                text = f"{node.user_name}\n{getattr(node, 'description', '')}"
+                if regex.search(text):
+                    label = (
+                        f"{type(node).__name__} ({getattr(node, 'node_type', '')}) - "
+                        f"{node.user_name} [{self._node_path(node)}]"
+                    )
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda n=node: self.app.open_page_diagram(
+                                getattr(n, "original", n)
+                            ),
+                        }
+                    )
 
-        # --- search FMEA/FMDA entries
-        for entry in getattr(self.app, "get_all_fmea_entries", lambda: [])():
-            fields = [
-                getattr(entry, "user_name", ""),
-                getattr(entry, "description", ""),
-                getattr(entry, "fmea_effect", ""),
-                getattr(entry, "fmea_cause", ""),
-            ]
-            if regex.search("\n".join(fields)):
-                doc_name = ""
-                is_fmeda = False
-                target_doc = None
-                for doc in getattr(self.app, "fmeas", []):
-                    if entry in doc.get("entries", []):
-                        doc_name = doc.get("name", "FMEA")
-                        target_doc = doc
-                        break
-                else:
-                    for doc in getattr(self.app, "fmedas", []):
+        if self.connections_var.get():
+            connections = getattr(self.app, "get_all_connections", lambda: [])()
+            for conn in connections:
+                fields = [
+                    getattr(conn, "name", ""),
+                    getattr(conn, "conn_type", ""),
+                    " ".join(getattr(conn, "guard", []) or []),
+                ]
+                if regex.search("\n".join(fields)):
+                    label = f"{type(conn).__name__} - {getattr(conn, 'name', '')}"
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda c=conn: getattr(
+                                self.app, "open_connection", lambda *_: None
+                            )(c),
+                        }
+                    )
+
+        if self.failures_var.get():
+            entries = getattr(self.app, "get_all_fmea_entries", lambda: [])()
+            for entry in entries:
+                fields = [
+                    getattr(entry, "user_name", ""),
+                    getattr(entry, "description", ""),
+                    getattr(entry, "fmea_effect", ""),
+                    getattr(entry, "fmea_cause", ""),
+                ]
+                if regex.search("\n".join(fields)):
+                    doc_name = ""
+                    is_fmeda = False
+                    target_doc = None
+                    for doc in getattr(self.app, "fmeas", []):
                         if entry in doc.get("entries", []):
-                            doc_name = doc.get("name", "FMEDA")
+                            doc_name = doc.get("name", "FMEA")
                             target_doc = doc
-                            is_fmeda = True
                             break
-                label = (
-                    f"{type(entry).__name__} - {entry.user_name or entry.description}"
-                    f" [FMEA: {doc_name or 'Global'}]"
-                )
-                self.results_box.insert(tk.END, label)
-
-                def _open(entry=entry, doc=target_doc, fmeda=is_fmeda):
-                    self.app.show_fmea_table(doc, fmeda=fmeda)
-                    tree = getattr(self.app, "_fmea_tree", None)
-                    node_map = getattr(self.app, "_fmea_node_map", {})
-                    if tree and node_map:
-                        for iid, node in node_map.items():
-                            if node is entry:
-                                tree.selection_set(iid)
-                                tree.focus(iid)
-                                tree.see(iid)
+                    else:
+                        for doc in getattr(self.app, "fmedas", []):
+                            if entry in doc.get("entries", []):
+                                doc_name = doc.get("name", "FMEDA")
+                                target_doc = doc
+                                is_fmeda = True
                                 break
+                    label = (
+                        f"{type(entry).__name__} - {entry.user_name or entry.description}"
+                        f" [FMEA: {doc_name or 'Global'}]"
+                    )
+                    self.results_box.insert(tk.END, label)
 
-                self.results.append({"label": label, "open": _open})
+                    def _open(entry=entry, doc=target_doc, fmeda=is_fmeda):
+                        self.app.show_fmea_table(doc, fmeda=fmeda)
+                        tree = getattr(self.app, "_fmea_tree", None)
+                        node_map = getattr(self.app, "_fmea_node_map", {})
+                        if tree and node_map:
+                            for iid, node in node_map.items():
+                                if node is entry:
+                                    tree.selection_set(iid)
+                                    tree.focus(iid)
+                                    tree.see(iid)
+                                    break
+
+                    self.results.append({"label": label, "open": _open})
+
+        if self.hazards_var.get():
+            for hazard in getattr(self.app, "hazards", []):
+                if regex.search(hazard):
+                    label = f"Hazard - {hazard}"
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda h=hazard: getattr(
+                                self.app, "show_hazard_list", lambda *_: None
+                            )(),
+                        }
+                    )
 
         if self.results:
             self.current_index = 0
             self._open_index(0)
+        else:
+            messagebox.showinfo("Search", "No matches found.")
 
     # ------------------------------------------------------------------
     def _open_index(self, index: int) -> None:

--- a/tests/test_search_toolbox.py
+++ b/tests/test_search_toolbox.py
@@ -1,0 +1,122 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from gui import search_toolbox, messagebox  # noqa: E402
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, value):
+        self._value = value
+
+
+class DummyListbox:
+    def delete(self, *_args):
+        pass
+
+    def insert(self, *_args):
+        pass
+
+    def select_clear(self, *_args):
+        pass
+
+    def selection_set(self, *_args):
+        pass
+
+    def activate(self, *_args):
+        pass
+
+    def see(self, *_args):
+        pass
+
+    def curselection(self):
+        return []
+
+
+class DummyApp:
+    hazards: list[str] = []
+
+    def get_all_nodes_in_model(self):
+        return []
+
+    def get_all_fmea_entries(self):
+        return []
+
+    def get_all_connections(self):
+        return []
+
+
+class SearchToolboxTests(unittest.TestCase):
+    def _make_tb(self, app):
+        tb = search_toolbox.SearchToolbox.__new__(search_toolbox.SearchToolbox)
+        tb.app = app
+        tb.search_var = DummyVar()
+        tb.case_var = DummyVar(False)
+        tb.regex_var = DummyVar(False)
+        tb.nodes_var = DummyVar(True)
+        tb.connections_var = DummyVar(True)
+        tb.failures_var = DummyVar(True)
+        tb.hazards_var = DummyVar(True)
+        tb.results_box = DummyListbox()
+        tb.results = []
+        tb.current_index = -1
+        return tb
+
+    def test_notifies_on_no_results(self):
+        tb = self._make_tb(DummyApp())
+        tb.search_var.set("missing")
+        infos = []
+        with patch.object(messagebox, "showinfo", lambda *a: infos.append(a)):
+            tb._run_search()
+        self.assertTrue(infos, "User was not notified when no results found")
+        self.assertIn("No matches found", infos[0][1])
+
+    def test_search_hazards(self):
+        class HazardApp(DummyApp):
+            hazards = ["Fire", "Collision"]
+
+        tb = self._make_tb(HazardApp())
+        tb.nodes_var.set(False)
+        tb.connections_var.set(False)
+        tb.failures_var.set(False)
+        tb.hazards_var.set(True)
+        tb.search_var.set("Fire")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("Hazard - Fire", tb.results[0]["label"])
+
+    def test_search_connection_guard(self):
+        class Conn:
+            def __init__(self):
+                self.name = "linkA"
+                self.conn_type = "Flow"
+                self.guard = ["g1"]
+
+        class ConnApp(DummyApp):
+            def __init__(self):
+                self._conns = [Conn()]
+
+            def get_all_connections(self):
+                return self._conns
+
+        tb = self._make_tb(ConnApp())
+        tb.nodes_var.set(False)
+        tb.connections_var.set(True)
+        tb.failures_var.set(False)
+        tb.hazards_var.set(False)
+        tb.search_var.set("g1")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("linkA", tb.results[0]["label"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add toggles to include nodes, connections, failures, and hazards in searches
- scan connection names/guards and project hazard list for matches
- expand regression suite with hazard and connection search tests

## Testing
- `pytest tests/test_search_toolbox.py -q`
- `pytest tests/test_copy_paste_selection.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a145be822c83279e8e77051b520b5e