### PR TITLE
Ensure GUI package bundled in executable

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -7,10 +7,13 @@ executable the dependencies are already bundled so the installation step
 is skipped.
 """
 import importlib
-import runpy
 import subprocess
 import sys
 from pathlib import Path
+
+# Hint PyInstaller to bundle AutoML and its dependencies (e.g. gui package)
+if False:  # pragma: no cover
+    import AutoML  # noqa: F401
 
 REQUIRED_PACKAGES = [
     "pillow",
@@ -36,10 +39,13 @@ def ensure_packages() -> None:
             subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
 
 def main() -> None:
+    """Entry point used by both source and bundled executions."""
     ensure_packages()
     base_path = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))
-    script = base_path / "AutoML.py"
-    runpy.run_path(str(script), run_name="__main__")
+    if str(base_path) not in sys.path:
+        sys.path.insert(0, str(base_path))
+    automl = importlib.import_module("AutoML")
+    automl.main()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- load AutoML module directly and add its directory to `sys.path` so `gui` package is found when running the PyInstaller exe
- ensure PyInstaller bundles AutoML and its `gui` package by including a dummy import

## Testing
- `python -m py_compile launcher.py`
- `pytest tests/test_gui_classes.py`


------
https://chatgpt.com/codex/tasks/task_b_68a44572ae108327bf8fdc4194797981