### PR TITLE
Group action relationships into single requirement pattern

### DIFF
--- a/tests/test_requirement_rule_generator.py
+++ b/tests/test_requirement_rule_generator.py
@@ -94,6 +94,51 @@ def test_rule_with_multiple_targets() -> None:
     assert "<object2_id>" in tmpl
 
 
+def test_grouped_actions_single_pattern() -> None:
+    cfg = {
+        "connection_rules": {
+            "Governance Diagram": {
+                "Performs": {"Role": ["Activity", "Procedure", "Task"]}
+            }
+        }
+    }
+    patterns = generate_patterns_from_config(cfg)
+    ids = {p["Pattern ID"] for p in patterns}
+    assert "GOV-performs-Role-group" in ids
+    assert "GOV-performs-Role-Activity" not in ids
+    tmpl = next(
+        p["Template"]
+        for p in patterns
+        if p["Pattern ID"] == "GOV-performs-Role-group"
+    )
+    assert "a) <object1_id>" in tmpl
+    assert "b) <object2_id>" in tmpl
+    assert "c) <object3_id>" in tmpl
+
+
+def test_grouped_actions_across_relations() -> None:
+    cfg = {
+        "connection_rules": {
+            "Governance Diagram": {
+                "Performs": {"Role": ["Activity"]},
+                "Executes": {"Role": ["Procedure"]},
+            }
+        }
+    }
+    patterns = generate_patterns_from_config(cfg)
+    ids = {p["Pattern ID"] for p in patterns}
+    assert "GOV-actions-Role-group" in ids
+    assert "GOV-performs-Role-Activity" not in ids
+    assert "GOV-executes-Role-Procedure" not in ids
+    tmpl = next(
+        p["Template"]
+        for p in patterns
+        if p["Pattern ID"] == "GOV-actions-Role-group"
+    )
+    assert "a) <object1_id>" in tmpl
+    assert "b) <object2_id>" in tmpl
+
+
 def test_rule_with_custom_template_and_variables() -> None:
     cfg = {
         "ai_nodes": ["R", "T"],


### PR DESCRIPTION
## Summary
- Consolidate action-type relationships across relation labels into a single grouped requirement pattern
- Use placeholder subjects when no override exists to keep templates generic
- Test cross-relation grouping to ensure only one requirement is emitted

## Testing
- `pytest`
- `python tools/metrics_generator.py --path analysis --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a4cd96a68c8327b590af63fe375622