### PR TITLE
feat: make validation probabilities configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1505,7 +1505,10 @@ industry practice:
 | 4      | 1×10⁻¹    | –        | –        |
 
 Projects with empirical data may substitute more precise values, but these
-approximations provide a justified starting point when none are available.
+approximations provide a justified starting point when none are available. The
+probability associated with each rating can be adjusted under **Project
+Properties → Validation Probabilities** and is persisted in the project's JSON
+file.
 
 These acceptance criteria and validation targets form the baseline for Safety
 Performance Indicators. Observed safety or AI metrics are traced back to these

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -16,6 +16,36 @@ CONTROLLABILITY_PROBABILITIES = {1: 1e-3, 2: 1e-2, 3: 1e-1}
 SEVERITY_PROBABILITIES = {1: 1e-3, 2: 1e-2, 3: 1e-1}
 
 
+def update_probability_tables(
+    exposure: dict | None = None,
+    controllability: dict | None = None,
+    severity: dict | None = None,
+) -> None:
+    """Replace default probability mappings with values from *exposure*,
+    *controllability* and *severity*.
+
+    Each argument should be a mapping from rating level to probability. Missing
+    arguments leave the current mapping unchanged. The dictionaries are updated
+    in-place so references held elsewhere remain valid.
+    """
+
+    if exposure is not None:
+        EXPOSURE_PROBABILITIES.clear()
+        EXPOSURE_PROBABILITIES.update(
+            {int(k): float(v) for k, v in dict(exposure).items()}
+        )
+    if controllability is not None:
+        CONTROLLABILITY_PROBABILITIES.clear()
+        CONTROLLABILITY_PROBABILITIES.update(
+            {int(k): float(v) for k, v in dict(controllability).items()}
+        )
+    if severity is not None:
+        SEVERITY_PROBABILITIES.clear()
+        SEVERITY_PROBABILITIES.update(
+            {int(k): float(v) for k, v in dict(severity).items()}
+        )
+
+
 def exposure_to_probability(level: int) -> float:
     """Return ``P(E|HB)`` for the given exposure rating.
 

--- a/tests/test_probability_config.py
+++ b/tests/test_probability_config.py
@@ -1,0 +1,23 @@
+from analysis.utils import (
+    exposure_to_probability,
+    controllability_to_probability,
+    severity_to_probability,
+    update_probability_tables,
+    EXPOSURE_PROBABILITIES,
+    CONTROLLABILITY_PROBABILITIES,
+    SEVERITY_PROBABILITIES,
+)
+
+
+def test_update_probability_tables():
+    defaults = (
+        EXPOSURE_PROBABILITIES.copy(),
+        CONTROLLABILITY_PROBABILITIES.copy(),
+        SEVERITY_PROBABILITIES.copy(),
+    )
+    update_probability_tables({1: 0.2}, {2: 0.3}, {3: 0.4})
+    assert exposure_to_probability(1) == 0.2
+    assert controllability_to_probability(2) == 0.3
+    assert severity_to_probability(3) == 0.4
+    # Restore defaults to avoid side effects
+    update_probability_tables(*defaults)


### PR DESCRIPTION
## Summary
- allow project properties to store exposure, controllability and severity probability mappings
- expose these probabilities in the Project Properties dialog for editing
- document and test configurable validation probability tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a150ad07508327a9f8af87c4bdf824