### PR TITLE
feat: allow governance documents to reference lifecycle

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -1700,7 +1700,9 @@
         "Driving Function": [],
         "Field Data": [],
         "Fleet": [],
-        "Guideline": [],
+        "Guideline": [
+          "Lifecycle Phase"
+        ],
         "Incident": [],
         "Lifecycle Phase": [],
         "Manufacturing Process": [],
@@ -1709,8 +1711,12 @@
         "Operation": [],
         "Organization": [],
         "Plan": [],
-        "Policy": [],
-        "Principle": [],
+        "Policy": [
+          "Lifecycle Phase"
+        ],
+        "Principle": [
+          "Lifecycle Phase"
+        ],
         "Procedure": [],
         "Process": [],
         "Record": [],
@@ -1718,7 +1724,9 @@
         "Safety Compliance": [],
         "Safety Issue": [],
         "Software Component": [],
-        "Standard": [],
+        "Standard": [
+          "Lifecycle Phase"
+        ],
         "System": [],
         "Task": [],
         "Test Suite": [],

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4177,27 +4177,32 @@ class SysMLDiagramWindow(tk.Frame):
                 "Used after Review",
                 "Used after Approval",
             ):
-                sname = src.properties.get("name")
-                dname = dst.properties.get("name")
-                if sname not in UNRESTRICTED_USAGE_SOURCES and (
-                    sname, dname
-                ) not in ALLOWED_USAGE:
-                    return False, (
-                        "No metamodel dependency between these work products"
-                    )
-                if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS and not (
-                    sname == "ODD" and dname == "Scenario Library"
-                ):
-                    return False, f"{conn_type} links must target a safety analysis work product"
-                if (
-                    sname in SAFETY_ANALYSIS_WORK_PRODUCTS
-                    and dname in SAFETY_ANALYSIS_WORK_PRODUCTS
-                ):
-                    if sname != "Mission Profile":
-                        if (sname, dname) in ALLOWED_PROPAGATIONS:
-                            return False, "Use a Propagate relationship between safety analysis work products"
-                        if (sname, dname) not in ALLOWED_ANALYSIS_USAGE:
-                            return False, "No metamodel dependency between these safety analyses"
+                special_doc_link = (
+                    src.obj_type in {"Guideline", "Policy", "Principle", "Standard"}
+                    and dst.obj_type == "Lifecycle Phase"
+                )
+                if not special_doc_link:
+                    sname = src.properties.get("name")
+                    dname = dst.properties.get("name")
+                    if sname not in UNRESTRICTED_USAGE_SOURCES and (
+                        sname, dname
+                    ) not in ALLOWED_USAGE:
+                        return False, (
+                            "No metamodel dependency between these work products"
+                        )
+                    if dname not in SAFETY_ANALYSIS_WORK_PRODUCTS and not (
+                        sname == "ODD" and dname == "Scenario Library"
+                    ):
+                        return False, f"{conn_type} links must target a safety analysis work product"
+                    if (
+                        sname in SAFETY_ANALYSIS_WORK_PRODUCTS
+                        and dname in SAFETY_ANALYSIS_WORK_PRODUCTS
+                    ):
+                        if sname != "Mission Profile":
+                            if (sname, dname) in ALLOWED_PROPAGATIONS:
+                                return False, "Use a Propagate relationship between safety analysis work products"
+                            if (sname, dname) not in ALLOWED_ANALYSIS_USAGE:
+                                return False, "No metamodel dependency between these safety analyses"
                 # Prevent multiple 'Used' relationships between the same
                 # work products within the active lifecycle phase. Only one
                 # of "Used By", "Used after Review" or "Used after Approval"

--- a/tests/test_governance_document_phase_used_by.py
+++ b/tests/test_governance_document_phase_used_by.py
@@ -1,0 +1,34 @@
+import types
+
+from gui import architecture
+
+
+def _window():
+    win = architecture.GovernanceDiagramWindow.__new__(
+        architecture.GovernanceDiagramWindow
+    )
+    win.repo = types.SimpleNamespace(diagrams={}, relationships=[], active_phase=None)
+    win.diagram_id = "d"
+    win.repo.diagrams["d"] = types.SimpleNamespace(diag_type="Governance Diagram")
+    return win
+
+
+def test_standard_used_by_phase_valid():
+    win = _window()
+    src = architecture.SysMLObject(1, "Standard", 0, 0, properties={"name": "STD"})
+    dst = architecture.SysMLObject(2, "Lifecycle Phase", 0, 0, properties={"name": "P"})
+    valid, _ = architecture.GovernanceDiagramWindow.validate_connection(
+        win, src, dst, "Used By"
+    )
+    assert valid
+
+
+def test_phase_used_by_standard_invalid():
+    win = _window()
+    src = architecture.SysMLObject(1, "Lifecycle Phase", 0, 0, properties={"name": "P"})
+    dst = architecture.SysMLObject(2, "Standard", 0, 0, properties={"name": "STD"})
+    valid, msg = architecture.GovernanceDiagramWindow.validate_connection(
+        win, src, dst, "Used By"
+    )
+    assert not valid
+    assert "not allowed" in msg.lower()

--- a/tests/test_governance_element_connection_rules.py
+++ b/tests/test_governance_element_connection_rules.py
@@ -13,3 +13,7 @@ def test_governance_element_connection_rules():
     assert set(rules["Uses"]["Role"]) == {"Document", "Data", "Record"}
     assert set(rules["Executes"]["Operation"]) == {"Procedure", "Process"}
     assert set(rules["Uses"]["Operation"]) == {"Data", "Document", "Record"}
+    assert set(rules["Used By"]["Guideline"]) == {"Lifecycle Phase"}
+    assert set(rules["Used By"]["Policy"]) == {"Lifecycle Phase"}
+    assert set(rules["Used By"]["Principle"]) == {"Lifecycle Phase"}
+    assert set(rules["Used By"]["Standard"]) == {"Lifecycle Phase"}


### PR DESCRIPTION
## Summary
- allow Guideline, Policy, Principle, and Standard nodes to connect to Lifecycle Phase via Used By
- test governance rules include Used By for lifecycle documents
- permit Used By links from governance documents to lifecycle phases

## Testing
- `python tools/metrics_generator.py --path analysis --output metrics.json`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a4bdf37f5c83279ac25abf61359a51