### PR TITLE
Render data nodes as database-style cylinders

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6380,6 +6380,38 @@ class SysMLDiagramWindow(tk.Frame):
         self.canvas.create_image(min(x1, x2), min(y1, y2), anchor="nw", image=img)
         self.gradient_cache[obj_id] = img
 
+    def _draw_cylinder(
+        self,
+        x1: float,
+        y1: float,
+        x2: float,
+        y2: float,
+        color: str,
+        outline: str,
+        obj_id: int,
+    ) -> None:
+        """Draw a cylinder shape matching the AI database icon."""
+
+        oval_h = min(10 * self.zoom, (y2 - y1) / 2)
+        self._draw_gradient_rect(x1, y1, x2, y2, color, obj_id)
+        self.canvas.create_rectangle(x1, y1, x2, y2, outline=outline, fill="")
+        self.canvas.create_oval(
+            x1,
+            y1 - oval_h,
+            x2,
+            y1 + oval_h,
+            fill=color,
+            outline=outline,
+        )
+        self.canvas.create_oval(
+            x1,
+            y2 - oval_h,
+            x2,
+            y2 + oval_h,
+            fill=color,
+            outline=outline,
+        )
+
 
     def _draw_open_arrow(
         self,
@@ -6862,32 +6894,16 @@ class SysMLDiagramWindow(tk.Frame):
                 fill=outline,
                 outline=outline,
             )
-        elif obj.obj_type == "Data":
-            rh = min(10 * self.zoom, h)
-            self.canvas.create_oval(
-                x - w,
-                y - h,
-                x + w,
-                y - h + 2 * rh,
-                outline=outline,
-                fill=color,
-            )
-            self.canvas.create_rectangle(
-                x - w,
-                y - h + rh,
-                x + w,
-                y + h - rh,
-                outline=outline,
-                fill=color,
-            )
-            self.canvas.create_oval(
-                x - w,
-                y + h - 2 * rh,
-                x + w,
-                y + h,
-                outline=outline,
-                fill=color,
-            )
+        elif obj.obj_type in ("Data", "Field Data", "AI Database"):
+            self._draw_cylinder(x - w, y - h, x + w, y + h, color, outline, obj.obj_id)
+            if obj.obj_type == "AI Database":
+                label = obj.properties.get("name", obj.obj_type)
+                self.canvas.create_text(
+                    x,
+                    y + h + 20 * self.zoom,
+                    text=label,
+                    font=self.font,
+                )
         elif obj.obj_type == "Document":
             self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
             self.canvas.create_rectangle(
@@ -7353,33 +7369,6 @@ class SysMLDiagramWindow(tk.Frame):
             self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
             self.canvas.create_polygon(
                 [c for pt in pts for c in pt], outline=outline, fill=""
-            )
-        elif obj.obj_type == "Field Data":
-            rh = min(10 * self.zoom, h)
-            self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
-            self.canvas.create_oval(
-                x - w,
-                y - h,
-                x + w,
-                y - h + 2 * rh,
-                outline=outline,
-                fill="",
-            )
-            self.canvas.create_rectangle(
-                x - w,
-                y - h + rh,
-                x + w,
-                y + h - rh,
-                outline=outline,
-                fill="",
-            )
-            self.canvas.create_oval(
-                x - w,
-                y + h - 2 * rh,
-                x + w,
-                y + h,
-                outline=outline,
-                fill="",
             )
         elif obj.obj_type == "Model":
             self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
@@ -8000,37 +7989,6 @@ class SysMLDiagramWindow(tk.Frame):
                     fill=color,
                     outline=outline,
                 )
