### PR TITLE
Add safety report templates

### DIFF
--- a/config/functional_safety_concept_template.json
+++ b/config/functional_safety_concept_template.json
@@ -1,0 +1,13 @@
+{
+  "elements": {
+    "hazop": "hazop",
+    "risk": "risk",
+    "safety_goals": "safety_goals",
+    "req_functional_safety": "req_functional_safety"
+  },
+  "sections": [
+    {"title": "Hazard Analysis", "content": "<hazop><risk>"},
+    {"title": "Safety Goals", "content": "<safety_goals>"},
+    {"title": "Functional Safety Requirements", "content": "<req_functional_safety>"}
+  ]
+}

--- a/config/item_definition_template.json
+++ b/config/item_definition_template.json
@@ -1,0 +1,11 @@
+{
+  "elements": {
+    "page_diagrams": "page_diagrams",
+    "sysml_diagrams": "sysml_diagrams"
+  },
+  "sections": [
+    {"title": "Item Overview", "content": "Describe the item and its purpose.<br/><page_diagrams>"},
+    {"title": "Operational Environment", "content": "Summarize operating conditions and assumptions."},
+    {"title": "Interfaces", "content": "List key interfaces and interactions.<br/><sysml_diagrams>"}
+  ]
+}

--- a/config/technical_safety_concept_template.json
+++ b/config/technical_safety_concept_template.json
@@ -1,0 +1,10 @@
+{
+  "elements": {
+    "sysml_diagrams": "sysml_diagrams",
+    "req_technical_safety": "req_technical_safety"
+  },
+  "sections": [
+    {"title": "System Architecture", "content": "<sysml_diagrams>"},
+    {"title": "Technical Safety Requirements", "content": "<req_technical_safety>"}
+  ]
+}

--- a/tests/test_safety_report_templates.py
+++ b/tests/test_safety_report_templates.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from config import load_report_template
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+def _load(name: str):
+    path = BASE_DIR / "config" / name
+    return load_report_template(path)
+
+
+def test_item_definition_template_valid():
+    data = _load("item_definition_template.json")
+    assert "sections" in data and data["sections"]
+
+
+def test_functional_safety_concept_template_valid():
+    data = _load("functional_safety_concept_template.json")
+    assert any(sec["title"] == "Safety Goals" for sec in data["sections"])
+
+
+def test_technical_safety_concept_template_valid():
+    data = _load("technical_safety_concept_template.json")
+    assert any("Technical Safety Requirements" in sec["title"] for sec in data["sections"])


### PR DESCRIPTION
## Summary
- add Item Definition report template
- add Functional Safety Concept report template
- add Technical Safety Concept report template
- cover templates with basic validation tests

## Testing
- `pytest`
- `radon cc -s -j AutoML.py analysis config gui gsn sysml tools` *(fails: command not found or installation issue)*

------
https://chatgpt.com/codex/tasks/task_b_68a4e456f6ec8327a20cf117ab952898