### PR TITLE
Clamp work product movement to process area bounds

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -11916,15 +11916,11 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         right = area.x + area.width / 2 - obj.width / 2
         top = area.y - area.height / 2 + obj.height / 2
         bottom = area.y + area.height / 2 - obj.height / 2
-        if left <= obj.x <= right and top <= obj.y <= bottom:
-            obj.properties["px"] = str(obj.x - area.x)
-            obj.properties["py"] = str(obj.y - area.y)
-        else:
-            # Outside the boundary: snap back to centre and reset offset
-            obj.x = area.x
-            obj.y = area.y
-            obj.properties["px"] = "0"
-            obj.properties["py"] = "0"
+        # Clamp coordinates to the process area so work products cannot escape.
+        obj.x = min(max(obj.x, left), right)
+        obj.y = min(max(obj.y, top), bottom)
+        obj.properties["px"] = str(obj.x - area.x)
+        obj.properties["py"] = str(obj.y - area.y)
 
     def on_left_press(self, event):  # pragma: no cover - requires tkinter
         pending_click = getattr(self, "_pending_wp_click", False)

--- a/tests/test_work_product_process_area_containment.py
+++ b/tests/test_work_product_process_area_containment.py
@@ -5,6 +5,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from gui.architecture import GovernanceDiagramWindow
 from sysml.sysml_repository import SysMLRepository
+import math
 
 
 def test_work_product_clamped_to_process_area():
@@ -30,6 +31,12 @@ def test_work_product_clamped_to_process_area():
     win._constrain_to_parent(wp)
 
     assert win.find_boundary_for_obj(wp) == area
+    right = area.x + area.width / 2 - wp.width / 2
+    bottom = area.y + area.height / 2 - wp.height / 2
+    assert math.isclose(wp.x, right)
+    assert math.isclose(wp.y, bottom)
+    assert wp.properties.get("px") == str(wp.x - area.x)
+    assert wp.properties.get("py") == str(wp.y - area.y)
 
 
 def test_add_work_product_existing_area_click():

--- a/tests/test_work_product_process_area_lock.py
+++ b/tests/test_work_product_process_area_lock.py
@@ -65,7 +65,8 @@ class WorkProductProcessAreaLockTests(unittest.TestCase):
         win.on_left_drag(self.DummyEvent(200, 0))
         win.on_left_release(self.DummyEvent(200, 0))
         self.assertEqual(wp.properties.get("boundary"), "1")
-        self.assertEqual((wp.x, wp.y), (boundary.x, boundary.y))
+        expected_x = boundary.x + boundary.width / 2 - wp.width / 2
+        self.assertEqual((wp.x, wp.y), (expected_x, boundary.y))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- clamp dragged work product positions to process area bounds rather than snapping to center
- extend tests to verify work product coordinates stay within process area on drag/release
- update locking tests for new clamped boundary behavior

## Testing
- `pytest -q`
- `radon cc -s -j gui/architecture.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a490e996788327a46a73abde7600e0