### PR TITLE
Add scrollbars to table widgets

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3271,8 +3271,10 @@ class SysMLDiagramWindow(tk.Frame):
 
         self.prop_frame = ttk.LabelFrame(self.toolbox, text="Properties")
         self.prop_frame.pack(fill=tk.BOTH, expand=True, padx=2, pady=2)
+        prop_view_frame = ttk.Frame(self.prop_frame)
+        prop_view_frame.pack(fill=tk.BOTH, expand=True)
         self.prop_view = ttk.Treeview(
-            self.prop_frame,
+            prop_view_frame,
             columns=("field", "value"),
             show="headings",
             height=8,
@@ -3281,7 +3283,14 @@ class SysMLDiagramWindow(tk.Frame):
         self.prop_view.heading("value", text="Value")
         self.prop_view.column("field", width=80, anchor="w")
         self.prop_view.column("value", width=120, anchor="w")
-        self.prop_view.pack(fill=tk.BOTH, expand=True)
+        vsb = ttk.Scrollbar(prop_view_frame, orient="vertical", command=self.prop_view.yview)
+        hsb = ttk.Scrollbar(prop_view_frame, orient="horizontal", command=self.prop_view.xview)
+        self.prop_view.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        self.prop_view.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        prop_view_frame.columnconfigure(0, weight=1)
+        prop_view_frame.rowconfigure(0, weight=1)
 
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -549,12 +549,20 @@ class CausalBayesianNetworkWindow(tk.Frame):
         )
         label = ttk.Label(frame, text=label_text)
         label.pack(side=tk.TOP, fill=tk.X)
-        tree = ttk.Treeview(frame, columns=cols, show="headings", height=0)
+        tree_frame = ttk.Frame(frame)
+        tree_frame.pack(side=tk.TOP, fill=tk.BOTH)
+        tree = ttk.Treeview(tree_frame, columns=cols, show="headings", height=0)
         for c in cols:
             tree.heading(c, text=c)
             is_prob = c == prob_col or (parents and c == joint_col)
             tree.column(c, width=80 if is_prob else 60, anchor=tk.CENTER)
-        tree.pack(side=tk.TOP, fill=tk.X)
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=tree.yview)
+        hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=tree.xview)
+        tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        tree_frame.columnconfigure(0, weight=1)
         if not parents:
             info = f"Prior probability that {name} is True"
         else:

--- a/gui/safety_case_table.py
+++ b/gui/safety_case_table.py
@@ -72,9 +72,11 @@ class SafetyCaseTable(tk.Frame):
                 width = 200
             self.tree.column(col, width=width, stretch=True, anchor="center")
         vsb = ttk.Scrollbar(self, orient="vertical", command=self.tree.yview)
-        self.tree.configure(yscrollcommand=vsb.set)
+        hsb = ttk.Scrollbar(self, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
         self.tree.grid(row=0, column=0, sticky="nsew")
         vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)
 

--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -71,18 +71,24 @@ class ThreatDialog(simpledialog.Dialog):
         )
 
         configure_table_style("Threat.Functions.Treeview")
+        func_frame = ttk.Frame(asset_tab)
+        func_frame.grid(row=2, column=0, sticky="nsew", padx=2)
+        func_frame.columnconfigure(0, weight=1)
+        func_frame.rowconfigure(0, weight=1)
         self.func_tree = ttk.Treeview(
-            asset_tab,
+            func_frame,
             columns=("function",),
             show="headings",
             style="Threat.Functions.Treeview",
         )
         self.func_tree.heading("function", text="Function")
         self.func_tree.column("function", width=680, stretch=True)
