### PR TITLE
Rename FaultTreeApp to AutoMLApp

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2041,7 +2041,7 @@ class DecompositionDialog(simpledialog.Dialog):
 ##########################################
 # Main Application (Parent Diagram)
 ##########################################
-class FaultTreeApp:
+class AutoMLApp:
     """Main application window for AutoML Analyzer."""
 
     #: Maximum number of characters displayed for a notebook tab title. Longer
@@ -21671,7 +21671,7 @@ def main():
         except tk.TclError:
             pass
 
-    app = FaultTreeApp(root)
+    app = AutoMLApp(root)
     root.mainloop()
 
 if __name__ == "__main__":

--- a/tests/test_cause_effect_diagram.py
+++ b/tests/test_cause_effect_diagram.py
@@ -96,7 +96,7 @@ numpy_stub.bool_ = bool
 sys.modules.setdefault("numpy", numpy_stub)
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 class DummyNode:
@@ -111,8 +111,8 @@ class DummyNode:
 
 class CauseEffectDiagramTests(unittest.TestCase):
     def setUp(self):
-        # Create a minimal FaultTreeApp instance without initialising Tk
-        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        # Create a minimal AutoMLApp instance without initialising Tk
+        self.app = AutoMLApp.__new__(AutoMLApp)
 
     def test_build_simplified_fta_model_includes_basic_events(self):
         be1 = DummyNode(2, "BASIC EVENT", "Cause 1")
@@ -132,7 +132,7 @@ class CauseEffectDiagramTests(unittest.TestCase):
         created_sizes.clear()
         top = DummyNode(1, "TOP EVENT", "Hazard")
         model = self.app.build_simplified_fta_model(top)
-        FaultTreeApp.auto_generate_fta_diagram(model, "out.png")
+        AutoMLApp.auto_generate_fta_diagram(model, "out.png")
         self.assertTrue(created_sizes, "Image.new was not called")
         width, height = created_sizes[0]
         self.assertGreaterEqual(width, 120)

--- a/tests/test_cause_effect_tool_enablement.py
+++ b/tests/test_cause_effect_tool_enablement.py
@@ -6,7 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
 from sysml.sysml_repository import SysMLRepository
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 class DummyListbox:
@@ -51,7 +51,7 @@ def test_cause_effect_tool_enabled_with_safety_analysis():
     toolbox.diagrams = {"Gov": diag.diag_id}
     toolbox.set_active_module("P1")
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
     app.tool_listboxes = {"Safety Analysis": lb}
     app.tool_categories = {"Safety Analysis": ["Cause & Effect Diagram"]}
@@ -62,9 +62,9 @@ def test_cause_effect_tool_enabled_with_safety_analysis():
     app.update_views = lambda: None
     app.tool_to_work_product = {"Cause & Effect Diagram": {"FTA"}}
     app.safety_mgmt_toolbox = toolbox
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(app, FaultTreeApp)
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(app, FaultTreeApp)
-    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(app, FaultTreeApp)
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(app, AutoMLApp)
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(app, AutoMLApp)
+    app.disable_work_product = AutoMLApp.disable_work_product.__get__(app, AutoMLApp)
 
     toolbox.on_change = app.refresh_tool_enablement
     toolbox.add_work_product("Gov", "FTA", "")
@@ -79,7 +79,7 @@ def test_cause_effect_tool_opens_on_double_click():
     def action():
         action_called["flag"] = True
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
     app.tool_actions = {"Cause & Effect Diagram": action}
     app.tool_to_work_product = {"Cause & Effect Diagram": {"FTA"}}

--- a/tests/test_cbn_undo.py
+++ b/tests/test_cbn_undo.py
@@ -8,7 +8,7 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
 sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from analysis import CausalBayesianNetwork, CausalBayesianNetworkDoc
 from sysml.sysml_repository import SysMLRepository
 
@@ -21,7 +21,7 @@ def test_cbn_diagram_undo_redo_node_add_and_move():
     repo._redo_stack = []
 
     # Minimal application setup
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     doc = CausalBayesianNetworkDoc("CBN")
     doc.network.add_node("A", cpd=0.5)
     doc.positions["A"] = (0, 0)
@@ -83,9 +83,9 @@ def test_cbn_diagram_undo_redo_node_add_and_move():
 
     app.export_model_data = export_model_data
     app.apply_model_data = apply_model_data
-    app.push_undo_state = FaultTreeApp.push_undo_state.__get__(app)
-    app.undo = FaultTreeApp.undo.__get__(app)
-    app.redo = FaultTreeApp.redo.__get__(app)
+    app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+    app.undo = AutoMLApp.undo.__get__(app)
+    app.redo = AutoMLApp.redo.__get__(app)
 
     # Record state then modify
     app.push_undo_state()

--- a/tests/test_clone_gsn_node.py
+++ b/tests/test_clone_gsn_node.py
@@ -11,13 +11,13 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from gsn.nodes import GSNNode
 
 
 class CloneGSNNodeTests(unittest.TestCase):
     def test_clone_preserves_gsn_node_attributes(self):
-        app = FaultTreeApp.__new__(FaultTreeApp)
+        app = AutoMLApp.__new__(AutoMLApp)
         original = GSNNode("goal", "Goal")
         clone = app.clone_node_preserving_id(original)
         self.assertIsInstance(clone, GSNNode)

--- a/tests/test_clone_sync_nodes.py
+++ b/tests/test_clone_sync_nodes.py
@@ -11,12 +11,12 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from AutoML import FaultTreeApp, FaultTreeNode
+from AutoML import AutoMLApp, FaultTreeNode
 
 
 class CloneSyncTests(unittest.TestCase):
     def setUp(self):
-        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app = AutoMLApp.__new__(AutoMLApp)
         self.app.fmea_entries = []
         self.app.fmeas = []
         self.app.fmedas = []

--- a/tests/test_copy_paste_selection.py
+++ b/tests/test_copy_paste_selection.py
@@ -11,7 +11,7 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from AutoML import FaultTreeApp, FaultTreeNode
+from AutoML import AutoMLApp, FaultTreeNode
 from gui import messagebox
 
 
@@ -27,7 +27,7 @@ class DummyTree:
 
 class CopyPasteSelectionTests(unittest.TestCase):
     def setUp(self):
-        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app = AutoMLApp.__new__(AutoMLApp)
         self.app.root_node = FaultTreeNode("root", "TOP EVENT")
         child = FaultTreeNode("child", "GATE", parent=self.app.root_node)
         self.app.root_node.children.append(child)
@@ -35,7 +35,7 @@ class CopyPasteSelectionTests(unittest.TestCase):
         self.app.selected_node = None
         self.app.clipboard_node = None
         self.app.analysis_tree = DummyTree(child)
-        self.app.find_node_by_id = FaultTreeApp.find_node_by_id.__get__(self.app)
+        self.app.find_node_by_id = AutoMLApp.find_node_by_id.__get__(self.app)
         self.app.top_events = []
         self.app.update_views = lambda: None
         self.app.cut_mode = False

--- a/tests/test_cyber_risk_assessment.py
+++ b/tests/test_cyber_risk_assessment.py
@@ -6,7 +6,7 @@ from analysis.models import (
     HaraEntry,
     CybersecurityGoal,
 )
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 class CyberRiskEntryTests(unittest.TestCase):
@@ -29,7 +29,7 @@ class CyberRiskEntryTests(unittest.TestCase):
         self.assertEqual(entry.cal, "CAL3")
 
     def test_sync_to_goals(self):
-        app = FaultTreeApp.__new__(FaultTreeApp)
+        app = AutoMLApp.__new__(AutoMLApp)
         cyber = CyberRiskEntry(
             damage_scenario="D",
             threat_scenario="T",
@@ -46,12 +46,12 @@ class CyberRiskEntryTests(unittest.TestCase):
         doc = HaraDoc("RA1", [], [entry])
         app.hara_docs = [doc]
         app.cybersecurity_goals = [CybersecurityGoal("CG1", "desc"), CybersecurityGoal("CG2", "d2")]
-        FaultTreeApp.sync_cyber_risk_to_goals(app)
+        AutoMLApp.sync_cyber_risk_to_goals(app)
         self.assertEqual(app.cybersecurity_goals[0].risk_assessments[0]["name"], "RA1")
         self.assertEqual(app.cybersecurity_goals[0].cal, cyber.cal)
 
     def test_get_cyber_goal_cal(self):
-        app = FaultTreeApp.__new__(FaultTreeApp)
+        app = AutoMLApp.__new__(AutoMLApp)
         cyber1 = CyberRiskEntry(
             damage_scenario="D1",
             threat_scenario="T1",

--- a/tests/test_cyber_risk_persistence.py
+++ b/tests/test_cyber_risk_persistence.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from analysis.models import HaraEntry, CyberRiskEntry
 
 def test_cyber_risk_entry_persistence():
@@ -29,7 +29,7 @@ def test_cyber_risk_entry_persistence():
             }
         ]
     }
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.top_events = []
     app.fmea_entries = []
     app.fmeas = []

--- a/tests/test_cybersecurity_goals.py
+++ b/tests/test_cybersecurity_goals.py
@@ -14,7 +14,7 @@ sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
 sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from analysis.models import CybersecurityGoal
 
 
@@ -31,7 +31,7 @@ class CybersecurityGoalTests(unittest.TestCase):
         self.assertEqual(goal.cal, "CAL3")
 
     def test_export_output(self):
-        app = FaultTreeApp.__new__(FaultTreeApp)
+        app = AutoMLApp.__new__(AutoMLApp)
         goal1 = CybersecurityGoal("CG1", "d1", risk_assessments=[{"name": "RA1", "cal": "CAL2"}])
         goal2 = CybersecurityGoal("CG2", "d2", risk_assessments=[{"name": "RA2", "cal": "CAL4"}])
         goal1.compute_cal()
