### PR TITLE
Deduplicate governance relation toolbox entries

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -1935,14 +1935,7 @@
         "Role": [
           "Data",
           "Document",
-          "Record",
-          "Model",
-          "Test Suite",
-          "Component",
-          "System",
-          "Process",
-          "Procedure",
-          "Plan"
+          "Record"
         ],
         "Safety Compliance": [],
         "Safety Issue": [],

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -11451,6 +11451,29 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
     def _rebuild_toolboxes(self) -> None:
         defs = _toolbox_defs()
         ai_data = defs.pop("Safety & AI Lifecycle", None)
+        # Exclude relationships already available in the global relationships
+        # toolbox.  Without this filtering a relation like ``Flow`` added to the
+        # left-hand toolbox via ``relation_tools`` would also appear under each
+        # category that referenced it, leading to duplicate buttons when
+        # switching categories.
+        global_rels = set(getattr(self, "relation_tools", []) or [])
+        if global_rels:
+            for data in defs.values():
+                data["relations"] = [
+                    r for r in data.get("relations", []) if r not in global_rels
+                ]
+                for sub in data.get("externals", {}).values():
+                    sub["relations"] = [
+                        r for r in sub.get("relations", []) if r not in global_rels
+                    ]
+            if ai_data:
+                ai_data["relations"] = [
+                    r for r in ai_data.get("relations", []) if r not in global_rels
+                ]
+                for sub in ai_data.get("externals", {}).values():
+                    sub["relations"] = [
+                        r for r in sub.get("relations", []) if r not in global_rels
+                    ]
         if hasattr(self.tools_frame, "pack_forget"):
             self.tools_frame.pack_forget()
         if getattr(self, "rel_frame", None) and hasattr(self.rel_frame, "pack_forget"):

--- a/tests/test_governance_toolbox_relation_dedup.py
+++ b/tests/test_governance_toolbox_relation_dedup.py
@@ -1,0 +1,65 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import gui.architecture as arch
+from gui.architecture import GovernanceDiagramWindow
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_global_relation_not_duplicated(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+
+    ai_data = {"nodes": [], "relations": ["Flow", "Assess"], "externals": {}}
+    defs_data = {"Entities": {"nodes": [], "relations": ["Bar"], "externals": {}},
+                 "Safety & AI Lifecycle": ai_data}
+    monkeypatch.setattr(arch, "_toolbox_defs", lambda: defs_data)
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def pack_forget(self, *a, **k):
+            pass
+
+        def bind(self, *a, **k):
+            pass
+
+        def configure(self, *a, **k):
+            pass
+
+        def destroy(self, *a, **k):
+            pass
+
+    def fake_sysml_init(self, master, title, tools, diagram_id=None, app=None, history=None, relation_tools=None, tool_groups=None):
+        self.app = app
+        self.repo = repo
+        self.diagram_id = diagram_id
+        self.toolbox = DummyWidget()
+        self.tools_frame = DummyWidget()
+        self.rel_frame = DummyWidget()
+        self.toolbox_selector = DummyWidget()
+        self.toolbox_var = types.SimpleNamespace(get=lambda: "", set=lambda v: None)
+        self.relation_tools = relation_tools or []
+        self._toolbox_frames = {}
+        self.canvas = types.SimpleNamespace(master=DummyWidget())
+
+    monkeypatch.setattr(arch.SysMLDiagramWindow, "__init__", fake_sysml_init)
+    monkeypatch.setattr(arch, "draw_icon", lambda *a, **k: None)
+    monkeypatch.setattr(arch.GovernanceDiagramWindow, "refresh_from_repository", lambda self: None)
+    monkeypatch.setattr(arch.ttk, "Combobox", DummyWidget)
+    monkeypatch.setattr(arch.ttk, "Frame", DummyWidget)
+    monkeypatch.setattr(arch.ttk, "LabelFrame", DummyWidget)
+    monkeypatch.setattr(arch.ttk, "Button", DummyWidget)
+
+    win = GovernanceDiagramWindow(None, None, diagram_id=diag.diag_id)
+    # Relation "Flow" should be removed from the category since it exists in the
+    # global relation toolbox.
+    assert ai_data["relations"] == ["Assess"]


### PR DESCRIPTION
## Summary
- avoid duplicating relation buttons when switching governance toolbox categories
- correct `Role`-`Uses` rule to match test expectations
- add regression test for global relation tool deduplication

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a40a373bac832787fa4f436cb36188