### PR TITLE
Allow Role to be responsible for Work Product

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -1548,7 +1548,8 @@
         "Role": [
           "Activity",
           "Process",
-          "Task"
+          "Task",
+          "Work Product"
         ],
         "Safety Compliance": [],
         "Safety Issue": [],

--- a/tests/test_governance_role_work_product_connection_rule.py
+++ b/tests/test_governance_role_work_product_connection_rule.py
@@ -1,0 +1,13 @@
+import types
+from gui import architecture
+
+
+def test_role_responsible_for_work_product_connection():
+    win = architecture.GovernanceDiagramWindow.__new__(architecture.GovernanceDiagramWindow)
+    win.repo = types.SimpleNamespace(diagrams={})
+    win.diagram_id = "d"
+    win.repo.diagrams["d"] = types.SimpleNamespace(diag_type="Governance Diagram")
+    src = architecture.SysMLObject(1, "Role", 0, 0)
+    dst = architecture.SysMLObject(2, "Work Product", 0, 0)
+    valid, _ = architecture.GovernanceDiagramWindow.validate_connection(win, src, dst, "Responsible for")
+    assert valid


### PR DESCRIPTION
## Summary
- Permit `Role` elements to link to `Work Product` via `Responsible for` relation
- Add regression test verifying governance diagram accepts Role→Work Product connection

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a4d19c4df4832783e5e7ea5fdad4a4