### PR TITLE
Search across nodes, connections, and safety terms

### DIFF
--- a/gui/search_toolbox.py
+++ b/gui/search_toolbox.py
@@ -7,6 +7,35 @@ from tkinter import ttk
 
 from gui import messagebox
 
+# Additional model sections that can be searched.  Each tuple contains a
+# human-readable category name, the name of a method on the ``app`` object
+# returning the elements for that category and a method name used to open a
+# result.  The app does not need to implement every function; missing ones
+# simply yield no results.
+EXTRA_CATEGORIES = [
+    ("SysML Elements", "get_all_sysml_elements", "open_sysml_element"),
+    ("SysML Relationships", "get_all_sysml_relationships", "open_sysml_relationship"),
+    ("GSN Elements", "get_all_gsn_elements", "open_gsn_element"),
+    ("FTA Elements", "get_all_fta_elements", "open_fta_element"),
+    ("Governance Elements", "get_all_governance_elements", "open_governance_element"),
+    ("Hazard Analysis Cells", "get_all_hazard_analysis_cells", "open_hazard_analysis_cell"),
+    ("FI2TC Cells", "get_all_fi2tc_cells", "open_fi2tc_cell"),
+    ("TC2FI Cells", "get_all_tc2fi_cells", "open_tc2fi_cell"),
+    ("STPA Cells", "get_all_stpa_cells", "open_stpa_cell"),
+    ("Risk Assessments", "get_all_risk_assessments", "open_risk_assessment"),
+    ("Threat Analyses", "get_all_threat_analyses", "open_threat_analysis"),
+    ("Product Goals", "get_all_product_goals", "open_product_goal"),
+    ("Requirements", "get_all_requirements", "open_requirement"),
+    ("FMEDA Entries", "get_all_fmeda_entries", "show_fmeda_table"),
+    ("Reliability Analyses", "get_all_reliability_analyses", "open_reliability_analysis"),
+    ("Mission Profiles", "get_all_mission_profiles", "open_mission_profile"),
+    ("ODD Libraries", "get_all_odd_libraries", "open_odd_library"),
+    ("Scenario Libraries", "get_all_scenario_libraries", "open_scenario_library"),
+    ("SPI Metrics", "get_all_spi_metrics", "open_spi_metric"),
+    ("Reviews", "get_all_reviews", "open_review"),
+    ("Fault Prioritization", "get_all_fault_prioritizations", "open_fault_prioritization"),
+]
+
 
 class SearchToolbox(tk.Toplevel):
     """Provide text-based search across model objects.
@@ -23,6 +52,15 @@ class SearchToolbox(tk.Toplevel):
         self.search_var = tk.StringVar()
         self.case_var = tk.BooleanVar(value=False)
         self.regex_var = tk.BooleanVar(value=False)
+        self.nodes_var = tk.BooleanVar(value=True)
+        self.connections_var = tk.BooleanVar(value=True)
+        self.failures_var = tk.BooleanVar(value=True)
+        self.hazards_var = tk.BooleanVar(value=True)
+        self.faults_var = tk.BooleanVar(value=True)
+        self.malfunctions_var = tk.BooleanVar(value=True)
+        self.fail_list_var = tk.BooleanVar(value=True)
+        self.trigger_var = tk.BooleanVar(value=True)
+        self.funcins_var = tk.BooleanVar(value=True)
         # each result is a mapping with keys: 'label' and 'open'
         self.results: list[dict[str, object]] = []
         self.current_index: int = -1
@@ -54,12 +92,34 @@ class SearchToolbox(tk.Toplevel):
             side=tk.LEFT
         )
 
+        sources = ttk.Frame(frame)
+        sources.grid(row=2, column=0, columnspan=5, sticky="w", pady=(4, 0))
+        ttk.Checkbutton(sources, text="Nodes", variable=self.nodes_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Connections", variable=self.connections_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Failures", variable=self.failures_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Hazards", variable=self.hazards_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Faults", variable=self.faults_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Malfunctions", variable=self.malfunctions_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Failures List", variable=self.fail_list_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Triggering Cond.", variable=self.trigger_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(sources, text="Functional Insuff.", variable=self.funcins_var).pack(side=tk.LEFT)
+
+        # Dynamically create toggles for a broad set of additional model
+        # components.  This allows the toolbox to scale with new diagram types
+        # without requiring further code changes.
+        self.extra_sources = EXTRA_CATEGORIES
+        self.extra_vars: dict[str, tk.BooleanVar] = {}
+        for name, _fetch, _open in self.extra_sources:
+            var = tk.BooleanVar(value=True)
+            self.extra_vars[name] = var
+            ttk.Checkbutton(sources, text=name, variable=var).pack(side=tk.LEFT)
+
         self.results_box = tk.Listbox(frame, height=10)
-        self.results_box.grid(row=2, column=0, columnspan=5, sticky="nsew", pady=(8, 0))
+        self.results_box.grid(row=3, column=0, columnspan=5, sticky="nsew", pady=(8, 0))
         self.results_box.bind("<Double-1>", self._open_selected)
 
         frame.columnconfigure(1, weight=1)
-        frame.rowconfigure(2, weight=1)
+        frame.rowconfigure(3, weight=1)
 
         self.transient(master)
         self.grab_set()
@@ -75,6 +135,27 @@ class SearchToolbox(tk.Toplevel):
             visited.add(parent.unique_id)
             parent = parent.parents[0] if parent.parents else None
         return " > ".join(reversed(parts))
+
+    # ------------------------------------------------------------------
+    def _obj_label(self, obj) -> str:
+        """Return a readable label for *obj*."""
+        if isinstance(obj, str):
+            return obj
+        return getattr(obj, "user_name", "") or getattr(obj, "name", "") or str(obj)
+
+    # ------------------------------------------------------------------
+    def _obj_text(self, obj) -> str:
+        """Return concatenated text fields for generic searches."""
+        if isinstance(obj, str):
+            return obj
+        parts = []
+        for attr in ("user_name", "name", "description", "label", "title"):
+            val = getattr(obj, attr, "")
+            if isinstance(val, (list, tuple)):
+                val = " ".join(str(v) for v in val)
+            if val:
+                parts.append(str(val))
+        return "\n".join(parts)
 
     # ------------------------------------------------------------------
     def _run_search(self) -> None:
@@ -94,71 +175,210 @@ class SearchToolbox(tk.Toplevel):
         self.results.clear()
         self.current_index = -1
 
-        # --- search fault tree / GSN nodes
-        for node in getattr(self.app, "get_all_nodes_in_model", lambda: [])():
-            text = f"{node.user_name}\n{getattr(node, 'description', '')}"
-            if regex.search(text):
-                label = (
-                    f"{type(node).__name__} ({getattr(node, 'node_type', '')}) - "
-                    f"{node.user_name} [{self._node_path(node)}]"
-                )
-                self.results_box.insert(tk.END, label)
-                self.results.append(
-                    {
-                        "label": label,
-                        "open": lambda n=node: self.app.open_page_diagram(
-                            getattr(n, "original", n)
-                        ),
-                    }
-                )
+        if self.nodes_var.get():
+            nodes = getattr(self.app, "get_all_nodes_in_model", lambda: [])()
+            for node in nodes:
+                text = f"{node.user_name}\n{getattr(node, 'description', '')}"
+                if regex.search(text):
+                    label = (
+                        f"{type(node).__name__} ({getattr(node, 'node_type', '')}) - "
+                        f"{node.user_name} [{self._node_path(node)}]"
+                    )
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda n=node: self.app.open_page_diagram(
+                                getattr(n, "original", n)
+                            ),
+                        }
+                    )
 
-        # --- search FMEA/FMDA entries
-        for entry in getattr(self.app, "get_all_fmea_entries", lambda: [])():
-            fields = [
-                getattr(entry, "user_name", ""),
-                getattr(entry, "description", ""),
-                getattr(entry, "fmea_effect", ""),
-                getattr(entry, "fmea_cause", ""),
-            ]
-            if regex.search("\n".join(fields)):
-                doc_name = ""
-                is_fmeda = False
-                target_doc = None
-                for doc in getattr(self.app, "fmeas", []):
-                    if entry in doc.get("entries", []):
-                        doc_name = doc.get("name", "FMEA")
-                        target_doc = doc
-                        break
-                else:
-                    for doc in getattr(self.app, "fmedas", []):
+        if self.connections_var.get():
+            connections = getattr(self.app, "get_all_connections", lambda: [])()
+            for conn in connections:
+                fields = [
+                    getattr(conn, "name", ""),
+                    getattr(conn, "conn_type", ""),
+                    " ".join(getattr(conn, "guard", []) or []),
+                ]
+                if regex.search("\n".join(fields)):
+                    label = f"{type(conn).__name__} - {getattr(conn, 'name', '')}"
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda c=conn: getattr(
+                                self.app, "open_connection", lambda *_: None
+                            )(c),
+                        }
+                    )
+
+        if self.failures_var.get():
+            entries = getattr(self.app, "get_all_fmea_entries", lambda: [])()
+            for entry in entries:
+                fields = [
+                    getattr(entry, "user_name", ""),
+                    getattr(entry, "description", ""),
+                    getattr(entry, "fmea_effect", ""),
+                    getattr(entry, "fmea_cause", ""),
+                ]
+                if regex.search("\n".join(fields)):
+                    doc_name = ""
+                    is_fmeda = False
+                    target_doc = None
+                    for doc in getattr(self.app, "fmeas", []):
                         if entry in doc.get("entries", []):
-                            doc_name = doc.get("name", "FMEDA")
+                            doc_name = doc.get("name", "FMEA")
                             target_doc = doc
-                            is_fmeda = True
                             break
-                label = (
-                    f"{type(entry).__name__} - {entry.user_name or entry.description}"
-                    f" [FMEA: {doc_name or 'Global'}]"
-                )
-                self.results_box.insert(tk.END, label)
-
-                def _open(entry=entry, doc=target_doc, fmeda=is_fmeda):
-                    self.app.show_fmea_table(doc, fmeda=fmeda)
-                    tree = getattr(self.app, "_fmea_tree", None)
-                    node_map = getattr(self.app, "_fmea_node_map", {})
-                    if tree and node_map:
-                        for iid, node in node_map.items():
-                            if node is entry:
-                                tree.selection_set(iid)
-                                tree.focus(iid)
-                                tree.see(iid)
+                    else:
+                        for doc in getattr(self.app, "fmedas", []):
+                            if entry in doc.get("entries", []):
+                                doc_name = doc.get("name", "FMEDA")
+                                target_doc = doc
+                                is_fmeda = True
                                 break
+                    label = (
+                        f"{type(entry).__name__} - {entry.user_name or entry.description}"
+                        f" [FMEA: {doc_name or 'Global'}]"
+                    )
+                    self.results_box.insert(tk.END, label)
 
-                self.results.append({"label": label, "open": _open})
+                    def _open(entry=entry, doc=target_doc, fmeda=is_fmeda):
+                        self.app.show_fmea_table(doc, fmeda=fmeda)
+                        tree = getattr(self.app, "_fmea_tree", None)
+                        node_map = getattr(self.app, "_fmea_node_map", {})
+                        if tree and node_map:
+                            for iid, node in node_map.items():
+                                if node is entry:
+                                    tree.selection_set(iid)
+                                    tree.focus(iid)
+                                    tree.see(iid)
+                                    break
+
+                    self.results.append({"label": label, "open": _open})
+
+        if self.hazards_var.get():
+            for hazard in getattr(self.app, "hazards", []):
+                if regex.search(hazard):
+                    label = f"Hazard - {hazard}"
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda h=hazard: getattr(
+                                self.app, "show_hazard_list", lambda *_: None
+                            )(),
+                        }
+                    )
+
+        if self.faults_var.get():
+            for fault in getattr(self.app, "faults", []):
+                if regex.search(fault):
+                    label = f"Fault - {fault}"
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda f=fault: getattr(
+                                self.app,
+                                "show_fault_list",
+                                lambda *_: None,
+                            )(),
+                        }
+                    )
+
+        if self.malfunctions_var.get():
+            malfunc_cb = getattr(
+                self.app,
+                "show_malfunction_editor",
+                getattr(self.app, "show_malfunctions_editor", lambda *_: None),
+            )
+            for mal in getattr(self.app, "malfunctions", []):
+                if regex.search(mal):
+                    label = f"Malfunction - {mal}"
+                    self.results_box.insert(tk.END, label)
+                    self.results.append({"label": label, "open": lambda m=mal: malfunc_cb()})
+
+        if self.fail_list_var.get():
+            for failure in getattr(self.app, "failures", []):
+                if regex.search(failure):
+                    label = f"Failure - {failure}"
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda f=failure: getattr(
+                                self.app,
+                                "show_failure_list",
+                                lambda *_: None,
+                            )(),
+                        }
+                    )
+
+        if self.trigger_var.get():
+            for tc in getattr(self.app, "triggering_conditions", []):
+                if regex.search(tc):
+                    label = f"Triggering Condition - {tc}"
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda t=tc: getattr(
+                                self.app,
+                                "show_triggering_condition_list",
+                                lambda *_: None,
+                            )(),
+                        }
+                    )
+
+        if self.funcins_var.get():
+            for fi in getattr(self.app, "functional_insufficiencies", []):
+                if regex.search(fi):
+                    label = f"Functional Insufficiency - {fi}"
+                    self.results_box.insert(tk.END, label)
+                    self.results.append(
+                        {
+                            "label": label,
+                            "open": lambda f=fi: getattr(
+                                self.app,
+                                "show_functional_insufficiency_list",
+                                lambda *_: None,
+                            )(),
+                        }
+                    )
+
+        # Generic search for any additional categories defined in
+        # ``EXTRA_CATEGORIES`` above.  Each category simply exposes a function
+        # on ``app`` that returns an iterable of objects.  We attempt to match
+        # against common name/description attributes and call the configured
+        # opener when a match is selected.
+        for name, fetcher, opener in self.extra_sources:
+            if not self.extra_vars[name].get():
+                continue
+            items = getattr(self.app, fetcher, lambda: [])()
+            for item in items:
+                text = self._obj_text(item)
+                if regex.search(text):
+                    prefix = name[:-1] if name.endswith("s") else name
+                    label = f"{prefix} - {self._obj_label(item)}"
+                    self.results_box.insert(tk.END, label)
+
+                    def _open(it=item, meth=opener):
+                        func = getattr(self.app, meth, lambda *_: None)
+                        try:
+                            func(it)
+                        except Exception:  # pragma: no cover - best effort
+                            func()
+
+                    self.results.append({"label": label, "open": _open})
 
         if self.results:
             self.current_index = 0
             self._open_index(0)
+        else:
+            messagebox.showinfo("Search", "No matches found.")
 
     # ------------------------------------------------------------------
     def _open_index(self, index: int) -> None:

--- a/tests/test_search_toolbox.py
+++ b/tests/test_search_toolbox.py
@@ -1,0 +1,172 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from gui import search_toolbox, messagebox  # noqa: E402
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, value):
+        self._value = value
+
+
+class DummyListbox:
+    def delete(self, *_args):
+        pass
+
+    def insert(self, *_args):
+        pass
+
+    def select_clear(self, *_args):
+        pass
+
+    def selection_set(self, *_args):
+        pass
+
+    def activate(self, *_args):
+        pass
+
+    def see(self, *_args):
+        pass
+
+    def curselection(self):
+        return []
+
+
+class DummyApp:
+    hazards: list[str] = []
+    faults: list[str] = []
+    malfunctions: list[str] = []
+    failures: list[str] = []
+    triggering_conditions: list[str] = []
+    functional_insufficiencies: list[str] = []
+
+    def get_all_nodes_in_model(self):
+        return []
+
+    def get_all_fmea_entries(self):
+        return []
+
+    def get_all_connections(self):
+        return []
+
+
+class SearchToolboxTests(unittest.TestCase):
+    def _make_tb(self, app):
+        tb = search_toolbox.SearchToolbox.__new__(search_toolbox.SearchToolbox)
+        tb.app = app
+        tb.search_var = DummyVar()
+        tb.case_var = DummyVar(False)
+        tb.regex_var = DummyVar(False)
+        tb.nodes_var = DummyVar(True)
+        tb.connections_var = DummyVar(True)
+        tb.failures_var = DummyVar(True)
+        tb.hazards_var = DummyVar(True)
+        tb.faults_var = DummyVar(True)
+        tb.malfunctions_var = DummyVar(True)
+        tb.fail_list_var = DummyVar(True)
+        tb.trigger_var = DummyVar(True)
+        tb.funcins_var = DummyVar(True)
+        tb.extra_sources = search_toolbox.EXTRA_CATEGORIES
+        tb.extra_vars = {name: DummyVar(False) for name, *_ in tb.extra_sources}
+        tb.results_box = DummyListbox()
+        tb.results = []
+        tb.current_index = -1
+        return tb
+
+    def test_notifies_on_no_results(self):
+        tb = self._make_tb(DummyApp())
+        tb.search_var.set("missing")
+        infos = []
+        with patch.object(messagebox, "showinfo", lambda *a: infos.append(a)):
+            tb._run_search()
+        self.assertTrue(infos, "User was not notified when no results found")
+        self.assertIn("No matches found", infos[0][1])
+
+    def test_search_hazards(self):
+        class HazardApp(DummyApp):
+            hazards = ["Fire", "Collision"]
+
+        tb = self._make_tb(HazardApp())
+        tb.nodes_var.set(False)
+        tb.connections_var.set(False)
+        tb.failures_var.set(False)
+        tb.hazards_var.set(True)
+        tb.search_var.set("Fire")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("Hazard - Fire", tb.results[0]["label"])
+
+    def test_search_faults(self):
+        class FaultApp(DummyApp):
+            faults = ["Short", "Open"]
+
+        tb = self._make_tb(FaultApp())
+        tb.nodes_var.set(False)
+        tb.connections_var.set(False)
+        tb.failures_var.set(False)
+        tb.hazards_var.set(False)
+        tb.faults_var.set(True)
+        tb.malfunctions_var.set(False)
+        tb.fail_list_var.set(False)
+        tb.trigger_var.set(False)
+        tb.funcins_var.set(False)
+        tb.search_var.set("Short")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("Fault - Short", tb.results[0]["label"])
+
+    def test_search_connection_guard(self):
+        class Conn:
+            def __init__(self):
+                self.name = "linkA"
+                self.conn_type = "Flow"
+                self.guard = ["g1"]
+
+        class ConnApp(DummyApp):
+            def __init__(self):
+                self._conns = [Conn()]
+
+            def get_all_connections(self):
+                return self._conns
+
+        tb = self._make_tb(ConnApp())
+        tb.nodes_var.set(False)
+        tb.connections_var.set(True)
+        tb.failures_var.set(False)
+        tb.hazards_var.set(False)
+        tb.search_var.set("g1")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("linkA", tb.results[0]["label"])
+
+    def test_search_extra_category(self):
+        class Obj:
+            def __init__(self):
+                self.name = "ExtraElement"
+
+        class ExtraApp(DummyApp):
+            def get_all_sysml_elements(self):
+                return [Obj()]
+
+        tb = self._make_tb(ExtraApp())
+        tb.extra_vars["SysML Elements"].set(True)
+        tb.nodes_var.set(False)
+        tb.connections_var.set(False)
+        tb.failures_var.set(False)
+        tb.search_var.set("Extra")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("SysML Element - ExtraElement", tb.results[0]["label"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add toggles for extensive model artifacts such as SysML, GSN, FTA, governance elements, hazard analysis cells, and more
- generically scan these additional collections and open their editors when matches are selected
- test generic search path with an extra category example

## Testing
- `pytest tests/test_search_toolbox.py -q`
- `pytest tests/test_copy_paste_selection.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a145be822c83279e8e77051b520b5e