### PR TITLE
Open safety cases in app tab

### DIFF
--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -207,8 +207,18 @@ class SafetyCaseExplorer(tk.Frame):
             return
         typ, obj = self.item_map.get(sel[0], (None, None))
         if typ == "case":
-            win = tk.Toplevel(self)
-            SafetyCaseTable(win, obj, app=self.app)
+            # Prefer opening safety cases within the application's document
+            # notebook so they appear as a new tab in the main working area
+            # instead of a separate window.  The ``SafetyCaseTable`` already
+            # provides scrollbars via its internal ``TableController`` so users
+            # can navigate large cases easily.
+            if self.app and hasattr(self.app, "_new_tab"):
+                tab = self.app._new_tab(f"Safety Case: {obj.name}")
+                table = SafetyCaseTable(tab, obj, app=self.app)
+                table.pack(fill=tk.BOTH, expand=True)
+            else:  # Fallback to a new toplevel window if no app context
+                win = tk.Toplevel(self)
+                SafetyCaseTable(win, obj, app=self.app)
         elif typ == "solution" and self.app:
             for case in self.library.cases:
                 if obj in case.solutions:

--- a/tests/test_safety_case_tab.py
+++ b/tests/test_safety_case_tab.py
@@ -1,0 +1,45 @@
+import types
+import gui.safety_case_explorer as safety_case_explorer
+
+
+def test_open_case_uses_app_tab(monkeypatch):
+    case = types.SimpleNamespace(name="MyCase", solutions=[])
+    explorer = safety_case_explorer.SafetyCaseExplorer.__new__(
+        safety_case_explorer.SafetyCaseExplorer
+    )
+    explorer.tree = types.SimpleNamespace(selection=lambda: ("i1",))
+    explorer.item_map = {"i1": ("case", case)}
+    called = {}
+
+    class DummyTab:
+        def __init__(self):
+            self.packed = False
+        def pack(self, **kwargs):
+            self.packed = True
+
+    def fake_new_tab(title):
+        called["title"] = title
+        return DummyTab()
+
+    explorer.app = types.SimpleNamespace(_new_tab=fake_new_tab)
+
+    class DummyTable:
+        def __init__(self, master, case, app=None):
+            called["master"] = master
+            called["case"] = case
+        def pack(self, **kwargs):
+            called["packed"] = True
+
+    monkeypatch.setattr(safety_case_explorer, "SafetyCaseTable", DummyTable)
+    monkeypatch.setattr(
+        safety_case_explorer.tk,
+        "Toplevel",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("Toplevel called")),
+    )
+
+    safety_case_explorer.SafetyCaseExplorer.open_item(explorer)
+
+    assert called["title"] == "Safety Case: MyCase"
+    assert called["master"].packed is False
+    assert called["case"] is case
+    assert called.get("packed") is True


### PR DESCRIPTION
## Summary
- Open safety cases inside the application's document notebook instead of spawning new windows, giving them scrollbars from the existing table controller
- Add regression test ensuring cases open on a tab and the previous toplevel window is not used

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a4a6798b688327a370890b57326b3b