### PR TITLE
Normalize toolbox button widths across diagram types

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -3798,11 +3798,13 @@ class SysMLDiagramWindow(tk.Frame):
         self.toolbox_canvas.itemconfig(self._toolbox_window, width=button_width)
 
         def _set_uniform_width(widget: tk.Misc) -> None:
-            for child in widget.winfo_children():
-                if isinstance(child, ttk.Button):
-                    child.pack_configure(fill=tk.X, expand=True)
-                else:
-                    _set_uniform_width(child)
+            for child in getattr(widget, "winfo_children", lambda: [])():
+                if hasattr(child, "pack_configure"):
+                    try:
+                        child.pack_configure(fill=tk.X, expand=True)
+                    except Exception:
+                        pass
+                _set_uniform_width(child)
 
         _set_uniform_width(self.toolbox)
 

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -190,11 +190,13 @@ class CausalBayesianNetworkWindow(tk.Frame):
         button_width = max_button_width(self.toolbox)
 
         def _set_uniform(widget: tk.Misc) -> None:
-            for child in widget.winfo_children():
-                if isinstance(child, ttk.Button):
-                    child.pack_configure(fill=tk.X, expand=True)
-                else:
-                    _set_uniform(child)
+            for child in getattr(widget, "winfo_children", lambda: [])():
+                if hasattr(child, "pack_configure"):
+                    try:
+                        child.pack_configure(fill=tk.X, expand=True)
+                    except Exception:
+                        pass
+                _set_uniform(child)
 
         _set_uniform(self.toolbox)
         self.toolbox.configure(width=button_width)

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -252,11 +252,13 @@ class GSNDiagramWindow(tk.Frame):
         self.toolbox_canvas.itemconfig(self._toolbox_window, width=button_width)
 
         def _set_uniform_width(widget: tk.Misc) -> None:
-            for child in widget.winfo_children():
-                if isinstance(child, ttk.Button):
-                    child.pack_configure(fill=tk.X, expand=True)
-                else:
-                    _set_uniform_width(child)
+            for child in getattr(widget, "winfo_children", lambda: [])():
+                if hasattr(child, "pack_configure"):
+                    try:
+                        child.pack_configure(fill=tk.X, expand=True)
+                    except Exception:
+                        pass
+                _set_uniform_width(child)
 
         _set_uniform_width(self.toolbox)
 


### PR DESCRIPTION
## Summary
- ensure toolbox buttons fill available width for governance and SysML diagram windows
- apply same uniform width logic to GSN and Bayesian network diagram toolboxes

## Testing
- `pytest`
- ⚠️ `pip install radon` (proxy failure)


------
https://chatgpt.com/codex/tasks/task_b_68a49039c2148327aebfe2d2edb00050