### PR TITLE
Add scrollbars to GUI tables

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -7,11 +7,34 @@ from tkinter import ttk
 
 
 def format_name_with_phase(name: str, phase: str | None) -> str:
-    """Return ``name`` with ``" (phase)"`` appended when ``phase`` is set."""
+    """Return ``name`` with ``" (phase)"`` appended when ``phase")" is set."""
 
     if phase:
         return f"{name} ({phase})" if name else f"({phase})"
     return name
+
+
+def add_treeview_scrollbars(tree: ttk.Treeview, container: ttk.Widget | None = None) -> None:
+    """Attach both vertical and horizontal scrollbars to ``tree``.
+
+    Parameters
+    ----------
+    tree:
+        The ``ttk.Treeview`` widget to augment.
+    container:
+        Parent widget that should hold the tree and scrollbars. Defaults to
+        ``tree.master``.
+    """
+
+    container = container or tree.master
+    vsb = ttk.Scrollbar(container, orient="vertical", command=tree.yview)
+    hsb = ttk.Scrollbar(container, orient="horizontal", command=tree.xview)
+    tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+    tree.grid(row=0, column=0, sticky="nsew")
+    vsb.grid(row=0, column=1, sticky="ns")
+    hsb.grid(row=1, column=0, sticky="ew")
+    container.rowconfigure(0, weight=1)
+    container.columnconfigure(0, weight=1)
 
 
 # ---------------------------------------------------------------------------

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3,7 +3,7 @@ import tkinter as tk
 import tkinter.font as tkFont
 import textwrap
 from tkinter import ttk, simpledialog
-from gui import messagebox, format_name_with_phase
+from gui import messagebox, format_name_with_phase, add_treeview_scrollbars
 try:  # Guard against environments where the tooltip module is unavailable
     from gui.tooltip import ToolTip
 except Exception:  # pragma: no cover - fallback for minimal installs
@@ -3271,8 +3271,10 @@ class SysMLDiagramWindow(tk.Frame):
 
         self.prop_frame = ttk.LabelFrame(self.toolbox, text="Properties")
         self.prop_frame.pack(fill=tk.BOTH, expand=True, padx=2, pady=2)
+        prop_tree_frame = ttk.Frame(self.prop_frame)
+        prop_tree_frame.pack(fill=tk.BOTH, expand=True)
         self.prop_view = ttk.Treeview(
-            self.prop_frame,
+            prop_tree_frame,
             columns=("field", "value"),
             show="headings",
             height=8,
@@ -3281,7 +3283,7 @@ class SysMLDiagramWindow(tk.Frame):
         self.prop_view.heading("value", text="Value")
         self.prop_view.column("field", width=80, anchor="w")
         self.prop_view.column("value", width=120, anchor="w")
-        self.prop_view.pack(fill=tk.BOTH, expand=True)
+        add_treeview_scrollbars(self.prop_view, prop_tree_frame)
 
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -11,7 +11,7 @@ from analysis.models import (
     global_requirements,
 )
 from gui.architecture import GovernanceDiagramWindow
-from gui import messagebox
+from gui import messagebox, add_treeview_scrollbars
 from sysml.sysml_repository import SysMLRepository
 from gui.toolboxes import configure_table_style, _wrap_val
 
@@ -274,14 +274,7 @@ class SafetyManagementWindow(tk.Frame):
                 )
 
         populate(ids)
-        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=tree.yview)
-        hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=tree.xview)
-        tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
-        tree.grid(row=0, column=0, sticky="nsew")
-        vsb.grid(row=0, column=1, sticky="ns")
-        hsb.grid(row=1, column=0, sticky="ew")
-        tree_frame.rowconfigure(0, weight=1)
-        tree_frame.columnconfigure(0, weight=1)
+        add_treeview_scrollbars(tree, tree_frame)
         tree_frame.pack(fill=tk.BOTH, expand=True)
         frame.refresh_table = populate
         return frame

--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -2,7 +2,7 @@
 import tkinter as tk
 from tkinter import ttk, simpledialog
 
