### PR TITLE
style: mac-like button appearance

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2237,6 +2237,21 @@ class AutoMLApp:
             self.style.theme_use("clam")
         except tk.TclError:
             pass
+        # Give all ttk buttons a macOS-like 3D capsule appearance so that
+        # buttons across the entire tool have a consistent style.
+        self.style.configure(
+            "TButton",
+            padding=(10, 5),
+            relief="raised",
+            borderwidth=1,
+            background="#e5e5e5",
+            foreground="black",
+        )
+        self.style.map(
+            "TButton",
+            background=[("active", "#d9d9d9"), ("pressed", "#d0d0d0")],
+            relief=[("pressed", "sunken"), ("!pressed", "raised")],
+        )
         self.style.configure(
             "Treeview",
             font=("Arial", 10),


### PR DESCRIPTION
## Summary
- apply macOS-inspired 3D capsule styling to all ttk buttons for a consistent look

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4306b56788327b0c7cccafbe57d7d