### PR TITLE
Reduce log window footprint

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2915,8 +2915,11 @@ class AutoMLApp:
         root.bind_all("<Control-y>", lambda event: self.redo())
         root.bind("<F1>", lambda event: self.show_about())
         self.main_pane = tk.PanedWindow(root, orient=tk.HORIZONTAL)
-        self.log_frame = logger.init_log_window(root)
-        self.log_frame.pack(side=tk.BOTTOM, fill=tk.BOTH)
+        # Initialise the log window with a smaller default height and prevent it from
+        # expanding vertically so it does not occupy a large portion of the main
+        # application window.
+        self.log_frame = logger.init_log_window(root, height=5)
+        self.log_frame.pack(side=tk.BOTTOM, fill=tk.X)
         self.toggle_log_button = ttk.Button(
             root, text="Hide Logs", command=self.toggle_logs
         )
@@ -10378,8 +10381,10 @@ class AutoMLApp:
             self.log_frame.pack_forget()
             self.toggle_log_button.config(text="Show Logs")
         else:
+            # When re-showing the log window, keep it constrained to its natural
+            # height by filling only horizontally.
             self.log_frame.pack(
-                side=tk.BOTTOM, fill=tk.BOTH, before=self.toggle_log_button
+                side=tk.BOTTOM, fill=tk.X, before=self.toggle_log_button
             )
             self.toggle_log_button.config(text="Hide Logs")
 


### PR DESCRIPTION
## Summary
- prevent log window from expanding vertically so it no longer fills half the tool window
- initialize log window with a smaller default height for better usability

## Testing
- `pytest tests/test_log_window_toggle.py` *(skipped: Tk not available)*

------
https://chatgpt.com/codex/tasks/task_b_68a4403005988327bb8545b5ecc06ed4