### PR TITLE
Add global properties tab for project elements

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -228,7 +228,7 @@ import sys
 import json
 import tkinter as tk
 from tkinter import ttk, filedialog, simpledialog, scrolledtext
-from gui import messagebox, logger
+from gui import messagebox, logger, add_treeview_scrollbars
 from gui.tooltip import ToolTip
 from gui.style_manager import StyleManager
 from gui.review_toolbox import (
@@ -2740,6 +2740,7 @@ class FaultTreeApp:
         tree_frame.columnconfigure(0, weight=1)
         self.analysis_tree.bind("<Double-1>", self.on_analysis_tree_double_click)
         self.analysis_tree.bind("<Button-3>", self.on_analysis_tree_right_click)
+        self.analysis_tree.bind("<<TreeviewSelect>>", self.on_analysis_tree_select)
         # Maintain backwards compatibility with older code referencing
         # ``self.treeview`` for the main explorer tree.
         self.treeview = self.analysis_tree
@@ -2758,6 +2759,17 @@ class FaultTreeApp:
         self.lifecycle_cb.pack(side=tk.LEFT, fill=tk.X, expand=True)
         self.lifecycle_cb.bind("<<ComboboxSelected>>", self.on_lifecycle_selected)
         self.tools_nb.pack(fill=tk.BOTH, expand=True)
+
+        # Properties tab for displaying metadata
+        prop_frame = ttk.Frame(self.tools_nb)
+        self.prop_view = ttk.Treeview(
+            prop_frame, columns=("field", "value"), show="headings"
+        )
+        self.prop_view.heading("field", text="Field")
+        self.prop_view.heading("value", text="Value")
+        add_treeview_scrollbars(self.prop_view, prop_frame)
+        self.tools_nb.add(prop_frame, text="Properties")
+
         # Tooltip helper for tabs (text may be clipped)
         self._tools_tip = ToolTip(self.tools_nb, "", automatic=False)
         self.tools_nb.bind("<Motion>", self._on_tool_tab_motion)
@@ -9214,6 +9226,76 @@ class FaultTreeApp:
         menu = tk.Menu(self.analysis_tree, tearoff=0)
         menu.add_command(label="Rename", command=self.rename_selected_tree_item)
         menu.tk_popup(event.x_root, event.y_root)
+
+    def on_analysis_tree_select(self, _event):
+        """Update property view when a tree item is selected."""
+        if not hasattr(self, "prop_view"):
+            return
+        item = self.analysis_tree.focus()
+        if not item:
+            return
+        tags = self.analysis_tree.item(item, "tags")
+        name = self.analysis_tree.item(item, "text")
+        meta = {"Name": name}
+        if tags:
+            meta["Type"] = tags[0]
+            if len(tags) > 1:
+                ident = tags[1]
+                meta["ID"] = ident
+                repo = SysMLRepository.get_instance()
+                elem = repo.elements.get(ident)
+                if elem:
+                    meta.update(
+                        {
+                            "Type": elem.elem_type,
+                            "Author": getattr(elem, "author", ""),
+                            "Created": getattr(elem, "created", ""),
+                            "Modified": getattr(elem, "modified", ""),
+                            "ModifiedBy": getattr(elem, "modified_by", ""),
+                        }
+                    )
+                else:
+                    diag = repo.diagrams.get(ident)
+                    if diag:
+                        meta.update(
+                            {
+                                "Type": diag.diag_type,
+                                "Author": getattr(diag, "author", ""),
+                                "Created": getattr(diag, "created", ""),
+                                "Modified": getattr(diag, "modified", ""),
+                                "ModifiedBy": getattr(diag, "modified_by", ""),
+                            }
+                        )
+        self.show_properties(meta=meta)
+
+    def show_properties(self, obj=None, meta=None):
+        """Display metadata for *obj* or *meta* dictionary in the properties tab."""
+        if not hasattr(self, "prop_view"):
+            return
+        self.prop_view.delete(*self.prop_view.get_children())
+        if obj:
+            if not obj:
+                return
+            self.prop_view.insert("", "end", values=("Type", obj.obj_type))
+            name = obj.properties.get("name", "")
+            if name:
+                self.prop_view.insert("", "end", values=("Name", name))
+            for k, v in obj.properties.items():
+                if k == "name":
+                    continue
+                self.prop_view.insert("", "end", values=(k, v))
+            if obj.element_id:
+                elem = SysMLRepository.get_instance().elements.get(obj.element_id)
+                if elem:
+                    self.prop_view.insert("", "end", values=("Author", getattr(elem, "author", "")))
+                    self.prop_view.insert("", "end", values=("Created", getattr(elem, "created", "")))
+                    self.prop_view.insert("", "end", values=("Modified", getattr(elem, "modified", "")))
+                    self.prop_view.insert(
+                        "", "end", values=("ModifiedBy", getattr(elem, "modified_by", ""))
+                    )
+        elif meta:
+            for k, v in meta.items():
+                self.prop_view.insert("", "end", values=(k, v))
 
     def rename_selected_tree_item(self):
         item = self.analysis_tree.focus()

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3528,21 +3528,24 @@ class SysMLDiagramWindow(tk.Frame):
                     command=lambda t=tool: self.select_tool(t),
                 ).pack(fill=tk.X, padx=2, pady=2)
 
