### PR TITLE
Equalize toolbox button widths

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3797,6 +3797,24 @@ class SysMLDiagramWindow(tk.Frame):
         self.toolbox_canvas.configure(width=button_width)
         self.toolbox_canvas.itemconfig(self._toolbox_window, width=button_width)
 
+        def max_text_len(widget: tk.Misc) -> int:
+            length = 0
+            for child in widget.winfo_children():
+                if isinstance(child, ttk.Button):
+                    length = max(length, len(str(child.cget("text"))))
+                else:
+                    length = max(length, max_text_len(child))
+            return length
+
+        def set_width(widget: tk.Misc, width: int) -> None:
+            for child in widget.winfo_children():
+                if isinstance(child, ttk.Button):
+                    child.configure(width=width)
+                else:
+                    set_width(child, width)
+
+        set_width(self.toolbox, max_text_len(self.toolbox) + 2)
+
         # Shrink the property view to match the button area so it does not force
         # the toolbox wider than needed. Allow the value column to stretch so it
         # can grow to fill the available space within the Properties tab.

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -72,6 +72,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
                 compound=tk.LEFT,
                 command=lambda t=name: self.select_tool(t),
             ).pack(fill=tk.X, padx=2, pady=2)
+        self._set_button_widths()
         # Pack then immediately hide so order relative to the canvas is preserved
         self.toolbox.pack(side=tk.LEFT, fill=tk.Y)
         self.toolbox.pack_forget()
@@ -119,6 +120,17 @@ class CausalBayesianNetworkWindow(tk.Frame):
         self.pack(fill=tk.BOTH, expand=True)
         self._bind_shortcuts()
         self.focus_set()
+
+    def _set_button_widths(self) -> None:
+        self.toolbox.update_idletasks()
+        width = 0
+        for child in self.toolbox.winfo_children():
+            if isinstance(child, ttk.Button):
+                width = max(width, len(str(child.cget("text"))))
+        width += 2
+        for child in self.toolbox.winfo_children():
+            if isinstance(child, ttk.Button):
+                child.configure(width=width)
 
     # ------------------------------------------------------------------
     def refresh_docs(self) -> None:

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -251,6 +251,24 @@ class GSNDiagramWindow(tk.Frame):
         self.toolbox_canvas.configure(width=button_width)
         self.toolbox_canvas.itemconfig(self._toolbox_window, width=button_width)
 
+        def max_text_len(widget: tk.Misc) -> int:
+            length = 0
+            for child in widget.winfo_children():
+                if isinstance(child, ttk.Button):
+                    length = max(length, len(str(child.cget("text"))))
+                else:
+                    length = max(length, max_text_len(child))
+            return length
+
+        def set_width(widget: tk.Misc, width: int) -> None:
+            for child in widget.winfo_children():
+                if isinstance(child, ttk.Button):
+                    child.configure(width=width)
+                else:
+                    set_width(child, width)
+
+        set_width(self.toolbox, max_text_len(self.toolbox) + 2)
+
     # ------------------------------------------------------------------
     def refresh(self):  # pragma: no cover - requires tkinter
         # Ensure the diagram has access to the application for SPI lookups


### PR DESCRIPTION
## Summary
- Harmonize toolbox button widths across diagram windows by setting each button to the size of the longest label.
- Apply uniform button sizing to SysML, GSN, and Bayesian Network toolboxes.

## Testing
- `pytest`
- ❌ `radon cc -j gui/architecture.py gui/gsn_diagram_window.py gui/causal_bayesian_network_window.py` *(dependency installation failed: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_b_68a48c9137288327a1fa66b55b0caecd