@@ -42,7 +42,7 @@ class CybersecurityGoalTests(unittest.TestCase):
         tmp.close()
         with mock.patch("tkinter.filedialog.asksaveasfilename", return_value=tmp.name), \
              mock.patch("gui.messagebox.showinfo"):
-            FaultTreeApp.export_cybersecurity_goal_requirements(app)
+            AutoMLApp.export_cybersecurity_goal_requirements(app)
 
         with open(tmp.name, newline="") as f:
             rows = list(csv.reader(f))

--- a/tests/test_diagram_rules_toolbox.py
+++ b/tests/test_diagram_rules_toolbox.py
@@ -16,7 +16,7 @@ sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
 sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
 sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def test_diagram_rules_toolbox_single_instance():
@@ -50,7 +50,7 @@ def test_diagram_rules_toolbox_single_instance():
     drt.DiagramRulesEditor = DummyEditor
 
     class DummyApp:
-        open_diagram_rules_toolbox = FaultTreeApp.open_diagram_rules_toolbox
+        open_diagram_rules_toolbox = AutoMLApp.open_diagram_rules_toolbox
 
         def __init__(self):
             self.doc_nb = DummyNotebook()

--- a/tests/test_empty_fault_tree_load.py
+++ b/tests/test_empty_fault_tree_load.py
@@ -12,11 +12,11 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 # Ensure repository root on path
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def _minimal_app():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.top_events = []
     app.fmeas = []
     app.fmedas = []

--- a/tests/test_failure_prob_quantity.py
+++ b/tests/test_failure_prob_quantity.py
@@ -5,7 +5,7 @@ sys.modules.setdefault('PIL.Image', types.ModuleType('PIL.Image'))
 sys.modules.setdefault('PIL.ImageDraw', types.ModuleType('PIL.ImageDraw'))
 sys.modules.setdefault('PIL.ImageFont', types.ModuleType('PIL.ImageFont'))
 sys.modules.setdefault('PIL.ImageTk', types.ModuleType('PIL.ImageTk'))
-from AutoML import FaultTreeNode, FaultTreeApp, GATE_NODE_TYPES
+from AutoML import FaultTreeNode, AutoMLApp, GATE_NODE_TYPES
 from analysis.models import MissionProfile, ReliabilityComponent
 
 class DummyApp:
@@ -45,7 +45,7 @@ class FailureProbabilityTests(unittest.TestCase):
         be.prob_formula = "linear"
 
         app = DummyApp(fm)
-        prob = FaultTreeApp.compute_failure_prob(app, be)
+        prob = AutoMLApp.compute_failure_prob(app, be)
         expected = (20.0 / 4) / 1e9
         self.assertAlmostEqual(prob, expected)
 

--- a/tests/test_fault_undo.py
+++ b/tests/test_fault_undo.py
@@ -11,12 +11,12 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from sysml.sysml_repository import SysMLRepository
 
 class FaultUndoRedoTests(unittest.TestCase):
     def setUp(self):
-        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app = AutoMLApp.__new__(AutoMLApp)
         # Minimal attributes for export_model_data
         self.app.top_events = []
         self.app.fmeas = []

--- a/tests/test_fta_undo.py
+++ b/tests/test_fta_undo.py
@@ -11,13 +11,13 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from AutoML import FaultTreeApp, FaultTreeNode
+from AutoML import AutoMLApp, FaultTreeNode
 from sysml.sysml_repository import SysMLRepository
 
 class FTAUndoRedoTests(unittest.TestCase):
     def setUp(self):
         # minimal app without Tk initialization
-        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app = AutoMLApp.__new__(AutoMLApp)
         self.app.top_events = []
         self.app.root_node = None
         self.app.selected_node = None

--- a/tests/test_functional_insufficiency_subtype.py
+++ b/tests/test_functional_insufficiency_subtype.py
@@ -6,12 +6,12 @@ sys.modules.setdefault('PIL.ImageDraw', types.ModuleType('PIL.ImageDraw'))
 sys.modules.setdefault('PIL.ImageFont', types.ModuleType('PIL.ImageFont'))
 sys.modules.setdefault('PIL.ImageTk', types.ModuleType('PIL.ImageTk'))
 
-from AutoML import FaultTreeApp, FaultTreeNode
+from AutoML import AutoMLApp, FaultTreeNode
 
 
 class FunctionalInsufficiencySubtypeTests(unittest.TestCase):
     def test_subtype_nodes_listed(self):
-        app = FaultTreeApp.__new__(FaultTreeApp)
+        app = AutoMLApp.__new__(AutoMLApp)
         top = FaultTreeNode("TE", "TOP EVENT")
 
         fi_type = FaultTreeNode("FI1", "Functional Insufficiency")

--- a/tests/test_governance_group_activation.py
+++ b/tests/test_governance_group_activation.py
@@ -7,7 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
 from sysml.sysml_repository import SysMLRepository
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 class DummyListbox:
@@ -59,10 +59,10 @@ def test_work_product_groups_follow_phase(work_product, parent):
     toolbox.diagrams = {"Gov": diag.diag_id}
     toolbox.set_active_module("P1")
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
-    app.tool_listboxes = {FaultTreeApp.WORK_PRODUCT_INFO[work_product][0]: lb}
-    app.tool_categories = {FaultTreeApp.WORK_PRODUCT_INFO[work_product][0]: []}
+    app.tool_listboxes = {AutoMLApp.WORK_PRODUCT_INFO[work_product][0]: lb}
+    app.tool_categories = {AutoMLApp.WORK_PRODUCT_INFO[work_product][0]: []}
     app.tool_actions = {}
     wp_menu = DummyMenu()
     parent_menu = wp_menu if work_product == parent else DummyMenu()
@@ -71,12 +71,12 @@ def test_work_product_groups_follow_phase(work_product, parent):
         app.work_product_menus[parent] = [(parent_menu, 0)]
     app.enabled_work_products = set()
     app.enable_process_area = lambda area: None
-    app.tool_to_work_product = {info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()}
+    app.tool_to_work_product = {info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()}
     app.update_views = lambda: None
     app.safety_mgmt_toolbox = toolbox
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(app, FaultTreeApp)
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(app, FaultTreeApp)
-    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(app, FaultTreeApp)
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(app, AutoMLApp)
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(app, AutoMLApp)
+    app.disable_work_product = AutoMLApp.disable_work_product.__get__(app, AutoMLApp)
 
     toolbox.add_work_product("Gov", work_product, "")
     toolbox.on_change = app.refresh_tool_enablement

--- a/tests/test_governance_phase_membership_infer.py
+++ b/tests/test_governance_phase_membership_infer.py
@@ -6,7 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
 from sysml.sysml_repository import SysMLRepository
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 class DummyListbox:
@@ -43,9 +43,9 @@ def test_repository_phase_enables_work_product():
     toolbox.diagrams = {"Gov": diag.diag_id}
     toolbox.set_active_module("P1")
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
-    info = FaultTreeApp.WORK_PRODUCT_INFO["GSN Argumentation"]
+    info = AutoMLApp.WORK_PRODUCT_INFO["GSN Argumentation"]
     app.tool_listboxes = {info[0]: lb}
     app.tool_categories = {info[0]: []}
     app.tool_actions = {}
@@ -54,12 +54,12 @@ def test_repository_phase_enables_work_product():
     app.work_product_menus = {"GSN Argumentation": [(wp_menu, 0)], "GSN": [(parent_menu, 0)]}
     app.enabled_work_products = set()
     app.enable_process_area = lambda area: None
-    app.tool_to_work_product = {info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()}
+    app.tool_to_work_product = {info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()}
     app.update_views = lambda: None
     app.safety_mgmt_toolbox = toolbox
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(app, FaultTreeApp)
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(app, FaultTreeApp)
-    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(app, FaultTreeApp)
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(app, AutoMLApp)
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(app, AutoMLApp)
+    app.disable_work_product = AutoMLApp.disable_work_product.__get__(app, AutoMLApp)
 
     toolbox.add_work_product("Gov", "GSN Argumentation", "")
     toolbox.on_change = app.refresh_tool_enablement

--- a/tests/test_governance_phase_toggle.py
+++ b/tests/test_governance_phase_toggle.py
@@ -129,7 +129,7 @@ def test_added_work_product_respects_phase(monkeypatch):
     sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
     sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
     sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
-    from AutoML import FaultTreeApp
+    from AutoML import AutoMLApp
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     diag = repo.create_diagram("Governance Diagram", name="Gov2")
@@ -172,7 +172,7 @@ def test_added_work_product_respects_phase(monkeypatch):
         def set(self, value):
             self.value = value
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
     menu = DummyMenu()
     app.tool_listboxes = {"Hazard & Threat Analysis": lb}
@@ -183,17 +183,17 @@ def test_added_work_product_respects_phase(monkeypatch):
     app.enable_process_area = lambda area: None
     app.hazop_analysis = lambda: None
     app.tool_to_work_product = {
-        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+        info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()
     }
     app.update_views = lambda: None
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
-        app, FaultTreeApp
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(
+        app, AutoMLApp
     )
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
-        app, FaultTreeApp
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
-        app, FaultTreeApp
+    app.on_lifecycle_selected = AutoMLApp.on_lifecycle_selected.__get__(
+        app, AutoMLApp
     )
     app.lifecycle_var = DummyVar("P1")
     app.safety_mgmt_toolbox = toolbox
@@ -247,7 +247,7 @@ def test_work_product_disables_when_leaving_phase(monkeypatch):
     sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
     sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
     sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
