### PR TITLE
Open Hazard Explorer in main tab

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -17493,10 +17493,12 @@ class AutoMLApp:
                     child.redraw()
 
     def show_hazard_explorer(self):
-        if hasattr(self, "_haz_exp_window") and self._haz_exp_window.winfo_exists():
-            self._haz_exp_window.lift()
-            return
-        self._haz_exp_window = HazardExplorerWindow(self)
+        if hasattr(self, "_haz_exp_tab") and self._haz_exp_tab.winfo_exists():
+            self.doc_nb.select(self._haz_exp_tab)
+        else:
+            self._haz_exp_tab = self._new_tab("Hazard Explorer")
+            self._haz_exp_window = HazardExplorerWindow(self._haz_exp_tab, self)
+            self._haz_exp_window.pack(fill=tk.BOTH, expand=True)
 
     def show_requirements_explorer(self):
         if hasattr(self, "_req_exp_tab") and self._req_exp_tab.winfo_exists():

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ The **Risk Assessment** view builds on the safety relevant malfunctions from a s
 
 If a cyber risk entry is selected, its damage scenario and CAL are stored with the row for traceability to cybersecurity goals. The calculated ASIL from each row is propagated to the referenced safety goal so that inherited ASIL levels appear consistently in all analyses and documentation, including FTA top level events.
 
-The **Hazard Explorer** window lists all hazards from every risk assessment in a read-only table for quick review or CSV export. A **Requirements Explorer** window lets you query global requirements with filters for text, type, ASIL and status.
+ The **Hazard Explorer** tab lists all hazards from every risk assessment in a read-only table for quick review or CSV export. A **Requirements Explorer** window lets you query global requirements with filters for text, type, ASIL and status.
 
 ## Causal Bayesian Network Analysis
 

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -3968,13 +3968,18 @@ class TC2FIWindow(tk.Frame):
         self.app.update_views()
 
 
-class HazardExplorerWindow(tk.Toplevel):
+class HazardExplorerWindow(tk.Frame):
     """Read-only list of hazards per risk assessment."""
 
-    def __init__(self, app):
-        super().__init__(app.root)
+    def __init__(self, master, app=None):
+        if app is None and hasattr(master, "root"):
+            app = master
+            master = tk.Toplevel(app.root)
+        super().__init__(master)
         self.app = app
-        self.title("Hazard Explorer")
+        if isinstance(master, tk.Toplevel):
+            master.title("Hazard Explorer")
+            self.pack(fill=tk.BOTH, expand=True)
 
         columns = ("Assessment", "Malfunction", "Hazard", "Severity")
         configure_table_style("HazExp.Treeview")

--- a/tests/test_hazard_explorer_tab.py
+++ b/tests/test_hazard_explorer_tab.py
@@ -1,0 +1,52 @@
+import types
+
+import AutoML
+from AutoML import AutoMLApp
+
+
+def test_show_hazard_explorer_creates_tab():
+    app = AutoMLApp.__new__(AutoMLApp)
+
+    class DummyNotebook:
+        def __init__(self):
+            self._tabs = []
+            self.selected = None
+
+        def select(self, tab):
+            self.selected = tab
+
+        def tabs(self):
+            return self._tabs
+
+    app.doc_nb = DummyNotebook()
+    app._tab_titles = {}
+    app._doc_all_tabs = []
+    app._doc_tab_offset = 0
+    app.MAX_VISIBLE_TABS = AutoMLApp.MAX_VISIBLE_TABS
+
+    def fake_new_tab(self, title):
+        tab = types.SimpleNamespace(title=title, winfo_exists=lambda: True)
+        self.doc_nb._tabs.append(tab)
+        return tab
+
+    app._new_tab = types.MethodType(fake_new_tab, app)
+
+    class DummyHazExp:
+        def __init__(self, master, app):
+            self.master = master
+
+        def pack(self, **kwargs):
+            pass
+
+    old_cls = AutoML.HazardExplorerWindow
+    AutoML.HazardExplorerWindow = DummyHazExp
+    try:
+        AutoMLApp.show_hazard_explorer(app)
+        assert app._haz_exp_tab.title == "Hazard Explorer"
+        assert app.doc_nb._tabs == [app._haz_exp_tab]
+
+        AutoMLApp.show_hazard_explorer(app)
+        assert app.doc_nb.selected is app._haz_exp_tab
+        assert len(app.doc_nb._tabs) == 1
+    finally:
+        AutoML.HazardExplorerWindow = old_cls


### PR DESCRIPTION
## Summary
- Open the Hazard Explorer inside the main document notebook instead of a separate window.
- Update Hazard Explorer implementation to operate as an embeddable frame.
- Document the new Hazard Explorer tab and add tests verifying tab creation.

## Testing
- `pytest tests/test_requirements_explorer_phase_filter.py tests/test_hazard_explorer_tab.py`


------
https://chatgpt.com/codex/tasks/task_b_68a42b57392c8327b2d104476364a841