### PR TITLE
Reduce log window footprint

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2915,8 +2915,10 @@ class AutoMLApp:
         root.bind_all("<Control-y>", lambda event: self.redo())
         root.bind("<F1>", lambda event: self.show_about())
         self.main_pane = tk.PanedWindow(root, orient=tk.HORIZONTAL)
-        self.log_frame = logger.init_log_window(root)
-        self.log_frame.pack(side=tk.BOTTOM, fill=tk.BOTH)
+        # Initialise the log window with a minimal height so it no longer
+        # consumes a significant portion of the main application window.
+        self.log_frame = logger.init_log_window(root, height=3)
+        self.log_frame.pack(side=tk.BOTTOM, fill=tk.X)
         self.toggle_log_button = ttk.Button(
             root, text="Hide Logs", command=self.toggle_logs
         )
@@ -10378,8 +10380,10 @@ class AutoMLApp:
             self.log_frame.pack_forget()
             self.toggle_log_button.config(text="Show Logs")
         else:
+            # When re-showing the log window, keep it constrained to its natural
+            # height by filling only horizontally.
             self.log_frame.pack(
-                side=tk.BOTTOM, fill=tk.BOTH, before=self.toggle_log_button
+                side=tk.BOTTOM, fill=tk.X, before=self.toggle_log_button
             )
             self.toggle_log_button.config(text="Hide Logs")
 

--- a/gui/logger.py
+++ b/gui/logger.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from tkinter import ttk
+import tkinter.font as tkfont
 
 log_widget = None
 _line_widget = None
@@ -28,6 +29,10 @@ def init_log_window(root, height=8, dark_mode: bool = True):
 
     global log_widget, _line_widget
     frame = ttk.Frame(root)
+    frame.pack_propagate(False)
+    font = tkfont.Font(root=root, family="Consolas", size=11)
+    line_height = font.metrics("linespace")
+    frame.configure(height=line_height * height)
 
     # Choose colours based on the requested theme
     if dark_mode:
@@ -54,7 +59,8 @@ def init_log_window(root, height=8, dark_mode: bool = True):
         background=bg,
         foreground=line_fg,
         state="disabled",
-        font=("Consolas", 11),
+        font=font,
+        height=height,
     )
     _line_widget.pack(side=tk.LEFT, fill=tk.Y)
 
@@ -65,7 +71,7 @@ def init_log_window(root, height=8, dark_mode: bool = True):
         frame,
         height=height,
         state="disabled",
-        font=("Consolas", 11),
+        font=font,
         wrap="word",
         background=bg,
         foreground=fg,


### PR DESCRIPTION
## Summary
- limit log window to a three-line height and only fill horizontally
- fix log window widget so its frame uses a fixed pixel height based on font metrics

## Testing
- `pytest tests/test_log_window_toggle.py` *(skipped: Tk not available)*

------
https://chatgpt.com/codex/tasks/task_b_68a4403005988327bb8545b5ecc06ed4