### PR TITLE
Include Tkinter in PyInstaller build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1584,6 +1584,11 @@ After building you can launch the application directly or use
 Windows. The bundled executable executes `launcher.py` internally so it
 performs the same dependency installation when run from source.
 
+The build scripts explicitly include Tkinter and its submodules so the GUI
+launches correctly when running the packaged executable. This prevents
+`ModuleNotFoundError: No module named 'tkinter'` errors on systems without a
+full Python installation.
+
 If a previous build failed and left an `AutoML.spec` file behind, the build
 scripts now delete it before running PyInstaller so your command line
 options are always applied.

--- a/bin/build_exe.bat
+++ b/bin/build_exe.bat
@@ -45,6 +45,11 @@ if exist AutoML.spec del AutoML.spec
 pyinstaller --noconfirm --onefile --windowed --name AutoML ^
     --exclude-module scipy ^
     --hidden-import=PIL.ImageTk ^
+    --hidden-import=tkinter ^
+    --hidden-import=tkinter.filedialog ^
+    --hidden-import=tkinter.simpledialog ^
+    --hidden-import=tkinter.scrolledtext ^
+    --hidden-import=tkinter.ttk ^
     --add-data "styles;styles" ^
     --add-data "AutoML.py;." ^
     %ICON_ARG% launcher.py

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -35,6 +35,11 @@ pyinstaller --noconfirm --onefile --windowed \
     --name AutoML \
     --exclude-module scipy \
     --hidden-import=PIL.ImageTk \
+    --hidden-import=tkinter \
+    --hidden-import=tkinter.filedialog \
+    --hidden-import=tkinter.simpledialog \
+    --hidden-import=tkinter.scrolledtext \
+    --hidden-import=tkinter.ttk \
     --add-data "styles:styles" \
     --add-data "AutoML.py:." launcher.py
 


### PR DESCRIPTION
## Summary
- Ensure PyInstaller bundles Tkinter and its submodules so the AutoML executable can launch its GUI
- Document Tkinter bundling in the build instructions

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_b_68a3d12adaec83279ef5de8d139942d0