### PR TITLE
Fix project properties probability persistence

### DIFF
--- a/tests/test_project_properties_persistence.py
+++ b/tests/test_project_properties_persistence.py
@@ -1,0 +1,89 @@
+import os
+import sys
+import types
+
+# Stub out PIL modules to avoid dependency
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from analysis.utils import (
+    CONTROLLABILITY_PROBABILITIES,
+    EXPOSURE_PROBABILITIES,
+    SEVERITY_PROBABILITIES,
+    update_probability_tables,
+)
+
+
+def _minimal_app():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.top_events = []
+    app.fmeas = []
+    app.fmedas = []
+    app.fmea_entries = []
+    app.fmeda_entries = []
+    app.mechanism_libraries = []
+    app.selected_mechanism_libraries = []
+    app.mission_profiles = []
+    app.reliability_analyses = []
+    app.hazop_docs = []
+    app.hara_docs = []
+    app.stpa_docs = []
+    app.threat_docs = []
+    app.fi2tc_docs = []
+    app.tc2fi_docs = []
+    app.hazop_entries = []
+    app.fi2tc_entries = []
+    app.tc2fi_entries = []
+    app.scenario_libraries = []
+    app.odd_libraries = []
+    app.faults = []
+    app.malfunctions = []
+    app.hazards = []
+    app.failures = []
+    app.project_properties = {}
+    app.reviews = []
+    app.review_data = None
+    app.versions = {}
+    app.update_odd_elements = lambda: None
+    app.update_failure_list = lambda: None
+    app.load_default_mechanisms = lambda: None
+    app.update_hazard_list = lambda: None
+    app.update_hara_statuses = lambda: None
+    app.update_fta_statuses = lambda: None
+    app.get_all_basic_events = lambda: []
+    app.get_all_nodes = lambda te: []
+    app.get_all_fmea_entries = lambda: []
+    app.update_global_requirements_from_nodes = lambda *args, **kwargs: None
+    app.sync_hara_to_safety_goals = lambda: None
+    app.close_page_diagram = lambda: None
+    app.update_views = lambda: None
+    return app
+
+
+def test_project_properties_probabilities_roundtrip():
+    exp_default = EXPOSURE_PROBABILITIES.copy()
+    ctrl_default = CONTROLLABILITY_PROBABILITIES.copy()
+    sev_default = SEVERITY_PROBABILITIES.copy()
+
+    app = _minimal_app()
+    app.project_properties = {
+        "exposure_probabilities": {1: 0.1, 2: 0.2, 3: 0.3, 4: 0.4},
+        "controllability_probabilities": {1: 0.5, 2: 0.6, 3: 0.7},
+        "severity_probabilities": {1: 0.8, 2: 0.9, 3: 1.0},
+    }
+    data = app.export_model_data(include_versions=False)
+    new_app = _minimal_app()
+    new_app.apply_model_data(data, ensure_root=False)
+    try:
+        assert new_app.project_properties["exposure_probabilities"][1] == 0.1
+        assert new_app.project_properties["controllability_probabilities"][2] == 0.6
+        assert new_app.project_properties["severity_probabilities"][3] == 1.0
+        assert set(new_app.project_properties["exposure_probabilities"].keys()) == {1, 2, 3, 4}
+    finally:
+        update_probability_tables(exp_default, ctrl_default, sev_default)


### PR DESCRIPTION
## Summary
- normalize project property probability mappings on load
- update probability tables after loading to ensure correct persistence
- test persistence of exposure, controllability, and severity probabilities

## Testing
- `pytest`
- `radon cc -j AutoML.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4dbd731b08327849e5da08d2ff9df