### PR TITLE
Add gradient and shadow to splash screen

### DIFF
--- a/gui/splash_screen.py
+++ b/gui/splash_screen.py
@@ -9,6 +9,17 @@ class SplashScreen(tk.Toplevel):
         super().__init__(master)
         self.duration = duration
         self.overrideredirect(True)
+
+        # Shadow window to create simple 3D effect
+        self.shadow = tk.Toplevel(master)
+        self.shadow.overrideredirect(True)
+        self.shadow.configure(bg="black")
+        try:
+            # Transparency might not be supported on all systems
+            self.shadow.attributes("-alpha", 0.3)
+        except tk.TclError:
+            pass
+
         self.canvas_size = 300
         # Black background so colors pop
         self.canvas = tk.Canvas(
@@ -19,6 +30,7 @@ class SplashScreen(tk.Toplevel):
             bg="black",
         )
         self.canvas.pack()
+        self._draw_gradient()
         self._center()
         # Initialize cube geometry
         self.angle = 0.0
@@ -48,7 +60,7 @@ class SplashScreen(tk.Toplevel):
         )
         # Start animation
         self.after(10, self._animate)
-        self.after(self.duration, self.destroy)
+        self.after(self.duration, self._close)
 
     def _center(self):
         self.update_idletasks()
@@ -56,7 +68,22 @@ class SplashScreen(tk.Toplevel):
         h = self.canvas_size
         x = (self.winfo_screenwidth() // 2) - (w // 2)
         y = (self.winfo_screenheight() // 2) - (h // 2)
+        # Position shadow slightly offset from the splash window
+        self.shadow.geometry(f"{w}x{h}+{x + 5}+{y + 5}")
         self.geometry(f"{w}x{h}+{x}+{y}")
+        self.shadow.lower(self)
+
+    def _draw_gradient(self):
+        """Draw a violet-to-black vertical gradient on the background."""
+        violet = (138, 43, 226)
+        steps = self.canvas_size
+        for i in range(steps):
+            ratio = i / steps
+            r = int(violet[0] * (1 - ratio))
+            g = int(violet[1] * (1 - ratio))
+            b = int(violet[2] * (1 - ratio))
+            color = f"#{r:02x}{g:02x}{b:02x}"
+            self.canvas.create_line(0, i, self.canvas_size, i, fill=color)
 
     def _project(self, x, y, z):
         """Project 3D point onto 2D canvas."""
@@ -117,3 +144,11 @@ class SplashScreen(tk.Toplevel):
         self._draw_cube()
         self._draw_gear()
         self.after(50, self._animate)
+
+    def _close(self):
+        """Destroy splash screen and accompanying shadow window."""
+        try:
+            self.shadow.destroy()
+        except Exception:
+            pass
+        self.destroy()


### PR DESCRIPTION
## Summary
- add violet-to-black background gradient to splash screen
- add offset shadow window for 3D appearance

## Testing
- `pytest` (fails: 1 failed, 772 passed, 6 skipped)


------
https://chatgpt.com/codex/tasks/task_b_68a4252b74b8832780102f02c9668af1