### PR TITLE
style: update window and toolbox colors

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2233,7 +2233,154 @@ class AutoMLApp:
             self.style.theme_use("clam")
         except tk.TclError:
             pass
-        self.style.configure("Treeview", font=("Arial", 10))
+        self.style.configure(
+            "Treeview",
+            font=("Arial", 10),
+            background="#ffffff",
+            fieldbackground="#ffffff",
+            foreground="black",
+            borderwidth=1,
+            relief="sunken",
+        )
+        self.style.configure(
+            "Treeview.Heading",
+            background="#b5bdc9",
+            foreground="black",
+            relief="raised",
+        )
+        self.style.map(
+            "Treeview.Heading",
+            background=[("active", "#4a6ea9"), ("!active", "#b5bdc9")],
+            foreground=[("active", "white"), ("!active", "black")],
+        )
+        # ------------------------------------------------------------------
+        # Global color theme inspired by Windows classic / Windows 7
+        # ------------------------------------------------------------------
+        # Overall workspace background
+        root.configure(background="#f0f0f0")
+        # General widget colours
+        self.style.configure("TFrame", background="#f0f0f0")
+        self.style.configure("TLabel", background="#f0f0f0", foreground="black")
+        self.style.configure(
+            "TEntry", fieldbackground="#ffffff", background="#ffffff", foreground="black"
+        )
+        self.style.configure(
+            "TCombobox",
+            fieldbackground="#ffffff",
+            background="#ffffff",
+            foreground="black",
+        )
+        self.style.configure(
+            "TMenubutton", background="#e7edf5", foreground="black"
+        )
+        self.style.configure(
+            "TScrollbar",
+            background="#c0d4eb",
+            troughcolor="#e2e6eb",
+            bordercolor="#888888",
+            arrowcolor="#555555",
+            lightcolor="#eaf2fb",
+            darkcolor="#5a6d84",
+            borderwidth=2,
+            relief="raised",
+        )
+        # Apply the scrollbar styling to both orientations
+        for orient in ("Horizontal.TScrollbar", "Vertical.TScrollbar"):
+            self.style.configure(orient,
+                                background="#c0d4eb",
+                                troughcolor="#e2e6eb",
+                                bordercolor="#888888",
+                                arrowcolor="#555555",
+                                lightcolor="#eaf2fb",
+                                darkcolor="#5a6d84",
+                                borderwidth=2,
+                                relief="raised")
+        # Toolbox/LabelFrame titles
+        self.style.configure(
+            "Toolbox.TLabelframe",
+            background="#fef9e7",
+            bordercolor="#888888",
+            lightcolor="#fffef7",
+            darkcolor="#bfae6a",
+            borderwidth=1,
+            relief="raised",
+        )
+        self.style.configure(
+            "Toolbox.TLabelframe.Label",
+            background="#fef9e7",
+            foreground="black",
+            font=("Segoe UI", 10, "bold"),
+            padding=(4, 0, 0, 0),
+            anchor="w",
+        )
+        # Notebook (ribbon-like) title bars with beveled edges
+        self.style.configure(
+            "TNotebook",
+            background="#c0d4eb",
+            lightcolor="#eaf2fb",
+            darkcolor="#5a6d84",
+            borderwidth=2,
+            relief="raised",
+        )
+        self.style.configure(
+            "TNotebook.Tab",
+            background="#b5bdc9",
+            foreground="#555555",
+            borderwidth=1,
+            relief="raised",
+        )
+        self.style.map(
+            "TNotebook.Tab",
+            background=[("selected", "#4a6ea9"), ("!selected", "#b5bdc9")],
+            foreground=[("selected", "white"), ("!selected", "#555555")],
+        )
+        # Closable notebook shares the same appearance
+        self.style.configure(
+            "ClosableNotebook",
+            background="#c0d4eb",
+            lightcolor="#eaf2fb",
+            darkcolor="#5a6d84",
+            borderwidth=2,
+            relief="raised",
+        )
+        self.style.configure(
+            "ClosableNotebook.Tab",
+            background="#b5bdc9",
+            foreground="#555555",
+            borderwidth=1,
+            relief="raised",
+        )
+        self.style.map(
+            "ClosableNotebook.Tab",
+            background=[("selected", "#4a6ea9"), ("!selected", "#b5bdc9")],
+            foreground=[("selected", "white"), ("!selected", "#555555")],
+        )
+        # Classic 3D buttons
+        self.style.configure(
+            "TButton",
+            background="#e7edf5",
+            borderwidth=2,
+            relief="raised",
+            lightcolor="#ffffff",
+            darkcolor="#7a8a99",
+        )
+        self.style.map(
+            "TButton",
+            relief=[("pressed", "sunken"), ("!pressed", "raised")],
+        )
+        # Navigation buttons used to scroll document tabs
+        self.style.configure(
+            "Nav.TButton",
+            background="#e7edf5",
+            borderwidth=2,
+            relief="raised",
+            lightcolor="#ffffff",
+            darkcolor="#7a8a99",
+        )
+        self.style.map(
+            "Nav.TButton",
+            relief=[("pressed", "sunken"), ("!pressed", "raised")],
+        )
         # Increase notebook tab font/size so titles are fully visible
         self.style.configure(
             "TNotebook.Tab", font=("Arial", 10), padding=(10, 5), width=20
@@ -2734,7 +2881,9 @@ class AutoMLApp:
         self.explorer_nb.add(self.analysis_tab, text="File Explorer")
 
         # --- Analyses Group ---
-        self.analysis_group = ttk.LabelFrame(self.analysis_tab, text="Analyses & Architecture")
+        self.analysis_group = ttk.LabelFrame(
+            self.analysis_tab, text="Analyses & Architecture", style="Toolbox.TLabelframe"
+        )
         self.analysis_group.pack(fill=tk.BOTH, expand=True)
 
         tree_frame = ttk.Frame(self.analysis_group)
@@ -2756,7 +2905,9 @@ class AutoMLApp:
         self.treeview = self.analysis_tree
 
         # --- Tools Section ---
-        self.tools_group = ttk.LabelFrame(self.analysis_tab, text="Tools")
+        self.tools_group = ttk.LabelFrame(
+            self.analysis_tab, text="Tools", style="Toolbox.TLabelframe"
+        )
         self.tools_group.pack(fill=tk.BOTH, expand=False, pady=5)
         top = ttk.Frame(self.tools_group)
         top.pack(side=tk.TOP, fill=tk.X)
@@ -2778,12 +2929,29 @@ class AutoMLApp:
         # found`` when instantiating the notebook widget.  The following styles
         # derive from the standard ``TNotebook``/``TNotebook.Tab`` styles and
         # merely customise the tab appearance.
-        style.configure("ToolsNotebook.TNotebook", padding=0)
+        style.configure(
+            "ToolsNotebook.TNotebook",
+            padding=0,
+            background="#c0d4eb",
+            lightcolor="#eaf2fb",
+            darkcolor="#5a6d84",
+            borderwidth=2,
+            relief="raised",
+        )
         style.configure(
             "ToolsNotebook.TNotebook.Tab",
             font=("Arial", 10),
             padding=(10, 5),
             width=20,
+            background="#b5bdc9",
+            foreground="#555555",
+            borderwidth=1,
+            relief="raised",
+        )
+        style.map(
+            "ToolsNotebook.TNotebook.Tab",
+            background=[("selected", "#4a6ea9"), ("!selected", "#b5bdc9")],
+            foreground=[("selected", "white"), ("!selected", "#555555")],
         )
         self.tools_left_btn = ttk.Button(
             nb_container, text="<", width=2, command=self._select_prev_tool_tab
@@ -2899,10 +3067,18 @@ class AutoMLApp:
 
         self.doc_nb.select = _wrapped_select
         self._tab_left_btn = ttk.Button(
-            self.doc_frame, text="<", width=2, command=self._select_prev_tab
+            self.doc_frame,
+            text="<",
+            width=2,
+            command=self._select_prev_tab,
+            style="Nav.TButton",
         )
         self._tab_right_btn = ttk.Button(
-            self.doc_frame, text=">", width=2, command=self._select_next_tab
+            self.doc_frame,
+            text=">",
+            width=2,
+            command=self._select_next_tab,
+            style="Nav.TButton",
         )
         self._tab_left_btn.pack(side=tk.LEFT, fill=tk.Y)
         self._tab_right_btn.pack(side=tk.RIGHT, fill=tk.Y)
@@ -4416,8 +4592,10 @@ class AutoMLApp:
         prop_win.geometry("420x380")
         dialog_font = tkFont.Font(family="Arial", size=10)
 
-        ttk.Label(prop_win, text="PDF Report Name:", font=dialog_font).grid(row=0, column=0, padx=10, pady=10, sticky="w")
-        pdf_entry = tk.Entry(prop_win, width=40, font=dialog_font)
+        ttk.Label(prop_win, text="PDF Report Name:", font=dialog_font).grid(
+            row=0, column=0, padx=10, pady=10, sticky="w"
+        )
+        pdf_entry = ttk.Entry(prop_win, width=40, font=dialog_font)
         pdf_entry.insert(0, self.project_properties.get("pdf_report_name", "AutoML-Analyzer PDF Report"))
         pdf_entry.grid(row=0, column=1, padx=10, pady=10)
 
@@ -4425,22 +4603,29 @@ class AutoMLApp:
         var_detailed = tk.BooleanVar(
             value=self.project_properties.get("pdf_detailed_formulas", True)
         )
-        chk = tk.Checkbutton(
+        chk = ttk.Checkbutton(
             prop_win,
             text="Show Detailed Formulas in PDF Report",
             variable=var_detailed,
-            font=dialog_font,
         )
         chk.grid(row=1, column=0, columnspan=2, padx=10, pady=5, sticky="w")
 
         # Probability mappings for validation target calculations
-        exp_frame = tk.LabelFrame(
-            prop_win, text="Exposure Probabilities P(E|HB)", font=dialog_font
-        )
+        try:
+            exp_frame = ttk.LabelFrame(
+                prop_win,
+                text="Exposure Probabilities P(E|HB)",
+                style="Toolbox.TLabelframe",
+            )
+        except TypeError:
+            exp_frame = ttk.LabelFrame(
+                prop_win,
+                text="Exposure Probabilities P(E|HB)",
+            )
         exp_frame.grid(row=2, column=0, columnspan=2, padx=10, pady=5, sticky="ew")
         exp_vars = {}
         for i in range(1, 5):
-            tk.Label(exp_frame, text=f"{i}:", font=dialog_font).grid(
+            ttk.Label(exp_frame, text=f"{i}:", font=dialog_font).grid(
                 row=0, column=(i - 1) * 2, padx=2, pady=2
             )
             var = tk.StringVar(
@@ -4448,7 +4633,7 @@ class AutoMLApp:
                     self.project_properties.get("exposure_probabilities", {}).get(i, 0.0)
                 )
             )
-            tk.Entry(
+            ttk.Entry(
                 exp_frame,
                 textvariable=var,
                 width=8,
@@ -4458,13 +4643,21 @@ class AutoMLApp:
             ).grid(row=0, column=(i - 1) * 2 + 1, padx=2, pady=2)
             exp_vars[i] = var
 
-        ctrl_frame = tk.LabelFrame(
-            prop_win, text="Controllability Probabilities P(C|E)", font=dialog_font
-        )
+        try:
+            ctrl_frame = ttk.LabelFrame(
+                prop_win,
+                text="Controllability Probabilities P(C|E)",
+                style="Toolbox.TLabelframe",
+            )
+        except TypeError:
+            ctrl_frame = ttk.LabelFrame(
+                prop_win,
+                text="Controllability Probabilities P(C|E)",
+            )
         ctrl_frame.grid(row=3, column=0, columnspan=2, padx=10, pady=5, sticky="ew")
         ctrl_vars = {}
         for i in range(1, 4):
-            tk.Label(ctrl_frame, text=f"{i}:", font=dialog_font).grid(
+            ttk.Label(ctrl_frame, text=f"{i}:", font=dialog_font).grid(
                 row=0, column=(i - 1) * 2, padx=2, pady=2
             )
             var = tk.StringVar(
@@ -4472,7 +4665,7 @@ class AutoMLApp:
                     self.project_properties.get("controllability_probabilities", {}).get(i, 0.0)
                 )
             )
-            tk.Entry(
+            ttk.Entry(
                 ctrl_frame,
                 textvariable=var,
                 width=8,
@@ -4482,13 +4675,21 @@ class AutoMLApp:
             ).grid(row=0, column=(i - 1) * 2 + 1, padx=2, pady=2)
             ctrl_vars[i] = var
 
-        sev_frame = tk.LabelFrame(
-            prop_win, text="Severity Probabilities P(S|C)", font=dialog_font
-        )
+        try:
+            sev_frame = ttk.LabelFrame(
+                prop_win,
+                text="Severity Probabilities P(S|C)",
+                style="Toolbox.TLabelframe",
+            )
+        except TypeError:
+            sev_frame = ttk.LabelFrame(
+                prop_win,
+                text="Severity Probabilities P(S|C)",
+            )
         sev_frame.grid(row=4, column=0, columnspan=2, padx=10, pady=5, sticky="ew")
         sev_vars = {}
         for i in range(1, 4):
-            tk.Label(sev_frame, text=f"{i}:", font=dialog_font).grid(
+            ttk.Label(sev_frame, text=f"{i}:", font=dialog_font).grid(
                 row=0, column=(i - 1) * 2, padx=2, pady=2
             )
             var = tk.StringVar(
@@ -4496,7 +4697,7 @@ class AutoMLApp:
                     self.project_properties.get("severity_probabilities", {}).get(i, 0.0)
                 )
             )
-            tk.Entry(
+            ttk.Entry(
                 sev_frame,
                 textvariable=var,
                 width=8,
@@ -12077,7 +12278,7 @@ class AutoMLApp:
         # Show allocation and safety goal traceability below the table
         frame = tk.Frame(win)
         frame.pack(fill=tk.BOTH, expand=True)
-        vbar = tk.Scrollbar(frame, orient="vertical")
+        vbar = ttk.Scrollbar(frame, orient="vertical")
         text = tk.Text(frame, wrap="word", yscrollcommand=vbar.set, height=8)
         text.tag_configure("added", foreground="blue")
         text.tag_configure("removed", foreground="red")
@@ -13802,11 +14003,21 @@ class AutoMLApp:
             "FMEA.Treeview",
             font=("Segoe UI", 10),
             rowheight=60,
+            background="#ffffff",
+            fieldbackground="#ffffff",
+            foreground="black",
         )
         style.configure(
             "FMEA.Treeview.Heading",
             font=("Segoe UI", 10, "bold"),
-            background="#d0d0d0",
+            background="#b5bdc9",
+            foreground="black",
+            relief="raised",
+        )
+        style.map(
+            "FMEA.Treeview.Heading",
+            background=[("active", "#4a6ea9"), ("!active", "#b5bdc9")],
+            foreground=[("active", "white"), ("!active", "black")],
         )
 
         columns = [
@@ -17660,13 +17871,15 @@ class AutoMLApp:
                 self._tab_right_btn.state(["!disabled"])
 
     def _make_doc_tab_visible(self, tab_id: str) -> None:
-        if tab_id not in self._doc_all_tabs:
+        all_tabs = getattr(self, "_doc_all_tabs", [])
+        if tab_id not in all_tabs:
             return
-        index = self._doc_all_tabs.index(tab_id)
-        if index < self._doc_tab_offset:
+        index = all_tabs.index(tab_id)
+        offset = getattr(self, "_doc_tab_offset", 0)
+        if index < offset:
             self._doc_tab_offset = index
             self._update_doc_tab_visibility()
-        elif index >= self._doc_tab_offset + self.MAX_VISIBLE_TABS:
+        elif index >= offset + self.MAX_VISIBLE_TABS:
             self._doc_tab_offset = index - self.MAX_VISIBLE_TABS + 1
             self._update_doc_tab_visibility()
 

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -40,6 +40,13 @@ from analysis.safety_management import (
     UNRESTRICTED_USAGE_SOURCES,
 )
 
+def _labelframe(master, *, text: str):
+    """Create a themed ``ttk.LabelFrame`` and fall back when style unsupported."""
+    try:
+        return ttk.LabelFrame(master, text=text, style="Toolbox.TLabelframe")
+    except TypeError:
+        return ttk.LabelFrame(master, text=text)
+
 # ---------------------------------------------------------------------------
 # Appearance customization
 # ---------------------------------------------------------------------------
@@ -3635,11 +3642,13 @@ class SysMLDiagramWindow(tk.Frame):
             groups = {"": tools}
         self.element_frames: dict[str, ttk.Frame] = {}
         for name, group_tools in groups.items():
-            frame = (
-                ttk.LabelFrame(self.tools_frame, text=f"{name} (elements)")
-                if name
-                else ttk.Frame(self.tools_frame)
-            )
+            if name:
+                frame = _labelframe(
+                    self.tools_frame,
+                    text=f"{name} (elements)",
+                )
+            else:
+                frame = ttk.Frame(self.tools_frame)
             frame.pack(fill=tk.X, padx=2, pady=2)
             self.element_frames[name] = frame
             for tool in group_tools:
@@ -3654,8 +3663,9 @@ class SysMLDiagramWindow(tk.Frame):
                 self.tool_buttons[tool] = btn
 
         if relation_tools:
-            self.rel_frame = ttk.LabelFrame(
-                self.toolbox, text="Relationships (relationships)"
+            self.rel_frame = _labelframe(
+                self.toolbox,
+                text="Relationships (relationships)",
             )
             self.rel_frame.pack(fill=tk.X, padx=2, pady=2)
             for tool in relation_tools:
@@ -3670,7 +3680,10 @@ class SysMLDiagramWindow(tk.Frame):
         if getattr(self.app, "prop_view", None):
             self.prop_view = self.app.prop_view
         else:
-            self.prop_frame = ttk.LabelFrame(self.toolbox, text="Properties")
+            self.prop_frame = _labelframe(
+                self.toolbox,
+                text="Properties",
+            )
             self.prop_frame.pack(fill=tk.BOTH, expand=True, padx=2, pady=2)
             prop_tree_frame = ttk.Frame(self.prop_frame)
             prop_tree_frame.pack(fill=tk.BOTH, expand=True)
@@ -11612,9 +11625,12 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                     destroy=lambda *a, **k: None,
                 )
             if hasattr(self.toolbox, "tk"):
-                frame = ttk.LabelFrame(self.toolbox, text=name)
+                frame = _labelframe(self.toolbox, text=name)
                 if data.get("nodes"):
-                    elem = ttk.LabelFrame(frame, text="Elements (elements)")
+                    elem = _labelframe(
+                        frame,
+                        text="Elements (elements)",
+                    )
                     elem.pack(fill=tk.X, padx=2, pady=2)
                     for node in data["nodes"]:
                         ttk.Button(
@@ -11625,7 +11641,10 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                             command=lambda t=node: self.select_tool(t),
                         ).pack(fill=tk.X, padx=2, pady=2)
                 if data.get("relations"):
-                    rel = ttk.LabelFrame(frame, text="Relationships (relationships)")
+                    rel = _labelframe(
+                        frame,
+                        text="Relationships (relationships)",
+                    )
                     rel.pack(fill=tk.X, padx=2, pady=2)
                     for rel_name in data["relations"]:
                         ttk.Button(
@@ -11636,10 +11655,16 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                             command=lambda t=rel_name: self.select_tool(t),
                         ).pack(fill=tk.X, padx=2, pady=2)
                 for grp, sub in data.get("externals", {}).items():
-                    sub_frame = ttk.LabelFrame(frame, text=f"Related {grp}")
+                    sub_frame = _labelframe(
+                        frame,
+                        text=f"Related {grp}",
+                    )
                     sub_frame.pack(fill=tk.X, padx=2, pady=2)
                     if sub.get("nodes"):
-                        selem = ttk.LabelFrame(sub_frame, text="Elements (elements)")
+                        selem = _labelframe(
+                            sub_frame,
+                            text="Elements (elements)",
+                        )
                         selem.pack(fill=tk.X, padx=2, pady=2)
                         for node in sub["nodes"]:
                             ttk.Button(
@@ -11650,7 +11675,10 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                                 command=lambda t=node: self.select_tool(t),
                             ).pack(fill=tk.X, padx=2, pady=2)
                     if sub.get("relations"):
-                        srel = ttk.LabelFrame(sub_frame, text="Relationships (relationships)")
+                        srel = _labelframe(
+                            sub_frame,
+                            text="Relationships (relationships)",
+                        )
                         srel.pack(fill=tk.X, padx=2, pady=2)
                         for rel_name in sub["relations"]:
                             ttk.Button(

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -115,7 +115,17 @@ class GSNDiagramWindow(tk.Frame):
             ("Context", self.add_context),
             ("Module", self.add_module),
         ]
-        node_frame = ttk.LabelFrame(self.toolbox, text="Elements (elements)")
+        try:
+            node_frame = ttk.LabelFrame(
+                self.toolbox,
+                text="Elements (elements)",
+                style="Toolbox.TLabelframe",
+            )
+        except TypeError:
+            node_frame = ttk.LabelFrame(
+                self.toolbox,
+                text="Elements (elements)",
+            )
         node_frame.pack(side=tk.TOP, fill=tk.X)
         for name, cmd in node_cmds:
             ttk.Button(
@@ -130,7 +140,17 @@ class GSNDiagramWindow(tk.Frame):
             ("Solved By", self.connect_solved_by),
             ("In Context Of", self.connect_in_context),
         ]
-        rel_frame = ttk.LabelFrame(self.toolbox, text="Relationships (relationships)")
+        try:
+            rel_frame = ttk.LabelFrame(
+                self.toolbox,
+                text="Relationships (relationships)",
+                style="Toolbox.TLabelframe",
+            )
+        except TypeError:
+            rel_frame = ttk.LabelFrame(
+                self.toolbox,
+                text="Relationships (relationships)",
+            )
         rel_frame.pack(side=tk.TOP, fill=tk.X)
         for name, cmd in rel_cmds:
             ttk.Button(


### PR DESCRIPTION
## Summary
- Extend Windows-classic palette to nested toolbox sections with a themed LabelFrame helper
- Style GSN toolbox element and relationship groups to match golden-beige headers
- Convert project properties dialog sections to ttk widgets using the shared toolbox palette

## Testing
- `python -m py_compile AutoML.py gui/gsn_diagram_window.py gui/architecture.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a42a43a10c832787aeb29990baac3d