### PR TITLE
feat: add descriptive governance shapes

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3605,23 +3605,23 @@ class SysMLDiagramWindow(tk.Frame):
             "Data acquisition": "arrow",
             "Database": "cylinder",
             "System Boundary": "rect",
-            "Business Unit": "rect",
+            "Business Unit": "department",
             "Data": "cylinder",
             "Document": "document",
-            "Guideline": "document",
-            "Metric": "diamond",
-            "Organization": "rect",
-            "Policy": "document",
-            "Principle": "triangle",
+            "Guideline": "compass",
+            "Metric": "chart",
+            "Organization": "building",
+            "Policy": "scroll",
+            "Principle": "scale",
             "Procedure": "document",
             "Record": "circle",
             "Role": "circle",
-            "Standard": "document",
-            "Process": "hexagon",
+            "Standard": "ribbon",
+            "Process": "gear",
             "Activity": "rect",
             "Task": "trapezoid",
-            "Operation": "ellipse",
-            "Driving Function": "triangle",
+            "Operation": "wrench",
+            "Driving Function": "steering",
             "Software Component": "rect",
             "Test Suite": "test",
             "System": "nested",
@@ -3630,16 +3630,17 @@ class SysMLDiagramWindow(tk.Frame):
             "Manufacturing Process": "hexagon",
             "Vehicle": "vehicle",
             "Fleet": "vehicle",
-            "Safety Compliance": "diamond",
+            "Safety Compliance": "shield_check",
             "Incident": "star",
             "Safety Issue": "triangle",
             "Field Data": "cylinder",
             "Model": "document",
             "Lifecycle Phase": "folder",
-            "Hazard": "triangle",
-            "Risk Assessment": "diamond",
-            "Safety Goal": "pentagon",
-            "Security Threat": "cross",
+            # Use more descriptive icon shapes for governance elements
+            "Hazard": "hazard",
+            "Risk Assessment": "clipboard",
+            "Safety Goal": "shield",
+            "Security Threat": "bug",
             "Report": "document",
             "Safety Case": "document",
             "Work Product": "rect",
@@ -6815,13 +6816,48 @@ class SysMLDiagramWindow(tk.Frame):
                 fill=outline,
             )
         elif obj.obj_type == "Business Unit":
+            # Building with a small flag on top to denote a unit
+            self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
             self.canvas.create_rectangle(
                 x - w,
                 y - h,
                 x + w,
                 y + h,
                 outline=outline,
-                fill=color,
+                fill="",
+            )
+            # simple windows
+            win_w = w * 0.4
+            win_h = h * 0.3
+            for dx in (-w * 0.6, 0):
+                self.canvas.create_rectangle(
+                    x + dx,
+                    y - h * 0.2,
+                    x + dx + win_w,
+                    y + h * 0.1,
+                    fill=StyleManager.get_instance().get_canvas_color(),
+                    outline=outline,
+                )
+            # flag
+            pole_x = x + w * 0.3
+            pole_top = y - h - h * 0.6
+            self.canvas.create_line(
+                pole_x,
+                y - h,
+                pole_x,
+                pole_top,
+                fill=outline,
+                width=max(2, self.zoom),
+            )
+            self.canvas.create_polygon(
+                pole_x,
+                pole_top,
+                pole_x + w * 0.4,
+                pole_top + h * 0.2,
+                pole_x,
+                pole_top + h * 0.4,
+                fill=outline,
+                outline=outline,
             )
         elif obj.obj_type == "Data":
             rh = min(10 * self.zoom, h)
@@ -6871,54 +6907,123 @@ class SysMLDiagramWindow(tk.Frame):
                 outline=outline,
             )
         elif obj.obj_type == "Guideline":
-            r = min(obj.width, obj.height) * self.zoom / 2
-            pts = []
-            for i in range(6):
-                angle = math.radians(60 * i)
-                px = x + r * math.cos(angle)
-                py = y + r * math.sin(angle)
-                pts.append((px, py))
-            self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
-            self.canvas.create_polygon(
-                [c for pt in pts for c in pt], outline=outline, fill=""
-            )
-        elif obj.obj_type == "Metric":
-            pts = [(x, y - h), (x + w, y), (x, y + h), (x - w, y)]
-            self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
-            self.canvas.create_polygon(
-                [c for pt in pts for c in pt], outline=outline, fill=""
-            )
-        elif obj.obj_type == "Organization":
-            radius = min(w, h)
-            self.drawing_helper._fill_gradient_circle(
-                self.canvas, x, y, radius, color
-            )
+            r = min(w, h)
+            self.drawing_helper._fill_gradient_circle(self.canvas, x, y, r, color)
             self.canvas.create_oval(
-                x - radius,
-                y - radius,
-                x + radius,
-                y + radius,
+                x - r,
+                y - r,
+                x + r,
+                y + r,
                 outline=outline,
                 fill="",
             )
