### PR TITLE
Fix duplicate relationship buttons in governance core toolbox

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -11229,8 +11229,6 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             frames = [self.tools_frame]
             if name == "Governance Core":
                 frames.append(action_frame)
-                if getattr(self, "rel_frame", None):
-                    frames.append(self.rel_frame)
             frames.append(build_frame(name, data))
             self._toolbox_frames[name] = frames
 

--- a/tests/test_governance_core_actions.py
+++ b/tests/test_governance_core_actions.py
@@ -61,6 +61,7 @@ def test_governance_core_has_add_buttons(monkeypatch):
     win._rebuild_toolboxes()
     assert "Governance Core" in win._toolbox_frames
     core_frames = win._toolbox_frames["Governance Core"]
+    assert win.rel_frame not in core_frames
     actions = core_frames[1]
     labels = [child.text for child in getattr(actions, "children", [])]
     assert {
@@ -69,3 +70,8 @@ def test_governance_core_has_add_buttons(monkeypatch):
         "Add Process Area",
         "Add Lifecycle Phase",
     } <= set(labels)
+
+    rel_sections = [child for child in getattr(core_frames[-1], "children", []) if getattr(child, "text", "") == "Relationships (relationships)"]
+    assert len(rel_sections) == 1
+    rel_labels = [child.text for child in getattr(rel_sections[0], "children", [])]
+    assert len(rel_labels) == len(set(rel_labels))


### PR DESCRIPTION
## Summary
- avoid adding the generic relationship frame to the Governance Core toolbox to prevent duplicated relationship buttons
- add a regression test ensuring Governance Core displays each relationship only once

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a3d5872a7483278572a13a66c8fd92