### PR TITLE
Refine capsule button glow

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -121,6 +121,7 @@ class CapsuleButton(tk.Canvas):
         self._border_dark: list[int] = []
         self._border_light: list[int] = []
         self._border_gap: list[int] = []
+        self._outer_shadow: list[int] = []
         self._text_item: Optional[int] = None
         self._text_shadow_item: Optional[int] = None
         self._image_item: Optional[int] = None
@@ -345,6 +346,15 @@ class CapsuleButton(tk.Canvas):
     def _draw_border(self, w: int, h: int) -> None:
         """Draw border and inner outline to mimic an inset capsule."""
         r = self._radius
+        shadow = _darken(self._current_color, 0.5)
+        self._outer_shadow = [
+            self.create_arc((-2, -2, 2 * r + 2, h + 2), start=90, extent=180, style=tk.ARC, outline=shadow, width=2),
+            self.create_line(r, -2, w - r, -2, fill=shadow, width=2),
+            self.create_arc((w - 2 * r - 2, -2, w + 2, h + 2), start=-90, extent=180, style=tk.ARC, outline=shadow, width=2),
+            self.create_line(-2, r, -2, h - r, fill=shadow, width=2),
+            self.create_line(r, h + 2, w - r, h + 2, fill=shadow, width=2),
+            self.create_line(w + 2, r, w + 2, h - r, fill=shadow, width=2),
+        ]
         inner = _darken(self._current_color, 0.7)
         self._border_outline = [
             self.create_arc((1, 1, 2 * r - 1, h - 1), start=90, extent=180, style=tk.ARC, outline=inner),
@@ -387,9 +397,11 @@ class CapsuleButton(tk.Canvas):
         dark = _darken(color, 0.8)
         light = _lighten(color, 1.2)
         gap = _darken(color, 0.7)
+        shadow = _darken(color, 0.5)
         self._apply_border_color(self._border_dark, dark)
         self._apply_border_color(self._border_light, light)
         self._apply_border_color(self._border_gap, gap)
+        self._apply_border_color(self._outer_shadow, shadow)
         self._current_color = color
 
     def _apply_border_color(self, items: list[int], color: str) -> None:
@@ -413,21 +425,19 @@ class CapsuleButton(tk.Canvas):
                 self.itemconfigure(item, fill=color)
 
     def _add_glow(self) -> None:
-        """Draw a bright oval to simulate an internal LED glow."""
+        """Lighten the button edges without covering the surface."""
         if self._glow_items:
             return
         w, h = int(self["width"]), int(self["height"])
-        glow_color = _lighten(self._current_color, 1.5)
+        r = self._radius
+        glow_color = _lighten(self._current_color, 1.3)
         self._glow_items = [
-            self.create_oval(
-                2,
-                2,
-                w - 2,
-                h - 2,
-                outline="",
-                fill=glow_color,
-                stipple="gray25",
-            )
+            self.create_arc((2, 2, 2 * r - 2, h - 2), start=90, extent=180, style=tk.ARC, outline=glow_color, width=2),
+            self.create_line(r, 2, w - r, 2, fill=glow_color, width=2),
+            self.create_arc((w - 2 * r + 2, 2, w - 2, h - 2), start=-90, extent=180, style=tk.ARC, outline=glow_color, width=2),
+            self.create_line(2, r, 2, h - r, fill=glow_color, width=2),
+            self.create_line(r, h - 2, w - r, h - 2, fill=glow_color, width=2),
+            self.create_line(w - 2, r, w - 2, h - r, fill=glow_color, width=2),
         ]
 
     def _remove_glow(self) -> None:

--- a/tests/test_capsule_button_glow_outline.py
+++ b/tests/test_capsule_button_glow_outline.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.capsule_button import CapsuleButton
+
+
+def test_glow_edges_only():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Glow")
+    btn.pack()
+    root.update_idletasks()
+    btn._on_enter(type("E", (), {})())
+    item_types = {btn.type(i) for i in btn._glow_items}
+    assert "oval" not in item_types
+    root.destroy()


### PR DESCRIPTION
## Summary
- lighten button edges without opaque highlight overlay
- draw outer shadow for recessed button appearance
- add test confirming glow uses outline rather than fill

## Testing
- `pytest`
- `pytest tests/test_capsule_button_glow_outline.py -q`
- `radon cc -j gui/capsule_button.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4e9edd79c8327955a3ef0121d0550