-        elif obj.obj_type == "AI Database":
-            top = y - h
-            bottom = y + h
-            oval_h = 10 * self.zoom
-            self._draw_gradient_rect(x - w, top, x + w, bottom, color, obj.obj_id)
-            self.canvas.create_rectangle(
-                x - w,
-                top,
-                x + w,
-                bottom,
-                outline=outline,
-                fill="",
-            )
-            self.canvas.create_oval(
-                x - w,
-                top - oval_h,
-                x + w,
-                top + oval_h,
-                fill=color,
-                outline=outline,
-            )
-            self.canvas.create_oval(
-                x - w,
-                bottom - oval_h,
-                x + w,
-                bottom + oval_h,
-                fill=color,
-                outline=outline,
-            )
-            label = obj.properties.get("name", obj.obj_type)
-            self.canvas.create_text(x, bottom + 20 * self.zoom, text=label, font=self.font)
         elif obj.obj_type == "ANN":
             # Draw three layers of neurons connected
             layers = [3, 6, 2]

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -393,13 +393,42 @@ def create_icon(
         for y in range(mid-r,mid+r+1):
             img.put(outline,(mid,y))
     elif shape == "cylinder":
-        img.put(c, to=(2, 4, size - 2, size - 4))
-        for x in range(2, size - 2):
-            img.put(outline, (x, 4))
-            img.put(outline, (x, size - 4))
-        for x in range(3, size - 3):
-            img.put(outline, (x, 3))
-            img.put(outline, (x, size - 3))
+        # Represent a database cylinder with elliptical caps and a filled body
+        left, right = 2, size - 2
+        top, bottom = 4, size - 4
+        cx = size // 2
+        rx = (right - left) // 2
+        ry = 2
+
+        # Fill the central body
+        img.put(c, to=(left, top, right, bottom))
+
+        # Fill the top ellipse
+        for y in range(top - ry, top + 1):
+            for x in range(left, right):
+                norm = ((x - cx) ** 2) / (rx * rx) + ((y - top) ** 2) / (ry * ry)
+                if norm <= 1:
+                    img.put(c, (x, y))
+
+        # Fill the bottom ellipse
+        for y in range(bottom, bottom + ry + 1):
+            for x in range(left, right):
+                norm = ((x - cx) ** 2) / (rx * rx) + ((y - bottom) ** 2) / (ry * ry)
+                if norm <= 1:
+                    img.put(c, (x, y))
+
+        # Draw the outlines for the ellipses
+        for x in range(left, right):
+            y = int(ry * math.sqrt(max(0, 1 - ((x - cx) ** 2) / (rx * rx))))
+            img.put(outline, (x, top - y))
+            img.put(outline, (x, top + y))
+            img.put(outline, (x, bottom - y))
+            img.put(outline, (x, bottom + y))
+
+        # Draw the vertical side outlines
+        for y in range(top, bottom):
+            img.put(outline, (left, y))
+            img.put(outline, (right - 1, y))
     elif shape == "document":
         img.put(c, to=(2, 2, size - 2, size - 2))
         fold = bg or "white"

--- a/tests/test_cylinder_rendering.py
+++ b/tests/test_cylinder_rendering.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import tkinter.font as tkFont
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import SysMLDiagramWindow
+from gui.style_manager import StyleManager
+
+
+class DummyFont:
+    def configure(self, **kwargs):
+        pass
+
+
+class DummyCanvas:
+    def create_text(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture
+def window(monkeypatch):
+    monkeypatch.setattr(tkFont, "Font", lambda *a, **k: DummyFont())
+    StyleManager._instance = None
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.zoom = 1
+    win.canvas = DummyCanvas()
+    win.font = DummyFont()
+    win.gradient_cache = {}
+    win.drawing_helper = SimpleNamespace()
+    win.selected_objs = set()
+    win.repo = SimpleNamespace(
+        elements={}, diagrams={}, element_diagrams={}, relationships=[], get_linked_diagram=lambda _id: None
+    )
+    win.diagram_id = "D1"
+    return win
+
+
+def test_cylinder_shapes_use_common_draw(window, monkeypatch):
+    calls = []
+    monkeypatch.setattr(window, "_draw_cylinder", lambda *args, **kwargs: calls.append(args))
+    for t in ["Data", "Field Data", "AI Database"]:
+        class Obj(SimpleNamespace):
+            __hash__ = object.__hash__
+
+        obj = Obj(
+            obj_type=t,
+            x=0,
+            y=0,
+            width=40,
+            height=20,
+            obj_id=1,
+            properties={},
+            element_id=None,
+            phase="",
+            requirements=[],
+            locked=False,
+            hidden=False,
+            collapsed={},
+        )
+        window.draw_object(obj)
+    assert len(calls) == 3
+


### PR DESCRIPTION
## Summary
- Factor shared cylinder drawing helper for diagram nodes
- Draw Data, Field Data, and AI Database using the same cylinder shape
- Add regression test ensuring data nodes use cylinder renderer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a35d4490d483278f339313a7ca493b