### PR TITLE
Search across nodes, connections, and safety terms

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -17132,11 +17132,13 @@ class FaultTreeApp:
             pd.redraw_canvas()
 
     def open_search_toolbox(self):
-        """Open the complex search toolbox window."""
-        if hasattr(self, "search_window") and self.search_window.winfo_exists():
-            self.search_window.lift()
+        """Open the search toolbox in a new working-area tab."""
+        if getattr(self, "search_tab", None) and self.search_tab.winfo_exists():
+            self.doc_nb.select(self.search_tab)
             return
-        self.search_window = SearchToolbox(self.root, self)
+        self.search_tab = SearchToolbox(self.doc_nb, self)
+        self.doc_nb.add(self.search_tab, text="Search")
+        self.doc_nb.select(self.search_tab)
 
     def open_style_editor(self):
         """Open the diagram style editor window."""
@@ -17215,6 +17217,10 @@ class FaultTreeApp:
             self.hbar = None
             self.vbar = None
             self.page_diagram = None
+            tab.destroy()
+            return
+        if tab is getattr(self, "search_tab", None):
+            self.search_tab = None
             tab.destroy()
             return
         for child in tab.winfo_children():

--- a/gui/search_toolbox.py
+++ b/gui/search_toolbox.py
@@ -7,18 +7,48 @@ from tkinter import ttk
 
 from gui import messagebox
 
+# Additional model sections that can be searched.  Each tuple contains a
+# human-readable category name, the name of a method on the ``app`` object
+# returning the elements for that category and a method name used to open a
+# result.  The app does not need to implement every function; missing ones
+# simply yield no results.
+EXTRA_CATEGORIES = [
+    ("SysML Elements", "get_all_sysml_elements", "open_sysml_element"),
+    ("SysML Relationships", "get_all_sysml_relationships", "open_sysml_relationship"),
+    ("GSN Elements", "get_all_gsn_elements", "open_gsn_element"),
+    ("FTA Elements", "get_all_fta_elements", "open_fta_element"),
+    ("Governance Elements", "get_all_governance_elements", "open_governance_element"),
+    ("Hazard Analysis Cells", "get_all_hazard_analysis_cells", "open_hazard_analysis_cell"),
+    ("FI2TC Cells", "get_all_fi2tc_cells", "open_fi2tc_cell"),
+    ("TC2FI Cells", "get_all_tc2fi_cells", "open_tc2fi_cell"),
+    ("STPA Cells", "get_all_stpa_cells", "open_stpa_cell"),
+    ("Risk Assessments", "get_all_risk_assessments", "open_risk_assessment"),
+    ("Threat Analyses", "get_all_threat_analyses", "open_threat_analysis"),
+    ("Product Goals", "get_all_product_goals", "open_product_goal"),
+    ("Requirements", "get_all_requirements", "open_requirement"),
+    ("FMEDA Entries", "get_all_fmeda_entries", "show_fmeda_table"),
+    ("Reliability Analyses", "get_all_reliability_analyses", "open_reliability_analysis"),
+    ("Mission Profiles", "get_all_mission_profiles", "open_mission_profile"),
+    ("ODD Libraries", "get_all_odd_libraries", "open_odd_library"),
+    ("Scenario Libraries", "get_all_scenario_libraries", "open_scenario_library"),
+    ("SPI Metrics", "get_all_spi_metrics", "open_spi_metric"),
+    ("Reviews", "get_all_reviews", "open_review"),
+    ("Fault Prioritization", "get_all_fault_prioritizations", "open_fault_prioritization"),
+]
 
-class SearchToolbox(tk.Toplevel):
+
+class SearchToolbox(ttk.Frame):
     """Provide text-based search across model objects.
 
-    Results show the object's class and origin.  Double-clicking a match
-    navigates to the corresponding diagram or table entry.
+    The search entry accepts optional *category* prefixes so users can issue
+    compact queries such as ``"nodes,connections: motor"``.  Results show the
+    object's class and origin.  Double-clicking a match navigates to the
+    corresponding diagram or table entry.
     """
 
     def __init__(self, master, app):
         super().__init__(master)
         self.app = app
