### PR TITLE
Fix project properties window fixed size

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -4690,6 +4690,7 @@ class AutoMLApp:
         prop_win = tk.Toplevel(self.root)
         prop_win.title("Project Properties")
         prop_win.geometry("420x380")
+        prop_win.resizable(False, False)
         dialog_font = tkFont.Font(family="Arial", size=10)
 
         ttk.Label(prop_win, text="PDF Report Name:", font=dialog_font).grid(


### PR DESCRIPTION
## Summary
- Make project properties dialog non-resizable so window size is fixed

## Testing
- `python tools/metrics_generator.py --path . --output metrics.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4dbeeb750832799b1cef3c72451e1