### PR TITLE
Enforce diagram rule updates on existing connections

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -351,6 +351,66 @@ def _arrow_forward_types() -> set[str]:
     return _ARROW_FORWARD_BASE | SAFETY_AI_RELATION_SET
 
 
+def _enforce_connection_rules() -> None:
+    """Remove existing connections that violate current configuration rules."""
+    repo = SysMLRepository.get_instance()
+    removed: set[str] = set()
+    for diag in repo.diagrams.values():
+        diag_rules = CONNECTION_RULES.get(diag.diag_type, {})
+        obj_map = {}
+        for o in diag.objects:
+            oid = o.get("obj_id") if isinstance(o, dict) else getattr(o, "obj_id", None)
+            obj_type = o.get("obj_type") if isinstance(o, dict) else getattr(o, "obj_type", None)
+            obj_map[oid] = obj_type
+        new_conns = []
+        for conn in diag.connections:
+            src_id = conn.get("src") if isinstance(conn, dict) else getattr(conn, "src", None)
+            dst_id = conn.get("dst") if isinstance(conn, dict) else getattr(conn, "dst", None)
+            src_type = obj_map.get(src_id)
+            dst_type = obj_map.get(dst_id)
+            if not src_type or not dst_type:
+                rel_id = conn.get("element_id") if isinstance(conn, dict) else getattr(conn, "element_id", "")
+                removed.add(rel_id)
+                continue
+            conn_type = conn.get("conn_type") if isinstance(conn, dict) else getattr(conn, "conn_type", None)
+            if diag.diag_type == "Governance Diagram" and conn_type != "Flow":
+                src_type = _GOV_TYPE_ALIASES.get(src_type, src_type)
+                dst_type = _GOV_TYPE_ALIASES.get(dst_type, dst_type)
+            valid = True
+            rules = diag_rules.get(conn_type)
+            if rules is not None:
+                targets = rules.get(src_type)
+                if not targets or dst_type not in targets:
+                    valid = False
+            elif conn_type in SAFETY_AI_RELATION_RULES:
+                if (
+                    src_type not in SAFETY_AI_NODE_TYPES
+                    and src_type not in GOVERNANCE_NODE_TYPES
+                ) or (
+                    dst_type not in SAFETY_AI_NODE_TYPES
+                    and dst_type not in GOVERNANCE_NODE_TYPES
+                ):
+                    valid = False
+                else:
+                    rule = SAFETY_AI_RELATION_RULES.get(conn_type)
+                    if rule and src_type in SAFETY_AI_NODE_TYPES:
+                        targets = rule.get(src_type)
+                        if not targets or dst_type not in targets:
+                            valid = False
+            if valid:
+                new_conns.append(conn)
+            else:
+                rel_id = conn.get("element_id") if isinstance(conn, dict) else getattr(conn, "element_id", "")
+                removed.add(rel_id)
+        if len(new_conns) != len(diag.connections):
+            diag.connections = new_conns
+            if diag.relationships:
+                diag.relationships = [r for r in diag.relationships if r not in removed]
+            repo.touch_diagram(diag.diag_id)
+    if removed:
+        repo.relationships = [r for r in repo.relationships if r.rel_id not in removed]
+
+
 def reload_config() -> None:
     """Reload diagram rule configuration at runtime."""
     global _CONFIG, ARCH_DIAGRAM_TYPES, SAFETY_AI_NODES, SAFETY_AI_NODE_TYPES
@@ -381,6 +441,7 @@ def reload_config() -> None:
     }
     NODE_CONNECTION_LIMITS = _CONFIG.get("node_connection_limits", {})
     GUARD_NODES = set(_CONFIG.get("guard_nodes", []))
+    _enforce_connection_rules()
 
 
 def _work_product_name(diag_type: str) -> str:
@@ -3658,15 +3719,6 @@ class SysMLDiagramWindow(tk.Frame):
             elif conn_type == "Re-use":
                 if src.obj_type not in ("Work Product", "Lifecycle Phase") or dst.obj_type != "Lifecycle Phase":
                     return False, "Re-use links must originate from a Work Product or Lifecycle Phase and target a Lifecycle Phase"
