### PR TITLE
Expand Properties tab value column

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3592,9 +3592,14 @@ class SysMLDiagramWindow(tk.Frame):
             )
             self.prop_view.heading("field", text="Field")
             self.prop_view.heading("value", text="Value")
-            self.prop_view.column("field", width=80, anchor="w")
-            self.prop_view.column("value", width=120, anchor="w")
+            # Ensure the field column stays fixed while the value column grows
+            # to utilize the available space within the Properties tab.
+            self.prop_view.column("field", width=80, anchor="w", stretch=False)
+            self.prop_view.column("value", width=180, anchor="w", stretch=True)
             add_treeview_scrollbars(self.prop_view, prop_tree_frame)
+            # Keep value column in sync with the Properties tab width.
+            self.prop_view.bind("<Configure>", self._resize_prop_columns)
+            prop_tree_frame.after(0, self._resize_prop_columns)
 
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
@@ -3693,6 +3698,17 @@ class SysMLDiagramWindow(tk.Frame):
         container.configure(width=container_width)
         canvas.configure(width=canvas_width)
         canvas.itemconfig(window, width=canvas_width)
+
+    def _resize_prop_columns(self, event: tk.Event | None = None) -> None:
+        """Adjust property view columns so the value column fills the tab."""
+        try:
+            self.prop_view.update_idletasks()
+            tree_width = event.width if event else self.prop_view.winfo_width()
+            field_width = self.prop_view.column("field")["width"]
+            new_width = max(tree_width - field_width, 20)
+            self.prop_view.column("value", width=new_width)
+        except Exception:
+            pass
 
     def update_property_view(self) -> None:
         """Display properties and metadata for the selected object."""


### PR DESCRIPTION
## Summary
- Ensure Properties tab value column automatically expands to fill tab width
- Sync architecture window value column with the tab width using the same approach

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3df6806548327892996f8143f27ca