### PR TITLE
Allow role-based triage and incident monitoring

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -1060,7 +1060,9 @@
       },
       "Monitors": {
         "Activity": [],
-        "Business Unit": [],
+        "Business Unit": [
+          "Incident"
+        ],
         "Component": [],
         "Data": [],
         "Document": [],
@@ -1074,7 +1076,9 @@
         "Metric": [],
         "Model": [],
         "Operation": [],
-        "Organization": [],
+        "Organization": [
+          "Incident"
+        ],
         "Plan": [],
         "Policy": [],
         "Principle": [],
@@ -1084,7 +1088,8 @@
         "Role": [
           "Activity",
           "Metric",
-          "Process"
+          "Process",
+          "Incident"
         ],
         "Safety Compliance": [],
         "Safety Issue": [],
@@ -3049,7 +3054,9 @@
       "Triage": {
         "AI Database": [],
         "ANN": [],
-        "Business Unit": [],
+        "Business Unit": [
+          "Safety Issue"
+        ],
         "Component": [],
         "Data": [],
         "Data acquisition": [],
@@ -3064,7 +3071,9 @@
         "Metric": [],
         "Model": [],
         "Operation": [],
-        "Organization": [],
+        "Organization": [
+          "Safety Issue"
+        ],
         "Plan": [],
         "Policy": [],
         "Principle": [],
@@ -3073,7 +3082,9 @@
         "Record": [],
         "Report": [],
         "Risk Assessment": [],
-        "Role": [],
+        "Role": [
+          "Safety Issue"
+        ],
         "Safety Compliance": [],
         "Safety Issue": [
           "Field Data"
@@ -3895,23 +3906,71 @@
       ],
       "subject": "Prototype team"
     },
-    "safety assessment workflow": {
-      "action": "assess and mitigate safety risks",
-      "relations": [
-        "Assesses",
-        "Uses",
-        "Mitigates",
-        "Develops",
-        "Verify",
-        "Produces"
-      ],
-      "subject": "Safety engineer"
-    },
-    "continuous improvement": {
-      "action": "improve deployed system",
-      "relations": [
-        "Monitors",
-        "Assesses",
+      "safety assessment workflow": {
+        "action": "assess and mitigate safety risks",
+        "relations": [
+          "Assesses",
+          "Uses",
+          "Mitigates",
+          "Develops",
+          "Verify",
+          "Produces"
+        ],
+        "subject": "Safety engineer"
+      },
+      "role safety issue triage": {
+        "action": "triage safety issue",
+        "relations": [
+          "Assesses",
+          "Triage"
+        ],
+        "subject": "Role"
+      },
+      "organization safety issue triage": {
+        "action": "triage safety issue",
+        "relations": [
+          "Assesses",
+          "Triage"
+        ],
+        "subject": "Organization"
+      },
+      "business unit safety issue triage": {
+        "action": "triage safety issue",
+        "relations": [
+          "Assesses",
+          "Triage"
+        ],
+        "subject": "Business Unit"
+      },
+      "role incident monitoring": {
+        "action": "monitor incident",
+        "relations": [
+          "Monitors",
+          "Assesses"
+        ],
+        "subject": "Role"
+      },
+      "organization incident monitoring": {
+        "action": "monitor incident",
+        "relations": [
+          "Monitors",
+          "Assesses"
+        ],
+        "subject": "Organization"
+      },
+      "business unit incident monitoring": {
+        "action": "monitor incident",
+        "relations": [
+          "Monitors",
+          "Assesses"
+        ],
+        "subject": "Business Unit"
+      },
+      "continuous improvement": {
+        "action": "improve deployed system",
+        "relations": [
+          "Monitors",
+          "Assesses",
         "Develops",
         "Produces"
       ],


### PR DESCRIPTION
## Summary
- permit Business Unit, Organization, and Role nodes to triage Safety Issues
- permit Business Unit, Organization, and Role nodes to monitor Incidents
- add workflow definitions for triaging safety issues and monitoring incidents

## Testing
- `pytest`
- `pip install radon` (failed: Could not find a version that satisfies the requirement radon)

------
https://chatgpt.com/codex/tasks/task_b_68a4cb7f16fc8327b0b8e672296590b3