### PR TITLE
Add glassy blue gradient and text/icon shadows to capsule buttons

### DIFF
--- a/tests/test_capsule_button_text_shadow.py
+++ b/tests/test_capsule_button_text_shadow.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.capsule_button import CapsuleButton
+
+
+def test_capsule_button_renders_text_shadow():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Test")
+    btn.pack()
+    root.update_idletasks()
+    text_items = [i for i in btn.find_withtag("all") if btn.type(i) == "text"]
+    assert len(text_items) >= 2
+    root.destroy()


### PR DESCRIPTION
## Summary
- give capsule buttons a light periwinkle base and aqua gradient for a glassy look
- add drop shadows to button text and icons for centered depth
- add test ensuring text shadow is rendered

## Testing
- `pytest -q`
- `radon cc -j gui/capsule_button.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4de55c4f0832787f2b888ea4ed27b