### PR TITLE
Normalize plan variants to single Plan toolbox item

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3554,18 +3554,18 @@ class SysMLDiagramWindow(tk.Frame):
         icon = self._icons.get(name)
         if icon is None:
             style = StyleManager.get_instance()
-            shape = self._shape_for_tool(name)
+            base = name[4:] if name.startswith("Add ") else name
+            if base.startswith("Generic "):
+                base = base[8:]
+            if base == "Process Area":
+                base = "Process"
+            if base in _PLAN_TYPES:
+                base = "Plan"
+            shape = self._shape_for_tool(base)
             if shape == "relation":
                 color = "black"
             else:
-                color = style.get_color(name)
-                if color == "#FFFFFF" and name.startswith("Add "):
-                    base = name[4:]
-                    if base.startswith("Generic "):
-                        base = base[8:]
-                    if base == "Process Area":
-                        base = "Process"
-                    color = style.get_color(base)
+                color = style.get_color(base)
                 if color == "#FFFFFF":
                     color = "black"
             icon = draw_icon(shape, color)
@@ -3579,6 +3579,8 @@ class SysMLDiagramWindow(tk.Frame):
                 name = name[8:]
             if name == "Process Area":
                 name = "System Boundary"
+        if name in _PLAN_TYPES:
+            name = "Plan"
         mapping = {
             "Select": "arrow",
             "Actor": "human",

--- a/tests/test_governance_icons.py
+++ b/tests/test_governance_icons.py
@@ -18,6 +18,15 @@ def test_governance_shapes_and_relations():
     assert shape(None, "Safety Goal") == "pentagon"
     assert shape(None, "Security Threat") == "cross"
     assert shape(None, "Plan") == "document"
+    for variant in [
+        "Safety Plan",
+        "Security Plan",
+        "Mitigation Plan",
+        "Deployment Plan",
+        "Maintenance Plan",
+        "Decommission Plan",
+    ]:
+        assert shape(None, variant) == "document"
 
     style = StyleManager.get_instance()
     for element in [


### PR DESCRIPTION
## Summary
- Map multiple plan variants to a unified "Plan" toolbox icon and shape
- Cover the normalization in tests to ensure all plan names render as a document

## Testing
- `pytest tests/test_governance_icons.py::test_governance_shapes_and_relations -q`
- `PYTHONPATH=. pytest tests/test_governance_element_stereotype_label.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a33522c6688327a6b3ca28a316f235