### PR TITLE
fix: ensure report templates visible in bundled executables

### DIFF
--- a/gui/report_template_manager.py
+++ b/gui/report_template_manager.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, simpledialog
 from pathlib import Path
 import json
+import sys
 
 from gui import messagebox
 
@@ -14,12 +15,17 @@ class ReportTemplateManager(tk.Frame):
     contains ``"template"``.
     """
 
+    @staticmethod
+    def _default_templates_dir() -> Path:
+        """Return directory containing bundled report templates."""
+
+        base = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parents[1]))
+        return base / "config"
+
     def __init__(self, master, app, templates_dir: Path | None = None):
         super().__init__(master)
         self.app = app
-        self.templates_dir = Path(
-            templates_dir or Path(__file__).resolve().parents[1] / "config"
-        )
+        self.templates_dir = Path(templates_dir or self._default_templates_dir())
 
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)

--- a/tests/test_report_template_manager.py
+++ b/tests/test_report_template_manager.py
@@ -107,3 +107,18 @@ def test_report_template_manager_edit_uses_editor(tmp_path, monkeypatch):
     mgr._edit_template()
     assert DummyEditor.called == 1
     assert mgr.app.titles == [f"Report Template: {file.stem}", f"Report Template: {file.stem}"]
+
+
+def test_report_template_manager_meipass_default(monkeypatch, tmp_path):
+    """Templates bundled in executables are discovered via sys._MEIPASS."""
+
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    (cfg_dir / "report_template.json").write_text("{}")
+    monkeypatch.setattr(sys, "_MEIPASS", tmp_path, raising=False)
+    mgr = object.__new__(ReportTemplateManager)
+    mgr.templates_dir = ReportTemplateManager._default_templates_dir()
+    mgr.listbox = DummyListbox()
+    ReportTemplateManager._refresh_list(mgr)
+    names = [mgr.listbox.get(i) for i in range(mgr.listbox.size())]
+    assert "report_template.json" in names


### PR DESCRIPTION
## Summary
- allow ReportTemplateManager to locate templates bundled in PyInstaller executables
- cover bundled template discovery with unit test

## Testing
- `pytest`
- ⚠️ `pip install radon` (failed: Could not find a version that satisfies the requirement radon)


------
https://chatgpt.com/codex/tasks/task_b_68a49e26526c8327bbeb6cbc1bf8cb77