### PR TITLE
Display diagram type in diagram names

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3404,12 +3404,20 @@ def diagram_type_abbreviation(diag_type: str | None) -> str:
 
 
 def format_diagram_name(diagram: "SysMLDiagram | None") -> str:
-    """Return the diagram name with its stereotype abbreviation appended."""
+    """Return the diagram name with its stereotype abbreviation appended.
+
+    The abbreviation is added only once, even if the diagram name already
+    contains it. This avoids duplicated suffixes when the caller repeatedly
+    formats the same name or when a user manually includes the abbreviation in
+    the diagram name.
+    """
     if not diagram:
         return ""
     abbr = diagram_type_abbreviation(diagram.diag_type)
     name = diagram.name or diagram.diag_id
-    return f"{name} : {abbr}" if abbr else name
+    if abbr and not name.endswith(f" : {abbr}"):
+        name = f"{name} : {abbr}"
+    return name
 
 
 class SysMLDiagramWindow(tk.Frame):

--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -7,6 +7,15 @@ import os
 import datetime
 import analysis.user_config as user_config
 
+
+def _diagram_type_abbreviation(diag_type: str | None) -> str:
+    """Return an upper-case abbreviation for *diag_type*.
+
+    The abbreviation is constructed from the first letter of each word in the
+    diagram type. For example ``"Internal Block Diagram"`` becomes ``"IBD"``.
+    """
+    return "" if not diag_type else "".join(word[0] for word in diag_type.split()).upper()
+
 @dataclass
 class SysMLElement:
     """Basic AutoML element stored in the repository."""
@@ -70,8 +79,12 @@ class SysMLDiagram:
 
     # ------------------------------------------------------------
     def display_name(self) -> str:
-        """Return diagram name annotated with its creation phase."""
-        return f"{self.name} ({self.phase})" if self.phase else self.name
+        """Return diagram name annotated with its type and creation phase."""
+        name = self.name or self.diag_id
+        abbr = _diagram_type_abbreviation(self.diag_type)
+        if abbr and not name.endswith(f" : {abbr}"):
+            name = f"{name} : {abbr}"
+        return f"{name} ({self.phase})" if self.phase else name
 
 class SysMLRepository:
     """Singleton repository for all AutoML elements and relationships."""

--- a/tests/test_format_diagram_name.py
+++ b/tests/test_format_diagram_name.py
@@ -11,3 +11,8 @@ def test_format_diagram_name_ibd():
     diag = SysMLDiagram("d2", "Internal Block Diagram", name="Struct")
     assert format_diagram_name(diag) == "Struct : IBD"
 
+
+def test_format_diagram_name_does_not_duplicate():
+    diag = SysMLDiagram("d3", "Control Flow Diagram", name="Diag : CFD")
+    assert format_diagram_name(diag) == "Diag : CFD"
+

--- a/tests/test_phase_display_and_freeze.py
+++ b/tests/test_phase_display_and_freeze.py
@@ -17,11 +17,12 @@ def test_display_name_and_phase_rename_propagation():
     diag = repo.create_diagram("Use Case Diagram", name="D1")
     tb.doc_phases = {"HAZOP": {"HZ1": "P1"}}
     assert elem.display_name() == "E1 (P1)"
-    assert diag.display_name() == "D1 (P1)"
+    assert diag.display_name() == "D1 : UCD (P1)"
     tb.rename_module("P1", "NP")
     assert elem.phase == "NP"
     assert diag.phase == "NP"
     assert elem.display_name() == "E1 (NP)"
+    assert diag.display_name() == "D1 : UCD (NP)"
     assert tb.doc_phases["HAZOP"]["HZ1"] == "NP"
 
 


### PR DESCRIPTION
## Summary
- Append diagram type abbreviations to diagram display names with phase awareness.
- Prevent duplicate diagram type suffixes when formatting names.
- Extend tests for new name formatting behavior.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a3dc819eac8327bd3571fba44836c4