### PR TITLE
feat(gui): add configurable toolbox icon size

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3530,6 +3530,7 @@ class SysMLDiagramWindow(tk.Frame):
         history=None,
         relation_tools: list[str] | None = None,
         tool_groups: dict[str, list[str]] | None = None,
+        icon_size: int = 16,
     ):
         super().__init__(master)
         self.app = app
@@ -3539,6 +3540,7 @@ class SysMLDiagramWindow(tk.Frame):
             self.master.geometry("800x600")
 
         self.repo = SysMLRepository.get_instance()
+        self.icon_size = icon_size
         if diagram_id and diagram_id in self.repo.diagrams:
             diagram = self.repo.diagrams[diagram_id]
         else:
@@ -3902,7 +3904,11 @@ class SysMLDiagramWindow(tk.Frame):
                     color = style.get_color(base)
                 if color == "#FFFFFF":
                     color = "black"
-            icon = draw_icon(shape, color)
+            size = getattr(self, "icon_size", 16)
+            if size == 16:
+                icon = draw_icon(shape, color)
+            else:
+                icon = draw_icon(shape, color, size=size)
             self._icons[name] = icon
         return icon
 

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -17,9 +17,10 @@ class CausalBayesianNetworkWindow(tk.Frame):
 
     NODE_RADIUS = 30
 
-    def __init__(self, master, app):
+    def __init__(self, master, app, icon_size: int = 16):
         super().__init__(master)
         self.app = app
+        self.icon_size = icon_size
         if isinstance(master, tk.Toplevel):
             master.title("Causal Bayesian Network Analysis")
 
@@ -39,13 +40,21 @@ class CausalBayesianNetworkWindow(tk.Frame):
 
         self.toolbox = ttk.Frame(body)
         self._icons = {
-            "Variable": draw_icon("circle", "lightgray"),
-            "Triggering Condition": draw_icon("circle", "lightblue"),
-            "Existing Triggering Condition": draw_icon("circle", "lightblue"),
-            "Functional Insufficiency": draw_icon("circle", "lightyellow"),
-            "Existing Functional Insufficiency": draw_icon("circle", "lightyellow"),
-            "Existing Malfunction": draw_icon("circle", "lightgreen"),
-            "Relationship": draw_icon("relation", "black"),
+            "Variable": draw_icon("circle", "lightgray", size=self.icon_size),
+            "Triggering Condition": draw_icon("circle", "lightblue", size=self.icon_size),
+            "Existing Triggering Condition": draw_icon(
+                "circle", "lightblue", size=self.icon_size
+            ),
+            "Functional Insufficiency": draw_icon(
+                "circle", "lightyellow", size=self.icon_size
+            ),
+            "Existing Functional Insufficiency": draw_icon(
+                "circle", "lightyellow", size=self.icon_size
+            ),
+            "Existing Malfunction": draw_icon(
+                "circle", "lightgreen", size=self.icon_size
+            ),
+            "Relationship": draw_icon("relation", "black", size=self.icon_size),
         }
         for name in (
             "Variable",

--- a/gui/icon_factory.py
+++ b/gui/icon_factory.py
@@ -4,9 +4,12 @@ import math
 
 
 def create_icon(
-    shape: str, color: str = "black", bg: Optional[str] = None
+    shape: str,
+    color: str = "black",
+    bg: Optional[str] = None,
+    size: int = 16,
 ) -> tk.PhotoImage:
-    """Return a small 16x16 PhotoImage for *shape* using *color*.
+    """Return a ``size``×``size`` :class:`tk.PhotoImage` for *shape*.
 
     Icons now have filled interiors and simple outlines so they look like
     miniature versions of the objects they represent. By default the returned
@@ -14,8 +17,18 @@ def create_icon(
     The implementation is deliberately lightweight and only uses
     ``tk.PhotoImage`` drawing primitives so it works in the same environments
     as the previous icon helpers.
+
+    Parameters
+    ----------
+    shape:
+        The geometric shape to draw (e.g. ``"circle"``).
+    color:
+        Fill color for the shape.
+    bg:
+        Optional background color. When omitted the background is transparent.
+    size:
+        Width and height of the icon in pixels.
     """
-    size = 16
     img = tk.PhotoImage(width=size, height=size)
     if bg:
         img.put(bg, to=(0, 0, size - 1, size - 1))


### PR DESCRIPTION
## Summary
- make icon factory support variable sizes for toolbox animations
- allow diagram windows to pass icon size and show icons in toolboxes
- auto-resize GSN toolbox to fit button labels

## Testing
- `pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a48395f5248327aff5dc4726e679eb