### PR TITLE
Hide logs by default and auto-show around popups

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2925,14 +2925,13 @@ class AutoMLApp:
         root.bind_all("<Control-y>", lambda event: self.redo())
         root.bind("<F1>", lambda event: self.show_about())
         self.main_pane = tk.PanedWindow(root, orient=tk.HORIZONTAL)
-        # Initialise the log window with a modest height so it no longer
-        # consumes a significant portion of the main application window.
+        # Initialise the log window but keep it hidden until requested.
         self.log_frame = logger.init_log_window(root, height=7)
-        self.log_frame.pack(side=tk.BOTTOM, fill=tk.X)
         self.toggle_log_button = ttk.Button(
-            root, text="Hide Logs", command=self.toggle_logs
+            root, text="Show Logs", command=self.toggle_logs
         )
         self.toggle_log_button.pack(side=tk.BOTTOM, fill=tk.X)
+        logger.set_toggle_button(self.toggle_log_button)
         self.main_pane.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
 
         self.explorer_nb = ttk.Notebook(self.main_pane)
@@ -10386,16 +10385,10 @@ class AutoMLApp:
         self.redraw_canvas()
 
     def toggle_logs(self):
-        if self.log_frame.winfo_manager():
-            self.log_frame.pack_forget()
-            self.toggle_log_button.config(text="Show Logs")
+        if logger.is_visible():
+            logger.hide_logs()
         else:
-            # When re-showing the log window, keep it constrained to its natural
-            # height by filling only horizontally.
-            self.log_frame.pack(
-                side=tk.BOTTOM, fill=tk.X, before=self.toggle_log_button
-            )
-            self.toggle_log_button.config(text="Hide Logs")
+            logger.show_logs()
 
     def auto_arrange(self):
         if self.root_node is None:

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -5,29 +5,35 @@ from . import logger
 
 def showinfo(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "INFO")
+    logger.flash_log()
     return "ok"
 
 
 def showwarning(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "WARNING")
+    logger.flash_log()
     return "ok"
 
 
 def showerror(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ERROR")
+    logger.flash_log()
     return "ok"
 
 
 def askyesno(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ASK")
+    logger.flash_log()
     return tk_messagebox.askyesno(title, message, **options)
 
 
 def askyesnocancel(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ASK")
+    logger.flash_log()
     return tk_messagebox.askyesnocancel(title, message, **options)
 
 
 def askokcancel(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ASK")
+    logger.flash_log()
     return tk_messagebox.askokcancel(title, message, **options)

--- a/tests/test_log_window_toggle.py
+++ b/tests/test_log_window_toggle.py
@@ -14,9 +14,9 @@ def test_toggle_log_area():
     except tk.TclError:
         pytest.skip("Tk not available")
     app = AutoMLApp(root)
-    assert app.log_frame.winfo_manager() == "pack"
-    app.toggle_logs()
     assert app.log_frame.winfo_manager() == ""
     app.toggle_logs()
     assert app.log_frame.winfo_manager() == "pack"
+    app.toggle_logs()
+    assert app.log_frame.winfo_manager() == ""
     root.destroy()


### PR DESCRIPTION
## Summary
- Hide log window by default and provide show/hide controls
- Automatically display logs on message box events and hide with slide animation
- Update logger helpers and tests for new behavior

## Testing
- `pytest tests/test_log_window_toggle.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a475910a0483279df5543e3ac7ddf8