-        self.func_tree.grid(row=2, column=0, sticky="nsew", padx=2)
-        fscroll = ttk.Scrollbar(asset_tab, orient="vertical", command=self.func_tree.yview)
-        self.func_tree.configure(yscrollcommand=fscroll.set)
-        fscroll.grid(row=2, column=1, sticky="ns")
+        fscroll_y = ttk.Scrollbar(func_frame, orient="vertical", command=self.func_tree.yview)
+        fscroll_x = ttk.Scrollbar(func_frame, orient="horizontal", command=self.func_tree.xview)
+        self.func_tree.configure(yscrollcommand=fscroll_y.set, xscrollcommand=fscroll_x.set)
+        self.func_tree.grid(row=0, column=0, sticky="nsew")
+        fscroll_y.grid(row=0, column=1, sticky="ns")
+        fscroll_x.grid(row=1, column=0, sticky="ew")
         self.func_tree.bind("<<TreeviewSelect>>", self.on_func_select)
         ttk.Button(asset_tab, text="Remove Function", command=self.remove_function).grid(
             row=3, column=0, sticky="w", padx=2, pady=2
@@ -96,6 +102,8 @@ class ThreatDialog(simpledialog.Dialog):
 
         ds_frame = ttk.Frame(asset_tab)
         ds_frame.grid(row=4, column=0, sticky="nsew")
+        ds_frame.columnconfigure(0, weight=1)
+        ds_frame.rowconfigure(0, weight=1)
         configure_table_style("Threat.Damage.Treeview")
         self.ds_tree = ttk.Treeview(
             ds_frame,
@@ -107,10 +115,12 @@ class ThreatDialog(simpledialog.Dialog):
         self.ds_tree.heading("type", text="Type")
         self.ds_tree.column("scenario", width=560, stretch=True)
         self.ds_tree.column("type", width=120, stretch=True)
-        self.ds_tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        ds_scroll = ttk.Scrollbar(ds_frame, orient="vertical", command=self.ds_tree.yview)
-        self.ds_tree.configure(yscrollcommand=ds_scroll.set)
-        ds_scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        ds_vsb = ttk.Scrollbar(ds_frame, orient="vertical", command=self.ds_tree.yview)
+        ds_hsb = ttk.Scrollbar(ds_frame, orient="horizontal", command=self.ds_tree.xview)
+        self.ds_tree.configure(yscrollcommand=ds_vsb.set, xscrollcommand=ds_hsb.set)
+        self.ds_tree.grid(row=0, column=0, sticky="nsew")
+        ds_vsb.grid(row=0, column=1, sticky="ns")
+        ds_hsb.grid(row=1, column=0, sticky="ew")
         self.ds_tree.bind("<<TreeviewSelect>>", self.on_ds_select)
 
         ds_edit = ttk.Frame(asset_tab)
@@ -154,8 +164,12 @@ class ThreatDialog(simpledialog.Dialog):
         ta_frame.rowconfigure(0, weight=1)
         ta_frame.rowconfigure(1, weight=1)
         configure_table_style("Threat.Scenarios.Treeview")
+        threat_frame = ttk.Frame(ta_frame)
+        threat_frame.grid(row=0, column=0, sticky="nsew")
+        threat_frame.columnconfigure(0, weight=1)
+        threat_frame.rowconfigure(0, weight=1)
         self.threat_tree = ttk.Treeview(
-            ta_frame,
+            threat_frame,
             columns=("stride", "scenario"),
             show="headings",
             style="Threat.Scenarios.Treeview",
@@ -165,24 +179,32 @@ class ThreatDialog(simpledialog.Dialog):
         self.threat_tree.column("stride", width=120, stretch=True)
         self.threat_tree.column("scenario", width=560, stretch=True)
         self.threat_tree.bind("<<TreeviewSelect>>", self.on_threat_select)
+        tscroll = ttk.Scrollbar(threat_frame, orient="vertical", command=self.threat_tree.yview)
+        th_hsb = ttk.Scrollbar(threat_frame, orient="horizontal", command=self.threat_tree.xview)
+        self.threat_tree.configure(yscrollcommand=tscroll.set, xscrollcommand=th_hsb.set)
         self.threat_tree.grid(row=0, column=0, sticky="nsew")
-        tscroll = ttk.Scrollbar(ta_frame, orient="vertical", command=self.threat_tree.yview)
-        self.threat_tree.configure(yscrollcommand=tscroll.set)
         tscroll.grid(row=0, column=1, sticky="ns")
+        th_hsb.grid(row=1, column=0, sticky="ew")
 
         configure_table_style("Threat.Paths.Treeview")
+        path_frame = ttk.Frame(ta_frame)
+        path_frame.grid(row=1, column=0, sticky="nsew")
+        path_frame.columnconfigure(0, weight=1)
+        path_frame.rowconfigure(0, weight=1)
         self.path_tree = ttk.Treeview(
-            ta_frame,
+            path_frame,
             columns=("path",),
             show="headings",
             style="Threat.Paths.Treeview",
         )
         self.path_tree.heading("path", text="Attack Path")
         self.path_tree.column("path", width=680, stretch=True)
-        self.path_tree.grid(row=1, column=0, sticky="nsew")
-        pscroll = ttk.Scrollbar(ta_frame, orient="vertical", command=self.path_tree.yview)
-        self.path_tree.configure(yscrollcommand=pscroll.set)
-        pscroll.grid(row=1, column=1, sticky="ns")
+        pscroll = ttk.Scrollbar(path_frame, orient="vertical", command=self.path_tree.yview)
+        phsb = ttk.Scrollbar(path_frame, orient="horizontal", command=self.path_tree.xview)
+        self.path_tree.configure(yscrollcommand=pscroll.set, xscrollcommand=phsb.set)
+        self.path_tree.grid(row=0, column=0, sticky="nsew")
+        pscroll.grid(row=0, column=1, sticky="ns")
+        phsb.grid(row=1, column=0, sticky="ew")
         self.path_tree.bind("<<TreeviewSelect>>", self.on_path_select)
 
         ts_edit = ttk.Frame(threat_tab)

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -61,9 +61,11 @@ class ThreatWindow(tk.Frame):
             width = 120 if col in {"asset", "functions", "type"} else 200
             self.tree.column(col, width=width, stretch=True)
         vsb = ttk.Scrollbar(content, orient="vertical", command=self.tree.yview)
-        self.tree.configure(yscrollcommand=vsb.set)
+        hsb = ttk.Scrollbar(content, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
         self.tree.grid(row=0, column=0, sticky="nsew")
         vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
         content.columnconfigure(0, weight=1)
         content.rowconfigure(0, weight=1)
         self.tree.bind("<Double-1>", self.on_double_click)

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -3978,8 +3978,10 @@ class HazardExplorerWindow(tk.Toplevel):
 
         columns = ("Assessment", "Malfunction", "Hazard", "Severity")
         configure_table_style("HazExp.Treeview")
+        tree_frame = ttk.Frame(self)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
         self.tree = EditableTreeview(
-            self,
+            tree_frame,
             columns=columns,
             show="headings",
             style="HazExp.Treeview",
@@ -3990,7 +3992,14 @@ class HazardExplorerWindow(tk.Toplevel):
             self.tree.heading(c, text=c)
             width = 200 if c == "Hazard" else 120
             self.tree.column(c, width=width)
-        self.tree.pack(fill=tk.BOTH, expand=True)
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        tree_frame.columnconfigure(0, weight=1)
+        tree_frame.rowconfigure(0, weight=1)
         ttk.Button(self, text="Export CSV", command=self.export_csv).pack(pady=5)
         self.refresh()
 
@@ -4137,8 +4146,10 @@ class RequirementsExplorerWindow(tk.Frame):
 
         self.columns = ("ID", "ASIL", "Type", "Status", "Parent", "Trace", "Links", "Text")
         configure_table_style("ReqExp.Treeview")
+        tree_frame = ttk.Frame(self)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
         self.tree = EditableTreeview(
-            self,
+            tree_frame,
             columns=self.columns,
             show="headings",
             style="ReqExp.Treeview",
@@ -4154,7 +4165,14 @@ class RequirementsExplorerWindow(tk.Frame):
             else:
                 width = 100
             self.tree.column(c, width=width)
-        self.tree.pack(fill=tk.BOTH, expand=True)
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.tree.yview)
+        hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.tree.xview)
+        self.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        tree_frame.columnconfigure(0, weight=1)
+        tree_frame.rowconfigure(0, weight=1)
         btnf = ttk.Frame(self)
         btnf.pack(pady=5)
         ttk.Button(btnf, text="Export CSV", command=self.export_csv).pack(side=tk.LEFT, padx=5)


### PR DESCRIPTION
## Summary
- Add vertical and horizontal scrollbars to property view in architecture toolbox
- Ensure threat analysis and explorer tables scroll in both directions
- Expand hazard, requirement, safety case, and probability tables with scrollbars for easier navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a1511bd86483279a08a513ae807773