### PR TITLE
Expand Properties tab value column

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2767,7 +2767,13 @@ class FaultTreeApp:
         )
         self.prop_view.heading("field", text="Field")
         self.prop_view.heading("value", text="Value")
+        # Keep the field column a fixed width so the value column can expand
+        # to occupy the remaining space of the tab. This makes long property
+        # values easier to read within the tools area's Properties tab.
+        self.prop_view.column("field", width=120, anchor="w", stretch=False)
+        self.prop_view.column("value", width=200, anchor="w", stretch=True)
         add_treeview_scrollbars(self.prop_view, prop_frame)
+        prop_frame.bind("<Configure>", self._resize_prop_columns)
         self.tools_nb.add(prop_frame, text="Properties")
 
         # Tooltip helper for tabs (text may be clipped)
@@ -9775,6 +9781,15 @@ class FaultTreeApp:
         if self._tools_tip.text != text:
             self._tools_tip.text = text
         self._tools_tip.show(x, y)
+
+    def _resize_prop_columns(self, event):
+        """Resize property view columns so value fills available space."""
+        try:
+            field_width = self.prop_view.column("field")["width"]
+            new_width = max(event.width - field_width - 20, 50)
+            self.prop_view.column("value", width=new_width)
+        except Exception:
+            pass
 
     def _on_doc_tab_motion(self, event):
         """Show tooltip for document notebook tabs when hovering over them."""

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3592,9 +3592,12 @@ class SysMLDiagramWindow(tk.Frame):
             )
             self.prop_view.heading("field", text="Field")
             self.prop_view.heading("value", text="Value")
-            self.prop_view.column("field", width=80, anchor="w")
-            self.prop_view.column("value", width=120, anchor="w")
+            # Ensure the field column stays fixed while the value column grows
+            # to utilize the available space within the Properties tab.
+            self.prop_view.column("field", width=80, anchor="w", stretch=False)
+            self.prop_view.column("value", width=180, anchor="w", stretch=True)
             add_treeview_scrollbars(self.prop_view, prop_tree_frame)
+            prop_tree_frame.bind("<Configure>", self._resize_prop_columns)
 
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
@@ -3693,6 +3696,15 @@ class SysMLDiagramWindow(tk.Frame):
         container.configure(width=container_width)
         canvas.configure(width=canvas_width)
         canvas.itemconfig(window, width=canvas_width)
+
+    def _resize_prop_columns(self, event) -> None:
+        """Adjust property view columns to fill the available space."""
+        try:
+            field_width = self.prop_view.column("field")["width"]
+            new_width = max(event.width - field_width - 20, 50)
+            self.prop_view.column("value", width=new_width)
+        except Exception:
+            pass
 
     def update_property_view(self) -> None:
         """Display properties and metadata for the selected object."""


### PR DESCRIPTION
## Summary
- Dynamically resize the Tools area Properties view so the value column fills remaining tab width
- Mirror resizing in architecture diagram windows to keep field column fixed and value flexible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3df6806548327892996f8143f27ca