### PR TITLE
Ensure tooltips vanish when leaving widgets

### DIFF
--- a/gui/tooltip.py
+++ b/gui/tooltip.py
@@ -17,7 +17,9 @@ class ToolTip:
         self.id = None
         if automatic:
             widget.bind("<Enter>", self._schedule)
-            widget.bind("<Leave>", self._hide)
+        # Always hide the tooltip when the pointer leaves the widget so
+        # tooltips shown manually disappear as expected.
+        widget.bind("<Leave>", self._hide)
 
     def _schedule(self, _event=None):
         self._unschedule()

--- a/tests/test_tooltip_leave.py
+++ b/tests/test_tooltip_leave.py
@@ -1,0 +1,31 @@
+import types
+
+from gui.tooltip import ToolTip
+
+
+class DummyWidget:
+    def __init__(self):
+        self.bound = {}
+
+    def bind(self, event, func):
+        self.bound[event] = func
+
+    def after_cancel(self, _id):
+        pass
+
+
+class DummyTipWindow:
+    def __init__(self):
+        self.destroyed = False
+
+    def destroy(self):
+        self.destroyed = True
+
+
+def test_manual_tooltip_hides_on_leave():
+    widget = DummyWidget()
+    tip = ToolTip(widget, "tip", automatic=False)
+    tip.tipwindow = DummyTipWindow()
+    # Simulate the pointer leaving the widget
+    widget.bound["<Leave>"]()
+    assert tip.tipwindow is None


### PR DESCRIPTION
## Summary
- Ensure `ToolTip` always hides on `<Leave>` events so manually displayed tooltips dismiss when the pointer exits their widget
- Add regression test verifying manual tooltips disappear on leave

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a4d91140a883278904388b716c0dee