### PR TITLE
Delete work products when removing process area

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2779,7 +2779,7 @@ class FaultTreeApp:
         # value column always fills the tab width. DO NOT REMOVE.
         self.prop_view.bind("<Configure>", self._resize_prop_columns)
         prop_frame.bind("<Configure>", self._resize_prop_columns)
-        prop_frame.after(0, self._resize_prop_columns)
+        self.root.after(0, self._resize_prop_columns)
         self.tools_nb.add(prop_frame, text="Properties")
 
         # Tooltip helper for tabs (text may be clipped)

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -9165,6 +9165,37 @@ class SysMLDiagramWindow(tk.Frame):
             if not confirmed:
                 return
             for obj in list(self.selected_objs):
+                if obj.obj_type == "System Boundary":
+                    wps = [
+                        o
+                        for o in self.objects
+                        if o.obj_type == "Work Product"
+                        and (
+                            o.properties.get("parent") == str(obj.obj_id)
+                            or o.properties.get("boundary") == str(obj.obj_id)
+                        )
+                    ]
+                    for wp in wps:
+                        name = wp.properties.get("name", "")
+                        if getattr(self.app, "can_remove_work_product", None):
+                            if not self.app.can_remove_work_product(name):
+                                messagebox.showerror(
+                                    "Delete",
+                                    f"Cannot delete work product '{name}' with existing artifacts.",
+                                )
+                                break
+                    else:
+                        for wp in wps:
+                            name = wp.properties.get("name", "")
+                            getattr(self.app, "disable_work_product", lambda *_: None)(name)
+                            toolbox = getattr(self.app, "safety_mgmt_toolbox", None)
+                            if toolbox:
+                                diag = self.repo.diagrams.get(self.diagram_id)
+                                diagram_name = diag.name if diag else ""
+                                toolbox.remove_work_product(diagram_name, name)
+                            self.remove_element_model(wp)
+                        self.remove_element_model(obj)
+                    continue
                 if obj.obj_type == "Work Product":
                     name = obj.properties.get("name", "")
                     if getattr(self.app, "can_remove_work_product", None):

--- a/tests/test_governance_work_product_removal.py
+++ b/tests/test_governance_work_product_removal.py
@@ -103,3 +103,105 @@ def test_cancel_delete_work_product_keeps_toolbox(monkeypatch, analysis):
 
     assert disabled == []
     assert len(toolbox.work_products) == 1
+
+
+def test_delete_process_area_removes_children(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Gov1", "FI2TC", "")
+
+    disabled: list[str] = []
+
+    class DummyApp:
+        def can_remove_work_product(self, name):
+            return True
+
+        def disable_work_product(self, name):
+            disabled.append(name)
+
+        safety_mgmt_toolbox = toolbox
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.selected_conn = None
+    win.zoom = 1.0
+    win.remove_object = GovernanceDiagramWindow.remove_object.__get__(win, GovernanceDiagramWindow)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.remove_part_model = GovernanceDiagramWindow.remove_part_model.__get__(win, GovernanceDiagramWindow)
+    win.remove_element_model = GovernanceDiagramWindow.remove_element_model.__get__(win, GovernanceDiagramWindow)
+
+    area = SysMLObject(1, "System Boundary", 0, 0, properties={"name": "Hazard & Threat Analysis"})
+    wp = SysMLObject(2, "Work Product", 0, 0, properties={"name": "FI2TC", "parent": "1"})
+    win.objects.extend([area, wp])
+    win.selected_objs = [area]
+    win.selected_obj = area
+    win.app = DummyApp()
+
+    monkeypatch.setattr(messagebox, "askyesno", lambda *args, **kwargs: True)
+    monkeypatch.setattr(messagebox, "showerror", lambda *args, **kwargs: None)
+
+    win.delete_selected()
+
+    assert disabled == ["FI2TC"]
+    assert toolbox.work_products == []
+    assert win.objects == []
+
+
+def test_delete_process_area_removes_boundary_children(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.add_work_product("Gov1", "Architecture Diagram", "")
+
+    disabled: list[str] = []
+
+    class DummyApp:
+        def can_remove_work_product(self, name):
+            return True
+
+        def disable_work_product(self, name):
+            disabled.append(name)
+
+        safety_mgmt_toolbox = toolbox
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.selected_conn = None
+    win.zoom = 1.0
+    win.remove_object = GovernanceDiagramWindow.remove_object.__get__(win, GovernanceDiagramWindow)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.remove_part_model = GovernanceDiagramWindow.remove_part_model.__get__(win, GovernanceDiagramWindow)
+    win.remove_element_model = GovernanceDiagramWindow.remove_element_model.__get__(win, GovernanceDiagramWindow)
+
+    area = SysMLObject(1, "System Boundary", 0, 0, properties={"name": "System Design (Item Definition)"})
+    wp = SysMLObject(2, "Work Product", 0, 0, properties={"name": "Architecture Diagram", "boundary": "1"})
+    win.objects.extend([area, wp])
+    win.selected_objs = [area]
+    win.selected_obj = area
+    win.app = DummyApp()
+
+    monkeypatch.setattr(messagebox, "askyesno", lambda *args, **kwargs: True)
+    monkeypatch.setattr(messagebox, "showerror", lambda *args, **kwargs: None)
+
+    win.delete_selected()
+
+    assert disabled == ["Architecture Diagram"]
+    assert toolbox.work_products == []
+    assert win.objects == []


### PR DESCRIPTION
## Summary
- handle work products linked via `boundary` when deleting a process area
- test removal of process area also deletes `boundary`-linked work products
- schedule property column resize via `root.after` to avoid GUI initialization error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a40c9676e08327b2eee9dda99c542a