### PR TITLE
Add LED hover glow and white highlights to capsule button

### DIFF
--- a/tests/test_capsule_button_control_blend.py
+++ b/tests/test_capsule_button_control_blend.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.capsule_button import CapsuleButton, _darken
+
+
+def test_capsule_button_tints_parent_background():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Blend", bg="#89aaff")
+    btn.pack()
+    root.update_idletasks()
+    expected_bg = _darken("#89aaff", 0.9)
+    assert root.cget("bg") == expected_bg
+    assert btn.cget("bg") == expected_bg
+    root.destroy()
+

--- a/tests/test_capsule_button_effects.py
+++ b/tests/test_capsule_button_effects.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.capsule_button import CapsuleButton
+
+
+def test_text_shadow_and_highlight():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Test")
+    btn.pack()
+    root.update_idletasks()
+    shadow = getattr(btn, "_text_shadow_item", None)
+    assert shadow is not None
+    assert btn.itemcget(shadow, "fill") != "#000000"
+    highlight = getattr(btn, "_text_highlight_item", None)
+    assert highlight is not None
+    root.destroy()
+
+
+def test_icon_highlight_no_shadow():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    img = tk.PhotoImage(width=10, height=10)
+    btn = CapsuleButton(root, image=img)
+    btn.pack()
+    root.update_idletasks()
+    assert getattr(btn, "_icon_highlight_item", None) is not None
+    assert getattr(btn, "_icon_shadow_item", None) is None
+    root.destroy()
+
+
+def test_glow_on_hover_and_press():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Glow")
+    btn.pack()
+    root.update_idletasks()
+    assert btn._glow_items == []
+    btn._on_enter(type("E", (), {})())
+    assert btn._glow_items
+    btn._on_press(type("E", (), {})())
+    assert btn._glow_items == []
+    btn._on_release(type("E", (), {"x":1,"y":1})())
+    assert btn._glow_items
+    root.destroy()


### PR DESCRIPTION
## Summary
- Introduce internal LED glow on hover and hide highlights when pressed for a recessed feel
- Give text and icons soft shadows with white shading and drop legacy icon shadows

## Testing
- `pytest -q`
- `pip install radon` *(fails: Tunnel connection failed: 403 Forbidden)*
- `radon cc -s -j gui/capsule_button.py > complexity.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4de55c4f0832787f2b888ea4ed27b