### PR TITLE
Fix tab detachment and process area handling

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4141,7 +4141,7 @@ class SysMLDiagramWindow(tk.Frame):
     def on_left_press(self, event):
         x = self.canvas.canvasx(event.x)
         y = self.canvas.canvasy(event.y)
-        if self._conn_tip:
+        if getattr(self, "_conn_tip", None):
             self._conn_tip.hide()
             self._conn_tip_obj = None
         conn_tools = _all_connection_tools()
@@ -4644,7 +4644,7 @@ class SysMLDiagramWindow(tk.Frame):
                     self.update_property_view()
 
     def on_left_drag(self, event):
-        if self._conn_tip:
+        if getattr(self, "_conn_tip", None):
             self._conn_tip.hide()
             self._conn_tip_obj = None
         if self.start and self.current_tool in _all_connection_tools():
@@ -5033,7 +5033,7 @@ class SysMLDiagramWindow(tk.Frame):
             self._connect_objects(source, new_obj, conn_type)
 
     def on_left_release(self, event):
-        if self._conn_tip:
+        if getattr(self, "_conn_tip", None):
             self._conn_tip.hide()
             self._conn_tip_obj = None
         if self.start and self.current_tool in _all_connection_tools():
@@ -5252,7 +5252,11 @@ class SysMLDiagramWindow(tk.Frame):
                 else:
                     self.selected_obj.properties.pop("boundary", None)
             elif self.selected_obj.obj_type == "Work Product":
-                self.selected_obj.properties.pop("boundary", None)
+                b = self.find_boundary_for_obj(self.selected_obj)
+                if b:
+                    self.selected_obj.properties["boundary"] = str(b.obj_id)
+                else:
+                    self.selected_obj.properties.pop("boundary", None)
             self._sync_to_repository()
         self.redraw()
 
@@ -5312,7 +5316,7 @@ class SysMLDiagramWindow(tk.Frame):
             self.temp_line_end = (x, y)
             self.redraw()
             return
-        if self._conn_tip:
+        if getattr(self, "_conn_tip", None):
             diag = self.repo.diagrams.get(self.diagram_id)
             obj = self.find_object(x, y)
             if (
@@ -11496,10 +11500,27 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
 
     def add_work_product(self):  # pragma: no cover - requires tkinter
         if not getattr(self, "canvas", None):
-            area_name = self._select_process_area()
-            if not area_name:
-                return
-            area = self._place_process_area(area_name, 100.0, 100.0)
+            objs = getattr(self, "objects", [])
+            areas = [o for o in objs if o.obj_type == "System Boundary"]
+            existing = {a.properties.get("name", ""): a for a in areas}
+            if len(areas) == 1:
+                # Give the user a chance to select a different area; if they
+                # cancel the dialog we automatically use the existing one.
+                area_name = self._select_process_area()
+                if not area_name:
+                    area = areas[0]
+                    area_name = area.properties.get("name", "")
+                else:
+                    area = existing.get(area_name)
+                    if area is None:
+                        area = self._place_process_area(area_name, 100.0, 100.0)
+            else:
+                area_name = self._select_process_area()
+                if not area_name:
+                    return
+                area = existing.get(area_name)
+                if area is None:
+                    area = self._place_process_area(area_name, 100.0, 100.0)
             wp_name = self._select_work_product_for_area(area_name)
             if not wp_name:
                 return
@@ -11608,7 +11629,7 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         if obj.obj_type != "Work Product":
             return
         if area is None:
-            pid = obj.properties.get("parent")
+            pid = obj.properties.get("parent") or obj.properties.get("boundary")
             if not pid:
                 return
             area = self.get_object(int(pid))
@@ -11618,10 +11639,15 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         right = area.x + area.width / 2 - obj.width / 2
         top = area.y - area.height / 2 + obj.height / 2
         bottom = area.y + area.height / 2 - obj.height / 2
-        obj.x = min(max(obj.x, left), right)
-        obj.y = min(max(obj.y, top), bottom)
-        obj.properties["px"] = str(obj.x - area.x)
-        obj.properties["py"] = str(obj.y - area.y)
+        if left <= obj.x <= right and top <= obj.y <= bottom:
+            obj.properties["px"] = str(obj.x - area.x)
+            obj.properties["py"] = str(obj.y - area.y)
+        else:
+            # Outside the boundary: snap back to centre and reset offset
+            obj.x = area.x
+            obj.y = area.y
+            obj.properties["px"] = "0"
+            obj.properties["py"] = "0"
 
     def on_left_press(self, event):  # pragma: no cover - requires tkinter
         pending_click = getattr(self, "_pending_wp_click", False)

--- a/gui/closable_notebook.py
+++ b/gui/closable_notebook.py
@@ -72,6 +72,15 @@ class ClosableNotebook(ttk.Notebook):
         self.protected: set[str] = set()
         self._drag_data: dict[str, int | None] = {"tab": None, "x": 0, "y": 0}
         self._dragging = False
+        # ``_root_bindings`` store identifiers for bindings that temporarily
+        # attach to the containing toplevel while a drag operation is active.
+        # This ensures that we still receive ``<B1-Motion>`` and
+        # ``<ButtonRelease-1>`` events even when the pointer is dragged outside
+        # of the notebook's visible area.
+        self._root: tk.Misc | None = None
+        self._root_motion: str | None = None
+        self._root_release: str | None = None
+
         self.bind("<ButtonPress-1>", self._on_press, True)
         self.bind("<B1-Motion>", self._on_motion)
         self.bind("<ButtonRelease-1>", self._on_release, True)
@@ -119,7 +128,18 @@ class ClosableNotebook(ttk.Notebook):
             self.state(["pressed"])
             self._active = index
             return "break"
+
         self._drag_data = {"tab": index, "x": event.x_root, "y": event.y_root}
+        # While the mouse button is held down we want to continue receiving
+        # motion and release events even if the pointer leaves the notebook's
+        # area.  Temporarily bind to the toplevel that contains this notebook
+        # so those events are forwarded to the handlers below.  The bindings
+        # are removed again in ``_reset_drag`` once the drag operation ends.
+        self._root = self.winfo_toplevel()
+        self._root_motion = self._root.bind("<B1-Motion>", self._on_motion, add="+")
+        self._root_release = self._root.bind(
+            "<ButtonRelease-1>", self._on_release, add="+"
+        )
         return None
 
     def _on_motion(self, event: tk.Event) -> None:
@@ -245,3 +265,17 @@ class ClosableNotebook(ttk.Notebook):
     def _reset_drag(self) -> None:
         self._drag_data = {"tab": None, "x": 0, "y": 0}
         self._dragging = False
+        if self._root is not None:
+            if self._root_motion:
+                try:
+                    self._root.unbind("<B1-Motion>", self._root_motion)
+                except tk.TclError:
+                    pass
+            if self._root_release:
+                try:
+                    self._root.unbind("<ButtonRelease-1>", self._root_release)
+                except tk.TclError:
+                    pass
+            self._root = None
+            self._root_motion = None
+            self._root_release = None


### PR DESCRIPTION
## Summary
- keep receiving mouse events after the pointer leaves a notebook so tabs detach into new windows correctly
- guard tooltip access and improve process-area dialogs and constraints for work products

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3e8003a308327ad1c953bf895843e