-            elif conn_type in ("Satisfied by", "Derived from"):
-                if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
-                    return False, "Requirement relations must connect Work Products"
-                from analysis.models import REQUIREMENT_WORK_PRODUCTS
-                req_wps = set(REQUIREMENT_WORK_PRODUCTS)
-                sname = src.properties.get("name")
-                dname = dst.properties.get("name")
-                if sname not in req_wps or dname not in req_wps:
-                    return False, "Requirement relations must connect requirement work products"
             elif conn_type == "Trace":
                 if src.obj_type != "Work Product" or dst.obj_type != "Work Product":
                     return False, "Trace links must connect Work Products"

--- a/tests/test_connection_rule_enforcement.py
+++ b/tests/test_connection_rule_enforcement.py
@@ -1,0 +1,45 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui import architecture
+from sysml.sysml_repository import SysMLRepository, SysMLRelationship
+
+
+def test_connection_rules_enforced_on_reload(tmp_path, monkeypatch):
+    cfg = {
+        "connection_rules": {
+            "Governance Diagram": {"Produces": {"Task": ["Work Product"]}}
+        }
+    }
+    path = tmp_path / "diagram_rules.json"
+    path.write_text(json.dumps(cfg))
+    orig_path = architecture._CONFIG_PATH
+    monkeypatch.setattr(architecture, "_CONFIG_PATH", path)
+    architecture.reload_config()
+
+    repo = SysMLRepository.reset_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    diag.objects = [
+        {"obj_id": 1, "obj_type": "Task"},
+        {"obj_id": 2, "obj_type": "Work Product"},
+    ]
+    rel = SysMLRelationship("r1", "Produces", "s", "t")
+    repo.relationships.append(rel)
+    diag.connections = [
+        {"src": 1, "dst": 2, "conn_type": "Produces", "element_id": "r1"}
+    ]
+    diag.relationships = ["r1"]
+
+    path.write_text(
+        json.dumps({"connection_rules": {"Governance Diagram": {"Produces": {}}}})
+    )
+    architecture.reload_config()
+
+    assert diag.connections == []
+    assert repo.relationships == []
+
+    monkeypatch.setattr(architecture, "_CONFIG_PATH", orig_path)
+    architecture.reload_config()

--- a/tests/test_requirement_rule_override.py
+++ b/tests/test_requirement_rule_override.py
@@ -1,0 +1,32 @@
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+import gui.architecture as arch
+
+
+def test_requirement_relation_respects_config():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    diag = SysMLDiagram(diag_id="d", diag_type="Governance Diagram")
+    repo.diagrams["d"] = diag
+
+    wp = SysMLObject(1, "Work Product", 0, 0, properties={"name": "WP"})
+    phase = SysMLObject(2, "Lifecycle Phase", 100, 0, properties={"name": "Phase"})
+    diag.objects = [wp, phase]
+
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.repo = repo
+    win.diagram_id = "d"
+    win.connections = []
+    win.objects = diag.objects
+
+    rules = arch.CONNECTION_RULES.setdefault("Governance Diagram", {})
+    orig = rules.get("Satisfied by")
+    rules["Satisfied by"] = {"Work Product": {"Lifecycle Phase"}}
+    try:
+        valid, msg = SysMLDiagramWindow.validate_connection(win, wp, phase, "Satisfied by")
+        assert valid, msg
+    finally:
+        if orig is None:
+            del rules["Satisfied by"]
+        else:
+            rules["Satisfied by"] = orig

--- a/tests/test_search_toolbox.py
+++ b/tests/test_search_toolbox.py
@@ -66,6 +66,13 @@ class SearchToolboxTests(unittest.TestCase):
         tb.search_var = DummyVar()
         tb.case_var = DummyVar(False)
         tb.regex_var = DummyVar(False)
+        tb.hazards_var = DummyVar(True)
+        tb.faults_var = DummyVar(True)
+        tb.malfunctions_var = DummyVar(True)
+        tb.fail_list_var = DummyVar(True)
+        tb.trigger_var = DummyVar(True)
+        tb.funcins_var = DummyVar(True)
+        tb.extra_sources = []
         tb.results_box = DummyListbox()
         tb.results = []
         tb.current_index = -1


### PR DESCRIPTION
## Summary
- purge model connections that no longer satisfy diagram rules after configuration changes
- expand search toolbox test stubs to fully initialise optional fields
- cover connection rule enforcement with regression test
- drop hardcoded requirement relation checks so configuration controls allowed endpoints
- ensure requirement relation config overrides are respected with regression test

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a15d607ef48327808f8d04be298f88