### PR TITLE
Allow roles to use work products

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -1923,7 +1923,8 @@
         "Role": [
           "Data",
           "Document",
-          "Record"
+          "Record",
+          "Work Product"
         ],
         "Safety Compliance": [],
         "Safety Issue": [],

--- a/tests/test_governance_element_connection_rules.py
+++ b/tests/test_governance_element_connection_rules.py
@@ -10,7 +10,7 @@ def test_governance_element_connection_rules():
     cfg = load_diagram_rules(Path(__file__).resolve().parents[1] / "config/diagram_rules.json")
     rules = cfg["connection_rules"]["Governance Diagram"]
     assert set(rules["Approves"]["Role"]) == {"Document", "Policy", "Procedure", "Record"}
-    assert set(rules["Uses"]["Role"]) == {"Document", "Data", "Record"}
+    assert set(rules["Uses"]["Role"]) == {"Document", "Data", "Record", "Work Product"}
     assert set(rules["Executes"]["Operation"]) == {"Procedure", "Process"}
     assert set(rules["Uses"]["Operation"]) == {"Data", "Document", "Record"}
     assert set(rules["Used By"]["Guideline"]) == {"Lifecycle Phase"}

--- a/tests/test_role_uses_work_product_connection_rule.py
+++ b/tests/test_role_uses_work_product_connection_rule.py
@@ -1,0 +1,35 @@
+import json
+import types
+from pathlib import Path
+
+from gui import architecture
+
+
+def test_role_uses_work_product(tmp_path, monkeypatch):
+    cfg = {
+        "connection_rules": {
+            "Governance Diagram": {"Uses": {"Role": ["Work Product"]}}
+        }
+    }
+    path = tmp_path / "diagram_rules.json"
+    path.write_text(json.dumps(cfg))
+    orig_path = architecture._CONFIG_PATH
+    monkeypatch.setattr(architecture, "_CONFIG_PATH", path)
+    architecture.reload_config()
+
+    win = architecture.GovernanceDiagramWindow.__new__(
+        architecture.GovernanceDiagramWindow
+    )
+    win.repo = types.SimpleNamespace(diagrams={})
+    win.diagram_id = "d"
+    win.repo.diagrams["d"] = types.SimpleNamespace(diag_type="Governance Diagram")
+    src = architecture.SysMLObject(1, "Role", 0, 0)
+    dst = architecture.SysMLObject(2, "Work Product", 0, 0)
+    valid, _ = architecture.GovernanceDiagramWindow.validate_connection(
+        win, src, dst, "Uses"
+    )
+    assert valid
+
+    monkeypatch.setattr(architecture, "_CONFIG_PATH", orig_path)
+    architecture.reload_config()
+


### PR DESCRIPTION
## Summary
- permit `Role` to `Uses` connect with `Work Product`
- test that Role can use Work Product in connection rules
- expand connection rule coverage in governance tests

## Testing
- `pytest tests/test_governance_element_connection_rules.py tests/test_role_uses_work_product_connection_rule.py -q`
- `pytest -q`
- `radon cc -s -j config/diagram_rules.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4cf986f7c83278697342174cee386