### PR TITLE
Hide stereotypes on boundary shapes

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -682,6 +682,13 @@ def _format_label(
 
     label = name or ""
     if obj is not None:
+        # Boundary shapes should never display a stereotype prefix even on
+        # governance diagrams.  Showing stereotypes like ``<<block>>`` or
+        # ``<<system>>`` above a boundary adds noise without providing useful
+        # information, so we short‑circuit here and return the plain name.
+        if obj.obj_type in {"System Boundary", "Block Boundary"}:
+            return label
+
         repo = getattr(_win, "repo", None)
         diag_id = getattr(_win, "diagram_id", None)
         diag = repo.diagrams.get(diag_id) if repo and diag_id is not None else None

--- a/tests/test_boundary_stereotype_label.py
+++ b/tests/test_boundary_stereotype_label.py
@@ -1,0 +1,60 @@
+import unittest
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+class DummyFont:
+    def measure(self, text: str) -> int:
+        return len(text)
+
+    def metrics(self, name: str) -> int:
+        return 1
+
+
+class DummyWindow:
+    _object_label_lines = SysMLDiagramWindow._object_label_lines
+
+    def __init__(self, diag_id):
+        self.repo = SysMLRepository.get_instance()
+        self.zoom = 1.0
+        self.font = DummyFont()
+        self.diagram_id = diag_id
+
+
+class BoundaryStereotypeLabelTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+
+    def test_block_boundary_label_omits_stereotype(self):
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Governance Diagram")
+        elem = repo.create_element("Block", name="Boundary")
+        obj = SysMLObject(
+            1,
+            "Block Boundary",
+            0.0,
+            0.0,
+            element_id=elem.elem_id,
+            properties={"name": "Boundary"},
+        )
+        win = DummyWindow(diag.diag_id)
+        self.assertEqual(["Boundary"], win._object_label_lines(obj))
+
+    def test_system_boundary_label_omits_stereotype(self):
+        repo = SysMLRepository.get_instance()
+        diag = repo.create_diagram("Governance Diagram")
+        elem = repo.create_element("System", name="System")
+        obj = SysMLObject(
+            1,
+            "System Boundary",
+            0.0,
+            0.0,
+            element_id=elem.elem_id,
+            properties={"name": "System"},
+        )
+        win = DummyWindow(diag.diag_id)
+        self.assertEqual(["System"], win._object_label_lines(obj))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- Prevent `System Boundary` and `Block Boundary` objects from displaying stereotype prefixes
- Add tests ensuring boundary labels omit stereotypes even in governance diagrams

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3aed5f76083279f8522418dc79747