### PR TITLE
Add launcher wrapper with automatic dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1525,24 +1525,38 @@ If sending fails with a connection error, the dialog will prompt again so you ca
 
 ## Dependencies
 
-AutoML relies on a few third‑party Python packages which must be installed
-before running the tool or creating the executable. Install them with pip:
+AutoML relies on a few third‑party Python packages. The new
+`launcher.py` script checks for these dependencies and installs any that are
+missing before handing off execution to `AutoML.py`. The required packages
+are:
+
+```
+Pillow openpyxl networkx matplotlib reportlab adjustText
+```
+
+You can still install them manually with pip if preferred:
 
 ```
 pip install pillow openpyxl networkx matplotlib reportlab adjustText
 ```
 
-PyInstaller requires these packages to be present so they are bundled into
-`AutoML.exe`. Missing dependencies, such as Pillow, will otherwise lead to
-`ModuleNotFoundError` when launching the built executable.
+When building the standalone executable with PyInstaller these packages must
+already be available so they can be bundled into `AutoML.exe`. Missing
+dependencies, such as Pillow, will otherwise lead to `ModuleNotFoundError`
+when launching the built executable.
 
-Note that Pillow provides the `PIL` module. The build scripts now verify
+Note that Pillow provides the `PIL` module. The build scripts verify
 dependencies with `python -m pip show` so the correct interpreter is used and
 pass `--hidden-import=PIL.ImageTk` to PyInstaller to ensure the module is
 bundled correctly.
 
 If double‑clicking `AutoML.py` closes immediately, launch it from a command
-prompt instead so any error messages remain visible.
+prompt instead so any error messages remain visible. Running `launcher.py`
+performs the dependency installation automatically:
+
+```
+python launcher.py
+```
 
 ## Diagram Styles
 
@@ -1557,7 +1571,8 @@ the desired style. All open diagrams update immediately.
 This project is licensed under the GNU General Public License version 3. See the [LICENSE](LICENSE) file for details.
 
 ## Building the Executable
-To create a standalone Windows executable with PyInstaller:
+To create a standalone Windows executable with PyInstaller that embeds the
+dependency-checking launcher:
 
 - **Linux/macOS:** run `bin/build_exe.sh`
 - **Windows:** run `bin\build_exe.bat`
@@ -1566,7 +1581,8 @@ You can invoke these scripts from any directory; they locate the repository
 root automatically. Both generate `AutoML.exe` inside the `bin` directory.
 After building you can launch the application directly or use
 `bin/run_automl.sh` on Unix-like systems or `bin\run_automl.bat` on
-Windows.
+Windows. The bundled executable executes `launcher.py` internally so it
+performs the same dependency installation when run from source.
 
 If a previous build failed and left an `AutoML.spec` file behind, the build
 scripts now delete it before running PyInstaller so your command line

--- a/bin/build_exe.bat
+++ b/bin/build_exe.bat
@@ -39,14 +39,15 @@ if defined ICON_PATH (
     )
 )
 
-REM Run PyInstaller from the repository root so it can locate AutoML.py
+REM Run PyInstaller from the repository root so it can locate launcher.py
 cd /d "%REPO_ROOT%"
 if exist AutoML.spec del AutoML.spec
 pyinstaller --noconfirm --onefile --windowed --name AutoML ^
     --exclude-module scipy ^
     --hidden-import=PIL.ImageTk ^
     --add-data "styles;styles" ^
-    %ICON_ARG% AutoML.py
+    --add-data "AutoML.py;." ^
+    %ICON_ARG% launcher.py
 if errorlevel 1 (
     echo Failed to build executable.
     exit /b %errorlevel%

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -35,7 +35,8 @@ pyinstaller --noconfirm --onefile --windowed \
     --name AutoML \
     --exclude-module scipy \
     --hidden-import=PIL.ImageTk \
-    --add-data "styles:styles" AutoML.py
+    --add-data "styles:styles" \
+    --add-data "AutoML.py:." launcher.py
 
 # Move the resulting executable to the bin directory
 mkdir -p bin

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Wrapper launcher for AutoML.
+
+This script ensures required third-party packages are available before
+executing :mod:`AutoML`.  When run inside the PyInstaller-built
+executable the dependencies are already bundled so the installation step
+is skipped.
+"""
+import importlib
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+
+REQUIRED_PACKAGES = [
+    "pillow",
+    "openpyxl",
+    "networkx",
+    "matplotlib",
+    "reportlab",
+    "adjustText",
+]
+
+def ensure_packages() -> None:
+    """Install any missing runtime dependencies.
+
+    When running from a PyInstaller executable, the packages are already
+    bundled and pip is not available, so the function simply returns.
+    """
+    if getattr(sys, "frozen", False):
+        return
+    for pkg in REQUIRED_PACKAGES:
+        try:
+            importlib.import_module(pkg)
+        except ImportError:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+
+def main() -> None:
+    ensure_packages()
+    base_path = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))
+    script = base_path / "AutoML.py"
+    runpy.run_path(str(script), run_name="__main__")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `launcher.py` wrapper that installs required packages before running `AutoML.py`
- update build scripts to package `launcher.py` and include `AutoML.py` as data
- document new launcher usage and executable build process in README

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3cb1eb8a8832782dfcbdd559deedf