### PR TITLE
Enable GLOBAL lifecycle phase in combo box

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9901,13 +9901,16 @@ class AutoMLApp:
     def update_lifecycle_cb(self) -> None:
         if not hasattr(self, "lifecycle_cb"):
             return
-        names = [m.name for m in getattr(self.safety_mgmt_toolbox, "modules", [])]
+        smt = getattr(self, "safety_mgmt_toolbox", None)
+        list_modules = getattr(smt, "list_modules", None)
+        names = (
+            list_modules()
+            if callable(list_modules)
+            else [m.name for m in getattr(smt, "modules", [])]
+        )
         self.lifecycle_cb.configure(values=names)
-        if (
-            self.safety_mgmt_toolbox.active_module
-            and self.safety_mgmt_toolbox.active_module in names
-        ):
-            self.lifecycle_var.set(self.safety_mgmt_toolbox.active_module)
+        if getattr(smt, "active_module", None) in names:
+            self.lifecycle_var.set(smt.active_module)
         else:
             self.lifecycle_var.set("")
 

--- a/tests/test_lifecycle_combobox_global.py
+++ b/tests/test_lifecycle_combobox_global.py
@@ -1,0 +1,23 @@
+import types
+from sysml.sysml_repository import SysMLRepository
+from analysis.safety_management import SafetyManagementToolbox, GovernanceModule
+from AutoML import AutoMLApp
+
+
+def test_global_phase_included_when_root_diagram_exists():
+    repo = SysMLRepository.reset_instance()
+    toolbox = SafetyManagementToolbox()
+    toolbox.modules = [GovernanceModule("P1")]
+    toolbox.create_diagram("RootDiag")
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.safety_mgmt_toolbox = toolbox
+    captured = {}
+
+    class DummyCB:
+        def configure(self, **kwargs):
+            captured.update(kwargs)
+
+    app.lifecycle_cb = DummyCB()
+    app.lifecycle_var = types.SimpleNamespace(set=lambda _v: None)
+    app.update_lifecycle_cb()
+    assert "GLOBAL" in captured.get("values", [])


### PR DESCRIPTION
## Summary
- populate lifecycle combo box using toolbox modules so GLOBAL phase is available
- add regression test covering GLOBAL phase when root diagrams exist

## Testing
- `python tools/metrics_generator.py --path . --output /tmp/metrics.json`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a4a6cac07883279c9e55d520ea6ec1