-    from AutoML import FaultTreeApp
+    from AutoML import AutoMLApp
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()
     diag = repo.create_diagram("Governance Diagram", name="Gov3")
@@ -290,7 +290,7 @@ def test_work_product_disables_when_leaving_phase(monkeypatch):
         def set(self, value):
             self.value = value
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
     menu = DummyMenu()
     app.tool_listboxes = {"Hazard & Threat Analysis": lb}
@@ -301,17 +301,17 @@ def test_work_product_disables_when_leaving_phase(monkeypatch):
     app.enable_process_area = lambda area: None
     app.hazop_analysis = lambda: None
     app.tool_to_work_product = {
-        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+        info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()
     }
     app.update_views = lambda: None
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
-        app, FaultTreeApp
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(
+        app, AutoMLApp
     )
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
-        app, FaultTreeApp
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
-        app, FaultTreeApp
+    app.on_lifecycle_selected = AutoMLApp.on_lifecycle_selected.__get__(
+        app, AutoMLApp
     )
     app.lifecycle_var = DummyVar("P2")
     app.safety_mgmt_toolbox = toolbox
@@ -376,7 +376,7 @@ def test_work_product_group_activation(analysis, parent, monkeypatch):
     ]
     toolbox.diagrams = {"GovX": diag.diag_id}
 
-    from AutoML import FaultTreeApp
+    from AutoML import AutoMLApp
 
     class DummyListbox:
         def __init__(self):
@@ -413,10 +413,10 @@ def test_work_product_group_activation(analysis, parent, monkeypatch):
         def set(self, value):
             self.value = value
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
     menu = DummyMenu()
-    area = FaultTreeApp.WORK_PRODUCT_INFO[analysis][0]
+    area = AutoMLApp.WORK_PRODUCT_INFO[analysis][0]
     app.tool_listboxes = {area: lb}
     app.tool_categories = {area: []}
     app.tool_actions = {}
@@ -425,26 +425,26 @@ def test_work_product_group_activation(analysis, parent, monkeypatch):
     if parent:
         parent_menu = DummyMenu()
         app.work_product_menus[parent] = [(parent_menu, 0)]
-        pinfo = FaultTreeApp.WORK_PRODUCT_INFO[parent]
+        pinfo = AutoMLApp.WORK_PRODUCT_INFO[parent]
         setattr(app, pinfo[2], lambda: None)
 
-    info = FaultTreeApp.WORK_PRODUCT_INFO[analysis]
+    info = AutoMLApp.WORK_PRODUCT_INFO[analysis]
     setattr(app, info[2], lambda: None)
 
     app.enabled_work_products = set()
     app.enable_process_area = lambda area: None
     app.tool_to_work_product = {
-        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+        info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()
     }
     app.update_views = lambda: None
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
-        app, FaultTreeApp
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(
+        app, AutoMLApp
     )
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
-        app, FaultTreeApp
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
-        app, FaultTreeApp
+    app.on_lifecycle_selected = AutoMLApp.on_lifecycle_selected.__get__(
+        app, AutoMLApp
     )
     app.lifecycle_var = DummyVar("P1")
     app.safety_mgmt_toolbox = toolbox
@@ -506,7 +506,7 @@ def test_work_product_group_activation(analysis, parent, monkeypatch):
 
     win.add_work_product()
 
-    tool_name = FaultTreeApp.WORK_PRODUCT_INFO[analysis][1]
+    tool_name = AutoMLApp.WORK_PRODUCT_INFO[analysis][1]
     assert menu.state == tk.DISABLED
     assert lb.item_colors.get(tool_name) == "gray"
     if parent_menu:

--- a/tests/test_gsn_copy_paste.py
+++ b/tests/test_gsn_copy_paste.py
@@ -12,7 +12,7 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp, FaultTreeNode
+from AutoML import AutoMLApp, FaultTreeNode
 from gsn import GSNNode, GSNDiagram
 from gui import messagebox
 
@@ -26,7 +26,7 @@ class DummyTree:
 
 class GSNCopyPasteTests(unittest.TestCase):
     def setUp(self):
-        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app = AutoMLApp.__new__(AutoMLApp)
         self.app.root_node = FaultTreeNode("root", "TOP EVENT")
         self.app.analysis_tree = DummyTree()
         self.app.top_events = []

--- a/tests/test_gsn_persistence.py
+++ b/tests/test_gsn_persistence.py
@@ -11,12 +11,12 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 import os
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from gsn import GSNNode, GSNDiagram, GSNModule
 
 
 def _minimal_app():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.top_events = []
     app.root_node = None
     app.fmea_entries = []

--- a/tests/test_gsn_undo.py
+++ b/tests/test_gsn_undo.py
@@ -11,14 +11,14 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 
 from gsn import GSNNode, GSNDiagram
 from gui.gsn_explorer import GSNExplorer
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def test_gsn_diagram_undo_redo_rename(monkeypatch):
     root = GSNNode("G", "Goal")
     diag = GSNDiagram(root)
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.gsn_diagrams = [diag]
     app.gsn_modules = []
     app.update_views = lambda: None
@@ -37,9 +37,9 @@ def test_gsn_diagram_undo_redo_rename(monkeypatch):
 
     app.export_model_data = export_model_data
     app.apply_model_data = apply_model_data
-    app.push_undo_state = FaultTreeApp.push_undo_state.__get__(app)
-    app.undo = FaultTreeApp.undo.__get__(app)
-    app.redo = FaultTreeApp.redo.__get__(app)
+    app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+    app.undo = AutoMLApp.undo.__get__(app)
+    app.redo = AutoMLApp.redo.__get__(app)
 
     explorer = GSNExplorer.__new__(GSNExplorer)
     explorer.app = app
@@ -65,7 +65,7 @@ def test_gsn_explorer_refreshes_after_undo(monkeypatch):
     root = GSNNode("G", "Goal")
     diag = GSNDiagram(root)
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.gsn_diagrams = [diag]
     app.gsn_modules = []
     app.update_views = lambda: None
@@ -84,8 +84,8 @@ def test_gsn_explorer_refreshes_after_undo(monkeypatch):
 
     app.export_model_data = export_model_data
     app.apply_model_data = apply_model_data
-    app.push_undo_state = FaultTreeApp.push_undo_state.__get__(app)
-    app.undo = FaultTreeApp.undo.__get__(app)
+    app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+    app.undo = AutoMLApp.undo.__get__(app)
 
     explorer = GSNExplorer.__new__(GSNExplorer)
     app._gsn_window = explorer

--- a/tests/test_gui_classes.py
+++ b/tests/test_gui_classes.py
@@ -4,7 +4,7 @@ import sys
 import inspect
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from gui.toolboxes import TC2FIWindow, RiskAssessmentWindow
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 try:
     from gui.faults_gui import FaultsWindow
 except Exception:  # pragma: no cover - optional dependency
@@ -27,13 +27,13 @@ class DoubleClickBindingTests(unittest.TestCase):
         self.assertIn('bind("<Double-1>"', src)
 
     def test_product_goals_editor_double_click_binding(self):
-        src = inspect.getsource(FaultTreeApp.show_product_goals_editor)
+        src = inspect.getsource(AutoMLApp.show_product_goals_editor)
         self.assertIn('bind("<Double-1>"', src)
 
 
 class ProductGoalsMatrixTests(unittest.TestCase):
     def test_matrix_has_all_columns_and_scrollbars(self):
-        src = inspect.getsource(FaultTreeApp.show_safety_goals_matrix)
+        src = inspect.getsource(AutoMLApp.show_safety_goals_matrix)
         for col in [
             'FTTI',
             'Acc Rate',

--- a/tests/test_hazard_severity.py
+++ b/tests/test_hazard_severity.py
@@ -17,7 +17,7 @@ sys.modules.setdefault("PIL.ImageDraw", pil.ImageDraw)
 sys.modules.setdefault("PIL.ImageFont", pil.ImageFont)
 
 from analysis.models import HaraDoc, HaraEntry
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def test_update_hazard_list_uses_entry_severity():
@@ -43,7 +43,7 @@ def test_update_hazard_list_uses_entry_severity():
         hazards=[],
     )
 
-    FaultTreeApp.update_hazard_list(app)
+    AutoMLApp.update_hazard_list(app)
 
     assert app.hazard_severity["HZ"] == 3
     assert "HZ" in app.hazards

--- a/tests/test_hazard_undo.py
+++ b/tests/test_hazard_undo.py
@@ -11,12 +11,12 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from sysml.sysml_repository import SysMLRepository
 
 class HazardSeverityUndoRedoTests(unittest.TestCase):
     def setUp(self):
-        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app = AutoMLApp.__new__(AutoMLApp)
         self.app.hazard_severity = {"H1": 1}
         self.app.hazards = ["H1"]
         self.app.hara_docs = []

--- a/tests/test_item_definition_persistence.py
+++ b/tests/test_item_definition_persistence.py
@@ -10,12 +10,12 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from analysis.models import global_requirements
 
 
 def _minimal_app():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.top_events = []
     app.fmeas = []
     app.fmedas = []

--- a/tests/test_log_window_toggle.py
+++ b/tests/test_log_window_toggle.py
@@ -5,7 +5,7 @@ import pytest
 import tkinter as tk
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def test_toggle_log_area():
@@ -13,7 +13,7 @@ def test_toggle_log_area():
         root = tk.Tk()
     except tk.TclError:
         pytest.skip("Tk not available")
-    app = FaultTreeApp(root)
+    app = AutoMLApp(root)
     assert app.log_frame.winfo_manager() == "pack"
     app.toggle_logs()
     assert app.log_frame.winfo_manager() == ""

