### PR TITLE
Normalize toolbox button sizing for diagram editors

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3797,6 +3797,15 @@ class SysMLDiagramWindow(tk.Frame):
         self.toolbox_canvas.configure(width=button_width)
         self.toolbox_canvas.itemconfig(self._toolbox_window, width=button_width)
 
+        def _set_uniform_width(widget: tk.Misc) -> None:
+            for child in widget.winfo_children():
+                if isinstance(child, ttk.Button):
+                    child.pack_configure(fill=tk.X, expand=True)
+                else:
+                    _set_uniform_width(child)
+
+        _set_uniform_width(self.toolbox)
+
         # Shrink the property view to match the button area so it does not force
         # the toolbox wider than needed. Allow the value column to stretch so it
         # can grow to fill the available space within the Properties tab.

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -77,6 +77,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
         self.toolbox.pack_forget()
         self.current_tool = "Select"
 
+        self.after_idle(self._fit_toolbox)
+
         self.canvas_container = ttk.Frame(body)
         self.canvas_container.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.canvas = tk.Canvas(
@@ -158,6 +160,32 @@ class CausalBayesianNetworkWindow(tk.Frame):
                 self.toolbox.pack(side=tk.LEFT, fill=tk.Y, before=self.canvas_container)
         else:
             self.toolbox.pack_forget()
+
+    # ------------------------------------------------------------------
+    def _fit_toolbox(self) -> None:
+        """Ensure all toolbox buttons share the width of the longest."""
+        self.toolbox.update_idletasks()
+
+        def max_button_width(widget: tk.Misc) -> int:
+            width = 0
+            for child in widget.winfo_children():
+                if isinstance(child, ttk.Button):
+                    width = max(width, child.winfo_reqwidth())
+                else:
+                    width = max(width, max_button_width(child))
+            return width
+
+        button_width = max_button_width(self.toolbox)
+
+        def _set_uniform(widget: tk.Misc) -> None:
+            for child in widget.winfo_children():
+                if isinstance(child, ttk.Button):
+                    child.pack_configure(fill=tk.X, expand=True)
+                else:
+                    _set_uniform(child)
+
+        _set_uniform(self.toolbox)
+        self.toolbox.configure(width=button_width)
 
     # ------------------------------------------------------------------
     def new_doc(self) -> None:

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -251,6 +251,15 @@ class GSNDiagramWindow(tk.Frame):
         self.toolbox_canvas.configure(width=button_width)
         self.toolbox_canvas.itemconfig(self._toolbox_window, width=button_width)
 
+        def _set_uniform_width(widget: tk.Misc) -> None:
+            for child in widget.winfo_children():
+                if isinstance(child, ttk.Button):
+                    child.pack_configure(fill=tk.X, expand=True)
+                else:
+                    _set_uniform_width(child)
+
+        _set_uniform_width(self.toolbox)
+
     # ------------------------------------------------------------------
     def refresh(self):  # pragma: no cover - requires tkinter
         # Ensure the diagram has access to the application for SPI lookups


### PR DESCRIPTION
## Summary
- keep toolbox buttons a consistent width in GSN diagram editor
- align toolbox button widths for SysML and Governance diagram editors
- make Bayesian Network toolbox buttons expand to match longest label

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a48c9137288327a1fa66b55b0caecd