### PR TITLE
Replace button shadows with shading overlays

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -122,9 +122,9 @@ class CapsuleButton(tk.Canvas):
         self._border_light: list[int] = []
         self._border_gap: list[int] = []
         self._text_item: Optional[int] = None
-        self._text_shadow_item: Optional[int] = None
+        self._text_shade_item: Optional[int] = None
         self._image_item: Optional[int] = None
-        self._text_shadow_item: Optional[int] = None
+        self._icon_shade_item: Optional[int] = None
         self._text_highlight_item: Optional[int] = None
         self._icon_highlight_item: Optional[int] = None
         self._draw_button()
@@ -261,15 +261,15 @@ class CapsuleButton(tk.Canvas):
 
 
     def _draw_content(self, w: int, h: int) -> None:
-        """Render optional image and text with soft shadows and highlights."""
+        """Render optional image and text with shading and highlights."""
         cx, cy = w // 2, h // 2
         self._text_item = None
-        self._text_shadow_item = None
+        self._text_shade_item = None
         self._image_item = None
-        self._text_shadow_item = None
+        self._icon_shade_item = None
         self._text_highlight_item = None
         self._icon_highlight_item = None
-        shadow_col = _darken(self._current_color, 0.6)
+        shade_col = _darken(self._current_color, 0.6)
         if self._image and self._text and self._compound == tk.LEFT:
             font = tkfont.nametofont("TkDefaultFont")
             text_w = font.measure(self._text)
@@ -280,6 +280,15 @@ class CapsuleButton(tk.Canvas):
             img_x = start + img_w // 2
             text_x = start + img_w + spacing + text_w // 2
             self._image_item = self.create_image(img_x, cy, image=self._image)
+            self._icon_shade_item = self.create_rectangle(
+                start,
+                cy - img_w // 2,
+                start + img_w,
+                cy + img_w // 2,
+                outline="",
+                fill="#000000",
+                stipple="gray25",
+            )
             self._icon_highlight_item = self.create_rectangle(
                 start,
                 cy - img_w // 2,
@@ -289,13 +298,14 @@ class CapsuleButton(tk.Canvas):
                 fill="#ffffff",
                 stipple="gray50",
             )
-            self._text_shadow_item = self.create_text(
-                text_x + 1,
-                cy + 1,
-                text=self._text,
-                fill=shadow_col,
-            )
             self._text_item = self.create_text(text_x, cy, text=self._text)
+            self._text_shade_item = self.create_text(
+                text_x,
+                cy,
+                text=self._text,
+                fill=shade_col,
+                stipple="gray25",
+            )
             self._text_highlight_item = self.create_text(
                 text_x,
                 cy,
@@ -303,18 +313,17 @@ class CapsuleButton(tk.Canvas):
                 fill="#ffffff",
                 stipple="gray50",
             )
-            self._text_item = self.create_text(text_x, cy, text=self._text)
         elif self._image:
-            self._icon_shadow_item = self.create_oval(
-                cx - self._image.width() // 2 + 1,
-                cy - self._image.height() // 2 + 1,
-                cx + self._image.width() // 2 + 1,
-                cy + self._image.height() // 2 + 1,
+            self._image_item = self.create_image(cx, cy, image=self._image)
+            self._icon_shade_item = self.create_rectangle(
+                cx - self._image.width() // 2,
+                cy - self._image.height() // 2,
+                cx + self._image.width() // 2,
+                cy + self._image.height() // 2,
                 outline="",
                 fill="#000000",
-                stipple="gray50",
+                stipple="gray25",
             )
-            self._image_item = self.create_image(cx, cy, image=self._image)
             self._icon_highlight_item = self.create_rectangle(
                 cx - self._image.width() // 2,
                 cy - self._image.height() // 2,
@@ -325,13 +334,14 @@ class CapsuleButton(tk.Canvas):
                 stipple="gray50",
             )
         else:
-            self._text_shadow_item = self.create_text(
-                cx + 1,
-                cy + 1,
-                text=self._text,
-                fill=shadow_col,
-            )
             self._text_item = self.create_text(cx, cy, text=self._text)
+            self._text_shade_item = self.create_text(
+                cx,
+                cy,
+                text=self._text,
+                fill=shade_col,
+                stipple="gray25",
+            )
             self._text_highlight_item = self.create_text(
                 cx,
                 cy,

--- a/tests/test_capsule_button_effects.py
+++ b/tests/test_capsule_button_effects.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from gui.capsule_button import CapsuleButton
 
 
-def test_text_shadow_and_highlight():
+def test_text_shading_and_highlight():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -16,15 +16,15 @@ def test_text_shadow_and_highlight():
     btn = CapsuleButton(root, text="Test")
     btn.pack()
     root.update_idletasks()
-    shadow = getattr(btn, "_text_shadow_item", None)
-    assert shadow is not None
-    assert btn.itemcget(shadow, "fill") != "#000000"
+    shade = getattr(btn, "_text_shade_item", None)
+    assert shade is not None
+    assert btn.itemcget(shade, "fill") != "#000000"
     highlight = getattr(btn, "_text_highlight_item", None)
     assert highlight is not None
     root.destroy()
 
 
-def test_icon_highlight_no_shadow():
+def test_icon_highlight_with_shade():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -34,7 +34,7 @@ def test_icon_highlight_no_shadow():
     btn.pack()
     root.update_idletasks()
     assert getattr(btn, "_icon_highlight_item", None) is not None
-    assert getattr(btn, "_icon_shadow_item", None) is None
+    assert getattr(btn, "_icon_shade_item", None) is not None
     root.destroy()
 
 

--- a/tests/test_capsule_button_shading.py
+++ b/tests/test_capsule_button_shading.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from gui.capsule_button import CapsuleButton
 
 
-def test_text_shadow_exists():
+def test_text_shade_exists():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -16,11 +16,11 @@ def test_text_shadow_exists():
     btn = CapsuleButton(root, text="Test")
     btn.pack()
     root.update_idletasks()
-    assert getattr(btn, "_text_shadow_item", None) is not None
+    assert getattr(btn, "_text_shade_item", None) is not None
     root.destroy()
 
 
-def test_icon_shadow_exists():
+def test_icon_shade_exists():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -29,5 +29,5 @@ def test_icon_shadow_exists():
     btn = CapsuleButton(root, image=img)
     btn.pack()
     root.update_idletasks()
-    assert getattr(btn, "_icon_shadow_item", None) is not None
+    assert getattr(btn, "_icon_shade_item", None) is not None
     root.destroy()

--- a/tests/test_capsule_button_text_shading.py
+++ b/tests/test_capsule_button_text_shading.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from gui.capsule_button import CapsuleButton
 
 
-def test_capsule_button_renders_text_shadow():
+def test_capsule_button_renders_text_shading():
     try:
         root = tk.Tk()
     except tk.TclError:
@@ -16,6 +16,5 @@ def test_capsule_button_renders_text_shadow():
     btn = CapsuleButton(root, text="Test")
     btn.pack()
     root.update_idletasks()
-    text_items = [i for i in btn.find_withtag("all") if btn.type(i) == "text"]
-    assert len(text_items) >= 2
+    assert getattr(btn, "_text_shade_item", None) is not None
     root.destroy()


### PR DESCRIPTION
## Summary
- remove text and icon shadows from custom capsule buttons and replace with translucent shading to imply depth
- adjust button effects tests to assert shading overlays and highlights
- update shading-specific tests to cover icon and text cases

## Testing
- `python tools/metrics_generator.py --path gui --output metrics.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4e643a7c483278b9355961e178428