### PR TITLE
Clamp process area resizing to contents

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4644,7 +4644,7 @@ class SysMLDiagramWindow(tk.Frame):
                     self.update_property_view()
 
     def on_left_drag(self, event):
-        if self._conn_tip:
+        if getattr(self, "_conn_tip", None):
             self._conn_tip.hide()
             self._conn_tip_obj = None
         if self.start and self.current_tool in _all_connection_tools():
@@ -4780,6 +4780,7 @@ class SysMLDiagramWindow(tk.Frame):
             if obj.obj_type in _FIXED_SIZE_TYPES:
                 return
             min_w, min_h = (10.0, 10.0)
+            child_left = child_right = child_top = child_bottom = None
             if obj.obj_type == "Block":
                 min_w, min_h = self._min_block_size(obj)
             elif obj.obj_type in ("Action", "CallBehaviorAction"):
@@ -4788,28 +4789,57 @@ class SysMLDiagramWindow(tk.Frame):
                 min_w, min_h = self._min_data_acquisition_size(obj)
             elif obj.obj_type == "Block Boundary":
                 min_w, min_h = _boundary_min_size(obj, self.objects)
+            elif obj.obj_type == "System Boundary":
+                wps = [
+                    o
+                    for o in self.objects
+                    if o.obj_type == "Work Product"
+                    and o.properties.get("parent") == str(obj.obj_id)
+                ]
+                if wps:
+                    child_left = min(w.x - w.width / 2 for w in wps)
+                    child_right = max(w.x + w.width / 2 for w in wps)
+                    child_top = min(w.y - w.height / 2 for w in wps)
+                    child_bottom = max(w.y + w.height / 2 for w in wps)
+                    min_w = max(min_w, child_right - child_left)
+                    min_h = max(min_h, child_bottom - child_top)
+                if getattr(self, "font", None):
+                    label_lines = self._object_label_lines(obj)
+                    if label_lines:
+                        text_w = max(self.font.measure(line) for line in label_lines)
+                        text_h = self.font.metrics("linespace") * len(label_lines)
+                        min_w = max(min_w, (text_w + 10 * self.zoom) / self.zoom)
+                        min_h = max(min_h, (text_h + 10 * self.zoom) / self.zoom)
             left = obj.x - obj.width / 2
             right = obj.x + obj.width / 2
             top = obj.y - obj.height / 2
             bottom = obj.y + obj.height / 2
             if "e" in self.resize_edge:
                 new_right = x / self.zoom
+                if child_right is not None and new_right < child_right:
+                    new_right = child_right
                 if new_right - left < min_w:
                     new_right = left + min_w
                 right = new_right
             if "w" in self.resize_edge:
                 new_left = x / self.zoom
+                if child_left is not None and new_left > child_left:
+                    new_left = child_left
                 if right - new_left < min_w:
                     new_left = right - min_w
                 left = new_left
             if obj.obj_type not in ("Fork", "Join", "Existing Element"):
                 if "s" in self.resize_edge:
                     new_bottom = y / self.zoom
+                    if child_bottom is not None and new_bottom < child_bottom:
+                        new_bottom = child_bottom
                     if new_bottom - top < min_h:
                         new_bottom = top + min_h
                     bottom = new_bottom
                 if "n" in self.resize_edge:
                     new_top = y / self.zoom
+                    if child_top is not None and new_top > child_top:
+                        new_top = child_top
                     if bottom - new_top < min_h:
                         new_top = bottom - min_h
                     top = new_top
@@ -5033,7 +5063,7 @@ class SysMLDiagramWindow(tk.Frame):
             self._connect_objects(source, new_obj, conn_type)
 
     def on_left_release(self, event):
-        if self._conn_tip:
+        if getattr(self, "_conn_tip", None):
             self._conn_tip.hide()
             self._conn_tip_obj = None
         if self.start and self.current_tool in _all_connection_tools():
@@ -5252,7 +5282,11 @@ class SysMLDiagramWindow(tk.Frame):
                 else:
                     self.selected_obj.properties.pop("boundary", None)
             elif self.selected_obj.obj_type == "Work Product":
-                self.selected_obj.properties.pop("boundary", None)
+                b = self.find_boundary_for_obj(self.selected_obj)
+                if b:
+                    self.selected_obj.properties["boundary"] = str(b.obj_id)
+                else:
+                    self.selected_obj.properties.pop("boundary", None)
             self._sync_to_repository()
         self.redraw()
 
@@ -11608,7 +11642,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         if obj.obj_type != "Work Product":
             return
         if area is None:
-            pid = obj.properties.get("parent")
+            pid = obj.properties.get("parent") or obj.properties.get("boundary")
             if not pid:
                 return
             area = self.get_object(int(pid))
@@ -11618,8 +11652,12 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         right = area.x + area.width / 2 - obj.width / 2
         top = area.y - area.height / 2 + obj.height / 2
         bottom = area.y + area.height / 2 - obj.height / 2
-        obj.x = min(max(obj.x, left), right)
-        obj.y = min(max(obj.y, top), bottom)
+        if "parent" not in obj.properties and obj.properties.get("boundary"):
+            obj.x = area.x
+            obj.y = area.y
+        else:
+            obj.x = min(max(obj.x, left), right)
+            obj.y = min(max(obj.y, top), bottom)
         obj.properties["px"] = str(obj.x - area.x)
         obj.properties["py"] = str(obj.y - area.y)
 

--- a/tests/test_process_area_resize.py
+++ b/tests/test_process_area_resize.py
@@ -1,0 +1,85 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+
+class DummyFont:
+    def measure(self, text: str) -> int:
+        return len(text)
+
+    def metrics(self, name: str) -> int:
+        return 1
+
+
+class DummyCanvas:
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+
+def _setup_window():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.canvas = DummyCanvas()
+    win.font = DummyFont()
+    win.app = None
+    win.start = None
+    win.select_rect_start = None
+    win.dragging_conn_mid = None
+    win.selected_conn = None
+    win.dragging_endpoint = None
+    win.dragging_point_index = None
+    win.conn_drag_offset = None
+    win.endpoint_drag_pos = None
+    win.current_tool = "Select"
+    win.drag_offset = (0, 0)
+    return win
+
+
+def test_process_area_resize_clamped_to_children():
+    win = _setup_window()
+    area = win._place_process_area("Risk Assessment", 0.0, 0.0)
+    wp = win._place_work_product("Risk Assessment", 50.0, 0.0, area=area)
+    win.selected_obj = area
+    win.resizing_obj = area
+    win.resize_edge = "e"
+
+    class Event:
+        x = 40
+        y = 0
+
+    win.on_left_drag(Event())
+    assert area.x + area.width / 2 >= wp.x + wp.width / 2
+
+
+def test_process_area_resize_respects_text_size():
+    win = _setup_window()
+    area = win._place_process_area("Risk Assessment", 0.0, 0.0)
+    area.width = 50.0
+    win.selected_obj = area
+    win.resizing_obj = area
+    win.resize_edge = "w"
+
+    class Event:
+        x = 40
+        y = 0
+
+    win.on_left_drag(Event())
+    expected_min_w = len("Risk Assessment") + 10
+    assert area.width >= expected_min_w


### PR DESCRIPTION
## Summary
- Prevent process areas from shrinking smaller than their child work products or label text
- Recognize work products with only `boundary` metadata when constraining to a process area
- Add tests verifying process area resize clamping

## Testing
- `pytest tests/test_work_product_process_area_containment.py tests/test_work_product_process_area_lock.py tests/test_process_area_resize.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3e78b4e3c8327aee2d67b09f07486