### PR TITLE
Default Gmail SMTP server

### DIFF
--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -226,6 +226,7 @@ class EmailConfigDialog(simpledialog.Dialog):
 
         tk.Label(server_tab, text="SMTP Server:").grid(row=0, column=0, sticky="w")
         self.server_entry = tk.Entry(server_tab)
+        self.server_entry.insert(0, "smtp.gmail.com")
         self.server_entry.grid(row=0, column=1, pady=2)
 
         tk.Label(server_tab, text="Port:").grid(row=1, column=0, sticky="w")


### PR DESCRIPTION
## Summary
- Add smtp.gmail.com as default SMTP server in email settings dialog

## Testing
- `PYTHONPATH=. pytest tests/test_review_toolbox_optional_pillow.py`


------
https://chatgpt.com/codex/tasks/task_b_68a41e1573e08327bbcf63e38e946cd2