-        self.prop_frame = ttk.LabelFrame(self.toolbox, text="Properties")
-        self.prop_frame.pack(fill=tk.BOTH, expand=True, padx=2, pady=2)
-        prop_tree_frame = ttk.Frame(self.prop_frame)
-        prop_tree_frame.pack(fill=tk.BOTH, expand=True)
-        self.prop_view = ttk.Treeview(
-            prop_tree_frame,
-            columns=("field", "value"),
-            show="headings",
-            height=8,
-        )
-        self.prop_view.heading("field", text="Field")
-        self.prop_view.heading("value", text="Value")
-        self.prop_view.column("field", width=80, anchor="w")
-        self.prop_view.column("value", width=120, anchor="w")
-        add_treeview_scrollbars(self.prop_view, prop_tree_frame)
+        if getattr(self.app, "prop_view", None):
+            self.prop_view = self.app.prop_view
+        else:
+            self.prop_frame = ttk.LabelFrame(self.toolbox, text="Properties")
+            self.prop_frame.pack(fill=tk.BOTH, expand=True, padx=2, pady=2)
+            prop_tree_frame = ttk.Frame(self.prop_frame)
+            prop_tree_frame.pack(fill=tk.BOTH, expand=True)
+            self.prop_view = ttk.Treeview(
+                prop_tree_frame,
+                columns=("field", "value"),
+                show="headings",
+                height=8,
+            )
+            self.prop_view.heading("field", text="Field")
+            self.prop_view.heading("value", text="Value")
+            self.prop_view.column("field", width=80, anchor="w")
+            self.prop_view.column("value", width=120, anchor="w")
+            add_treeview_scrollbars(self.prop_view, prop_tree_frame)
 
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
@@ -3638,6 +3641,9 @@ class SysMLDiagramWindow(tk.Frame):
 
     def update_property_view(self) -> None:
         """Display properties and metadata for the selected object."""
+        if self.app and hasattr(self.app, "show_properties"):
+            self.app.show_properties(obj=self.selected_obj)
+            return
         if not hasattr(self, "prop_view"):
             return
         self.prop_view.delete(*self.prop_view.get_children())

--- a/tests/test_properties_metadata.py
+++ b/tests/test_properties_metadata.py
@@ -1,0 +1,49 @@
+from AutoML import FaultTreeApp
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_analysis_tree_selection_shows_metadata():
+    # reset repository
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Use Case Diagram", name="Diag")
+
+    # setup minimal app instance without running __init__
+    app = FaultTreeApp.__new__(FaultTreeApp)
+
+    class DummyTree:
+        def __init__(self):
+            self._focus = "i1"
+            self.items = {
+                "i1": {"text": diag.name, "tags": ("arch", diag.diag_id)}
+            }
+
+        def focus(self):
+            return self._focus
+
+        def item(self, item, attr):
+            return self.items[item][attr]
+
+    class DummyPropView:
+        def __init__(self):
+            self.rows = []
+
+        def delete(self, *items):
+            self.rows = []
+
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def insert(self, _parent, _index, values):
+            self.rows.append(values)
+
+    app.analysis_tree = DummyTree()
+    app.prop_view = DummyPropView()
+    # bind methods
+    app.show_properties = FaultTreeApp.show_properties.__get__(app)
+    app.on_analysis_tree_select = FaultTreeApp.on_analysis_tree_select.__get__(app)
+
+    app.on_analysis_tree_select(None)
+    values = {k: v for k, v in app.prop_view.rows}
+    assert values["Author"] == diag.author
+    assert values["Created"] == diag.created


### PR DESCRIPTION
## Summary
- show author and timestamps in Properties tab for selected project items
- add regression test for property metadata display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3bbc0201883279d688b9e7d932406