### PR TITLE
feat: allow governance documents to reference lifecycle

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -1700,7 +1700,9 @@
         "Driving Function": [],
         "Field Data": [],
         "Fleet": [],
-        "Guideline": [],
+        "Guideline": [
+          "Lifecycle Phase"
+        ],
         "Incident": [],
         "Lifecycle Phase": [],
         "Manufacturing Process": [],
@@ -1709,8 +1711,12 @@
         "Operation": [],
         "Organization": [],
         "Plan": [],
-        "Policy": [],
-        "Principle": [],
+        "Policy": [
+          "Lifecycle Phase"
+        ],
+        "Principle": [
+          "Lifecycle Phase"
+        ],
         "Procedure": [],
         "Process": [],
         "Record": [],
@@ -1718,7 +1724,9 @@
         "Safety Compliance": [],
         "Safety Issue": [],
         "Software Component": [],
-        "Standard": [],
+        "Standard": [
+          "Lifecycle Phase"
+        ],
         "System": [],
         "Task": [],
         "Test Suite": [],

--- a/tests/test_governance_element_connection_rules.py
+++ b/tests/test_governance_element_connection_rules.py
@@ -13,3 +13,7 @@ def test_governance_element_connection_rules():
     assert set(rules["Uses"]["Role"]) == {"Document", "Data", "Record"}
     assert set(rules["Executes"]["Operation"]) == {"Procedure", "Process"}
     assert set(rules["Uses"]["Operation"]) == {"Data", "Document", "Record"}
+    assert set(rules["Used By"]["Guideline"]) == {"Lifecycle Phase"}
+    assert set(rules["Used By"]["Policy"]) == {"Lifecycle Phase"}
+    assert set(rules["Used By"]["Principle"]) == {"Lifecycle Phase"}
+    assert set(rules["Used By"]["Standard"]) == {"Lifecycle Phase"}


### PR DESCRIPTION
## Summary
- allow Guideline, Policy, Principle, and Standard nodes to connect to Lifecycle Phase via Used By
- test governance rules include Used By for lifecycle documents

## Testing
- `python tools/metrics_generator.py --path analysis --output metrics.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4bdf37f5c83279ac25abf61359a51