### PR TITLE
Allow organization constrained by policy connection

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -452,7 +452,9 @@
         "Metric": [],
         "Model": [],
         "Operation": [],
-        "Organization": [],
+        "Organization": [
+          "Policy"
+        ],
         "Plan": [],
         "Policy": [],
         "Principle": [],

--- a/tests/test_governance_element_connection_rules.py
+++ b/tests/test_governance_element_connection_rules.py
@@ -17,3 +17,4 @@ def test_governance_element_connection_rules():
     assert set(rules["Used By"]["Policy"]) == {"Lifecycle Phase"}
     assert set(rules["Used By"]["Principle"]) == {"Lifecycle Phase"}
     assert set(rules["Used By"]["Standard"]) == {"Lifecycle Phase"}
+    assert set(rules["Constrained by"]["Organization"]) == {"Policy"}


### PR DESCRIPTION
## Summary
- permit "Constrained by" relationship from Organization to Policy in governance diagram rules
- add regression test for Organization constrained by Policy

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path . --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a4cc7f6c0c832783f42d96bfe9a130