### PR TITLE
Use scaled wrench icon for operation nodes

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -6950,6 +6950,52 @@ class SysMLDiagramWindow(tk.Frame):
             fill=outline,
         )
 
+    def _draw_icon_shape(
+        self, shape: str, x: float, y: float, r: float, color: str
+    ) -> None:
+        """Draw *shape* centered at ``(x, y)`` with radius *r* using the icon image."""
+        size = max(1, int(r * 2))
+        cache = getattr(self, "_scaled_icons", {})
+        key = (shape, color, size)
+        icon = cache.get(key)
+        if icon is None:
+            base = self._create_icon(shape, color)
+            if size != 16:
+                icon = base.zoom(size, size).subsample(16, 16)
+            else:
+                icon = base
+            cache[key] = icon
+            self._scaled_icons = cache
+        self.canvas.create_image(
+            x - size / 2, y - size / 2, anchor="nw", image=icon
+        )
+
+    def _draw_gear(
+        self, x: float, y: float, r: float, color: str, outline: str
+    ) -> None:
+        """Draw a gear centered at (*x*, *y*) with radius *r*."""
+        pts: list[tuple[float, float]] = []
+        teeth = 8
+        for i in range(teeth * 2):
+            angle = math.radians(360 / (teeth * 2) * i)
+            rad = r if i % 2 == 0 else r * 0.7
+            px = x + rad * math.cos(angle)
+            py = y + rad * math.sin(angle)
+            pts.append((px, py))
+        self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
+        self.canvas.create_polygon(
+            [coord for pt in pts for coord in pt], outline=outline, fill=""
+        )
+        hole = r * 0.4
+        self.canvas.create_oval(
+            x - hole,
+            y - hole,
+            x + hole,
+            y + hole,
+            outline=outline,
+            fill=StyleManager.get_instance().get_canvas_color(),
+        )
+
     def draw_object(self, obj: SysMLObject):
         x = obj.x * self.zoom
         y = obj.y * self.zoom
@@ -7299,20 +7345,15 @@ class SysMLDiagramWindow(tk.Frame):
                 font=label_font,
                 anchor="s",
             )
-        elif obj.obj_type == "Process" or obj.obj_type == "Manufacturing Process":
+        elif obj.obj_type in (
+            "Process",
+            "Manufacturing Process",
+        ):
             r = min(w, h)