-from gui import messagebox
+from gui import messagebox, add_treeview_scrollbars
 from gui.toolboxes import configure_table_style
 from analysis.models import (
     AttackPath,
@@ -71,18 +71,19 @@ class ThreatDialog(simpledialog.Dialog):
         )
 
         configure_table_style("Threat.Functions.Treeview")
+        func_frame = ttk.Frame(asset_tab)
+        func_frame.grid(row=2, column=0, sticky="nsew", padx=2)
+        func_frame.columnconfigure(0, weight=1)
+        func_frame.rowconfigure(0, weight=1)
         self.func_tree = ttk.Treeview(
-            asset_tab,
+            func_frame,
             columns=("function",),
             show="headings",
             style="Threat.Functions.Treeview",
         )
         self.func_tree.heading("function", text="Function")
         self.func_tree.column("function", width=680, stretch=True)
-        self.func_tree.grid(row=2, column=0, sticky="nsew", padx=2)
-        fscroll = ttk.Scrollbar(asset_tab, orient="vertical", command=self.func_tree.yview)
-        self.func_tree.configure(yscrollcommand=fscroll.set)
-        fscroll.grid(row=2, column=1, sticky="ns")
+        add_treeview_scrollbars(self.func_tree, func_frame)
         self.func_tree.bind("<<TreeviewSelect>>", self.on_func_select)
         ttk.Button(asset_tab, text="Remove Function", command=self.remove_function).grid(
             row=3, column=0, sticky="w", padx=2, pady=2
@@ -96,6 +97,8 @@ class ThreatDialog(simpledialog.Dialog):
 
         ds_frame = ttk.Frame(asset_tab)
         ds_frame.grid(row=4, column=0, sticky="nsew")
+        ds_frame.columnconfigure(0, weight=1)
+        ds_frame.rowconfigure(0, weight=1)
         configure_table_style("Threat.Damage.Treeview")
         self.ds_tree = ttk.Treeview(
             ds_frame,
@@ -107,10 +110,7 @@ class ThreatDialog(simpledialog.Dialog):
         self.ds_tree.heading("type", text="Type")
         self.ds_tree.column("scenario", width=560, stretch=True)
         self.ds_tree.column("type", width=120, stretch=True)
-        self.ds_tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        ds_scroll = ttk.Scrollbar(ds_frame, orient="vertical", command=self.ds_tree.yview)
-        self.ds_tree.configure(yscrollcommand=ds_scroll.set)
-        ds_scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        add_treeview_scrollbars(self.ds_tree, ds_frame)
         self.ds_tree.bind("<<TreeviewSelect>>", self.on_ds_select)
 
         ds_edit = ttk.Frame(asset_tab)
@@ -153,9 +153,14 @@ class ThreatDialog(simpledialog.Dialog):
         ta_frame.columnconfigure(0, weight=1)
         ta_frame.rowconfigure(0, weight=1)
         ta_frame.rowconfigure(1, weight=1)
+
         configure_table_style("Threat.Scenarios.Treeview")
+        threat_frame = ttk.Frame(ta_frame)
+        threat_frame.grid(row=0, column=0, sticky="nsew")
+        threat_frame.columnconfigure(0, weight=1)
+        threat_frame.rowconfigure(0, weight=1)
         self.threat_tree = ttk.Treeview(
-            ta_frame,
+            threat_frame,
             columns=("stride", "scenario"),
             show="headings",
             style="Threat.Scenarios.Treeview",
@@ -165,24 +170,22 @@ class ThreatDialog(simpledialog.Dialog):
         self.threat_tree.column("stride", width=120, stretch=True)
         self.threat_tree.column("scenario", width=560, stretch=True)
         self.threat_tree.bind("<<TreeviewSelect>>", self.on_threat_select)
-        self.threat_tree.grid(row=0, column=0, sticky="nsew")
-        tscroll = ttk.Scrollbar(ta_frame, orient="vertical", command=self.threat_tree.yview)
-        self.threat_tree.configure(yscrollcommand=tscroll.set)
-        tscroll.grid(row=0, column=1, sticky="ns")
+        add_treeview_scrollbars(self.threat_tree, threat_frame)
 
         configure_table_style("Threat.Paths.Treeview")
+        path_frame = ttk.Frame(ta_frame)
+        path_frame.grid(row=1, column=0, sticky="nsew")
+        path_frame.columnconfigure(0, weight=1)
+        path_frame.rowconfigure(0, weight=1)
         self.path_tree = ttk.Treeview(
-            ta_frame,
+            path_frame,
             columns=("path",),
             show="headings",
             style="Threat.Paths.Treeview",
         )
         self.path_tree.heading("path", text="Attack Path")
         self.path_tree.column("path", width=680, stretch=True)
-        self.path_tree.grid(row=1, column=0, sticky="nsew")
-        pscroll = ttk.Scrollbar(ta_frame, orient="vertical", command=self.path_tree.yview)
-        self.path_tree.configure(yscrollcommand=pscroll.set)
-        pscroll.grid(row=1, column=1, sticky="ns")
+        add_treeview_scrollbars(self.path_tree, path_frame)
         self.path_tree.bind("<<TreeviewSelect>>", self.on_path_select)
 
         ts_edit = ttk.Frame(threat_tab)

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -2,7 +2,7 @@
 import tkinter as tk
 from tkinter import ttk, simpledialog
 
-from gui import messagebox
+from gui import messagebox, add_treeview_scrollbars
 from gui.toolboxes import ToolTip, configure_table_style
 from analysis.models import ThreatDoc, ThreatEntry
 from sysml.sysml_repository import SysMLRepository
@@ -60,10 +60,7 @@ class ThreatWindow(tk.Frame):
             self.tree.heading(col, text=headers[col])
             width = 120 if col in {"asset", "functions", "type"} else 200
             self.tree.column(col, width=width, stretch=True)
-        vsb = ttk.Scrollbar(content, orient="vertical", command=self.tree.yview)
-        self.tree.configure(yscrollcommand=vsb.set)
-        self.tree.grid(row=0, column=0, sticky="nsew")
-        vsb.grid(row=0, column=1, sticky="ns")
+        add_treeview_scrollbars(self.tree, content)
         content.columnconfigure(0, weight=1)
         content.rowconfigure(0, weight=1)
         self.tree.bind("<Double-1>", self.on_double_click)

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -1,7 +1,7 @@
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 import tkinter as tk
 from tkinter import ttk, filedialog, simpledialog
-from gui import messagebox, format_name_with_phase
+from gui import messagebox, format_name_with_phase, add_treeview_scrollbars
 import csv
 import copy
 import textwrap
@@ -4137,8 +4137,10 @@ class RequirementsExplorerWindow(tk.Frame):
 
         self.columns = ("ID", "ASIL", "Type", "Status", "Parent", "Trace", "Links", "Text")
         configure_table_style("ReqExp.Treeview")
+        table_frame = ttk.Frame(self)
+        table_frame.pack(fill=tk.BOTH, expand=True)
         self.tree = EditableTreeview(
-            self,
+            table_frame,
             columns=self.columns,
             show="headings",
             style="ReqExp.Treeview",
@@ -4154,7 +4156,7 @@ class RequirementsExplorerWindow(tk.Frame):
             else:
                 width = 100
             self.tree.column(c, width=width)
-        self.tree.pack(fill=tk.BOTH, expand=True)
+        add_treeview_scrollbars(self.tree, table_frame)
         btnf = ttk.Frame(self)
         btnf.pack(pady=5)
         ttk.Button(btnf, text="Export CSV", command=self.export_csv).pack(side=tk.LEFT, padx=5)


### PR DESCRIPTION
## Summary
- add `add_treeview_scrollbars` helper for easy vertical and horizontal scrolling
- use new helper in requirements editor and other tables
- wire properties, threat analysis, and requirements views through scrollable containers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1511bd86483279a08a513ae807773