-        elif obj.obj_type == "Policy":
-            r = min(obj.width, obj.height) * self.zoom / 2
-            pts = []
-            for i in range(8):
-                angle = math.radians(45 * i + 22.5)
-                px = x + r * math.cos(angle)
-                py = y + r * math.sin(angle)
-                pts.append((px, py))
-            self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
+            self.canvas.create_line(
+                x,
+                y,
+                x,
+                y - r,
+                fill=outline,
+                width=max(2, self.zoom),
+            )
             self.canvas.create_polygon(
-                [c for pt in pts for c in pt], outline=outline, fill=""
+                x,
+                y - r,
+                x + r * 0.3,
+                y - r * 0.3,
+                x - r * 0.3,
+                y - r * 0.3,
+                fill=outline,
+                outline=outline,
+            )
+        elif obj.obj_type == "Metric":
+            # Bar chart with three bars
+            bar_w = w * 0.4
+            spacing = w * 0.1
+            heights = [h * 0.6, h * 0.9, h * 0.4]
+            for i, bh in enumerate(heights):
+                bx1 = x - w + i * (bar_w + spacing)
+                bx2 = bx1 + bar_w
+                by2 = y + h
+                by1 = by2 - bh
+                self._draw_gradient_rect(bx1, by1, bx2, by2, color, obj.obj_id)
+                self.canvas.create_rectangle(
+                    bx1,
+                    by1,
+                    bx2,
+                    by2,
+                    outline=outline,
+                    fill="",
+                )
+        elif obj.obj_type == "Organization":
+            # Office building with windows
+            self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
+            self.canvas.create_rectangle(
+                x - w,
+                y - h,
+                x + w,
+                y + h,
+                outline=outline,
+                fill="",
+            )
+            cols, rows = 3, 2
+            win_w = (2 * w * 0.6) / cols
+            win_h = (2 * h * 0.6) / rows
+            start_x = x - w + w * 0.2
+            start_y = y - h + h * 0.2
+            for i in range(cols):
+                for j in range(rows):
+                    wx1 = start_x + i * win_w
+                    wy1 = start_y + j * win_h
+                    wx2 = wx1 + win_w * 0.7
+                    wy2 = wy1 + win_h * 0.7
+                    self.canvas.create_rectangle(
+                        wx1,
+                        wy1,
+                        wx2,
+                        wy2,
+                        fill=StyleManager.get_instance().get_canvas_color(),
+                        outline=outline,
+                    )
+        elif obj.obj_type == "Policy":
+            # Scroll with rolled ends
+            roll_r = min(w, h) * 0.3
+            body_left = x - w + roll_r
+            body_right = x + w - roll_r
+            self._draw_gradient_rect(body_left, y - h, body_right, y + h, color, obj.obj_id)
+            self.canvas.create_rectangle(
+                body_left,
+                y - h,
+                body_right,
+                y + h,
+                outline=outline,
+                fill="",
+            )
+            self.canvas.create_oval(
+                x - w,
+                y - h,
+                x - w + 2 * roll_r,
+                y + h,
+                outline=outline,
+                fill=color,
+            )
+            self.canvas.create_oval(
+                x + w - 2 * roll_r,
+                y - h,
+                x + w,
+                y + h,
+                outline=outline,
+                fill=color,
             )
         elif obj.obj_type == "Principle":
-            pts = [(x, y - h), (x + w, y + h), (x - w, y + h)]
-            self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
-            self.canvas.create_polygon(
-                [c for pt in pts for c in pt], outline=outline, fill=""
-            )
+            # Scales of justice
+            self.canvas.create_line(x, y - h, x, y + h, fill=outline, width=max(2, self.zoom))
+            self.canvas.create_line(x - w * 0.8, y - h * 0.3, x + w * 0.8, y - h * 0.3, fill=outline, width=max(2, self.zoom))
+            self.canvas.create_line(x - w * 0.4, y - h * 0.3, x - w * 0.6, y + h * 0.4, fill=outline)
+            self.canvas.create_line(x - w * 0.4, y - h * 0.3, x - w * 0.2, y + h * 0.4, fill=outline)
+            self.canvas.create_oval(x - w * 0.7, y + h * 0.4, x - w * 0.3, y + h * 0.8, fill=color, outline=outline)
+            self.canvas.create_line(x + w * 0.4, y - h * 0.3, x + w * 0.2, y + h * 0.4, fill=outline)
+            self.canvas.create_line(x + w * 0.4, y - h * 0.3, x + w * 0.6, y + h * 0.4, fill=outline)
+            self.canvas.create_oval(x + w * 0.3, y + h * 0.4, x + w * 0.7, y + h * 0.8, fill=color, outline=outline)
         elif obj.obj_type == "Procedure":
             offset = w * 0.3
             pts = [
@@ -6952,30 +7057,32 @@ class SysMLDiagramWindow(tk.Frame):
                 fill=StyleManager.get_instance().get_canvas_color(),
             )
         elif obj.obj_type == "Standard":
