### PR TITLE
Refine AI requirement classification

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -17,6 +17,16 @@ _CONFIG = load_diagram_rules(_CONFIG_PATH)
 _AI_NODES = set(_CONFIG.get("ai_nodes", []))
 _AI_RELATIONS = set(_CONFIG.get("ai_relations", []))
 
+
+def _is_ai_specific_relation(conn_type: str | None) -> bool:
+    """Return True if *conn_type* represents an AI-specific relationship."""
+    if not conn_type:
+        return False
+    lowered = conn_type.lower()
+    return conn_type in _AI_RELATIONS and any(
+        key in lowered for key in ("train", "curat")
+    )
+
 # Map relationship labels or connection types to requirement actions.  Each
 # entry defines the verb to use, whether the destination element acts as a
 # constraint instead of an object, and an optional default subject.  The
@@ -432,9 +442,9 @@ class GovernanceDiagram:
 
             req_type = "organizational"
             if (
-                conn_type in _AI_RELATIONS
-                or self.node_types.get(src) in _AI_NODES
+                self.node_types.get(src) in _AI_NODES
                 or self.node_types.get(dst) in _AI_NODES
+                or _is_ai_specific_relation(conn_type)
             ):
                 req_type = "AI safety"
 

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -149,3 +149,14 @@ def test_tasks_create_requirement_actions():
     acquire_req = next(r for r in reqs if r.action == "acquire data")
     assert acquire_req.subject == "Engineering team"
     assert acquire_req.req_type == "AI safety"
+
+
+def test_generic_ai_relation_defaults_to_organizational():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Policy", node_type="Policy")
+    diagram.add_task("Role1", node_type="Role")
+    diagram.add_relationship("Role1", "Policy", conn_type="Assesses")
+
+    reqs = diagram.generate_requirements()
+    assess_req = next(r for r in reqs if r.action == "assess" and r.subject == "Role1")
+    assert assess_req.req_type == "organizational"


### PR DESCRIPTION
## Summary
- avoid misclassifying generic governance relations as AI safety requirements
- add regression test ensuring non-AI relations default to organizational type

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path analysis --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a4d4cdde7c8327919d632ff1704720