### PR TITLE
Auto-install cryptography for encrypted save/load

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -19017,10 +19017,19 @@ class FaultTreeApp:
         try:
             from cryptography.fernet import Fernet
         except Exception:  # pragma: no cover - dependency check
-            messagebox.showerror(
-                "Save Model", "cryptography package is required for encrypted save."
-            )
-            return
+            import subprocess
+            import sys
+
+            try:
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", "cryptography"]
+                )
+                from cryptography.fernet import Fernet
+            except Exception:
+                messagebox.showerror(
+                    "Save Model", "cryptography package is required for encrypted save."
+                )
+                return
         from tkinter import simpledialog
         import base64
         import gzip
@@ -19063,10 +19072,19 @@ class FaultTreeApp:
             try:
                 from cryptography.fernet import Fernet, InvalidToken
             except Exception:  # pragma: no cover - dependency check
-                messagebox.showerror(
-                    "Load Model", "cryptography package is required for encrypted files."
-                )
-                return
+                import subprocess
+                import sys
+
+                try:
+                    subprocess.check_call(
+                        [sys.executable, "-m", "pip", "install", "cryptography"]
+                    )
+                    from cryptography.fernet import Fernet, InvalidToken
+                except Exception:
+                    messagebox.showerror(
+                        "Load Model", "cryptography package is required for encrypted files."
+                    )
+                    return
             from tkinter import simpledialog
             import base64
             import gzip


### PR DESCRIPTION
## Summary
- Install the `cryptography` package on demand when saving models so encrypted `.autml` exports always work
- Apply the same auto-install logic when loading encrypted project files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3ca61aa4083278ebd1b5b8a2fbb1a