### PR TITLE
Allow certain governance constraints

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -433,7 +433,9 @@
       },
       "Constrained by": {
         "Activity": [],
-        "Business Unit": [],
+        "Business Unit": [
+          "Principle"
+        ],
         "Component": [],
         "Data": [],
         "Document": [
@@ -452,7 +454,9 @@
         "Metric": [],
         "Model": [],
         "Operation": [],
-        "Organization": [],
+        "Organization": [
+          "Policy"
+        ],
         "Plan": [],
         "Policy": [],
         "Principle": [],

--- a/tests/test_governance_constrained_by_rules.py
+++ b/tests/test_governance_constrained_by_rules.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from config import load_diagram_rules
+
+
+def test_constrained_by_rules() -> None:
+    cfg = load_diagram_rules(Path(__file__).resolve().parents[1] / "config/diagram_rules.json")
+    rules = cfg["connection_rules"]["Governance Diagram"]["Constrained by"]
+    assert set(rules["Organization"]) == {"Policy"}
+    assert set(rules["Business Unit"]) == {"Principle"}


### PR DESCRIPTION
## Summary
- permit Organization to be constrained by Policy and Business Unit by Principle
- add regression test for governance diagram connection rules

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path . --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a4cc9301108327a638cd199b5cbe83