### PR TITLE
Show bidirectional governance connections in tooltips

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -751,7 +751,10 @@
         "Manufacturing Process": [],
         "Metric": [],
         "Model": [],
-        "Operation": [],
+        "Operation": [
+          "Procedure",
+          "Process"
+        ],
         "Organization": [],
         "Plan": [],
         "Policy": [],
@@ -1850,7 +1853,11 @@
         "Manufacturing Process": [],
         "Metric": [],
         "Model": [],
-        "Operation": [],
+        "Operation": [
+          "Data",
+          "Document",
+          "Record"
+        ],
         "Organization": [],
         "Plan": [],
         "Policy": [],

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -315,6 +315,29 @@ def _toolbox_defs() -> dict[str, dict[str, list[str] | dict]]:
         }
     return defs
 
+
+def _gov_connection_text(node_type: str) -> str:
+    """Return tooltip text listing governance connections for ``node_type``."""
+    node_type = _GOV_TYPE_ALIASES.get(node_type, node_type)
+    rules = CONNECTION_RULES.get("Governance Diagram", {})
+    outgoing: dict[str, list[str]] = {}
+    incoming: dict[str, list[str]] = {}
+    for rel, srcs in rules.items():
+        targets = srcs.get(node_type)
+        if targets:
+            outgoing[rel] = sorted(targets)
+        for src, dests in srcs.items():
+            if node_type in dests:
+                incoming.setdefault(rel, []).append(src)
+    if not outgoing and not incoming:
+        return ""
+    lines = ["To Others | From Others"]
+    for rel in sorted(set(outgoing) | set(incoming)):
+        outs = ", ".join(outgoing.get(rel, []))
+        ins = ", ".join(sorted(incoming.get(rel, [])))
+        lines.append(f"{rel}: {outs} | {ins}")
+    return "\n".join(lines)
+
 # Node type aliases used when validating governance diagram connections.
 # Governance tasks are implemented using SysML ``Action`` elements but are
 # presented as "Task" to users.  Mapping aliases before applying connection
@@ -3560,6 +3583,12 @@ class SysMLDiagramWindow(tk.Frame):
         canvas_frame.columnconfigure(0, weight=1)
         canvas_frame.rowconfigure(0, weight=1)
 
+        if ToolTip:
+            self._conn_tip = ToolTip(self.canvas, "", automatic=False)
+        else:  # pragma: no cover - tooltip module unavailable
+            self._conn_tip = None
+        self._conn_tip_obj = None
+
         # Keep references to gradient images used for element backgrounds
         self.gradient_cache: dict[int, tk.PhotoImage] = {}
         # Track bounding boxes for compartment toggle buttons
@@ -5148,6 +5177,8 @@ class SysMLDiagramWindow(tk.Frame):
             self.redraw()
 
     def on_mouse_move(self, event):
+        x = self.canvas.canvasx(event.x)
+        y = self.canvas.canvasy(event.y)
         if self.start and self.current_tool in (
             "Association",
             "Include",
@@ -5170,10 +5201,29 @@ class SysMLDiagramWindow(tk.Frame):
             "Control Action",
             "Feedback",
         ):
-            x = self.canvas.canvasx(event.x)
-            y = self.canvas.canvasy(event.y)
             self.temp_line_end = (x, y)
             self.redraw()
+            return
+        if self._conn_tip:
+            diag = self.repo.diagrams.get(self.diagram_id)
+            obj = self.find_object(x, y)
+            if (
+                diag
+                and diag.diag_type == "Governance Diagram"
+                and obj
+                and obj is not self._conn_tip_obj
+            ):
+                text = _gov_connection_text(obj.obj_type)
+                if text:
+                    self._conn_tip.text = text
+                    self._conn_tip.show()
+                    self._conn_tip_obj = obj
+                else:
+                    self._conn_tip.hide()
+                    self._conn_tip_obj = None
+            elif not obj and self._conn_tip_obj is not None:
+                self._conn_tip.hide()
+                self._conn_tip_obj = None
 
     def on_double_click(self, event):
         x = self.canvas.canvasx(event.x)

--- a/tests/test_governance_element_connection_rules.py
+++ b/tests/test_governance_element_connection_rules.py
@@ -11,3 +11,5 @@ def test_governance_element_connection_rules():
     rules = cfg["connection_rules"]["Governance Diagram"]
     assert set(rules["Approves"]["Role"]) == {"Document", "Policy", "Procedure", "Record"}
     assert set(rules["Uses"]["Role"]) == {"Document", "Data", "Record"}
+    assert set(rules["Executes"]["Operation"]) == {"Procedure", "Process"}
+    assert set(rules["Uses"]["Operation"]) == {"Data", "Document", "Record"}

--- a/tests/test_governance_tooltips.py
+++ b/tests/test_governance_tooltips.py
@@ -1,0 +1,81 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+from config import load_diagram_rules
+
+
+class DummyCanvas:
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+
+class DummyTip:
+    def __init__(self, widget, text, automatic=False):
+        self.text = text
+
+    def show(self, x=None, y=None):
+        pass
+
+    def hide(self):
+        pass
+
+
+def _expected_text(cfg, node_type: str) -> str:
+    rules = cfg["connection_rules"]["Governance Diagram"]
+    outgoing = {}
+    incoming = {}
+    for rel, srcs in rules.items():
+        targets = srcs.get(node_type, [])
+        if targets:
+            outgoing[rel] = sorted(targets)
+        for src, dests in srcs.items():
+            if node_type in dests:
+                incoming.setdefault(rel, []).append(src)
+    if not outgoing and not incoming:
+        return ""
+    lines = ["To Others | From Others"]
+    for rel in sorted(set(outgoing) | set(incoming)):
+        outs = ", ".join(outgoing.get(rel, []))
+        ins = ", ".join(sorted(incoming.get(rel, [])))
+        lines.append(f"{rel}: {outs} | {ins}")
+    return "\n".join(lines)
+
+
+def test_governance_element_tooltips(monkeypatch):
+    cfg = load_diagram_rules(Path(__file__).resolve().parents[1] / "config/diagram_rules.json")
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov")
+
+    role = SysMLObject(1, "Role", 0.0, 0.0)
+    org = SysMLObject(2, "Organization", 200.0, 0.0)
+    op = SysMLObject(3, "Operation", 400.0, 0.0)
+
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.canvas = DummyCanvas()
+    win._conn_tip = DummyTip(win.canvas, "")
+    win._conn_tip_obj = None
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.current_tool = "Select"
+    win.start = None
+    win.zoom = 1.0
+    win.objects = [role, org, op]
+    win.find_object = SysMLDiagramWindow.find_object.__get__(win)
+
+    win.on_mouse_move(types.SimpleNamespace(x=0, y=0))
+    assert win._conn_tip.text == _expected_text(cfg, "Role")
+
+    win.on_mouse_move(types.SimpleNamespace(x=200, y=0))
+    assert win._conn_tip.text == _expected_text(cfg, "Organization")
+
+    win.on_mouse_move(types.SimpleNamespace(x=400, y=0))
+    assert win._conn_tip.text == _expected_text(cfg, "Operation")


### PR DESCRIPTION
## Summary
- expand Operation diagram rules with execute and use relationships
- display outgoing and incoming governance connections in tooltip columns
- test tooltip behavior including Operation

## Testing
- `pytest tests/test_governance_tooltips.py tests/test_governance_element_connection_rules.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3d533204c8327aa9405a037699be5