--- a/tests/test_odd_validation_targets.py
+++ b/tests/test_odd_validation_targets.py
@@ -1,12 +1,12 @@
 import unittest
 
-from AutoML import FaultTreeApp, FaultTreeNode
+from AutoML import AutoMLApp, FaultTreeNode
 from analysis.models import HazopDoc, HazopEntry, HaraDoc, HaraEntry
 
 
 class OddValidationTargetTests(unittest.TestCase):
     def test_traces_validation_targets_from_scenario_description(self):
-        app = FaultTreeApp.__new__(FaultTreeApp)
+        app = AutoMLApp.__new__(AutoMLApp)
         app.scenario_libraries = [
             {
                 "name": "Default",

--- a/tests/test_pas8800_mechanisms.py
+++ b/tests/test_pas8800_mechanisms.py
@@ -51,14 +51,14 @@ def test_pas8800_library_non_empty():
 
 def test_default_mechanisms_include_pas8800():
     _stub_review_toolbox()
-    from AutoML import FaultTreeApp
+    from AutoML import AutoMLApp
 
     class Dummy:
         def __init__(self):
             self.mechanism_libraries = []
             self.selected_mechanism_libraries = []
 
-    Dummy.load_default_mechanisms = FaultTreeApp.load_default_mechanisms
+    Dummy.load_default_mechanisms = AutoMLApp.load_default_mechanisms
     obj = Dummy()
     obj.load_default_mechanisms()
 

--- a/tests/test_pdf_template_export.py
+++ b/tests/test_pdf_template_export.py
@@ -60,7 +60,7 @@ sys.modules.setdefault("reportlab.lib.styles", reportlab.lib.styles)
 sys.modules.setdefault("reportlab.lib.colors", reportlab.lib.colors)
 sys.modules.setdefault("reportlab.platypus", reportlab.platypus)
 
-from AutoML import FaultTreeApp, filedialog, messagebox
+from AutoML import AutoMLApp, filedialog, messagebox
 
 
 def test_generate_pdf_report_exports_template(tmp_path, monkeypatch):
@@ -73,7 +73,7 @@ def test_generate_pdf_report_exports_template(tmp_path, monkeypatch):
     monkeypatch.setattr(messagebox, "showinfo", lambda *a, **k: None)
     monkeypatch.setattr(messagebox, "showerror", lambda *a, **k: None)
 
-    app = type("A", (), {"project_properties": {}, "_generate_pdf_report": FaultTreeApp._generate_pdf_report})()
+    app = type("A", (), {"project_properties": {}, "_generate_pdf_report": AutoMLApp._generate_pdf_report})()
     app._generate_pdf_report()
 
     assert pdf_path.with_suffix(".json").exists()

--- a/tests/test_phase_requirements_main_menu.py
+++ b/tests/test_phase_requirements_main_menu.py
@@ -11,12 +11,12 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("ImageTk"))
 sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("ImageDraw"))
 sys.modules.setdefault("PIL.ImageFont", types.ModuleType("ImageFont"))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from analysis import SafetyManagementToolbox
 
 
 def test_phase_requirements_menu_populated(monkeypatch):
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     toolbox = SafetyManagementToolbox()
     toolbox.add_module("Phase1")
     app.safety_mgmt_toolbox = toolbox
@@ -48,8 +48,8 @@ def test_phase_requirements_menu_populated(monkeypatch):
 
     app.phase_req_menu = DummyMenu()
     req_menu = DummyMenu()
-    FaultTreeApp._add_lifecycle_requirements_menu(app, req_menu)
-    FaultTreeApp._refresh_phase_requirements_menu(app)
+    AutoMLApp._add_lifecycle_requirements_menu(app, req_menu)
+    AutoMLApp._refresh_phase_requirements_menu(app)
 
     labels = [label for label, _ in app.phase_req_menu.items]
     assert "Phase1" in labels and "Lifecycle" in labels
@@ -65,7 +65,7 @@ def test_phase_requirements_menu_populated(monkeypatch):
 
 
 def test_generate_phase_requirements_delegates(monkeypatch):
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     events = []
 
     def fake_open(show_diagrams=True):
@@ -76,13 +76,13 @@ def test_generate_phase_requirements_delegates(monkeypatch):
         generate_phase_requirements=lambda p: events.append(p)
     )
 
-    FaultTreeApp.generate_phase_requirements(app, "PhaseX")
+    AutoMLApp.generate_phase_requirements(app, "PhaseX")
 
     assert events == [False, "PhaseX"]
 
 
 def test_generate_lifecycle_requirements_delegates(monkeypatch):
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     events = []
 
     def fake_open(show_diagrams=True):
@@ -93,13 +93,13 @@ def test_generate_lifecycle_requirements_delegates(monkeypatch):
         generate_lifecycle_requirements=lambda: events.append("lifecycle")
     )
 
-    FaultTreeApp.generate_lifecycle_requirements(app)
+    AutoMLApp.generate_lifecycle_requirements(app)
 
     assert events == [False, "lifecycle"]
 
 
 def test_apply_model_data_refreshes_phase_menu(monkeypatch):
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     # Stub required methods and attributes used during model loading
     app.disable_work_product = lambda name: None
     app.enable_work_product = lambda name: None
@@ -118,11 +118,11 @@ def test_apply_model_data_refreshes_phase_menu(monkeypatch):
 
     calls: list[bool] = []
     monkeypatch.setattr(
-        FaultTreeApp, "_refresh_phase_requirements_menu", lambda self: calls.append(True)
+        AutoMLApp, "_refresh_phase_requirements_menu", lambda self: calls.append(True)
     )
 
     data = {"top_events": [], "safety_mgmt_toolbox": {"modules": [{"name": "P1"}]}}
-    FaultTreeApp.apply_model_data(app, data, ensure_root=False)
+    AutoMLApp.apply_model_data(app, data, ensure_root=False)
 
     assert calls
     assert app.safety_mgmt_toolbox.on_change == app._on_toolbox_change

--- a/tests/test_phase_visibility.py
+++ b/tests/test_phase_visibility.py
@@ -21,7 +21,7 @@ sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
 sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
 sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 def test_elements_follow_phase_visibility():
     repo = SysMLRepository.reset_instance()
@@ -82,7 +82,7 @@ def test_on_lifecycle_selected_refreshes_diagrams():
     repo = SysMLRepository.reset_instance()
     toolbox = SafetyManagementToolbox()
     toolbox.modules = [GovernanceModule("P1")]
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.lifecycle_var = types.SimpleNamespace(get=lambda: "P1")
     app.safety_mgmt_toolbox = toolbox
     refreshed = {"count": 0}
@@ -101,7 +101,7 @@ def test_on_lifecycle_selected_refreshes_diagrams():
     app.diagram_tabs = {"d": DummyTab()}
     app.update_views = lambda: None
     app.refresh_tool_enablement = lambda: None
-    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(app, FaultTreeApp)
+    app.on_lifecycle_selected = AutoMLApp.on_lifecycle_selected.__get__(app, AutoMLApp)
     app.on_lifecycle_selected()
     assert refreshed["count"] == 1
 
@@ -125,7 +125,7 @@ def test_governance_diagram_refreshes_on_phase_change():
     toolbox.set_active_module("P2")
     obj2 = SysMLObject(2, "Work Product", 0.0, 0.0, properties={"name": "Spec2"})
     diag.objects.append(asdict(obj2))
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.lifecycle_var = types.SimpleNamespace(get=lambda: "P2")
     app.safety_mgmt_toolbox = toolbox
     app.update_views = lambda: None
@@ -138,6 +138,6 @@ def test_governance_diagram_refreshes_on_phase_change():
     container = types.SimpleNamespace(winfo_children=lambda: [inner])
     app.diagram_tabs = {diag.diag_id: types.SimpleNamespace(winfo_children=lambda: [container])}
 
-    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(app, FaultTreeApp)
+    app.on_lifecycle_selected = AutoMLApp.on_lifecycle_selected.__get__(app, AutoMLApp)
     app.on_lifecycle_selected()
     assert len(win.objects) == 1 and win.objects[0].obj_id == 2

--- a/tests/test_properties_metadata.py
+++ b/tests/test_properties_metadata.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from sysml.sysml_repository import SysMLRepository
 from gui.architecture import ArchitectureManagerDialog, SysMLObject
 from types import SimpleNamespace
@@ -16,7 +16,7 @@ def test_analysis_tree_selection_shows_metadata():
     diag = repo.create_diagram("Use Case Diagram", name="Diag")
 
     # setup minimal app instance without running __init__
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
 
     class DummyTree:
         def __init__(self):
@@ -47,8 +47,8 @@ def test_analysis_tree_selection_shows_metadata():
     app.analysis_tree = DummyTree()
     app.prop_view = DummyPropView()
     # bind methods
-    app.show_properties = FaultTreeApp.show_properties.__get__(app)
-    app.on_analysis_tree_select = FaultTreeApp.on_analysis_tree_select.__get__(app)
+    app.show_properties = AutoMLApp.show_properties.__get__(app)
+    app.on_analysis_tree_select = AutoMLApp.on_analysis_tree_select.__get__(app)
 
     app.on_analysis_tree_select(None)
     values = {k: v for k, v in app.prop_view.rows}
@@ -76,7 +76,7 @@ def test_architecture_tree_selection_shows_metadata():
 
     app = SimpleNamespace()
     app.prop_view = DummyPropView()
-    app.show_properties = FaultTreeApp.show_properties.__get__(app)
+    app.show_properties = AutoMLApp.show_properties.__get__(app)
 
     class DummyTree:
         def __init__(self):
