### PR TITLE
Expose requirement pattern relations in governance toolbox

### DIFF
--- a/tests/test_requirement_pattern_relations_toolbox.py
+++ b/tests/test_requirement_pattern_relations_toolbox.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import _all_connection_tools, REQ_PATTERN_RELATIONS
+
+
+def test_requirement_patterns_relations_present():
+    tools = set(_all_connection_tools())
+    missing = [r for r in REQ_PATTERN_RELATIONS if r not in tools]
+    assert not missing, f"Missing relations: {missing}"


### PR DESCRIPTION
## Summary
- load relations from requirement patterns and merge into governance toolbox
- ensure all requirement relations are recognized for drawing and arrow handling
- test coverage for requirement pattern relation availability

## Testing
- `pytest tests/test_requirement_pattern_relations_toolbox.py tests/test_toolbox_dynamic_relations.py::test_irrelevant_relations_filtered -q`
- `pytest tests/test_governance_additional_relationship_requirements.py::test_generate_requirements_for_additional_relationships -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3f404b86c8327a9baf32df7f941c5