### PR TITLE
Fix tooltip coordinate handling to avoid UnboundLocalError

### DIFF
--- a/gui/tooltip.py
+++ b/gui/tooltip.py
@@ -23,7 +23,7 @@ class ToolTip:
         self._unschedule()
         self.id = self.widget.after(self.delay, self._show)
 
-    def _show(self, _x: int | None = None, _y: int | None = None):
+    def _show(self, x: int | None = None, y: int | None = None):
         if self.tipwindow or not self.text:
             return
 
@@ -87,7 +87,7 @@ class ToolTip:
     def show(self, x: int | None = None, y: int | None = None):
         """Show the tooltip immediately."""
         self._hide()
-        self._show()
+        self._show(x, y)
 
     def hide(self):
         """Hide the tooltip immediately."""


### PR DESCRIPTION
## Summary
- prevent UnboundLocalError in `ToolTip._show` by correctly handling provided coordinates and falling back to pointer location
- ensure `ToolTip.show` passes optional coordinates to `_show`

## Testing
- `pytest tests/test_governance_tooltips.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4739f5d0c8327b1cf9e52382cfb7a