@@ -109,7 +109,7 @@ def test_diagram_selection_clears_tree_and_shows_object_properties():
 
     obj = SysMLObject(1, "Actor", 0, 0, properties={"name": "Act"})
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
 
     class DummyTree:
         def __init__(self):
@@ -146,8 +146,8 @@ def test_diagram_selection_clears_tree_and_shows_object_properties():
 
     app.analysis_tree = DummyTree()
     app.prop_view = DummyPropView()
-    app.show_properties = FaultTreeApp.show_properties.__get__(app)
-    app.on_analysis_tree_select = FaultTreeApp.on_analysis_tree_select.__get__(app)
+    app.show_properties = AutoMLApp.show_properties.__get__(app)
+    app.on_analysis_tree_select = AutoMLApp.on_analysis_tree_select.__get__(app)
 
     app.on_analysis_tree_select(None)
 

--- a/tests/test_render_cause_effect_diagram.py
+++ b/tests/test_render_cause_effect_diagram.py
@@ -11,11 +11,11 @@ if PIL_stub is None:
 PIL_stub.ImageTk = object
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 class CauseEffectPDFTests(unittest.TestCase):
     def setUp(self):
-        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app = AutoMLApp.__new__(AutoMLApp)
 
     def test_render_cause_effect_diagram_size(self):
         row = {

--- a/tests/test_report_template_toolbox.py
+++ b/tests/test_report_template_toolbox.py
@@ -17,7 +17,7 @@ sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
 sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
 sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from config import validate_report_template
 from gui.report_template_toolbox import layout_report_template
 
@@ -53,7 +53,7 @@ def test_report_template_toolbox_single_instance():
     rtt.ReportTemplateEditor = DummyEditor
 
     class DummyApp:
-        open_report_template_toolbox = FaultTreeApp.open_report_template_toolbox
+        open_report_template_toolbox = AutoMLApp.open_report_template_toolbox
 
         def __init__(self):
             self.doc_nb = DummyNotebook()

--- a/tests/test_requirement_patterns_toolbox.py
+++ b/tests/test_requirement_patterns_toolbox.py
@@ -15,7 +15,7 @@ sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
 sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
 sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 import tkinter as tk
 import pytest
 from gui.requirement_patterns_toolbox import RequirementPatternsEditor
@@ -52,7 +52,7 @@ def test_requirement_patterns_toolbox_single_instance():
     rpt.RequirementPatternsEditor = DummyEditor
 
     class DummyApp:
-        open_requirement_patterns_toolbox = FaultTreeApp.open_requirement_patterns_toolbox
+        open_requirement_patterns_toolbox = AutoMLApp.open_requirement_patterns_toolbox
 
         def __init__(self):
             self.doc_nb = DummyNotebook()

--- a/tests/test_requirement_traces_persistence.py
+++ b/tests/test_requirement_traces_persistence.py
@@ -11,12 +11,12 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from analysis.models import global_requirements
 
 
 def _minimal_app():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.top_events = []
     app.fmeas = []
     app.fmedas = []

--- a/tests/test_requirement_work_products.py
+++ b/tests/test_requirement_work_products.py
@@ -3,7 +3,7 @@ import types
 from analysis.models import REQUIREMENT_TYPE_OPTIONS
 from gui.architecture import GovernanceDiagramWindow, SysMLObject
 from sysml.sysml_repository import SysMLRepository
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def _fmt(req: str) -> str:
@@ -15,7 +15,7 @@ def _fmt(req: str) -> str:
 def test_work_product_created_for_each_requirement_type():
     for req in REQUIREMENT_TYPE_OPTIONS:
         name = f"{_fmt(req)} Requirement Specification"
-        assert name in FaultTreeApp.WORK_PRODUCT_INFO
+        assert name in AutoMLApp.WORK_PRODUCT_INFO
 
 
 def test_add_requirement_work_product(monkeypatch):

--- a/tests/test_requirements_explorer_enablement.py
+++ b/tests/test_requirements_explorer_enablement.py
@@ -6,7 +6,7 @@ import tkinter as tk
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 class DummyMenu:
@@ -37,7 +37,7 @@ def test_explorer_menu_enabled_with_work_product():
         update_views=lambda: None,
     )
 
-    FaultTreeApp.enable_work_product(app, "Requirement Specification", refresh=False)
+    AutoMLApp.enable_work_product(app, "Requirement Specification", refresh=False)
 
     assert menu.states[2] == tk.NORMAL
 

--- a/tests/test_requirements_matrix_enablement.py
+++ b/tests/test_requirements_matrix_enablement.py
@@ -6,7 +6,7 @@ import tkinter as tk
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 class DummyMenu:
@@ -37,6 +37,6 @@ def test_matrix_menu_enabled_with_work_product():
         update_views=lambda: None,
     )
 
-    FaultTreeApp.enable_work_product(app, "Requirement Specification", refresh=False)
+    AutoMLApp.enable_work_product(app, "Requirement Specification", refresh=False)
 
     assert menu.states[0] == tk.NORMAL

--- a/tests/test_review_toolbox_optional_pillow.py
+++ b/tests/test_review_toolbox_optional_pillow.py
@@ -1,9 +1,9 @@
 import types
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def test_enable_stpa_without_pillow():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.tool_listboxes = {}
     app.tool_actions = {}
     app.tool_categories = {}
@@ -13,5 +13,5 @@ def test_enable_stpa_without_pillow():
     app.enable_process_area = lambda area: None
     app.manage_architecture = lambda: None
     app.show_requirements_editor = lambda: None
-    FaultTreeApp.enable_work_product(app, "STPA")
+    AutoMLApp.enable_work_product(app, "STPA")
     assert "STPA" in app.enabled_work_products

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -14,7 +14,7 @@ sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
 sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 
 from gsn import GSNNode, GSNDiagram
-from AutoML import FaultTreeApp, PMHF_TARGETS
+from AutoML import AutoMLApp, PMHF_TARGETS
 from analysis.constants import CHECK_MARK
 
 
@@ -126,7 +126,7 @@ def test_edit_probability_updates_spi(monkeypatch):
         unique_id=1,
     )
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
@@ -139,7 +139,7 @@ def test_edit_probability_updates_spi(monkeypatch):
     monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
     monkeypatch.setattr("AutoML.simpledialog.askfloat", lambda *a, **k: 2e-4)
 
-    FaultTreeApp.show_safety_case(app)
+    AutoMLApp.show_safety_case(app)
     tree = app._safety_case_tree
     row = next(iter(tree.data))
     tree.next_column = "Achieved Probability"
@@ -159,7 +159,7 @@ def test_edit_probability_updates_spi(monkeypatch):
             CaptureTree.instances.append(self)
 
     monkeypatch.setattr("AutoML.ttk.Treeview", CaptureTree)
-    FaultTreeApp.show_safety_performance_indicators(app)
+    AutoMLApp.show_safety_performance_indicators(app)
     spi_tree = CaptureTree.instances[-1]
     iid = next(iter(spi_tree.data))
     assert spi_tree.data[iid]["values"][2] == f"{2e-4:.2e}"
@@ -185,7 +185,7 @@ def test_safety_case_shows_validation_target(monkeypatch):
         unique_id=1,
     )
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
@@ -196,7 +196,7 @@ def test_safety_case_shows_validation_target(monkeypatch):
     monkeypatch.setattr("AutoML.ttk.Button", DummyButton)
     monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
 
-    FaultTreeApp.show_safety_case(app)
+    AutoMLApp.show_safety_case(app)
     tree = app._safety_case_tree
     assert tree.columns[4] == "Validation Target"
     assert tree.columns[6] == "SPI"
@@ -225,7 +225,7 @@ def test_pmfh_autopopulates_validation_target_and_probability(monkeypatch):
         unique_id=1,
     )
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
@@ -236,16 +236,16 @@ def test_pmfh_autopopulates_validation_target_and_probability(monkeypatch):
     app.update_views = lambda: None
 
     monkeypatch.setattr("AutoML.AutoML_Helper.calculate_probability_recursive", lambda te: 2e-6)
-    monkeypatch.setattr("AutoML.FaultTreeApp.update_basic_event_probabilities", lambda self: None)
-    monkeypatch.setattr("AutoML.FaultTreeApp.get_all_basic_events", lambda self: [])
-    monkeypatch.setattr("AutoML.FaultTreeApp.get_failure_mode_node", lambda self, be: None)
-    monkeypatch.setattr("AutoML.FaultTreeApp.get_all_fmea_entries", lambda self: [])
+    monkeypatch.setattr("AutoML.AutoMLApp.update_basic_event_probabilities", lambda self: None)
+    monkeypatch.setattr("AutoML.AutoMLApp.get_all_basic_events", lambda self: [])
+    monkeypatch.setattr("AutoML.AutoMLApp.get_failure_mode_node", lambda self, be: None)
+    monkeypatch.setattr("AutoML.AutoMLApp.get_all_fmea_entries", lambda self: [])
     monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)
     monkeypatch.setattr("AutoML.ttk.Button", DummyButton)
     monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
 
-    FaultTreeApp.calculate_pmfh(app)
-    FaultTreeApp.show_safety_case(app)
+    AutoMLApp.calculate_pmfh(app)
+    AutoMLApp.show_safety_case(app)
 
     tree = app._safety_case_tree
     iid = next(iter(tree.data))
@@ -273,7 +273,7 @@ def test_edit_probability_in_spi_explorer(monkeypatch):
         unique_id=1,
     )
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
@@ -287,7 +287,7 @@ def test_edit_probability_in_spi_explorer(monkeypatch):
     monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
     monkeypatch.setattr("AutoML.simpledialog.askfloat", lambda *a, **k: 5e-5)
 
