### PR TITLE
Fix GUI message box display and add test

### DIFF
--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -1,39 +1,68 @@
-"""Replacement for tkinter.messagebox that logs messages to the GUI log window."""
+"""Replacement for :mod:`tkinter.messagebox` that also logs messages.
+
+The original implementation only logged messages to the GUI log window and
+returned ``"ok"`` without displaying the actual message boxes.  As a result,
+users would not see the pop-up dialogs they expected.  This module now invokes
+the real Tk message box functions while still logging the messages.  If the
+environment does not support a Tk display (e.g. during automated tests), the
+underlying Tk calls are safely skipped to avoid errors.
+"""
+
+from tkinter import TclError
 import tkinter.messagebox as tk_messagebox
+
 from . import logger
 
 
 def showinfo(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "INFO")
     logger.show_temporarily()
-    return "ok"
+    try:
+        return tk_messagebox.showinfo(title, message, **options)
+    except (TclError, RuntimeError):
+        return "ok"
 
 
 def showwarning(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "WARNING")
     logger.show_temporarily()
-    return "ok"
+    try:
+        return tk_messagebox.showwarning(title, message, **options)
+    except (TclError, RuntimeError):
+        return "ok"
 
 
 def showerror(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ERROR")
     logger.show_temporarily()
-    return "ok"
+    try:
+        return tk_messagebox.showerror(title, message, **options)
+    except (TclError, RuntimeError):
+        return "ok"
 
 
 def askyesno(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ASK")
     logger.show_temporarily()
-    return tk_messagebox.askyesno(title, message, **options)
+    try:
+        return tk_messagebox.askyesno(title, message, **options)
+    except (TclError, RuntimeError):
+        return False
 
 
 def askyesnocancel(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ASK")
     logger.show_temporarily()
-    return tk_messagebox.askyesnocancel(title, message, **options)
+    try:
+        return tk_messagebox.askyesnocancel(title, message, **options)
+    except (TclError, RuntimeError):
+        return None
 
 
 def askokcancel(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ASK")
     logger.show_temporarily()
-    return tk_messagebox.askokcancel(title, message, **options)
+    try:
+        return tk_messagebox.askokcancel(title, message, **options)
+    except (TclError, RuntimeError):
+        return False

--- a/tests/test_messagebox.py
+++ b/tests/test_messagebox.py
@@ -1,0 +1,18 @@
+from gui import messagebox
+import tkinter.messagebox as tk_messagebox
+
+
+def test_showinfo_invokes_tk(monkeypatch):
+    calls = {}
+
+    def fake_showinfo(title, message, **options):
+        calls['args'] = (title, message)
+        return 'ok'
+
+    monkeypatch.setattr(tk_messagebox, 'showinfo', fake_showinfo)
+    monkeypatch.setattr(messagebox.logger, 'log_message', lambda *a, **k: None)
+    monkeypatch.setattr(messagebox.logger, 'show_temporarily', lambda: None)
+
+    messagebox.showinfo('Title', 'Message')
+
+    assert calls['args'] == ('Title', 'Message')


### PR DESCRIPTION
## Summary
- Ensure GUI messagebox functions display real Tk dialogs in addition to logging
- Handle headless environments gracefully when message boxes are invoked
- Add unit test confirming wrapper delegates to tkinter

## Testing
- `pytest`
- `pip install radon -i https://pypi.python.org/simple` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a4990756648327854fc501fbde354f