### PR TITLE
feat(gui): add gradient window theme

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -231,6 +231,7 @@ from tkinter import ttk, filedialog, simpledialog, scrolledtext
 from gui import messagebox, logger, add_treeview_scrollbars
 from gui.tooltip import ToolTip
 from gui.style_manager import StyleManager
+from gui.gradient_theme import apply_gradient_theme
 from gui.review_toolbox import (
     ReviewToolbox,
     ReviewData,
@@ -2233,6 +2234,7 @@ class AutoMLApp:
             self.style.theme_use("clam")
         except tk.TclError:
             pass
+        apply_gradient_theme(self.style)
         self.style.configure("Treeview", font=("Arial", 10))
         # Increase notebook tab font/size so titles are fully visible
         self.style.configure(
@@ -13798,6 +13800,7 @@ class AutoMLApp:
             style.theme_use("clam")
         except tk.TclError:
             pass
+        apply_gradient_theme(style)
         style.configure(
             "FMEA.Treeview",
             font=("Segoe UI", 10),
@@ -17660,7 +17663,7 @@ class AutoMLApp:
                 self._tab_right_btn.state(["!disabled"])
 
     def _make_doc_tab_visible(self, tab_id: str) -> None:
-        if tab_id not in self._doc_all_tabs:
+        if not hasattr(self, "_doc_all_tabs") or tab_id not in self._doc_all_tabs:
             return
         index = self._doc_all_tabs.index(tab_id)
         if index < self._doc_tab_offset:

--- a/gui/gradient_theme.py
+++ b/gui/gradient_theme.py
@@ -1,0 +1,30 @@
+import tkinter as tk
+from tkinter import ttk
+
+def apply_gradient_theme(style: ttk.Style) -> None:
+    """Apply a light-blue to white gradient background to ttk frames.
+
+    A thin dark line is added at the bottom to give a subtle 3D effect.
+    The created gradient image is stored on ``style`` to prevent garbage
+    collection.
+    """
+    root = style.master if hasattr(style, 'master') else None
+    if root is None:
+        root = tk._get_default_root()
+        if root is None:
+            return
+    height = 64
+    img = tk.PhotoImage(master=root, width=1, height=height)
+    r1, g1, b1 = root.winfo_rgb("#add8e6")  # light blue
+    r2, g2, b2 = root.winfo_rgb("#ffffff")  # white
+    for i in range(height - 1):
+        r = int(r1 + (r2 - r1) * i / (height - 1)) // 256
+        g = int(g1 + (g2 - g1) * i / (height - 1)) // 256
+        b = int(b1 + (b2 - b1) * i / (height - 1)) // 256
+        img.put(f"#{r:02x}{g:02x}{b:02x}", to=(0, i))
+    # dark bottom line for subtle depth
+    img.put("#708090", to=(0, height - 1))
+    style.element_create("GradientFrame", "image", img, border=0, sticky="nsew")
+    style.layout("TFrame", [("GradientFrame", {"sticky": "nsew"})])
+    # keep reference
+    style._gradient_image = img

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -38,6 +38,7 @@ from analysis.models import (
 from analysis.safety_management import ACTIVE_TOOLBOX, SAFETY_ANALYSIS_WORK_PRODUCTS
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.constants import CHECK_MARK, CROSS_MARK
+from gui.gradient_theme import apply_gradient_theme
 from gui.icon_factory import create_icon
 from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
 from gui.architecture import (
@@ -86,6 +87,7 @@ def configure_table_style(style_name: str, rowheight: int = 60) -> None:
         style.theme_use("clam")
     except tk.TclError:
         pass
+    apply_gradient_theme(style)
     border_opts = {"bordercolor": "black", "borderwidth": 1, "relief": "solid"}
     style.configure(
         style_name,


### PR DESCRIPTION
## Summary
- add `apply_gradient_theme` to render frames with a light blue to white gradient and dark bottom edge
- apply gradient style to main app, FMEA tables, and analysis tables
- guard `_make_doc_tab_visible` against missing tab list during early events

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a4277c3ef4832786dbf7189872e409