### PR TITLE
Remove visible seam from capsule button

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -82,23 +82,44 @@ class CapsuleButton(tk.Canvas):
         r = self._radius
         color = self._current_color
         outline = "#b3b3b3"
+        # Draw the filled shapes without outlines so the seams between the
+        # rectangle and arcs are not visible.
         self._shape_items = [
             self.create_arc(
                 (0, 0, 2 * r, h),
                 start=90,
                 extent=180,
-                outline=outline,
+                style=tk.CHORD,
+                outline="",
                 fill=color,
             ),
-            self.create_rectangle((r, 0, w - r, h), outline=outline, fill=color),
+            self.create_rectangle((r, 0, w - r, h), outline="", fill=color),
             self.create_arc(
                 (w - 2 * r, 0, w, h),
                 start=-90,
                 extent=180,
-                outline=outline,
+                style=tk.CHORD,
+                outline="",
                 fill=color,
             ),
         ]
+        # Single outline surrounding the entire button for a smooth border
+        self.create_arc(
+            (0, 0, 2 * r, h),
+            start=90,
+            extent=180,
+            style=tk.ARC,
+            outline=outline,
+        )
+        self.create_line(r, 0, w - r, 0, fill=outline)
+        self.create_line(r, h, w - r, h, fill=outline)
+        self.create_arc(
+            (w - 2 * r, 0, w, h),
+            start=-90,
+            extent=180,
+            style=tk.ARC,
+            outline=outline,
+        )
         self._text_item = self.create_text(w // 2, h // 2, text=self._text)
 
     def _set_color(self, color: str) -> None:


### PR DESCRIPTION
## Summary
- draw capsule button fill without per-segment outlines and add a unified border to avoid visible seams

## Testing
- `pytest`
- `radon cc -s -j .` *(fails: command not found / could not install radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a4814d5d00832793cadd303ef67f6d