-        self.title("Search")
 
         self.search_var = tk.StringVar()
         self.case_var = tk.BooleanVar(value=False)
@@ -27,25 +57,24 @@ class SearchToolbox(tk.Toplevel):
         self.results: list[dict[str, object]] = []
         self.current_index: int = -1
 
-        frame = ttk.Frame(self)
-        frame.pack(fill=tk.BOTH, expand=True, padx=8, pady=8)
+        self._init_handlers()
 
-        ttk.Label(frame, text="Find:").grid(row=0, column=0, sticky="w")
-        entry = ttk.Entry(frame, textvariable=self.search_var)
+        ttk.Label(self, text="Query:").grid(row=0, column=0, sticky="w")
+        entry = ttk.Entry(self, textvariable=self.search_var)
         entry.grid(row=0, column=1, sticky="ew")
         entry.focus_set()
 
-        ttk.Button(frame, text="Find", command=self._run_search).grid(
+        ttk.Button(self, text="Find", command=self._run_search).grid(
             row=0, column=2, padx=(4, 0)
         )
-        ttk.Button(frame, text="Next", command=self._find_next).grid(
+        ttk.Button(self, text="Next", command=self._find_next).grid(
             row=0, column=3, padx=(4, 0)
         )
-        ttk.Button(frame, text="Prev", command=self._find_prev).grid(
+        ttk.Button(self, text="Prev", command=self._find_prev).grid(
             row=0, column=4, padx=(4, 0)
         )
 
-        opts = ttk.Frame(frame)
+        opts = ttk.Frame(self)
         opts.grid(row=1, column=0, columnspan=5, sticky="w", pady=(4, 0))
         ttk.Checkbutton(opts, text="Case sensitive", variable=self.case_var).pack(
             side=tk.LEFT
@@ -54,15 +83,17 @@ class SearchToolbox(tk.Toplevel):
             side=tk.LEFT
         )
 
-        self.results_box = tk.Listbox(frame, height=10)
-        self.results_box.grid(row=2, column=0, columnspan=5, sticky="nsew", pady=(8, 0))
+        ttk.Label(
+            self,
+            text="Use 'category: text' to limit search. Separate multiple categories with commas.",
+        ).grid(row=2, column=0, columnspan=5, sticky="w", pady=(4, 0))
+
+        self.results_box = tk.Listbox(self, height=10)
+        self.results_box.grid(row=3, column=0, columnspan=5, sticky="nsew", pady=(8, 0))
         self.results_box.bind("<Double-1>", self._open_selected)
 
-        frame.columnconfigure(1, weight=1)
-        frame.rowconfigure(2, weight=1)
-
-        self.transient(master)
-        self.grab_set()
+        self.columnconfigure(1, weight=1)
+        self.rowconfigure(3, weight=1)
 
     # ------------------------------------------------------------------
     def _node_path(self, node) -> str:
@@ -77,43 +108,110 @@ class SearchToolbox(tk.Toplevel):
         return " > ".join(reversed(parts))
 
     # ------------------------------------------------------------------
-    def _run_search(self) -> None:
-        pattern = self.search_var.get().strip()
-        if not pattern:
-            return
-        flags = 0 if self.case_var.get() else re.IGNORECASE
-        try:
-            regex = re.compile(
-                pattern if self.regex_var.get() else re.escape(pattern), flags
-            )
-        except re.error as exc:  # pragma: no cover - user feedback path
-            messagebox.showerror("Search", f"Invalid pattern: {exc}")
-            return
+    def _obj_label(self, obj) -> str:
+        """Return a readable label for *obj*."""
+        if isinstance(obj, str):
+            return obj
+        return getattr(obj, "user_name", "") or getattr(obj, "name", "") or str(obj)
 
-        self.results_box.delete(0, tk.END)
-        self.results.clear()
-        self.current_index = -1
+    # ------------------------------------------------------------------
+    def _obj_text(self, obj) -> str:
+        """Return concatenated text fields for generic searches."""
+        if isinstance(obj, str):
+            return obj
+        parts = []
+        for attr in ("user_name", "name", "description", "label", "title"):
+            val = getattr(obj, attr, "")
+            if isinstance(val, (list, tuple)):
+                val = " ".join(str(v) for v in val)
+            if val:
+                parts.append(str(val))
+        return "\n".join(parts)
 
-        # --- search fault tree / GSN nodes
-        for node in getattr(self.app, "get_all_nodes_in_model", lambda: [])():
+    # ------------------------------------------------------------------
+    def _init_handlers(self) -> None:
+        """Initialise search handlers for each supported category."""
+        self.handlers: dict[str, callable] = {
+            "nodes": self._search_nodes,
+            "connections": self._search_connections,
+            "failures": self._search_failures,
+            "hazards": self._search_hazards,
+            "faults": self._search_faults,
+            "malfunctions": self._search_malfunctions,
+            "failureslist": self._search_failure_list,
+            "triggers": self._search_triggers,
+            "funcins": self._search_funcins,
+        }
+        for name, fetcher, opener in EXTRA_CATEGORIES:
+            parts = name.split()
+            key = parts[0].lower()
+            if key in self.handlers and len(parts) > 1:
+                key = (parts[0] + parts[1]).lower()
+            elif key in self.handlers:
+                key = f"{key}{len(self.handlers)}"
+            self.handlers[key] = self._make_extra_handler(name, fetcher, opener)
+
+    # ------------------------------------------------------------------
+    def _make_extra_handler(self, name: str, fetcher: str, opener: str):
+        def handler(regex):
+            items = getattr(self.app, fetcher, lambda: [])()
+            for item in items:
+                text = self._obj_text(item)
+                if regex.search(text):
+                    prefix = name[:-1] if name.endswith("s") else name
+                    label = f"{prefix} - {self._obj_label(item)}"
+
+                    def _open(it=item, meth=opener):
+                        func = getattr(self.app, meth, lambda *_: None)
+                        try:
+                            func(it)
+                        except Exception:  # pragma: no cover - best effort
+                            func()
+
+                    self._add_result(label, _open)
+
+        return handler
+
+    # ------------------------------------------------------------------
+    def _add_result(self, label: str, open_cb) -> None:
+        self.results_box.insert(tk.END, label)
+        self.results.append({"label": label, "open": open_cb})
+
+    # ------------------------------------------------------------------
+    def _search_nodes(self, regex) -> None:
+        nodes = getattr(self.app, "get_all_nodes_in_model", lambda: [])()
+        for node in nodes:
             text = f"{node.user_name}\n{getattr(node, 'description', '')}"
             if regex.search(text):
                 label = (
                     f"{type(node).__name__} ({getattr(node, 'node_type', '')}) - "
                     f"{node.user_name} [{self._node_path(node)}]"
                 )
-                self.results_box.insert(tk.END, label)
-                self.results.append(
-                    {
-                        "label": label,
-                        "open": lambda n=node: self.app.open_page_diagram(
-                            getattr(n, "original", n)
-                        ),
-                    }
+                self._add_result(
+                    label,
+                    lambda n=node: self.app.open_page_diagram(getattr(n, "original", n)),
                 )
 
-        # --- search FMEA/FMDA entries
-        for entry in getattr(self.app, "get_all_fmea_entries", lambda: [])():
+    # ------------------------------------------------------------------
+    def _search_connections(self, regex) -> None:
+        connections = getattr(self.app, "get_all_connections", lambda: [])()
+        for conn in connections:
+            fields = [
+                getattr(conn, "name", ""),
+                getattr(conn, "conn_type", ""),
+                " ".join(getattr(conn, "guard", []) or []),
+            ]
+            if regex.search("\n".join(fields)):
+                label = f"{type(conn).__name__} - {getattr(conn, 'name', '')}"
+                self._add_result(
+                    label,
+                    lambda c=conn: getattr(self.app, "open_connection", lambda *_: None)(c),
+                )
+
+    # ------------------------------------------------------------------
+    def _search_failures(self, regex) -> None:
+        entries = getattr(self.app, "get_all_fmea_entries", lambda: [])()
+        for entry in entries:
             fields = [
                 getattr(entry, "user_name", ""),
                 getattr(entry, "description", ""),
@@ -140,7 +238,6 @@ class SearchToolbox(tk.Toplevel):
                     f"{type(entry).__name__} - {entry.user_name or entry.description}"
                     f" [FMEA: {doc_name or 'Global'}]"
                 )
-                self.results_box.insert(tk.END, label)
 
                 def _open(entry=entry, doc=target_doc, fmeda=is_fmeda):
                     self.app.show_fmea_table(doc, fmeda=fmeda)
@@ -154,11 +251,113 @@ class SearchToolbox(tk.Toplevel):
                                 tree.see(iid)
                                 break
 
-                self.results.append({"label": label, "open": _open})
+                self._add_result(label, _open)
+
+    # ------------------------------------------------------------------
+    def _search_hazards(self, regex) -> None:
+        for hazard in getattr(self.app, "hazards", []):
+            if regex.search(hazard):
+                label = f"Hazard - {hazard}"
+                self._add_result(
+                    label,
+                    lambda h=hazard: getattr(self.app, "show_hazard_list", lambda *_: None)(),
+                )
+
+    # ------------------------------------------------------------------
+    def _search_faults(self, regex) -> None:
+        for fault in getattr(self.app, "faults", []):
+            if regex.search(fault):
+                label = f"Fault - {fault}"
+                self._add_result(
+                    label,
+                    lambda f=fault: getattr(self.app, "show_fault_list", lambda *_: None)(),
+                )
+
+    # ------------------------------------------------------------------
+    def _search_malfunctions(self, regex) -> None:
+        malfunc_cb = getattr(
+            self.app,
+            "show_malfunction_editor",
+            getattr(self.app, "show_malfunctions_editor", lambda *_: None),
+        )
+        for mal in getattr(self.app, "malfunctions", []):
+            if regex.search(mal):
+                label = f"Malfunction - {mal}"
+                self._add_result(label, lambda m=mal: malfunc_cb())
+
+    # ------------------------------------------------------------------
+    def _search_failure_list(self, regex) -> None:
+        for failure in getattr(self.app, "failures", []):
+            if regex.search(failure):
+                label = f"Failure - {failure}"
+                self._add_result(
+                    label,
+                    lambda f=failure: getattr(
+                        self.app, "show_failure_list", lambda *_: None
+                    )(),
+                )
+
+    # ------------------------------------------------------------------
+    def _search_triggers(self, regex) -> None:
+        for tc in getattr(self.app, "triggering_conditions", []):
+            if regex.search(tc):
+                label = f"Triggering Condition - {tc}"
+                self._add_result(
+                    label,
+                    lambda t=tc: getattr(
+                        self.app, "show_triggering_condition_list", lambda *_: None
+                    )(),
+                )
+
+    # ------------------------------------------------------------------
+    def _search_funcins(self, regex) -> None:
+        for fi in getattr(self.app, "functional_insufficiencies", []):
+            if regex.search(fi):
+                label = f"Functional Insufficiency - {fi}"
+                self._add_result(
+                    label,
+                    lambda f=fi: getattr(
+                        self.app, "show_functional_insufficiency_list", lambda *_: None
+                    )(),
+                )
+
+    # ------------------------------------------------------------------
+    def _run_search(self) -> None:
+        query = self.search_var.get().strip()
+        if not query:
+            return
+
+        categories = None
+        pattern = query
+        if ":" in query:
+            cat_part, pattern = query.split(":", 1)
+            categories = [c.strip().lower() for c in cat_part.split(",") if c.strip()]
+            pattern = pattern.strip()
+
+        flags = 0 if self.case_var.get() else re.IGNORECASE
+        try:
+            regex = re.compile(
+                pattern if self.regex_var.get() else re.escape(pattern), flags
+            )
+        except re.error as exc:  # pragma: no cover - user feedback path
+            messagebox.showerror("Search", f"Invalid pattern: {exc}")
+            return
+
+        self.results_box.delete(0, tk.END)
+        self.results.clear()
+        self.current_index = -1
+
+        keys = categories if categories else list(self.handlers.keys())
+        for key in keys:
+            handler = self.handlers.get(key)
+            if handler:
+                handler(regex)
 
         if self.results:
             self.current_index = 0
             self._open_index(0)
+        else:
+            messagebox.showinfo("Search", "No matches found.")
 
     # ------------------------------------------------------------------
     def _open_index(self, index: int) -> None:

--- a/tests/test_search_toolbox.py
+++ b/tests/test_search_toolbox.py
@@ -1,0 +1,141 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from gui import search_toolbox, messagebox  # noqa: E402
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, value):
+        self._value = value
+
+
+class DummyListbox:
+    def delete(self, *_args):
+        pass
+
+    def insert(self, *_args):
+        pass
+
+    def select_clear(self, *_args):
+        pass
+
+    def selection_set(self, *_args):
+        pass
+
+    def activate(self, *_args):
+        pass
+
+    def see(self, *_args):
+        pass
+
+    def curselection(self):
+        return []
+
+
+class DummyApp:
+    hazards: list[str] = []
+    faults: list[str] = []
+    malfunctions: list[str] = []
+    failures: list[str] = []
+    triggering_conditions: list[str] = []
+    functional_insufficiencies: list[str] = []
+
+    def get_all_nodes_in_model(self):
+        return []
+
+    def get_all_fmea_entries(self):
+        return []
+
+    def get_all_connections(self):
+        return []
+
+
+class SearchToolboxTests(unittest.TestCase):
+    def _make_tb(self, app):
+        tb = search_toolbox.SearchToolbox.__new__(search_toolbox.SearchToolbox)
+        tb.app = app
+        tb.search_var = DummyVar()
+        tb.case_var = DummyVar(False)
+        tb.regex_var = DummyVar(False)
+        tb.results_box = DummyListbox()
+        tb.results = []
+        tb.current_index = -1
+        tb._init_handlers()
+        return tb
+
+    def test_notifies_on_no_results(self):
+        tb = self._make_tb(DummyApp())
+        tb.search_var.set("missing")
+        infos = []
+        with patch.object(messagebox, "showinfo", lambda *a: infos.append(a)):
+            tb._run_search()
+        self.assertTrue(infos, "User was not notified when no results found")
+        self.assertIn("No matches found", infos[0][1])
+
+    def test_search_hazards(self):
+        class HazardApp(DummyApp):
+            hazards = ["Fire", "Collision"]
+
+        tb = self._make_tb(HazardApp())
+        tb.search_var.set("hazards: Fire")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("Hazard - Fire", tb.results[0]["label"])
+
+    def test_search_faults(self):
+        class FaultApp(DummyApp):
+            faults = ["Short", "Open"]
+
+        tb = self._make_tb(FaultApp())
+        tb.search_var.set("faults: Short")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("Fault - Short", tb.results[0]["label"])
+
+    def test_search_connection_guard(self):
+        class Conn:
+            def __init__(self):
+                self.name = "linkA"
+                self.conn_type = "Flow"
+                self.guard = ["g1"]
+
+        class ConnApp(DummyApp):
+            def __init__(self):
+                self._conns = [Conn()]
+
+            def get_all_connections(self):
+                return self._conns
+
+        tb = self._make_tb(ConnApp())
+        tb.search_var.set("connections: g1")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("linkA", tb.results[0]["label"])
+
+    def test_search_extra_category(self):
+        class Obj:
+            def __init__(self):
+                self.name = "ExtraElement"
+
+        class ExtraApp(DummyApp):
+            def get_all_sysml_elements(self):
+                return [Obj()]
+
+        tb = self._make_tb(ExtraApp())
+        tb.search_var.set("sysml: Extra")
+        tb._run_search()
+        self.assertEqual(len(tb.results), 1)
+        self.assertIn("SysML Element - ExtraElement", tb.results[0]["label"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- streamline search toolbox with query-based entry and compact layout
- map query prefixes to model handlers so results span nodes, connections, hazards, faults, and extensible categories
- open search toolbox as a tab in the workspace and clear it on close

## Testing
- `pytest tests/test_search_toolbox.py -q`
- `pytest tests/test_copy_paste_selection.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a145be822c83279e8e77051b520b5e