### PR TITLE
Prompt for work product name when creating via connection

### DIFF
--- a/tests/test_governance_generic_work_product.py
+++ b/tests/test_governance_generic_work_product.py
@@ -7,6 +7,7 @@ from gui.architecture import GovernanceDiagramWindow
 from analysis import SafetyManagementToolbox
 from sysml.sysml_repository import SysMLRepository
 import pytest
+import types
 
 
 def test_add_generic_work_product(monkeypatch):
@@ -44,10 +45,12 @@ def test_add_generic_work_product(monkeypatch):
     win.add_generic_work_product()
 
     assert enable_calls == ["Custom WP"]
-    assert any(
-        o.obj_type == "Work Product" and o.properties.get("name") == "Custom WP"
+    obj = next(
+        o
         for o in win.objects
+        if o.obj_type == "Work Product" and o.properties.get("name") == "Custom WP"
     )
+    assert obj.properties.get("name_locked") != "1"
     assert any(wp.analysis == "Custom WP" for wp in toolbox.work_products)
 
     _sm.ACTIVE_TOOLBOX = prev_tb
@@ -95,3 +98,42 @@ def test_add_generic_work_product_name_conflict(monkeypatch):
     assert errors
 
     _sm.ACTIVE_TOOLBOX = prev_tb
+
+
+def test_connection_creates_generic_work_product(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.app = types.SimpleNamespace(
+        WORK_PRODUCT_INFO={},
+        enable_work_product=lambda *a, **k: None,
+        refresh_tool_enablement=lambda: None,
+        safety_mgmt_toolbox=None,
+    )
+
+    src = win._place_work_product("Requirement Specification", 0.0, 0.0)
+
+    connected = []
+    win._connect_objects = lambda s, d, c: connected.append((s, d, c))
+
+    monkeypatch.setattr(
+        "gui.architecture.simpledialog.askstring", lambda *a, **k: "Custom WP"
+    )
+
+    win._create_obj_and_conn(src, 100.0, 100.0, "Derived from", "Document")
+
+    obj = next(
+        o for o in win.objects if o.obj_type == "Work Product" and o.properties.get("name") == "Custom WP"
+    )
+    assert obj.properties.get("name_locked") != "1"
+    assert connected and connected[0][2] == "Derived from"

--- a/tests/test_work_product_name_read_only.py
+++ b/tests/test_work_product_name_read_only.py
@@ -19,8 +19,14 @@ class DummyVar:
 def test_work_product_name_read_only():
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
-    diag = repo.create_diagram("Governance Diagram")
-    obj = SysMLObject(1, "Work Product", 0.0, 0.0, properties={"name": "Risk Assessment"})
+    repo.create_diagram("Governance Diagram")
+    obj = SysMLObject(
+        1,
+        "Work Product",
+        0.0,
+        0.0,
+        properties={"name": "Risk Assessment", "name_locked": "1"},
+    )
     dlg = SysMLObjectDialog.__new__(SysMLObjectDialog)
     dlg.obj = obj
     dlg.master = object()
@@ -33,6 +39,25 @@ def test_work_product_name_read_only():
     dlg._behaviors = []
     dlg.apply()
     assert obj.properties["name"] == "Risk Assessment"
+
+
+def test_work_product_name_editable_when_unlocked():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    repo.create_diagram("Governance Diagram")
+    obj = SysMLObject(1, "Work Product", 0.0, 0.0, properties={"name": "Custom"})
+    dlg = SysMLObjectDialog.__new__(SysMLObjectDialog)
+    dlg.obj = obj
+    dlg.master = object()
+    dlg.name_var = DummyVar("Renamed")
+    dlg.width_var = DummyVar(str(obj.width))
+    dlg.height_var = DummyVar(str(obj.height))
+    dlg.entries = {}
+    dlg.listboxes = {}
+    dlg._operations = []
+    dlg._behaviors = []
+    dlg.apply()
+    assert obj.properties["name"] == "Renamed"
 
 
 def test_process_area_name_read_only():
@@ -111,6 +136,12 @@ def test_place_work_product_sets_name_locked():
     win = _create_win()
     win._place_work_product("FMEA", 0.0, 0.0)
     assert win.objects[-1].properties.get("name_locked") == "1"
+
+
+def test_place_generic_work_product_unlocked():
+    win = _create_win()
+    win._place_work_product("Generic", 0.0, 0.0, lock_name=False)
+    assert win.objects[-1].properties.get("name_locked") != "1"
 
 
 def test_place_process_area_sets_name_locked():


### PR DESCRIPTION
## Summary
- ensure generic work products dropped onto the canvas prompt for a name and remain editable
- gate name editability on a `name_locked` flag so unlocked work products can be renamed
- test creating generic work products directly and via connections retains an editable name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3d8f7b6bc83279b60e9654d4a0700