### PR TITLE
Include tkinter in PyInstaller build

### DIFF
--- a/bin/build_exe.bat
+++ b/bin/build_exe.bat
@@ -27,6 +27,15 @@ for %%P in (openpyxl networkx matplotlib reportlab adjustText) do (
     )
 )
 
+REM ``tkinter`` is a standard library module but may not be installed with
+REM minimal Python distributions.  Verify it is available before building so
+REM that the bundled executable contains the GUI components.
+python -c "import tkinter" >NUL 2>&1 || (
+    echo Missing required module 'tkinter'. Install the Tk bindings for your Python distribution.
+    echo For example, on Debian/Ubuntu: sudo apt-get install python3-tk.
+    exit /b 1
+)
+
 REM Ask the user for an optional icon to embed in the executable
 set "ICON_ARG="
 set /P "ICON_PATH=Enter path to .ico icon file (leave blank for none): "
@@ -45,6 +54,7 @@ if exist AutoML.spec del AutoML.spec
 pyinstaller --noconfirm --onefile --windowed --name AutoML ^
     --exclude-module scipy ^
     --hidden-import=PIL.ImageTk ^
+    --hidden-import=tkinter ^
     --add-data "styles;styles" ^
     --add-data "AutoML.py;." ^
     %ICON_ARG% launcher.py

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -18,6 +18,15 @@ for pkg in openpyxl networkx matplotlib reportlab adjustText; do
     }
 done
 
+# ``tkinter`` is a standard library module but may be shipped separately on
+# some platforms (e.g. on Debian based systems it is provided by the
+# ``python3-tk`` package).  Ensure it is available before attempting to build.
+python -c "import tkinter" >/dev/null 2>&1 || {
+    echo "Missing required module 'tkinter'. Install the Tk bindings for your "
+         "Python distribution (e.g. 'sudo apt-get install python3-tk')." >&2
+    exit 1
+}
+
 # Warn if running a pre-release Python build which may cause PyInstaller errors
 if python -c "import sys, re; v=sys.version; print('pre' if re.search('(alpha|beta|candidate|rc)', v) else '')" | grep -q pre; then
     echo "Warning: pre-release Python builds can fail with PyInstaller. Use a stable release." >&2
@@ -35,6 +44,7 @@ pyinstaller --noconfirm --onefile --windowed \
     --name AutoML \
     --exclude-module scipy \
     --hidden-import=PIL.ImageTk \
+    --hidden-import=tkinter \
     --add-data "styles:styles" \
     --add-data "AutoML.py:." launcher.py
 

--- a/launcher.py
+++ b/launcher.py
@@ -35,6 +35,20 @@ def ensure_packages() -> None:
         except ImportError:
             subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
 
+    # ``tkinter`` is part of the Python standard library but on some
+    # platforms (e.g. minimal Linux installations) it is provided by a
+    # separate package.  Import it explicitly so we can present a clear
+    # error message if it is missing rather than failing later when
+    # :mod:`AutoML` is executed.
+    try:
+        importlib.import_module("tkinter")
+    except ImportError as exc:  # pragma: no cover - depends on system setup
+        raise RuntimeError(
+            "tkinter is required for AutoML. Install the Tk bindings for "
+            "your Python distribution (e.g. 'sudo apt-get install python3-tk' "
+            "on Debian/Ubuntu)."
+        ) from exc
+
 def main() -> None:
     ensure_packages()
     base_path = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))


### PR DESCRIPTION
## Summary
- Ensure tkinter is bundled in PyInstaller builds
- Verify tkinter availability and provide clearer error when missing

## Testing
- `pytest tests/test_gui_classes.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3d12adaec83279ef5de8d139942d0