### PR TITLE
Fix property view focus when switching from tree to diagram selection

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9276,6 +9276,12 @@ class FaultTreeApp:
         if obj:
             if not obj:
                 return
+            if hasattr(self, "analysis_tree"):
+                try:
+                    self.analysis_tree.selection_set(())
+                    self.analysis_tree.focus("")
+                except Exception:
+                    pass
             self.prop_view.insert("", "end", values=("Type", obj.obj_type))
             name = obj.properties.get("name", "")
             if name:

--- a/tests/test_properties_metadata.py
+++ b/tests/test_properties_metadata.py
@@ -1,6 +1,11 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from AutoML import FaultTreeApp
 from sysml.sysml_repository import SysMLRepository
-from gui.architecture import ArchitectureManagerDialog
+from gui.architecture import ArchitectureManagerDialog, SysMLObject
 from types import SimpleNamespace
 
 
@@ -95,3 +100,59 @@ def test_architecture_tree_selection_shows_metadata():
     values = {k: v for k, v in app.prop_view.rows}
     assert values["Author"] == diag.author
     assert values["Created"] == diag.created
+
+
+def test_diagram_selection_clears_tree_and_shows_object_properties():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Use Case Diagram", name="Diag")
+
+    obj = SysMLObject(1, "Actor", 0, 0, properties={"name": "Act"})
+
+    app = FaultTreeApp.__new__(FaultTreeApp)
+
+    class DummyTree:
+        def __init__(self):
+            self._focus = "i1"
+            self._sel = ("i1",)
+            self.items = {"i1": {"text": diag.name, "tags": ("arch", diag.diag_id)}}
+
+        def focus(self, item=None):
+            if item is None:
+                return self._focus
+            self._focus = item
+
+        def item(self, item, attr):
+            return self.items[item][attr]
+
+        def selection(self):
+            return self._sel
+
+        def selection_set(self, sel):
+            self._sel = tuple(sel)
+
+    class DummyPropView:
+        def __init__(self):
+            self.rows = []
+
+        def delete(self, *items):
+            self.rows = []
+
+        def get_children(self):
+            return list(range(len(self.rows)))
+
+        def insert(self, _parent, _index, values):
+            self.rows.append(values)
+
+    app.analysis_tree = DummyTree()
+    app.prop_view = DummyPropView()
+    app.show_properties = FaultTreeApp.show_properties.__get__(app)
+    app.on_analysis_tree_select = FaultTreeApp.on_analysis_tree_select.__get__(app)
+
+    app.on_analysis_tree_select(None)
+
+    app.show_properties(obj=obj)
+    values = {k: v for k, v in app.prop_view.rows}
+    assert values["Name"] == "Act"
+    assert values["Type"] == "Actor"
+    assert app.analysis_tree.selection() == ()


### PR DESCRIPTION
## Summary
- Clear analysis tree selection when a diagram object is chosen so the properties pane follows the diagram focus
- Test that selecting a diagram element after a tree item updates the properties and deselects the tree

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3c348913c832787a3ebf665c50668