### PR TITLE
Simplify deletion confirmation for governance and SysML diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -8849,11 +8849,10 @@ class SysMLDiagramWindow(tk.Frame):
 
     def delete_selected(self, _event=None):
         if self.selected_objs:
-            result = messagebox.askyesnocancel(
-                "Delete",
-                "Remove element from model?\nYes = Model, No = Diagram",
+            confirmed = messagebox.askyesno(
+                "Delete", "Delete element permanently?"
             )
-            if result is None:
+            if not confirmed:
                 return
             for obj in list(self.selected_objs):
                 if obj.obj_type == "Work Product":
@@ -8871,13 +8870,10 @@ class SysMLDiagramWindow(tk.Frame):
                         diag = self.repo.diagrams.get(self.diagram_id)
                         diagram_name = diag.name if diag else ""
                         toolbox.remove_work_product(diagram_name, name)
-                if result:
-                    if obj.obj_type == "Part":
-                        self.remove_part_model(obj)
-                    else:
-                        self.remove_element_model(obj)
+                if obj.obj_type == "Part":
+                    self.remove_part_model(obj)
                 else:
-                    self.remove_object(obj)
+                    self.remove_element_model(obj)
             self.selected_objs = []
             self.selected_obj = None
             if getattr(self.app, "refresh_tool_enablement", None):

--- a/tests/test_governance_work_product_removal.py
+++ b/tests/test_governance_work_product_removal.py
@@ -46,10 +46,60 @@ def test_delete_work_product_updates_toolbox(monkeypatch, analysis):
     win.selected_obj = wp
     win.app = DummyApp()
 
-    monkeypatch.setattr(messagebox, "askyesnocancel", lambda *args, **kwargs: False)
+    monkeypatch.setattr(messagebox, "askyesno", lambda *args, **kwargs: True)
     monkeypatch.setattr(messagebox, "showerror", lambda *args, **kwargs: None)
 
     win.delete_selected()
 
     assert disabled == [analysis]
     assert toolbox.work_products == []
+
+
+@pytest.mark.parametrize("analysis", ["FI2TC", "TC2FI"])
+def test_cancel_delete_work_product_keeps_toolbox(monkeypatch, analysis):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Gov1", analysis, "")
+
+    disabled: list[str] = []
+
+    class DummyApp:
+        def can_remove_work_product(self, name):
+            return True
+
+        def disable_work_product(self, name):
+            disabled.append(name)
+
+        safety_mgmt_toolbox = toolbox
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.selected_conn = None
+    win.zoom = 1.0
+    win.remove_object = GovernanceDiagramWindow.remove_object.__get__(win, GovernanceDiagramWindow)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.remove_part_model = GovernanceDiagramWindow.remove_part_model.__get__(win, GovernanceDiagramWindow)
+    win.remove_element_model = GovernanceDiagramWindow.remove_element_model.__get__(win, GovernanceDiagramWindow)
+
+    wp = SysMLObject(1, "Work Product", 0, 0, properties={"name": analysis})
+    win.objects.append(wp)
+    win.selected_objs = [wp]
+    win.selected_obj = wp
+    win.app = DummyApp()
+
+    monkeypatch.setattr(messagebox, "askyesno", lambda *args, **kwargs: False)
+    monkeypatch.setattr(messagebox, "showerror", lambda *args, **kwargs: None)
+
+    win.delete_selected()
+
+    assert disabled == []
+    assert len(toolbox.work_products) == 1


### PR DESCRIPTION
## Summary
- Ask for permanent deletion when removing elements in SysML/Governance diagrams
- Update governance work product tests for new confirmation behaviour

## Testing
- `PYTHONPATH=. pytest tests/test_governance_work_product_removal.py`


------
https://chatgpt.com/codex/tasks/task_b_68a3ca16d9848327852b083657446985