### PR TITLE
Deduplicate governance toolbox relations by category

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -279,26 +279,23 @@ def _relations_for(nodes: list[str]) -> list[str]:
     rels: set[str] = set()
     node_set = set(nodes)
 
+    def add_from(rules: dict[str, dict[str, set[str]]]) -> None:
+        for rel, srcs in rules.items():
+            for src, dests in srcs.items():
+                # A relation is relevant only when an element in ``node_set``
+                # can connect to another element in ``node_set`` using that
+                # relation.  Once a matching pair is found we stop scanning the
+                # remaining sources to avoid recording duplicate labels.
+                if src in node_set and node_set.intersection(dests):
+                    rels.add(rel)
+                    break
+
     # Only consider relationships defined for Governance diagrams.  Iterating
     # over all diagram rules caused every connection label to appear in each
     # toolbox even when a node had no valid targets for that relation.
-    gov_rules = CONNECTION_RULES.get("Governance Diagram", {})
-    for rel, srcs in gov_rules.items():
-        for src, dests in srcs.items():
-            # A relation is relevant only when an element in ``node_set`` can
-            # connect to another element in ``node_set`` using that relation.
-            # Previously, relations were surfaced whenever a node could act as
-            # either source *or* target.  This caused connections that required
-            # nodes outside the toolbox to appear.  Filtering to pairs within
-            # the toolbox ensures each displayed relationship is actionable for
-            # the current context.
-            if src in node_set and node_set.intersection(dests):
-                rels.add(rel)
+    add_from(CONNECTION_RULES.get("Governance Diagram", {}))
     # Apply the same filtering to Safety & AI specific rules.
-    for rel, srcs in SAFETY_AI_RELATION_RULES.items():
-        for src, dests in srcs.items():
-            if src in node_set and node_set.intersection(dests):
-                rels.add(rel)
+    add_from(SAFETY_AI_RELATION_RULES)
     return sorted(rels)
 
 

--- a/tests/test_governance_toolbox_relation_dedup.py
+++ b/tests/test_governance_toolbox_relation_dedup.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui import architecture
+
+
+def test_toolbox_relations_have_no_duplicates():
+    defs = architecture._toolbox_defs()
+    for group, data in defs.items():
+        rels = data.get("relations", [])
+        assert rels == sorted(set(rels))
+        for ext in data.get("externals", {}).values():
+            ext_rels = ext.get("relations", [])
+            assert ext_rels == sorted(set(ext_rels))


### PR DESCRIPTION
## Summary
- Ensure `_relations_for` stops scanning once a relevant pair is found to avoid duplicate relationship labels
- Add regression test verifying each toolbox and its externals list unique, sorted relationship names

## Testing
- `pytest tests/test_governance_toolbox_relation_dedup.py -q`
- `pytest tests/test_toolbox_dynamic_relations.py tests/test_governance_toolbox_relation_dedup.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a408225c0c8327b79f1352e730e5bd