### PR TITLE
Remove button text and icon drop shadows

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -114,8 +114,11 @@ class CapsuleButton(tk.Canvas):
         self._border_gap: list[int] = []
         self._outer_shadow: list[int] = []
         self._text_item: Optional[int] = None
-        self._text_shadow_item: Optional[int] = None
-        self._icon_shadow_item: Optional[int] = None
+        # Drop-shadow canvas items were previously stored in
+        # ``_text_shadow_item`` and ``_icon_shadow_item``.  The shadow effect
+        # made text and icons appear doubled, so these attributes and the
+        # associated rendering have been removed entirely.  Highlight items are
+        # still tracked to provide a subtle sheen without duplicating content.
         self._image_item: Optional[int] = None
         self._text_highlight_item: Optional[int] = None
         self._icon_highlight_item: Optional[int] = None
@@ -256,8 +259,9 @@ class CapsuleButton(tk.Canvas):
         """Render optional image and text without drop shadows."""
         cx, cy = w // 2, h // 2
         self._text_item = None
-        self._text_shadow_item = None
-        self._icon_shadow_item = None
+        # Shadow items were removed to avoid doubled rendering of
+        # text and icons.  Only the main content and optional highlight items
+        # are recreated when drawing the button.
         self._image_item = None
         self._text_highlight_item = None
         self._icon_highlight_item = None

--- a/tests/test_capsule_button_effects.py
+++ b/tests/test_capsule_button_effects.py
@@ -16,7 +16,7 @@ def test_text_highlight_without_shadow():
     btn = CapsuleButton(root, text="Test")
     btn.pack()
     root.update_idletasks()
-    assert getattr(btn, "_text_shadow_item", None) is None
+    assert not hasattr(btn, "_text_shadow_item")
     highlight = getattr(btn, "_text_highlight_item", None)
     assert highlight is not None
     root.destroy()
@@ -32,7 +32,7 @@ def test_icon_highlight_without_shadow():
     btn.pack()
     root.update_idletasks()
     assert getattr(btn, "_icon_highlight_item", None) is not None
-    assert getattr(btn, "_icon_shadow_item", None) is None
+    assert not hasattr(btn, "_icon_shadow_item")
     root.destroy()
 
 

--- a/tests/test_capsule_button_shadows.py
+++ b/tests/test_capsule_button_shadows.py
@@ -16,7 +16,7 @@ def test_text_shadow_removed():
     btn = CapsuleButton(root, text="Test")
     btn.pack()
     root.update_idletasks()
-    assert getattr(btn, "_text_shadow_item", None) is None
+    assert not hasattr(btn, "_text_shadow_item")
     root.destroy()
 
 
@@ -29,5 +29,5 @@ def test_icon_shadow_removed():
     btn = CapsuleButton(root, image=img)
     btn.pack()
     root.update_idletasks()
-    assert getattr(btn, "_icon_shadow_item", None) is None
+    assert not hasattr(btn, "_icon_shadow_item")
     root.destroy()


### PR DESCRIPTION
## Summary
- remove canvas shadow items from CapsuleButton to prevent doubled text and icons
- adjust capsule button tests to assert absence of text and icon shadow attributes

## Testing
- `python tools/metrics_generator.py --path gui --output metrics.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4eb82fa648327aad154bbbb984d01