### PR TITLE
Allow work product to lifecycle phase trace

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -726,7 +726,8 @@
         "Test Suite": [],
         "Vehicle": [],
         "Work Product": [
-          "Work Product"
+          "Work Product",
+          "Lifecycle Phase"
         ],
         "AI Database": [
           "Work Product"
@@ -1666,7 +1667,8 @@
         "Test Suite": [],
         "Vehicle": [],
         "Work Product": [
-          "Work Product"
+          "Work Product",
+          "Lifecycle Phase"
         ],
         "AI Database": [
           "Work Product"

--- a/tests/test_trace_work_product_lifecycle_phase.py
+++ b/tests/test_trace_work_product_lifecycle_phase.py
@@ -1,0 +1,22 @@
+from sysml.sysml_repository import SysMLRepository, SysMLDiagram
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+
+
+def test_work_product_to_lifecycle_phase_trace_allowed():
+    SysMLRepository.reset_instance()
+    repo = SysMLRepository.get_instance()
+    diag = SysMLDiagram(diag_id="d", diag_type="Governance Diagram")
+    repo.diagrams["d"] = diag
+
+    wp = SysMLObject(1, "Work Product", 0, 0, properties={"name": "WP"})
+    phase = SysMLObject(2, "Lifecycle Phase", 100, 0, properties={"name": "Phase"})
+    diag.objects = [wp, phase]
+
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.repo = repo
+    win.diagram_id = "d"
+    win.connections = []
+    win.objects = diag.objects
+
+    valid, msg = SysMLDiagramWindow.validate_connection(win, wp, phase, "Trace")
+    assert valid, msg


### PR DESCRIPTION
## Summary
- permit tracing work products directly to lifecycle phases
- test trace from work product to lifecycle phase

## Testing
- `pytest`
- `python tools/metrics_generator.py --path . --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a4c7ba2d2c8327940c51d4d182d5f5