-            pts = []
-            teeth = 8
-            for i in range(teeth * 2):
-                angle = math.radians(360 / (teeth * 2) * i)
-                rad = r if i % 2 == 0 else r * 0.7
-                px = x + rad * math.cos(angle)
-                py = y + rad * math.sin(angle)
-                pts.append((px, py))
-            self.drawing_helper._fill_gradient_polygon(self.canvas, pts, color)
-            self.canvas.create_polygon([c for pt in pts for c in pt], outline=outline, fill="")
-            hole = r * 0.4
-            self.canvas.create_oval(x - hole, y - hole, x + hole, y + hole, outline=outline, fill=StyleManager.get_instance().get_canvas_color())
+            self._draw_gear(x, y, r, color, outline)
+        elif obj.obj_type == "Operation":
+            r = min(w, h)
+            self._draw_icon_shape("wrench", x, y, r, color)
         elif obj.obj_type == "Activity":
             self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
             self._create_round_rect(
@@ -7336,41 +7377,6 @@ class SysMLDiagramWindow(tk.Frame):
             self.canvas.create_polygon(
                 [c for pt in pts for c in pt], outline=outline, fill=""
             )
-        elif obj.obj_type == "Operation":
-            handle_w = w * 0.25
-            head_r = w
-            bg = StyleManager.get_instance().get_canvas_color()
-            self.drawing_helper._fill_gradient_circle(self.canvas, x, y, head_r, color)
-            self.canvas.create_oval(x - head_r, y - head_r, x + head_r, y + head_r, outline=outline, fill="")
-            notch = [
-                (x + head_r * 0.4, y - head_r * 0.7),
-                (x + head_r, y - head_r * 0.2),
-                (x + head_r, y + head_r * 0.2),
-                (x + head_r * 0.4, y + head_r * 0.7),
-            ]
-            self.canvas.create_polygon(notch, fill=bg, outline=bg)
-            self.canvas.create_line(
-                x + head_r * 0.4,
-                y - head_r * 0.7,
-                x + head_r,
-                y - head_r * 0.2,
-                fill=outline,
-                width=max(2, self.zoom),
-            )
-            self.canvas.create_line(
-                x + head_r * 0.4,
-                y + head_r * 0.7,
-                x + head_r,
-                y + head_r * 0.2,
-                fill=outline,
-                width=max(2, self.zoom),
-            )
-            hx1, hx2 = x - handle_w / 2, x + handle_w / 2
-            hy1, hy2 = y, y + h
-            self._draw_gradient_rect(hx1, hy1, hx2, hy2, color, obj.obj_id)
-            self.canvas.create_rectangle(hx1, hy1, hx2, hy2, outline=outline, fill="")
-            hole_r = handle_w * 0.4
-            self.canvas.create_oval(x - hole_r, hy2 - hole_r * 2, x + hole_r, hy2, outline=outline, fill=bg)
         elif obj.obj_type == "Driving Function":
             r = min(w, h)
             self.drawing_helper._fill_gradient_circle(self.canvas, x, y, r, color)

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -347,6 +347,7 @@ def create_icon(
         mid = size // 2
         head_cy = 5
         r = 5
+        # Draw the outer head
         for y in range(head_cy - r, head_cy + r + 1):
             for x in range(mid - r, mid + r + 1):
                 dist = (x - mid) ** 2 + (y - head_cy) ** 2
@@ -354,18 +355,35 @@ def create_icon(
                     img.put(c, (x, y))
                 if r * r <= dist <= (r + 1) * (r + 1):
                     img.put(outline, (x, y))
-        notch_start = mid + r // 2
+        # Hollow out the head for an open-end look
+        inner = r - 2
+        for y in range(head_cy - inner, head_cy + inner + 1):
+            for x in range(mid - inner, mid + inner + 1):
+                dist = (x - mid) ** 2 + (y - head_cy) ** 2
+                if dist <= inner * inner:
+                    img.put(bg or "white", (x, y))
+                if inner * inner <= dist <= (inner + 1) * (inner + 1):
+                    img.put(outline, (x, y))
+        # Carve out a larger jaw opening for clearer wrench shape
+        notch_start = mid + 1
         for x in range(notch_start, mid + r + 1):
-            span = x - notch_start
-            for y in range(head_cy - span, head_cy + span + 1):
+            span = x - notch_start + 1
+            y_top = head_cy - span
+            y_bottom = head_cy + span
+            for y in range(y_top, y_bottom + 1):
                 img.put(bg or "white", (x, y))
-            img.put(outline, (x, head_cy - span))
-            img.put(outline, (x, head_cy + span))
+            if y_top >= head_cy - r:
+                img.put(outline, (x, y_top))
+            if y_bottom <= head_cy + r:
+                img.put(outline, (x, y_bottom))
+        # Draw the handle
+        handle_start = head_cy + inner
         for x in range(mid - 1, mid + 2):
-            img.put(c, to=(x, head_cy, x + 1, size - 2))
-        for y in range(head_cy, size - 2):
+            img.put(c, to=(x, handle_start, x + 1, size - 2))
+        for y in range(handle_start, size - 2):
             img.put(outline, (mid - 1, y))
             img.put(outline, (mid + 1, y))
+        # Add a small cap at the end of the handle
         for x in range(mid - 1, mid + 2):
             for y in range(size - 4, size - 2):
                 img.put(bg or "white", (x, y))


### PR DESCRIPTION
## Summary
- draw operation diagram nodes by scaling the wrench icon for a perfect match
- cache scaled icons per size and color for reuse

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3b4952fa48327921d8261b80da34e