-            r = min(obj.width, obj.height) * self.zoom / 2
-            pts = []
-            for i in range(10):
-                angle = math.radians(36 * i - 90)
-                radius = r if i % 2 == 0 else r * 0.4
-                px = x + radius * math.cos(angle)
-                py = y + radius * math.sin(angle)
-                pts.append((px, py))
-            self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
+            r = min(w, h) * 0.6
+            cy = y - h * 0.2
+            self.drawing_helper._fill_gradient_circle(self.canvas, x, cy, r, color)
+            self.canvas.create_oval(x - r, cy - r, x + r, cy + r, outline=outline, fill="")
             self.canvas.create_polygon(
-                [c for pt in pts for c in pt], outline=outline, fill=""
+                x - r, cy + r * 0.2, x - r * 0.2, y + h, x, cy + r * 0.2,
+                fill=color, outline=outline
+            )
+            self.canvas.create_polygon(
+                x + r, cy + r * 0.2, x + r * 0.2, y + h, x, cy + r * 0.2,
+                fill=color, outline=outline
             )
         elif obj.obj_type == "Process" or obj.obj_type == "Manufacturing Process":
-            r = min(obj.width, obj.height) * self.zoom / 2
+            r = min(w, h)
             pts = []
-            for i in range(6):
-                angle = math.radians(60 * i)
-                px = x + r * math.cos(angle)
-                py = y + r * math.sin(angle)
+            teeth = 8
+            for i in range(teeth * 2):
+                angle = math.radians(360 / (teeth * 2) * i)
+                rad = r if i % 2 == 0 else r * 0.7
+                px = x + rad * math.cos(angle)
+                py = y + rad * math.sin(angle)
                 pts.append((px, py))
             self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
-            self.canvas.create_polygon(
-                [c for pt in pts for c in pt], outline=outline, fill=""
-            )
+            self.canvas.create_polygon([c for pt in pts for c in pt], outline=outline, fill="")
+            hole = r * 0.4
+            self.canvas.create_oval(x - hole, y - hole, x + hole, y + hole, outline=outline, fill=StyleManager.get_instance().get_canvas_color())
         elif obj.obj_type == "Activity":
             self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
             self._create_round_rect(
@@ -7000,24 +7107,19 @@ class SysMLDiagramWindow(tk.Frame):
                 [c for pt in pts for c in pt], outline=outline, fill=""
             )
         elif obj.obj_type == "Operation":
-            radius = min(w, h)
-            self.drawing_helper._fill_gradient_circle(
-                self.canvas, x, y, radius, color
-            )
-            self.canvas.create_oval(
-                x - radius,
-                y - radius,
-                x + radius,
-                y + radius,
-                outline=outline,
-                fill="",
-            )
+            handle_w = w * 0.3
+            self._draw_gradient_rect(x - handle_w/2, y, x + handle_w/2, y + h, color, obj.obj_id)
+            self.canvas.create_rectangle(x - handle_w/2, y, x + handle_w/2, y + h, outline=outline, fill="")
+            head_r = w
+            self.canvas.create_arc(x - head_r, y - head_r, x + head_r, y + head_r, start=30, extent=300, style=tk.ARC, outline=outline, width=max(2, self.zoom))
         elif obj.obj_type == "Driving Function":
