### PR TITLE
Add pressed state to capsule button

### DIFF
--- a/tests/test_capsule_button_pressed.py
+++ b/tests/test_capsule_button_pressed.py
@@ -1,0 +1,23 @@
+import tkinter as tk
+
+import pytest
+
+from gui.capsule_button import CapsuleButton
+
+
+def test_capsule_button_darkens_when_pressed():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Test", bg="#888888")
+    btn.pack()
+    root.update_idletasks()
+
+    btn.event_generate("<ButtonPress-1>", x=1, y=1)
+    assert btn._current_color == btn._pressed_color
+
+    btn.event_generate("<ButtonRelease-1>", x=1, y=1)
+    assert btn._current_color == btn._hover_color
+
+    root.destroy()


### PR DESCRIPTION
## Summary
- Darken CapsuleButton on press and restore on release
- Test CapsuleButton pressed color behaviour

## Testing
- `pytest`
- `python tools/metrics_generator.py --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a483c673348327ac7b12ec9680f44f