### PR TITLE
Refine capsule button visuals with shading overlay

### DIFF
--- a/tests/test_capsule_button_effects.py
+++ b/tests/test_capsule_button_effects.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from gui.capsule_button import CapsuleButton
 
 
-def test_text_shadow_and_highlight():
+def test_text_shading():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -16,15 +16,14 @@ def test_text_shadow_and_highlight():
     btn = CapsuleButton(root, text="Test")
     btn.pack()
     root.update_idletasks()
-    shadow = getattr(btn, "_text_shadow_item", None)
-    assert shadow is not None
-    assert btn.itemcget(shadow, "fill") != "#000000"
-    highlight = getattr(btn, "_text_highlight_item", None)
-    assert highlight is not None
+    shade = getattr(btn, "_content_shade_item", None)
+    assert shade is not None
+    assert getattr(btn, "_text_shadow_item", None) is None
+    assert getattr(btn, "_text_highlight_item", None) is None
     root.destroy()
 
 
-def test_icon_highlight_no_shadow():
+def test_icon_shading():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -33,8 +32,9 @@ def test_icon_highlight_no_shadow():
     btn = CapsuleButton(root, image=img)
     btn.pack()
     root.update_idletasks()
-    assert getattr(btn, "_icon_highlight_item", None) is not None
+    assert getattr(btn, "_content_shade_item", None) is not None
     assert getattr(btn, "_icon_shadow_item", None) is None
+    assert getattr(btn, "_icon_highlight_item", None) is None
     root.destroy()
 
 

--- a/tests/test_capsule_button_shading.py
+++ b/tests/test_capsule_button_shading.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from gui.capsule_button import CapsuleButton
 
 
-def test_text_shadow_exists():
+def test_text_shading_exists():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -16,11 +16,12 @@ def test_text_shadow_exists():
     btn = CapsuleButton(root, text="Test")
     btn.pack()
     root.update_idletasks()
-    assert getattr(btn, "_text_shadow_item", None) is not None
+    assert getattr(btn, "_content_shade_item", None) is not None
+    assert getattr(btn, "_text_shadow_item", None) is None
     root.destroy()
 
 
-def test_icon_shadow_exists():
+def test_icon_shading_exists():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -29,5 +30,6 @@ def test_icon_shadow_exists():
     btn = CapsuleButton(root, image=img)
     btn.pack()
     root.update_idletasks()
-    assert getattr(btn, "_icon_shadow_item", None) is not None
+    assert getattr(btn, "_content_shade_item", None) is not None
+    assert getattr(btn, "_icon_shadow_item", None) is None
     root.destroy()

--- a/tests/test_capsule_button_text_overlay.py
+++ b/tests/test_capsule_button_text_overlay.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from gui.capsule_button import CapsuleButton
 
 
-def test_capsule_button_renders_text_shadow():
+def test_capsule_button_renders_single_text_with_shading():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -17,5 +17,6 @@ def test_capsule_button_renders_text_shadow():
     btn.pack()
     root.update_idletasks()
     text_items = [i for i in btn.find_withtag("all") if btn.type(i) == "text"]
-    assert len(text_items) >= 2
+    assert len(text_items) == 1
+    assert getattr(btn, "_content_shade_item", None) is not None
     root.destroy()


### PR DESCRIPTION
## Summary
- remove text and icon shadow rendering from capsule button
- overlay content with subtle shading that lightens on hover and darkens when pressed
- adjust tests to expect shading overlay instead of shadow artifacts

## Testing
- `pytest`
- `radon cc -j gui/capsule_button.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4e643a7c483278b9355961e178428