### PR TITLE
Make tooltips transparent and style buttons like macOS

### DIFF
--- a/gui/mac_button_style.py
+++ b/gui/mac_button_style.py
@@ -4,25 +4,25 @@ from tkinter import ttk
 
 
 def apply_mac_button_style(style: ttk.Style | None = None) -> ttk.Style:
-    """Configure ``ttk.Button`` widgets to mimic macOS capsule buttons.
+    """Configure ``ttk.Button`` widgets with a transparent capsule look.
 
-    The function adjusts padding, border and relief to give buttons a rounded
-    3D appearance that resembles native macOS controls.  The style changes are
-    applied to the passed ``ttk.Style`` instance.  If no *style* is supplied a
-    new instance is created.
+    The function removes the heavy relief and solid background so that buttons
+    blend with their parent widget, similar to the translucent controls on
+    macOS.  The style changes are applied to the passed ``ttk.Style`` instance.
+    If no *style* is supplied a new instance is created.
     """
     style = style or ttk.Style()
     style.configure(
         "TButton",
         padding=(10, 5),
-        relief="raised",
-        borderwidth=1,
+        relief="flat",
+        borderwidth=0,
         foreground="black",
-        background="#e1e1e1",
+        background="",
     )
     style.map(
         "TButton",
-        background=[("active", "#f5f5f5"), ("pressed", "#d9d9d9")],
-        relief=[("pressed", "sunken"), ("!pressed", "raised")],
+        background=[("active", "#d9d9d9"), ("pressed", "#c0c0c0")],
+        relief=[("pressed", "flat"), ("!pressed", "flat")],
     )
     return style

--- a/gui/tooltip.py
+++ b/gui/tooltip.py
@@ -31,11 +31,13 @@ class ToolTip:
             y = self.widget.winfo_rooty() + self.widget.winfo_height() + 1
         self.tipwindow = tw = tk.Toplevel(self.widget)
         tw.wm_overrideredirect(True)
-        # Ensure the tooltip stays above other windows
+        # Ensure the tooltip stays above other windows and make background transparent
         try:
             tw.wm_attributes("-topmost", True)
+            tw.wm_attributes("-transparentcolor", "#ffffe0")
         except tk.TclError:
             pass
+        tw.configure(bg="#ffffe0")
 
         lines = self.text.split("\n")
         max_len = max((len(line) for line in lines), default=1)
@@ -49,8 +51,8 @@ class ToolTip:
             width=width,
             height=height,
             background="#ffffe0",
-            relief="solid",
-            borderwidth=1,
+            relief="flat",
+            borderwidth=0,
             wrap="none",
         )
         vbar = ttk.Scrollbar(tw, orient="vertical", command=text.yview)


### PR DESCRIPTION
## Summary
- allow tooltip backgrounds to be transparent
- give ttk buttons a flat, transparent capsule look

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a43668b41c832793d56a3e4234daeb