-            pts = [(x - w, y - h), (x + w, y), (x - w, y + h)]
-            self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
-            self.canvas.create_polygon(
-                [c for pt in pts for c in pt], outline=outline, fill=""
-            )
+            r = min(w, h)
+            self.drawing_helper._fill_gradient_circle(self.canvas, x, y, r, color)
+            self.canvas.create_oval(x - r, y - r, x + r, y + r, outline=outline, fill="")
+            inner = r * 0.4
+            self.canvas.create_oval(x - inner, y - inner, x + inner, y + inner, outline=outline, fill=StyleManager.get_instance().get_canvas_color())
+            self.canvas.create_line(x - r, y, x + r, y, fill=outline, width=max(2, self.zoom))
+            self.canvas.create_line(x, y - r, x, y + r, fill=outline, width=max(2, self.zoom))
         elif obj.obj_type in ("Software Component", "Component"):
             self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
             self.canvas.create_rectangle(
@@ -7179,16 +7281,19 @@ class SysMLDiagramWindow(tk.Frame):
             )
         elif obj.obj_type == "Safety Compliance":
             pts = [
-                (x, y - h),
-                (x + w, y - h / 3),
-                (x + w * 0.6, y + h),
-                (x - w * 0.6, y + h),
-                (x - w, y - h / 3),
+                (x - w * 0.8, y - h * 0.7),
+                (x + w * 0.8, y - h * 0.7),
+                (x + w * 0.6, y + h * 0.1),
+                (x, y + h),
+                (x - w * 0.6, y + h * 0.1),
             ]
             self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
-            self.canvas.create_polygon(
-                [c for pt in pts for c in pt], outline=outline, fill=""
-            )
+            self.canvas.create_polygon([c for pt in pts for c in pt], outline=outline, fill="")
+            chk_start = (x - w * 0.4, y)
+            chk_mid = (x - w * 0.1, y + h * 0.3)
+            chk_end = (x + w * 0.5, y - h * 0.2)
+            self.canvas.create_line(*chk_start, *chk_mid, fill=outline, width=max(2, self.zoom))
+            self.canvas.create_line(*chk_mid, *chk_end, fill=outline, width=max(2, self.zoom))
         elif obj.obj_type == "Incident":
             r = min(obj.width, obj.height) * self.zoom / 2
             pts = []
@@ -7258,25 +7363,67 @@ class SysMLDiagramWindow(tk.Frame):
             self.canvas.create_line(x + w, y + h, x + w + off, y + h + off, fill=outline)
             self.canvas.create_line(x - w, y + h, x - w + off, y + h + off, fill=outline)
         elif obj.obj_type == "Hazard":
+            # Warning triangle with exclamation mark
             pts = [(x, y - h), (x + w, y + h), (x - w, y + h)]
             self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
             self.canvas.create_polygon(
                 [c for pt in pts for c in pt], outline=outline, fill=""
             )
