### PR TITLE
Enhance capsule button depth with shaded background

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -89,6 +89,7 @@ class CapsuleButton(tk.Canvas):
         self._radius = height // 2
         self._shape_items: list[int] = []
         self._shine_items: list[int] = []
+        self._shade_items: list[int] = []
         # Border items are split into dark and light segments to create a
         # recessed "hole" effect around the button outline.  ``_border_outline``
         # draws a thin dark line between the button and its hole for an extra
@@ -144,16 +145,18 @@ class CapsuleButton(tk.Canvas):
                 fill=color,
             ),
         ]
+        self._shine_items = []
+        self._shade_items = []
         self._draw_highlight(w, h)
         self._draw_content(w, h)
         self._draw_border(w, h)
 
     def _draw_highlight(self, w: int, h: int) -> None:
-        """Draw shiny highlight and diffused circles on the capsule ends."""
+        """Draw shiny highlight, diffused circles and bottom shade."""
         r = self._radius
         color = self._current_color
         top_highlight = _lighten(color, 1.4)
-        self._shine_items = [
+        self._shine_items.append(
             self.create_oval(
                 1,
                 1,
@@ -163,7 +166,19 @@ class CapsuleButton(tk.Canvas):
                 fill=top_highlight,
                 stipple="gray25",
             )
-        ]
+        )
+        bottom_shade = _darken(color, 0.9)
+        self._shade_items.append(
+            self.create_oval(
+                1,
+                h // 2,
+                w - 1,
+                h - 1,
+                outline="",
+                fill=bottom_shade,
+                stipple="gray50",
+            )
+        )
         small_r = max(r // 3, 2)
         centers = [(r // 2, h // 2), (w - r // 2, h // 2)]
         for cx, cy in centers:
@@ -248,6 +263,9 @@ class CapsuleButton(tk.Canvas):
         highlight = _lighten(color, 1.4)
         for item in self._shine_items:
             self.itemconfigure(item, fill=highlight)
+        shade = _darken(color, 0.9)
+        for item in self._shade_items:
+            self.itemconfigure(item, fill=shade)
         inner = _darken(color, 0.7)
         dark = _darken(color, 0.8)
         light = _lighten(color, 1.2)

--- a/tests/test_capsule_button_shine.py
+++ b/tests/test_capsule_button_shine.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from gui.capsule_button import CapsuleButton
 
 
-def test_capsule_button_has_diffused_circles():
+def test_capsule_button_has_diffused_circles_and_shade():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -17,4 +17,5 @@ def test_capsule_button_has_diffused_circles():
     btn.pack()
     root.update_idletasks()
     assert len(getattr(btn, "_shine_items", [])) >= 7
+    assert len(getattr(btn, "_shade_items", [])) >= 1
     root.destroy()


### PR DESCRIPTION
## Summary
- add bottom shade to capsule buttons for a 3D transparent look
- test that capsule buttons render diffused circles and shade

## Testing
- `pytest -q`
- ⚠️ `radon cc -j gui/capsule_button.py tests/test_capsule_button_shine.py` (failed: command not found; package installation blocked)


------
https://chatgpt.com/codex/tasks/task_b_68a4db97221c8327806a05c5a0ca51a1