### PR TITLE
Guard property view resizing

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2767,7 +2767,19 @@ class FaultTreeApp:
         )
         self.prop_view.heading("field", text="Field")
         self.prop_view.heading("value", text="Value")
+        # ------------------------------------------------------------------
+        # NEVER DELETE OR TOUCH THIS:
+        # Keep the field column fixed so the value column can expand to occupy
+        # the remaining tab width, making long property values easier to read.
+        # ------------------------------------------------------------------
+        self.prop_view.column("field", width=120, anchor="w", stretch=False)
+        self.prop_view.column("value", width=200, anchor="w", stretch=True)
         add_treeview_scrollbars(self.prop_view, prop_frame)
+        # Bind resize handlers on both the treeview and its container so the
+        # value column always fills the tab width. DO NOT REMOVE.
+        self.prop_view.bind("<Configure>", self._resize_prop_columns)
+        prop_frame.bind("<Configure>", self._resize_prop_columns)
+        prop_frame.after(0, self._resize_prop_columns)
         self.tools_nb.add(prop_frame, text="Properties")
 
         # Tooltip helper for tabs (text may be clipped)
@@ -9775,6 +9787,23 @@ class FaultTreeApp:
         if self._tools_tip.text != text:
             self._tools_tip.text = text
         self._tools_tip.show(x, y)
+
+    # ----------------------------------------------------------------------
+    # NEVER DELETE OR TOUCH THIS: helper keeps the value column synced with
+    # the Properties tab width. Removing this breaks property display.
+    # ----------------------------------------------------------------------
+    def _resize_prop_columns(self, event: tk.Event | None = None) -> None:
+        """Resize property view columns so the value column fills the tab."""
+        if not hasattr(self, "prop_view"):
+            return
+
+        # Determine the current width of the treeview widget. When invoked via
+        # ``after`` there is no event, so query the widget directly.
+        self.prop_view.update_idletasks()
+        tree_width = event.width if event else self.prop_view.winfo_width()
+        field_width = self.prop_view.column("field")["width"]
+        new_width = max(tree_width - field_width, 20)
+        self.prop_view.column("value", width=new_width)
 
     def _on_doc_tab_motion(self, event):
         """Show tooltip for document notebook tabs when hovering over them."""

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3592,9 +3592,19 @@ class SysMLDiagramWindow(tk.Frame):
             )
             self.prop_view.heading("field", text="Field")
             self.prop_view.heading("value", text="Value")
-            self.prop_view.column("field", width=80, anchor="w")
-            self.prop_view.column("value", width=120, anchor="w")
+            # --------------------------------------------------------------
+            # NEVER DELETE OR TOUCH THIS:
+            # Keep the field column fixed so the value column can grow to fill
+            # the Properties tab width for readability.
+            # --------------------------------------------------------------
+            self.prop_view.column("field", width=80, anchor="w", stretch=False)
+            self.prop_view.column("value", width=180, anchor="w", stretch=True)
             add_treeview_scrollbars(self.prop_view, prop_tree_frame)
+            # Bind resize handlers on both widgets to keep value column synced.
+            # DO NOT REMOVE.
+            self.prop_view.bind("<Configure>", self._resize_prop_columns)
+            prop_tree_frame.bind("<Configure>", self._resize_prop_columns)
+            prop_tree_frame.after(0, self._resize_prop_columns)
 
         canvas_frame = ttk.Frame(self)
         canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
@@ -3693,6 +3703,21 @@ class SysMLDiagramWindow(tk.Frame):
         container.configure(width=container_width)
         canvas.configure(width=canvas_width)
         canvas.itemconfig(window, width=canvas_width)
+
+    # ------------------------------------------------------------------
+    # NEVER DELETE OR TOUCH THIS: required for keeping the value column
+    # aligned with the Properties tab width.
+    # ------------------------------------------------------------------
+    def _resize_prop_columns(self, event: tk.Event | None = None) -> None:
+        """Adjust property view columns so the value column fills the tab."""
+        if not hasattr(self, "prop_view"):
+            return
+
+        self.prop_view.update_idletasks()
+        tree_width = event.width if event else self.prop_view.winfo_width()
+        field_width = self.prop_view.column("field")["width"]
+        new_width = max(tree_width - field_width, 20)
+        self.prop_view.column("value", width=new_width)
 
     def update_property_view(self) -> None:
         """Display properties and metadata for the selected object."""


### PR DESCRIPTION
## Summary
- Lock in Tools area's Properties tab column widths so value column always fills tab, and warn future agents to never remove this block
- Apply same guarded resizing logic in architecture diagrams

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3df6806548327892996f8143f27ca