-        elif obj.obj_type == "Risk Assessment":
-            pts = [(x, y - h), (x + w, y), (x, y + h), (x - w, y)]
-            self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
-            self.canvas.create_polygon(
-                [c for pt in pts for c in pt], outline=outline, fill=""
+            mark_top = y - h * 0.2
+            mark_bottom = y + h * 0.5
+            self.canvas.create_line(
+                x,
+                mark_top,
+                x,
+                mark_bottom,
+                fill=outline,
+                width=max(2, self.zoom),
             )
+            dot_r = max(2, self.zoom * 1.5)
+            self.canvas.create_oval(
+                x - dot_r / 2,
+                mark_bottom + dot_r / 4,
+                x + dot_r / 2,
+                mark_bottom + dot_r * 1.25,
+                fill=outline,
+                outline=outline,
+            )
+        elif obj.obj_type == "Risk Assessment":
+            # Clipboard with a check mark
+            clip_h = min(10 * self.zoom, h * 0.3)
+            board_top = y - h + clip_h
+            self._draw_gradient_rect(x - w, board_top, x + w, y + h, color, obj.obj_id)
+            self.canvas.create_rectangle(
+                x - w,
+                board_top,
+                x + w,
+                y + h,
+                outline=outline,
+                fill="",
+            )
+            clip_w = w * 0.6
+            self.canvas.create_rectangle(
+                x - clip_w,
+                y - h,
+                x + clip_w,
+                board_top,
+                outline=outline,
+                fill=color,
+            )
+            chk_start = (x - w * 0.6, y)
+            chk_mid = (x - w * 0.2, y + h * 0.4)
+            chk_end = (x + w * 0.6, y - h * 0.2)
+            self.canvas.create_line(*chk_start, *chk_mid, fill=outline, width=max(2, self.zoom))
+            self.canvas.create_line(*chk_mid, *chk_end, fill=outline, width=max(2, self.zoom))
         elif obj.obj_type == "Safety Goal":
-            r = min(obj.width, obj.height) * self.zoom / 2
-            pts = []
-            for i in range(5):
-                angle = math.radians(72 * i - 90)
-                px = x + r * math.cos(angle)
-                py = y + r * math.sin(angle)
-                pts.append((px, py))
+            # Shield shape
+            pts = [
+                (x - w * 0.8, y - h * 0.7),
+                (x + w * 0.8, y - h * 0.7),
+                (x + w * 0.6, y + h * 0.1),
+                (x, y + h),
+                (x - w * 0.6, y + h * 0.1),
+            ]
             self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
             self.canvas.create_polygon(
                 [c for pt in pts for c in pt], outline=outline, fill=""
@@ -7306,8 +7453,46 @@ class SysMLDiagramWindow(tk.Frame):
                 outline=outline,
             )
         elif obj.obj_type == "Security Threat":
-            self.canvas.create_line(x - w, y - h, x + w, y + h, fill=outline, width=2)
-            self.canvas.create_line(x - w, y + h, x + w, y - h, fill=outline, width=2)
+            # Simple bug silhouette to represent a threat
+            body_w = w * 0.6
+            body_h = h * 0.6
+            self.canvas.create_oval(
+                x - body_w,
+                y - body_h / 2,
+                x + body_w,
+                y + body_h / 2,
+                fill=color,
+                outline=outline,
+            )
+            head_r = min(w, h) * 0.25
+            self.canvas.create_oval(
+                x - head_r,
+                y - body_h / 2 - head_r * 1.2,
+                x + head_r,
+                y - body_h / 2 + head_r * 0.2,
+                fill=color,
+                outline=outline,
+            )
+            leg_y = [y - body_h / 4, y, y + body_h / 4]
+            leg_len = w * 0.9
+            for ly in leg_y:
+                self.canvas.create_line(x - body_w, ly, x - leg_len, ly, fill=outline)
+                self.canvas.create_line(x + body_w, ly, x + leg_len, ly, fill=outline)
+            # antennae
+            self.canvas.create_line(
+                x - head_r * 0.5,
+                y - body_h / 2 - head_r * 1.2,
+                x - head_r,
+                y - body_h / 2 - head_r * 1.8,
+                fill=outline,
+            )
+            self.canvas.create_line(
+                x + head_r * 0.5,
+                y - body_h / 2 - head_r * 1.2,
+                x + head_r,
+                y - body_h / 2 - head_r * 1.8,
+                fill=outline,
+            )
         elif obj.obj_type == "Use Case":
             radius = min(w, h)
             self.drawing_helper._fill_gradient_circle(
@@ -11900,18 +12085,22 @@ class ArchitectureManagerDialog(tk.Frame):
             "Database": self._create_icon("cylinder", style.get_color("Database")),
             "ANN": self._create_icon("neural", style.get_color("ANN")),
             "Data acquisition": self._create_icon("arrow", style.get_color("Data acquisition")),
-            "Business Unit": self._create_icon("rect", style.get_color("Business Unit")),
+            "Business Unit": self._create_icon("department", style.get_color("Business Unit")),
             "Data": self._create_icon("circle", style.get_color("Data")),
             "Document": self._create_icon("document", style.get_color("Document")),
-            "Guideline": self._create_icon("document", style.get_color("Guideline")),
-            "Metric": self._create_icon("diamond", style.get_color("Metric")),
-            "Organization": self._create_icon("rect", style.get_color("Organization")),
-            "Policy": self._create_icon("document", style.get_color("Policy")),
-            "Principle": self._create_icon("triangle", style.get_color("Principle")),
+            "Guideline": self._create_icon("compass", style.get_color("Guideline")),
+            "Metric": self._create_icon("chart", style.get_color("Metric")),
+            "Organization": self._create_icon("building", style.get_color("Organization")),
+            "Policy": self._create_icon("scroll", style.get_color("Policy")),
+            "Principle": self._create_icon("scale", style.get_color("Principle")),
             "Procedure": self._create_icon("document", style.get_color("Procedure")),
             "Record": self._create_icon("circle", style.get_color("Record")),
             "Role": self._create_icon("circle", style.get_color("Role")),
-            "Standard": self._create_icon("document", style.get_color("Standard")),
+            "Standard": self._create_icon("ribbon", style.get_color("Standard")),
+            "Safety Compliance": self._create_icon("shield_check", style.get_color("Safety Compliance")),
+            "Process": self._create_icon("gear", style.get_color("Process")),
+            "Operation": self._create_icon("wrench", style.get_color("Operation")),
+            "Driving Function": self._create_icon("steering", style.get_color("Driving Function")),
         }
         self.default_diag_icon = self._create_icon("rect", "gray")
         self.default_elem_icon = self._create_icon("rect", style.get_color("Existing Element"))

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from typing import Optional
+import math
 
 
 def create_icon(
@@ -123,6 +124,259 @@ def create_icon(
             img.put(outline, (mid + span, 2 + y))
         for x in range(2, size - 2):
             img.put(outline, (x, height + 2))
+    elif shape == "hazard":
+        mid = size // 2
+        height = size - 4
+        for y in range(height):
+            span = (y * mid) // height
+            img.put(c, to=(mid - span, 2 + y, mid + span + 1, 3 + y))
+            img.put(outline, (mid - span, 2 + y))
+            img.put(outline, (mid + span, 2 + y))
+        for x in range(2, size - 2):
+            img.put(outline, (x, height + 2))
+        for y in range(5, height):
+            img.put(outline, (mid, y))
+        for dy in range(height + 1, height + 3):
+            img.put(outline, (mid, dy))
+    elif shape == "clipboard":
+        img.put(c, to=(2, 4, size - 2, size - 2))
+        for x in range(2, size - 2):
+            img.put(outline, (x, 4))
+            img.put(outline, (x, size - 2))
+        for y in range(4, size - 2):
+            img.put(outline, (2, y))
+            img.put(outline, (size - 2, y))
+        for x in range(4, size - 4):
+            img.put(c, (x, 2))
+            img.put(outline, (x, 2))
+            img.put(outline, (x, 4))
+        img.put(outline, (4, 2))
+        img.put(outline, (size - 5, 2))
+        for i in range(3):
+            img.put(outline, (5 + i, 9 + i))
+        for i in range(5):
+            img.put(outline, (8 + i, 11 - i))
+    elif shape == "shield":
+        mid = size // 2
+        height = size - 4
+        for y in range(height):
+            if y < 4:
+                span = mid - 1
+            else:
+                span = max(mid - (y - 3), 0)
+            img.put(c, to=(mid - span, 2 + y, mid + span + 1, 3 + y))
+            img.put(outline, (mid - span, 2 + y))
+            img.put(outline, (mid + span, 2 + y))
+        img.put(outline, (mid, size - 2))
+    elif shape == "bug":
+        mid = size // 2
+        body_top = 5
+        body_bottom = size - 3
+        rx = size // 2 - 3
+        ry = (body_bottom - body_top) // 2
+        cy = (body_top + body_bottom) // 2
+        for y in range(body_top, body_bottom):
+            for x in range(size):
+                norm = ((x - mid) ** 2) / (rx * rx) + ((y - cy) ** 2) / (ry * ry)
+                if norm <= 1:
+                    img.put(c, (x, y))
+                if 1 <= norm <= 1.2:
+                    img.put(outline, (x, y))
+        head_r = 3
+        head_cy = body_top - head_r + 1
+        for y in range(head_cy - head_r, head_cy + head_r + 1):
+            for x in range(mid - head_r, mid + head_r + 1):
+                dist = (x - mid) ** 2 + (y - head_cy) ** 2
+                if dist <= head_r * head_r:
+                    img.put(c, (x, y))
+                if head_r * head_r <= dist <= (head_r + 1) * (head_r + 1):
+                    img.put(outline, (x, y))
+        for i, ly in enumerate([cy - 2, cy, cy + 2]):
+            for dx in range(3):
+                img.put(outline, (mid - rx - dx, ly + (dx % 2 - 1)))
+                img.put(outline, (mid + rx + dx, ly + (dx % 2 - 1)))
+        img.put(outline, (mid - 1, head_cy - head_r - 1))
+        img.put(outline, (mid - 2, head_cy - head_r - 2))
+        img.put(outline, (mid + 1, head_cy - head_r - 1))
+        img.put(outline, (mid + 2, head_cy - head_r - 2))
+    elif shape == "building":
+        img.put(c, to=(3,3,size-3,size-1))
+        for x in range(3, size-3):
+            img.put(outline, (x,3))
+            img.put(outline, (x,size-2))
+        for y in range(3, size-2):
+            img.put(outline, (3,y))
+            img.put(outline, (size-4,y))
+        for x in range(5, size-5, 4):
+            for y in range(5, size-4, 4):
+                img.put(bg or "white", to=(x,y,x+2,y+2))
+                for i in range(3):
+                    img.put(outline,(x+i,y))
+                    img.put(outline,(x+i,y+2))
+                for j in range(3):
+                    img.put(outline,(x,y+j))
+                    img.put(outline,(x+2,y+j))
+    elif shape == "department":
+        img.put(c, to=(3,5,size-3,size-1))
+        for x in range(3, size-3):
+            img.put(outline,(x,5))
+            img.put(outline,(x,size-2))
+        for y in range(5, size-2):
+            img.put(outline,(3,y))
+            img.put(outline,(size-4,y))
+        pole = size-5
+        for y in range(1,5):
+            img.put(outline,(pole,y))
+        img.put(c, to=(pole,1,size-2,3))
+        for x in range(pole, size-2):
+            img.put(outline,(x,1))
+            img.put(outline,(x,3))
+        img.put(outline,(pole,2))
+        img.put(outline,(size-2,2))
+    elif shape == "scroll":
+        img.put(c, to=(4,3,size-4,size-3))
+        for x in range(4,size-4):
+            img.put(outline,(x,3))
+            img.put(outline,(x,size-3))
+        for y in range(3,size-3):
+            img.put(outline,(4,y))
+            img.put(outline,(size-4,y))
+        for y in range(3,size-3):
+            img.put(c,(2,y)); img.put(c,(size-3,y))
+            img.put(outline,(2,y)); img.put(outline,(size-3,y))
+    elif shape == "scale":
+        mid=size//2
+        for y in range(3,size-3):
+            img.put(outline,(mid,y))
+        arm_y=6
+        for x in range(mid-6,mid+7):
+            img.put(outline,(x,arm_y))
+        for dx in range(4):
+            img.put(outline,(mid-4+dx,arm_y+dx+1))
+            img.put(outline,(mid+4-dx,arm_y+dx+1))
+        for x in range(mid-6,mid-1):
+            for y in range(arm_y+5,arm_y+7):
+                img.put(c,(x,y))
+                img.put(outline,(x,y))
+        for x in range(mid+1,mid+6):
+            for y in range(arm_y+5,arm_y+7):
+                img.put(c,(x,y))
+                img.put(outline,(x,y))
+    elif shape == "compass":
+        mid=size//2
+        r=size//2-2
+        for y in range(size):
+            for x in range(size):
+                d=(x-mid)**2+(y-mid)**2
+                if d<=r*r:
+                    img.put(c,(x,y))
+                if r*r<=d<= (r+1)*(r+1):
+                    img.put(outline,(x,y))
+        for y in range(mid):
+            img.put(outline,(mid,y))
+        for i in range(3):
+            img.put(outline,(mid-i,i))
+            img.put(outline,(mid+i,i))
+    elif shape == "ribbon":
+        mid=size//2
+        r=size//2-3
+        cy=mid-2
+        for y in range(size):
+            for x in range(size):
+                d=(x-mid)**2+(y-cy)**2
+                if d<=r*r:
+                    img.put(c,(x,y))
+                if r*r<=d<= (r+1)*(r+1):
+                    img.put(outline,(x,y))
+        for i in range(3):
+            img.put(c,(mid-r+i,cy+r))
+            img.put(c,(mid+r-i,cy+r))
+            img.put(outline,(mid-r+i,cy+r))
+            img.put(outline,(mid+r-i,cy+r))
+    elif shape == "chart":
+        heights=[8,12,5]
+        for i,h in enumerate(heights):
+            x1=2+i*5
+            for x in range(x1,x1+3):
+                for y in range(size-2-h,size-2):
+                    img.put(c,(x,y))
+                img.put(outline,(x,size-2-h))
+                img.put(outline,(x,size-2))
+            for y in range(size-2-h,size-2):
+                img.put(outline,(x1,y))
+                img.put(outline,(x1+2,y))
+    elif shape == "shield_check":
+        mid=size//2
+        for y in range(2,size-2):
+            span=mid-1 if y<5 else max(mid-(y-4),0)
+            img.put(c,to=(mid-span,y,mid+span+1,y+1))
+            img.put(outline,(mid-span,y))
+            img.put(outline,(mid+span,y))
+        img.put(outline,(mid,size-2))
+        for i in range(3):
+            img.put(outline,(4+i,9+i))
+        for i in range(5):
+            img.put(outline,(7+i,13-i))
+    elif shape == "gear":
+        mid=size//2
+        r1=size//2-1
+        r2=int(r1*0.7)
+        points=[]
+        teeth=8
+        for i in range(teeth*2):
+            ang=math.radians(360/(teeth*2)*i)
+            rad=r1 if i%2==0 else r2
+            x=int(mid+rad*math.cos(ang))
+            y=int(mid+rad*math.sin(ang))
+            points.append((x,y))
+        for y in range(size):
+            xs=[]
+            for i in range(len(points)):
+                x1,y1=points[i]; x2,y2=points[(i+1)%len(points)]
+                if y1==y2 or y<min(y1,y2) or y>=max(y1,y2):
+                    continue
+                x=x1+(y-y1)*(x2-x1)/(y2-y1)
+                xs.append(int(x))
+            xs.sort()
+            for j in range(0,len(xs),2):
+                img.put(c,to=(xs[j],y,xs[j+1]+1,y+1))
+        for x,y in points:
+            img.put(outline,(x,y))
+    elif shape == "wrench":
+        mid=size//2
+        for x in range(mid-1,mid+2):
+            img.put(c,to=(x,mid,x+1,size-2))
+            for y in range(mid,size-2):
+                img.put(outline,(mid-1,y))
+                img.put(outline,(mid+1,y))
+        for y in range(mid-5,mid-1):
+            for x in range(mid-3,mid+3):
+                if x in (mid-3,mid+2) or y in (mid-5,mid-2):
+                    img.put(outline,(x,y))
+                else:
+                    img.put(c,(x,y))
+    elif shape == "steering":
+        mid=size//2
+        r=size//2-2
+        for y in range(size):
+            for x in range(size):
+                d=(x-mid)**2+(y-mid)**2
+                if d<=r*r:
+                    img.put(c,(x,y))
+                if r*r<=d<= (r+1)*(r+1):
+                    img.put(outline,(x,y))
+        inner=int(r*0.4)
+        for y in range(size):
+            for x in range(size):
+                d=(x-mid)**2+(y-mid)**2
+                if d<=inner*inner:
+                    img.put(bg or "white",(x,y))
+                    if inner*inner<=d<= (inner+1)*(inner+1):
+                        img.put(outline,(x,y))
+        for x in range(mid-r,mid+r+1):
+            img.put(outline,(x,mid))
+        for y in range(mid-r,mid+r+1):
+            img.put(outline,(mid,y))
     elif shape == "cylinder":
         img.put(c, to=(2, 4, size - 2, size - 4))
         for x in range(2, size - 2):

--- a/tests/test_governance_icons.py
+++ b/tests/test_governance_icons.py
@@ -9,14 +9,24 @@ from gui.style_manager import StyleManager
 
 def test_governance_shapes_and_relations():
     shape = SysMLDiagramWindow._shape_for_tool
-    assert shape(None, "Process") == "hexagon"
     assert shape(None, "Task") == "trapezoid"
     assert shape(None, "Vehicle") == "vehicle"
     assert shape(None, "Approves") == "relation"
-    assert shape(None, "Hazard") == "triangle"
-    assert shape(None, "Risk Assessment") == "diamond"
-    assert shape(None, "Safety Goal") == "pentagon"
-    assert shape(None, "Security Threat") == "cross"
+    assert shape(None, "Hazard") == "hazard"
+    assert shape(None, "Risk Assessment") == "clipboard"
+    assert shape(None, "Safety Goal") == "shield"
+    assert shape(None, "Security Threat") == "bug"
+    assert shape(None, "Organization") == "building"
+    assert shape(None, "Business Unit") == "department"
+    assert shape(None, "Policy") == "scroll"
+    assert shape(None, "Principle") == "scale"
+    assert shape(None, "Guideline") == "compass"
+    assert shape(None, "Standard") == "ribbon"
+    assert shape(None, "Metric") == "chart"
+    assert shape(None, "Safety Compliance") == "shield_check"
+    assert shape(None, "Process") == "gear"
+    assert shape(None, "Operation") == "wrench"
+    assert shape(None, "Driving Function") == "steering"
     assert shape(None, "Plan") == "document"
     assert shape(None, "Data") == "cylinder"
     assert shape(None, "Field Data") == "cylinder"
@@ -27,6 +37,17 @@ def test_governance_shapes_and_relations():
         "Risk Assessment",
         "Safety Goal",
         "Security Threat",
+        "Organization",
+        "Business Unit",
+        "Policy",
+        "Principle",
+        "Guideline",
+        "Standard",
+        "Metric",
+        "Safety Compliance",
+        "Process",
+        "Operation",
+        "Driving Function",
         "Plan",
         "Data",
         "Field Data",


### PR DESCRIPTION
## Summary
- use building, department, scroll, scale and other custom icons for governance elements
- render matching shapes for organization, business unit, policies, metrics and more
- extend icon tests to cover new descriptive mappings

## Testing
- `pytest tests/test_governance_icons.py`


------
https://chatgpt.com/codex/tasks/task_b_68a343f58c4483278f69859963a78295