-    FaultTreeApp.show_safety_performance_indicators(app)
+    AutoMLApp.show_safety_performance_indicators(app)
     tree = app._spi_tree
     iid = next(iter(tree.data))
     tree.selection_set(iid)
@@ -312,7 +312,7 @@ def test_spi_shows_pmhf_and_validation(monkeypatch):
         unique_id=1,
     )
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.push_undo_state = lambda: None
@@ -322,7 +322,7 @@ def test_spi_shows_pmhf_and_validation(monkeypatch):
     monkeypatch.setattr("AutoML.ttk.Button", DummyButton)
     monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
 
-    FaultTreeApp.show_safety_performance_indicators(app)
+    AutoMLApp.show_safety_performance_indicators(app)
     tree = app._spi_tree
     assert len(tree.data) == 2
     targets = {row["values"][1]: row for row in tree.data.values()}
@@ -352,7 +352,7 @@ def test_pmhf_skips_sotif_probabilities(monkeypatch):
         unique_id=2,
     )
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.push_undo_state = lambda: None
@@ -369,17 +369,17 @@ def test_pmhf_skips_sotif_probabilities(monkeypatch):
         return 2e-6 if te is fusa else 3e-5
 
     monkeypatch.setattr("AutoML.AutoML_Helper.calculate_probability_recursive", fake_prob)
-    monkeypatch.setattr("AutoML.FaultTreeApp.update_basic_event_probabilities", lambda self: None)
-    monkeypatch.setattr("AutoML.FaultTreeApp.get_all_basic_events", lambda self: [])
-    monkeypatch.setattr("AutoML.FaultTreeApp.get_failure_mode_node", lambda self, be: None)
-    monkeypatch.setattr("AutoML.FaultTreeApp.get_all_fmea_entries", lambda self: [])
+    monkeypatch.setattr("AutoML.AutoMLApp.update_basic_event_probabilities", lambda self: None)
+    monkeypatch.setattr("AutoML.AutoMLApp.get_all_basic_events", lambda self: [])
+    monkeypatch.setattr("AutoML.AutoMLApp.get_failure_mode_node", lambda self, be: None)
+    monkeypatch.setattr("AutoML.AutoMLApp.get_all_fmea_entries", lambda self: [])
     monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)
     monkeypatch.setattr("AutoML.ttk.Button", DummyButton)
     monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
 
-    FaultTreeApp.show_safety_performance_indicators(app)
+    AutoMLApp.show_safety_performance_indicators(app)
 
-    FaultTreeApp.calculate_pmfh(app)
+    AutoMLApp.calculate_pmfh(app)
 
     assert sotif.spi_probability == 1e-4
     assert fusa.probability == 2e-6
@@ -400,7 +400,7 @@ def test_edit_notes_updates_node(monkeypatch):
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
@@ -411,7 +411,7 @@ def test_edit_notes_updates_node(monkeypatch):
     monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
     monkeypatch.setattr("AutoML.simpledialog.askstring", lambda *a, **k: "new note")
 
-    FaultTreeApp.show_safety_case(app)
+    AutoMLApp.show_safety_case(app)
     tree = app._safety_case_tree
     row = next(iter(tree.data))
     tree.next_column = "Notes"
@@ -428,7 +428,7 @@ def test_safety_case_lists_and_toggles(monkeypatch):
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
@@ -439,7 +439,7 @@ def test_safety_case_lists_and_toggles(monkeypatch):
     monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
     monkeypatch.setattr("AutoML.messagebox.askokcancel", lambda *a, **k: True)
 
-    FaultTreeApp.show_safety_case(app)
+    AutoMLApp.show_safety_case(app)
     tree = app._safety_case_tree
     assert len(tree.data) == 1
     iid = next(iter(tree.data))
