### PR TITLE
Render Operation shape using scaled icon routine

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -7041,6 +7041,77 @@ class SysMLDiagramWindow(tk.Frame):
             fill=StyleManager.get_instance().get_canvas_color(),
         )
 
+    def _draw_wrench(
+        self, x: float, y: float, r: float, color: str, outline: str
+    ) -> None:
+        """Draw a wrench centered at (*x*, *y*) with radius *r*.
+
+        The shape mirrors the 16×16 icon from :mod:`gui.icon_factory` using the
+        same pixel routine scaled to the desired size.
+        """
+        size = 16
+        scale = (2 * r) / size
+        mid = size / 2
+        head_cy = 5
+        head_r = 5
+        inner = head_r - 2
+
+        bg = StyleManager.get_instance().get_canvas_color()
+
+        def _pt(px: float, py: float) -> tuple[float, float]:
+            return x - r + px * scale, y - r + py * scale
+
+        # Outer head
+        cx, cy = _pt(mid, head_cy)
+        hr = head_r * scale
+        self.canvas.create_oval(
+            cx - hr,
+            cy - hr,
+            cx + hr,
+            cy + hr,
+            fill=color,
+            outline=outline,
+        )
+
+        # Hollow center
+        ir = inner * scale
+        self.canvas.create_oval(
+            cx - ir,
+            cy - ir,
+            cx + ir,
+            cy + ir,
+            fill=bg,
+            outline=outline,
+        )
+
+        # Notch carved from the head
+        notch_start = mid + 1
+        p1 = _pt(notch_start, head_cy - 1)
+        p2 = _pt(mid + head_r, head_cy - head_r)
+        p3 = _pt(mid + head_r, head_cy + head_r)
+        p4 = _pt(notch_start, head_cy + 1)
+        self.canvas.create_polygon(
+            [coord for pt in (p1, p2, p3, p4) for coord in pt],
+            fill=bg,
+            outline=outline,
+        )
+
+        # Handle
+        handle_start = head_cy + inner
+        handle_bottom = size - 2
+        hl, ht = _pt(mid - 1, handle_start)
+        hr_x, hb = _pt(mid + 1, handle_bottom)
+        self.canvas.create_rectangle(hl, ht, hr_x, hb, fill=color, outline="")
+        self.canvas.create_line(hl, ht, hl, hb, fill=outline)
+        self.canvas.create_line(hr_x, ht, hr_x, hb, fill=outline)
+
+        # Cap at end of handle
+        cap_top = size - 4
+        cap_bottom = size - 2
+        cl, ct = _pt(mid - 1, cap_top)
+        cr, cb = _pt(mid + 1, cap_bottom)
+        self.canvas.create_rectangle(cl, ct, cr, cb, fill=bg, outline=outline)
+
     def draw_object(self, obj: SysMLObject):
         x = obj.x * self.zoom
         y = obj.y * self.zoom
@@ -7398,7 +7469,7 @@ class SysMLDiagramWindow(tk.Frame):
             self._draw_gear(x, y, r, color, outline)
         elif obj.obj_type == "Operation":
             r = min(w, h)
-            self._draw_icon_shape("wrench", x, y, r, color)
+            self._draw_wrench(x, y, r, color, outline)
         elif obj.obj_type == "Activity":
             self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
             self._create_round_rect(


### PR DESCRIPTION
## Summary
- Replace custom wrench drawing with scaled version of existing 16x16 icon routine so Operation shapes match the original icon.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3c500b8808327a5bcafc67d29c1bb