### PR TITLE
Add shading to capsule button for 3D effect

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -89,6 +89,7 @@ class CapsuleButton(tk.Canvas):
         self._radius = height // 2
         self._shape_items: list[int] = []
         self._shine_items: list[int] = []
+        self._shade_items: list[int] = []
         # Border items are split into dark and light segments to create a
         # recessed "hole" effect around the button outline.  ``_border_outline``
         # draws a thin dark line between the button and its hole for an extra
@@ -145,6 +146,7 @@ class CapsuleButton(tk.Canvas):
             ),
         ]
         self._draw_highlight(w, h)
+        self._draw_shade(w, h)
         self._draw_content(w, h)
         self._draw_border(w, h)
 
@@ -180,6 +182,21 @@ class CapsuleButton(tk.Canvas):
                         stipple="gray25",
                     )
                 )
+
+    def _draw_shade(self, w: int, h: int) -> None:
+        """Add a translucent shade to suggest the far side of the capsule."""
+        shade_color = _darken(self._current_color, 0.9)
+        self._shade_items = [
+            self.create_oval(
+                1,
+                h // 2,
+                w - 1,
+                h - 1,
+                outline="",
+                fill=shade_color,
+                stipple="gray25",
+            )
+        ]
 
     def _draw_content(self, w: int, h: int) -> None:
         """Render optional image and text within the button."""
@@ -248,6 +265,9 @@ class CapsuleButton(tk.Canvas):
         highlight = _lighten(color, 1.4)
         for item in self._shine_items:
             self.itemconfigure(item, fill=highlight)
+        shade = _darken(color, 0.9)
+        for item in self._shade_items:
+            self.itemconfigure(item, fill=shade)
         inner = _darken(color, 0.7)
         dark = _darken(color, 0.8)
         light = _lighten(color, 1.2)

--- a/tests/test_capsule_button_shade.py
+++ b/tests/test_capsule_button_shade.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.capsule_button import CapsuleButton, _darken
+
+
+def test_capsule_button_has_background_shade():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Test", bg="#888888")
+    btn.pack()
+    root.update_idletasks()
+    assert getattr(btn, "_shade_items", []), "shade not created"
+    shade_color = btn.itemcget(btn._shade_items[0], "fill")
+    assert shade_color == _darken("#888888", 0.9)
+    root.destroy()


### PR DESCRIPTION
## Summary
- Add translucent bottom shade to `CapsuleButton` for enhanced 3D capsule appearance
- Cover shading with new `test_capsule_button_shade`

## Testing
- `pytest -q`
- `radon cc -j gui/capsule_button.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4db97221c8327806a05c5a0ca51a1