@@ -462,7 +462,7 @@ def test_safety_case_cancel_does_not_toggle(monkeypatch):
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: types.SimpleNamespace(
         winfo_exists=lambda: True, winfo_children=lambda: []
@@ -483,7 +483,7 @@ def test_safety_case_edit_updates_table(monkeypatch):
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
@@ -502,7 +502,7 @@ def test_safety_case_edit_updates_table(monkeypatch):
 
     monkeypatch.setattr("AutoML.GSNElementConfig", fake_config)
 
-    FaultTreeApp.show_safety_case(app)
+    AutoMLApp.show_safety_case(app)
     tree = app._safety_case_tree
     iid = next(iter(tree.data))
     tree.selection_set(iid)
@@ -520,7 +520,7 @@ def test_safety_case_undo_redo_toggle(monkeypatch):
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
@@ -541,16 +541,16 @@ def test_safety_case_undo_redo_toggle(monkeypatch):
 
     app.export_model_data = export_model_data
     app.apply_model_data = apply_model_data
-    app.push_undo_state = FaultTreeApp.push_undo_state.__get__(app)
-    app.undo = FaultTreeApp.undo.__get__(app)
-    app.redo = FaultTreeApp.redo.__get__(app)
+    app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+    app.undo = AutoMLApp.undo.__get__(app)
+    app.redo = AutoMLApp.redo.__get__(app)
 
     monkeypatch.setattr("AutoML.ttk.Treeview", DummyTree)
     monkeypatch.setattr("AutoML.ttk.Button", DummyButton)
     monkeypatch.setattr("AutoML.tk.Menu", DummyMenu)
     monkeypatch.setattr("AutoML.messagebox.askokcancel", lambda *a, **k: True)
 
-    FaultTreeApp.show_safety_case(app)
+    AutoMLApp.show_safety_case(app)
     tree = app._safety_case_tree
     event = types.SimpleNamespace(x=0, y=0)
     tree.bindings["<Double-Button-1>"](event)
@@ -574,7 +574,7 @@ def test_export_safety_case_writes_rows(tmp_path, monkeypatch):
     diag = GSNDiagram(root)
     diag.add_node(sol)
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = types.SimpleNamespace(select=lambda tab: None)
     app._new_tab = lambda title: DummyTab()
     app.all_gsn_diagrams = [diag]
@@ -588,7 +588,7 @@ def test_export_safety_case_writes_rows(tmp_path, monkeypatch):
     path = tmp_path / "out.csv"
     monkeypatch.setattr("AutoML.filedialog.asksaveasfilename", lambda **k: str(path))
 
-    FaultTreeApp.show_safety_case(app)
+    AutoMLApp.show_safety_case(app)
     app.export_safety_case_csv()
 
     with open(path, newline="") as f:

--- a/tests/test_safety_concept_persistence.py
+++ b/tests/test_safety_concept_persistence.py
@@ -11,12 +11,12 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 from analysis.models import global_requirements
 
 
 def _minimal_app():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.top_events = []
     app.fmeas = []
     app.fmedas = []

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -18,7 +18,7 @@ sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
 sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
 sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 import AutoML
 from analysis.safety_management import (
     SafetyManagementToolbox,
@@ -240,7 +240,7 @@ def test_rename_module_updates_phase_references():
 
 def test_disable_work_product_rejects_existing_docs():
     """Work product types with existing documents cannot be removed."""
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.enabled_work_products = {"HAZOP"}
     app.work_product_menus = {}
     app.tool_listboxes = {}
@@ -264,7 +264,7 @@ def test_disable_work_product_rejects_existing_docs():
 
 
 def test_open_safety_management_toolbox_uses_browser(monkeypatch):
-    """FaultTreeApp opens the Safety & Security Management window and toolbox."""
+    """AutoMLApp opens the Safety & Security Management window and toolbox."""
     SysMLRepository._instance = None
 
     class DummyTab:
@@ -290,7 +290,7 @@ def test_open_safety_management_toolbox_uses_browser(monkeypatch):
     monkeypatch.setattr(smt, "SafetyManagementWindow", DummySMW)
 
     class DummyApp:
-        open_safety_management_toolbox = FaultTreeApp.open_safety_management_toolbox
+        open_safety_management_toolbox = AutoMLApp.open_safety_management_toolbox
 
         def __init__(self):
             self.doc_nb = DummyNotebook()
@@ -404,7 +404,7 @@ def test_safety_diagrams_visible_in_analysis_tree():
             self.items[iid] = {"parent": parent, "text": text}
             return iid
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.refresh_model = lambda: None
     app.compute_occurrence_counts = lambda: {}
     app.diagram_icons = {}
@@ -454,7 +454,7 @@ def test_gsn_diagrams_visible_in_analysis_tree():
     root = GSNNode("Goal1", "Goal")
     diag = GSNDiagram(root)
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.refresh_model = lambda: None
     app.compute_occurrence_counts = lambda: {}
     app.diagram_icons = {}
@@ -499,7 +499,7 @@ def test_explorers_removed_from_safety_concept_group():
             self.items[iid] = {"parent": parent, "text": text, "tags": tags}
             return iid
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.refresh_model = lambda: None
     app.compute_occurrence_counts = lambda: {}
     app.diagram_icons = {}
@@ -545,7 +545,7 @@ def test_joint_reviews_visible_in_analysis_tree():
     joint = ReviewData(name="JR1", mode="joint")
     peer = ReviewData(name="PR1", mode="peer")
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.refresh_model = lambda: None
     app.compute_occurrence_counts = lambda: {}
     app.diagram_icons = {}
@@ -641,7 +641,7 @@ def test_disabled_work_products_absent_from_analysis_tree():
             self.items[iid] = {"parent": parent, "text": text}
             return iid
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.refresh_model = lambda: None
     app.compute_occurrence_counts = lambda: {}
     app.diagram_icons = {}
@@ -676,7 +676,7 @@ def test_disabled_work_products_absent_from_analysis_tree():
 
 
 def test_enable_work_product_refreshes_views():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     called = {"count": 0}
     app.update_views = lambda: called.__setitem__("count", called["count"] + 1)
     app.tool_listboxes = {}
@@ -685,15 +685,15 @@ def test_enable_work_product_refreshes_views():
     app.tool_actions = {}
     app.enabled_work_products = set()
     app.enable_process_area = lambda area: None
-    FaultTreeApp.enable_work_product(app, "HAZOP")
+    AutoMLApp.enable_work_product(app, "HAZOP")
     assert called["count"] == 1
     app.hazop_docs = []
-    FaultTreeApp.disable_work_product(app, "HAZOP")
+    AutoMLApp.disable_work_product(app, "HAZOP")
     assert called["count"] == 2
 
 
 def test_open_work_product_requires_enablement():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     opened = {"count": 0}
     app.tool_actions = {"HAZOP Analysis": lambda: opened.__setitem__("count", opened["count"] + 1)}
     app.arch_diagrams = []
@@ -716,7 +716,7 @@ def test_phase_without_diagrams_disables_products():
 
 
 def test_menu_work_products_toggle_and_guard_existing_docs():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.tool_listboxes = {}
     app.tool_categories = {}
     app.tool_actions = {}
@@ -747,14 +747,14 @@ def test_menu_work_products_toggle_and_guard_existing_docs():
         app.tool_categories = {}
         if attr:
             setattr(app, attr, [])
-        FaultTreeApp.enable_work_product(app, name)
+        AutoMLApp.enable_work_product(app, name)
         assert menu.state == tk.NORMAL
         if attr:
             getattr(app, attr).append(object())
-            assert not FaultTreeApp.disable_work_product(app, name)
+            assert not AutoMLApp.disable_work_product(app, name)
             assert menu.state == tk.NORMAL
             getattr(app, attr).clear()
-        assert FaultTreeApp.disable_work_product(app, name)
+        assert AutoMLApp.disable_work_product(app, name)
         assert menu.state == tk.DISABLED
 
 def test_governance_diagram_opens_with_governance_toolbox(monkeypatch):
@@ -764,7 +764,7 @@ def test_governance_diagram_opens_with_governance_toolbox(monkeypatch):
     diag = repo.create_diagram("Governance Diagram", name="GovA")
     diag.tags.append("safety-management")
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.management_diagrams = [diag]
     app.diagram_tabs = {}
 
@@ -900,7 +900,7 @@ def test_work_products_filtered_by_phase_in_tree():
             self.items[iid] = {"parent": parent, "text": text}
             return iid
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.refresh_model = lambda: None
     app.compute_occurrence_counts = lambda: {}
     app.diagram_icons = {}
@@ -1005,7 +1005,7 @@ def test_governance_enables_tools_per_phase():
         def set(self, value):
             self.value = value
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
     menu_arch = DummyMenu()
     menu_req = DummyMenu()
@@ -1021,20 +1021,20 @@ def test_governance_enables_tools_per_phase():
     app.manage_architecture = lambda: None
     app.show_requirements_editor = lambda: None
     app.tool_to_work_product = {
-        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+        info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()
     }
     app.update_views = lambda: None
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
-        app, FaultTreeApp
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(
+        app, AutoMLApp
     )
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
-        app, FaultTreeApp
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(
-        app, FaultTreeApp
+    app.disable_work_product = AutoMLApp.disable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
-        app, FaultTreeApp
+    app.on_lifecycle_selected = AutoMLApp.on_lifecycle_selected.__get__(
+        app, AutoMLApp
     )
     app.safety_mgmt_toolbox = toolbox
     toolbox.on_change = app.refresh_tool_enablement
@@ -1120,7 +1120,7 @@ def test_phase_without_governance_disables_tools():
         def set(self, value):
             self.value = value
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
     menu_arch = DummyMenu()
     app.tool_listboxes = {"System Design (Item Definition)": lb}
@@ -1131,20 +1131,20 @@ def test_phase_without_governance_disables_tools():
     app.enable_process_area = lambda area: None
     app.manage_architecture = lambda: None
     app.tool_to_work_product = {
-        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+        info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()
     }
     app.update_views = lambda: None
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
-        app, FaultTreeApp
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(
+        app, AutoMLApp
     )
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
-        app, FaultTreeApp
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(
-        app, FaultTreeApp
+    app.disable_work_product = AutoMLApp.disable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
-        app, FaultTreeApp
+    app.on_lifecycle_selected = AutoMLApp.on_lifecycle_selected.__get__(
+        app, AutoMLApp
     )
     app.safety_mgmt_toolbox = toolbox
     toolbox.on_change = app.refresh_tool_enablement
@@ -1271,7 +1271,7 @@ def test_child_work_product_enables_parent_menu():
     parent_menu = DummyMenu()
     child_menu = DummyMenu()
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.tool_listboxes = {}
     app.tool_actions = {}
     app.tool_categories = {}
@@ -1283,12 +1283,12 @@ def test_child_work_product_enables_parent_menu():
     app.enabled_work_products = set()
     app.update_views = lambda: None
 
-    FaultTreeApp.enable_work_product(app, "HAZOP")
+    AutoMLApp.enable_work_product(app, "HAZOP")
 
     assert child_menu.state == tk.NORMAL
     assert parent_menu.state == tk.NORMAL
 
-    FaultTreeApp.disable_work_product(app, "HAZOP", force=True)
+    AutoMLApp.disable_work_product(app, "HAZOP", force=True)
     assert parent_menu.state == tk.DISABLED
 
 
@@ -1312,7 +1312,7 @@ def test_refresh_tool_enablement_enables_parent_menus():
     fmeda_menu = DummyMenu()
     quant_menu = DummyMenu()
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.tool_listboxes = {}
     app.tool_categories = {}
     app.tool_actions = {}
@@ -1327,7 +1327,7 @@ def test_refresh_tool_enablement_enables_parent_menus():
     app.enabled_work_products = set()
     app.safety_mgmt_toolbox = toolbox
 
-    FaultTreeApp.refresh_tool_enablement(app)
+    AutoMLApp.refresh_tool_enablement(app)
 
     assert hazop_menu.state == tk.NORMAL
     assert qual_menu.state == tk.NORMAL
@@ -1388,7 +1388,7 @@ def test_phase_without_diagrams_disables_tools():
         def set(self, value):
             self.value = value
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
     menu_arch = DummyMenu()
     app.tool_listboxes = {"System Design (Item Definition)": lb}
@@ -1399,20 +1399,20 @@ def test_phase_without_diagrams_disables_tools():
     app.enable_process_area = lambda area: None
     app.manage_architecture = lambda: None
     app.tool_to_work_product = {
-        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+        info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()
     }
     app.update_views = lambda: None
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
-        app, FaultTreeApp
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(
+        app, AutoMLApp
     )
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
-        app, FaultTreeApp
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(
-        app, FaultTreeApp
+    app.disable_work_product = AutoMLApp.disable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.on_lifecycle_selected = FaultTreeApp.on_lifecycle_selected.__get__(
-        app, FaultTreeApp
+    app.on_lifecycle_selected = AutoMLApp.on_lifecycle_selected.__get__(
+        app, AutoMLApp
     )
     app.safety_mgmt_toolbox = toolbox
     toolbox.on_change = app.refresh_tool_enablement
@@ -1462,7 +1462,7 @@ def test_governance_without_declarations_keeps_tools_enabled():
         def entryconfig(self, _idx, state=tk.DISABLED):
             self.state = state
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
     menu_arch = DummyMenu()
     menu_req = DummyMenu()
@@ -1478,17 +1478,17 @@ def test_governance_without_declarations_keeps_tools_enabled():
     app.manage_architecture = lambda: None
     app.show_requirements_editor = lambda: None
     app.tool_to_work_product = {
-        info[1]: name for name, info in FaultTreeApp.WORK_PRODUCT_INFO.items()
+        info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()
     }
     app.update_views = lambda: None
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
-        app, FaultTreeApp
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(
+        app, AutoMLApp
     )
-    app.enable_work_product = FaultTreeApp.enable_work_product.__get__(
-        app, FaultTreeApp
+    app.enable_work_product = AutoMLApp.enable_work_product.__get__(
+        app, AutoMLApp
     )
-    app.disable_work_product = FaultTreeApp.disable_work_product.__get__(
-        app, FaultTreeApp
+    app.disable_work_product = AutoMLApp.disable_work_product.__get__(
+        app, AutoMLApp
     )
     app.safety_mgmt_toolbox = toolbox
 
@@ -1769,7 +1769,7 @@ def test_explorer_handles_duplicate_names(monkeypatch):
 
 
 def test_tools_include_safety_management_explorer():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.manage_safety_management = lambda: None
     app.open_safety_management_toolbox = lambda: None
     app.show_safety_performance_indicators = lambda: None
@@ -1878,7 +1878,7 @@ def test_governance_hierarchy_in_analysis_tree():
             }
             return iid
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.refresh_model = lambda: None
     app.compute_occurrence_counts = lambda: {}
     app.diagram_icons = {}
@@ -1956,7 +1956,7 @@ def test_folder_double_click_opens_safety_management_explorer():
                 return self._focus
             self._focus = iid
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.refresh_model = lambda: None
     app.compute_occurrence_counts = lambda: {}
     app.diagram_icons = {}
@@ -2413,11 +2413,11 @@ def test_each_analysis_enabled_only_in_own_phase():
 
 def test_work_product_info_includes_requirement_types():
     for wp in REQUIREMENT_WORK_PRODUCTS:
-        assert wp in FaultTreeApp.WORK_PRODUCT_INFO
+        assert wp in AutoMLApp.WORK_PRODUCT_INFO
 
 
 def test_disable_requirement_work_product_keeps_editor():
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.update_views = lambda: None
     app.tool_listboxes = {}
     app.tool_categories = {}
@@ -2427,12 +2427,12 @@ def test_disable_requirement_work_product_keeps_editor():
     app.enable_process_area = lambda area: None
 
     wp1, wp2 = REQUIREMENT_WORK_PRODUCTS[:2]
-    FaultTreeApp.enable_work_product(app, wp1)
-    FaultTreeApp.enable_work_product(app, wp2)
+    AutoMLApp.enable_work_product(app, wp1)
+    AutoMLApp.enable_work_product(app, wp2)
     assert "Requirements Editor" in app.tool_actions
-    FaultTreeApp.disable_work_product(app, wp1)
+    AutoMLApp.disable_work_product(app, wp1)
     assert "Requirements Editor" in app.tool_actions
-    FaultTreeApp.disable_work_product(app, wp2)
+    AutoMLApp.disable_work_product(app, wp2)
     assert "Requirements Editor" not in app.tool_actions
 
 
@@ -2489,7 +2489,7 @@ def test_focus_governance_diagram_sets_phase_and_hides_functions():
         def set(self, v):
             self.value = v
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.diagram_tabs = {}
     app.doc_nb = DummyNotebook(app)
     app._new_tab = types.MethodType(_new_tab, app)
@@ -2501,12 +2501,12 @@ def test_focus_governance_diagram_sets_phase_and_hides_functions():
     toolbox.on_change = lambda: changes.append("x")
     AutoML.GovernanceDiagramWindow = lambda *args, **kwargs: None
 
-    FaultTreeApp.open_arch_window(app, d1)
+    AutoMLApp.open_arch_window(app, d1)
     app.doc_nb.select(app.diagram_tabs[d1])
     assert toolbox.active_module == "Phase1"
     assert app.lifecycle_var.value == "Phase1"
 
-    FaultTreeApp.open_arch_window(app, d2)
+    AutoMLApp.open_arch_window(app, d2)
     app.doc_nb.select(app.diagram_tabs[d2])
     assert toolbox.active_module == "Phase2"
     assert app.lifecycle_var.value == "Phase2"
@@ -2546,7 +2546,7 @@ def test_tab_focus_triggers_refresh():
         def nametowidget(self, widget):
             return widget
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     tab = DummyTab()
     nb = DummyNotebook(tab)
     app.refresh_all = types.MethodType(lambda self: None, app)

--- a/tests/test_safety_management_dedup.py
+++ b/tests/test_safety_management_dedup.py
@@ -17,7 +17,7 @@ sys.modules.setdefault("PIL.ImageTk", PIL_stub.ImageTk)
 sys.modules.setdefault("PIL.ImageDraw", PIL_stub.ImageDraw)
 sys.modules.setdefault("PIL.ImageFont", PIL_stub.ImageFont)
 
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def test_safety_management_toolbox_single_instance(monkeypatch):
@@ -57,7 +57,7 @@ def test_safety_management_toolbox_single_instance(monkeypatch):
     monkeypatch.setattr(analysis, "SafetyManagementToolbox", DummyToolbox)
 
     class DummyApp:
-        open_safety_management_toolbox = FaultTreeApp.open_safety_management_toolbox
+        open_safety_management_toolbox = AutoMLApp.open_safety_management_toolbox
 
         def __init__(self):
             self.doc_nb = DummyNotebook()

--- a/tests/test_safety_management_persistence.py
+++ b/tests/test_safety_management_persistence.py
@@ -11,15 +11,15 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 import os
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp, HazopDoc
+from AutoML import AutoMLApp, HazopDoc
 from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
 from sysml.sysml_repository import SysMLRepository
 
 
 def _minimal_app():
-    """Return a barebones ``FaultTreeApp`` suitable for serialisation tests."""
+    """Return a barebones ``AutoMLApp`` suitable for serialisation tests."""
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.top_events = []
     app.root_node = None
     app.fmea_entries = []
@@ -100,8 +100,8 @@ def test_apply_model_enables_governed_work_products(monkeypatch):
         enabled.append(name)
         self.enabled_work_products.add(name)
 
-    monkeypatch.setattr(FaultTreeApp, "enable_work_product", record_enable)
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(app, FaultTreeApp)
+    monkeypatch.setattr(AutoMLApp, "enable_work_product", record_enable)
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(app, AutoMLApp)
     toolbox = SafetyManagementToolbox()
     toolbox.add_work_product("Gov", "HAZOP", "Rationale")
     data = {"safety_mgmt_toolbox": toolbox.to_dict()}
@@ -114,11 +114,11 @@ def test_apply_model_without_governance_disables_work_products(monkeypatch):
     app.enabled_work_products = {"HAZOP"}
     disabled = []
     monkeypatch.setattr(
-        FaultTreeApp,
+        AutoMLApp,
         "disable_work_product",
         lambda self, name: disabled.append(name) or True,
     )
-    app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(app, FaultTreeApp)
+    app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(app, AutoMLApp)
     app.apply_model_data({}, ensure_root=False)
     assert disabled == ["HAZOP"]
     assert app.enabled_work_products == set()
@@ -166,8 +166,8 @@ def test_only_active_phase_work_products_enabled_on_load(monkeypatch):
     data = app.export_model_data(include_versions=False)
 
     new_app = _minimal_app()
-    new_app.refresh_tool_enablement = FaultTreeApp.refresh_tool_enablement.__get__(
-        new_app, FaultTreeApp
+    new_app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(
+        new_app, AutoMLApp
     )
 
     def enable_wp(self, name, *, refresh: bool = True):
@@ -177,8 +177,8 @@ def test_only_active_phase_work_products_enabled_on_load(monkeypatch):
         self.enabled_work_products.discard(name)
         return True
 
-    monkeypatch.setattr(FaultTreeApp, "enable_work_product", enable_wp, raising=False)
-    monkeypatch.setattr(FaultTreeApp, "disable_work_product", disable_wp, raising=False)
+    monkeypatch.setattr(AutoMLApp, "enable_work_product", enable_wp, raising=False)
+    monkeypatch.setattr(AutoMLApp, "disable_work_product", disable_wp, raising=False)
 
     new_app.apply_model_data(data, ensure_root=False)
     assert new_app.enabled_work_products == {"Architecture Diagram"}

--- a/tests/test_sync_nodes_by_id.py
+++ b/tests/test_sync_nodes_by_id.py
@@ -13,12 +13,12 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from AutoML import FaultTreeApp, FaultTreeNode
+from AutoML import AutoMLApp, FaultTreeNode
 
 
 class SyncNodesTests(unittest.TestCase):
     def setUp(self):
-        self.app = FaultTreeApp.__new__(FaultTreeApp)
+        self.app = AutoMLApp.__new__(AutoMLApp)
         self.original = FaultTreeNode("Orig", "BASIC EVENT")
         self.clone1 = FaultTreeNode("Clone1", "BASIC EVENT")
         self.clone1.is_primary_instance = False

--- a/tests/test_tab_dedup.py
+++ b/tests/test_tab_dedup.py
@@ -1,7 +1,7 @@
 import types
 
 import AutoML
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def test_new_tab_reuses_existing(monkeypatch):
@@ -36,7 +36,7 @@ def test_new_tab_reuses_existing(monkeypatch):
 
     monkeypatch.setattr(AutoML, "ttk", types.SimpleNamespace(Frame=lambda master: DummyFrame()))
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = DummyNotebook()
 
     first = app._new_tab("My Tab")

--- a/tests/test_tab_truncation.py
+++ b/tests/test_tab_truncation.py
@@ -1,7 +1,7 @@
 import types
 
 import AutoML
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 def test_long_tab_title_truncated(monkeypatch):
@@ -36,16 +36,16 @@ def test_long_tab_title_truncated(monkeypatch):
 
     monkeypatch.setattr(AutoML, "ttk", types.SimpleNamespace(Frame=lambda master: DummyFrame()))
 
-    app = FaultTreeApp.__new__(FaultTreeApp)
+    app = AutoMLApp.__new__(AutoMLApp)
     app.doc_nb = DummyNotebook()
 
-    long_title = "x" * (FaultTreeApp.MAX_TAB_TEXT_LENGTH + 10)
+    long_title = "x" * (AutoMLApp.MAX_TAB_TEXT_LENGTH + 10)
     tab = app._new_tab(long_title)
 
     tab_id = app.doc_nb.tabs()[0]
     displayed = app.doc_nb.tab(tab_id, "text")
     assert displayed.endswith("…")
-    assert len(displayed) == FaultTreeApp.MAX_TAB_TEXT_LENGTH
+    assert len(displayed) == AutoMLApp.MAX_TAB_TEXT_LENGTH
 
     second = app._new_tab(long_title)
     assert second is tab

--- a/tests/test_validate_float.py
+++ b/tests/test_validate_float.py
@@ -1,12 +1,12 @@
 import unittest
-from AutoML import FaultTreeApp
+from AutoML import AutoMLApp
 
 
 class ValidateFloatTests(unittest.TestCase):
     def test_allows_scientific_notation(self):
-        self.assertTrue(FaultTreeApp.validate_float(None, "1e"))
-        self.assertTrue(FaultTreeApp.validate_float(None, "1e-"))
-        self.assertTrue(FaultTreeApp.validate_float(None, "1e-8"))
+        self.assertTrue(AutoMLApp.validate_float(None, "1e"))
+        self.assertTrue(AutoMLApp.validate_float(None, "1e-"))
+        self.assertTrue(AutoMLApp.validate_float(None, "1e-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace `FaultTreeApp` with `AutoMLApp` across application and tests to reflect new naming

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a4153917dc83278a47ad0535f2e01e