### PR TITLE
Enhance capsule button with inner outline

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -91,6 +91,7 @@ class CapsuleButton(tk.Canvas):
         # recessed "hole" effect around the button outline.
         self._border_dark: list[int] = []
         self._border_light: list[int] = []
+        self._border_gap: list[int] = []
         self._text_item: Optional[int] = None
         self._image_item: Optional[int] = None
         self._draw_button()
@@ -149,11 +150,22 @@ class CapsuleButton(tk.Canvas):
         r = self._radius
         dark = _darken(self._current_color, 0.8)
         light = _lighten(self._current_color, 1.2)
+        gap = _darken(self._current_color, 0.7)
+        inset = 1
         # Dark top/left edges
         self._border_dark = [
             self.create_arc((0, 0, 2 * r, h), start=90, extent=180, style=tk.ARC, outline=dark, width=2),
             self.create_line(r, 0, w - r, 0, fill=dark, width=2),
             self.create_line(0, r, 0, h - r, fill=dark, width=2),
+        ]
+        # Thin dark outline inside the border to accentuate the recessed effect
+        self._border_gap = [
+            self.create_arc((inset, inset, 2 * r - inset, h - inset), start=90, extent=180, style=tk.ARC, outline=gap, width=1),
+            self.create_line(r, inset, w - r, inset, fill=gap, width=1),
+            self.create_line(inset, r, inset, h - r, fill=gap, width=1),
+            self.create_arc((w - 2 * r + inset, inset, w - inset, h - inset), start=-90, extent=180, style=tk.ARC, outline=gap, width=1),
+            self.create_line(r, h - inset, w - r, h - inset, fill=gap, width=1),
+            self.create_line(w - inset, r, w - inset, h - r, fill=gap, width=1),
         ]
         # Light bottom/right edges
         self._border_light = [
@@ -170,8 +182,10 @@ class CapsuleButton(tk.Canvas):
             self.itemconfigure(item, fill=highlight)
         dark = _darken(color, 0.8)
         light = _lighten(color, 1.2)
+        gap = _darken(color, 0.7)
         self._apply_border_color(self._border_dark, dark)
         self._apply_border_color(self._border_light, light)
+        self._apply_border_color(self._border_gap, gap)
         self._current_color = color
 
     def _apply_border_color(self, items: list[int], color: str) -> None:

--- a/tests/test_capsule_button_pressed.py
+++ b/tests/test_capsule_button_pressed.py
@@ -2,7 +2,7 @@ import tkinter as tk
 
 import pytest
 
-from gui.capsule_button import CapsuleButton
+from gui.capsule_button import CapsuleButton, _darken
 
 
 def test_capsule_button_darkens_when_pressed():
@@ -19,5 +19,22 @@ def test_capsule_button_darkens_when_pressed():
 
     btn.event_generate("<ButtonRelease-1>", x=1, y=1)
     assert btn._current_color == btn._hover_color
+
+    root.destroy()
+
+
+def test_capsule_button_has_inner_outline():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Test", bg="#888888")
+    btn.pack()
+    root.update_idletasks()
+
+    expected = _darken(btn._current_color, 0.7)
+    for item in btn._border_gap:
+        option = "fill" if btn.type(item) == "line" else "outline"
+        assert btn.itemcget(item, option) == expected
 
     root.destroy()


### PR DESCRIPTION
## Summary
- add thin dark outline inside CapsuleButton border for a deeper recessed look
- test inner outline colour and ensure it renders on creation

## Testing
- `python tools/metrics_generator.py --path gui --output /tmp/metrics.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4898baddc83278485541ab838e203