### PR TITLE
fix: add image support to capsule button

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -40,6 +40,8 @@ class CapsuleButton(tk.Canvas):
         bg: str = "#e1e1e1",
         hover_bg: Optional[str] = None,
         state: str | None = None,
+        image: tk.PhotoImage | None = None,
+        compound: str = tk.CENTER,
         **kwargs,
     ) -> None:
         init_kwargs = {
@@ -53,8 +55,12 @@ class CapsuleButton(tk.Canvas):
             pass
         # ``style`` and ``state`` are ttk-specific options.  Strip them from
         # ``kwargs`` before forwarding to ``Canvas.__init__`` and track the
-        # ``state`` value ourselves.
+        # ``state`` value ourselves.  ``image`` and ``compound`` are also Tk
+        # button options which ``Canvas`` does not understand, so remove them
+        # here and handle them manually.
         kwargs.pop("style", None)
+        kwargs.pop("image", None)
+        kwargs.pop("compound", None)
         init_kwargs.update(kwargs)
         super().__init__(master, **init_kwargs)
         self._state: set[str] = set()
@@ -62,12 +68,15 @@ class CapsuleButton(tk.Canvas):
             self._state.add("disabled")
         self._command = command
         self._text = text
+        self._image = image
+        self._compound = compound
         self._normal_color = bg
         self._hover_color = hover_bg or _lighten(bg, 1.2)
         self._current_color = self._normal_color
         self._radius = height // 2
         self._shape_items: list[int] = []
         self._text_item: Optional[int] = None
+        self._image_item: Optional[int] = None
         self._draw_button()
         self.bind("<Enter>", self._on_enter)
         self.bind("<Leave>", self._on_leave)
@@ -99,7 +108,21 @@ class CapsuleButton(tk.Canvas):
                 fill=color,
             ),
         ]
-        self._text_item = self.create_text(w // 2, h // 2, text=self._text)
+        img_w = self._image.width() if self._image else 0
+        if self._image and self._compound == tk.LEFT:
+            x_img = 4 + img_w // 2
+            y_img = h // 2
+            self._image_item = self.create_image(x_img, y_img, image=self._image)
+            self._text_item = self.create_text(
+                x_img + img_w // 2 + 4,
+                h // 2,
+                text=self._text,
+                anchor="w",
+            )
+        else:
+            if self._image:
+                self._image_item = self.create_image(w // 2, h // 2, image=self._image)
+            self._text_item = self.create_text(w // 2, h // 2, text=self._text)
 
     def _set_color(self, color: str) -> None:
         for item in self._shape_items:
@@ -140,6 +163,8 @@ class CapsuleButton(tk.Canvas):
             self._command = command
         bg = kwargs.pop("bg", None)
         hover_bg = kwargs.pop("hover_bg", None)
+        image = kwargs.pop("image", None)
+        compound = kwargs.pop("compound", None)
         width = kwargs.get("width")
         height = kwargs.get("height")
         state = kwargs.pop("state", None)
@@ -156,7 +181,11 @@ class CapsuleButton(tk.Canvas):
             self._set_color(self._normal_color)
         if hover_bg is not None and bg is None:
             self._hover_color = hover_bg
-        if width is not None or height is not None or text is not None:
+        if image is not None:
+            self._image = image
+        if compound is not None:
+            self._compound = compound
+        if width is not None or height is not None or text is not None or image is not None or compound is not None:
             self._draw_button()
         # Always re-apply the current state so that disabled buttons retain
         # their disabled appearance even after reconfiguration.


### PR DESCRIPTION
## Summary
- allow CapsuleButton to accept `image` and `compound` options
- draw icons and reapply state on reconfiguration

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a4812952588327921ef60ad54fc745