### PR TITLE
Ensure temporary log window fits message content

### DIFF
--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -26,8 +26,8 @@ def _log_and_return(title: str | None, message: str | None, level: str) -> str:
         Log level to associate with the message.
     """
 
-    logger.log_message(f"{title}: {message}", level)
-    logger.show_temporarily()
+    lines = logger.log_message(f"{title}: {message}", level)
+    logger.show_temporarily(lines=lines)
     return "ok"
 
 
@@ -44,8 +44,8 @@ def showerror(title=None, message=None, **options):
 
 
 def askyesno(title=None, message=None, **options):
-    logger.log_message(f"{title}: {message}", "ASK")
-    logger.show_temporarily()
+    lines = logger.log_message(f"{title}: {message}", "ASK")
+    logger.show_temporarily(lines=lines)
     try:
         return tk_messagebox.askyesno(title, message, **options)
     except (TclError, RuntimeError):
@@ -53,8 +53,8 @@ def askyesno(title=None, message=None, **options):
 
 
 def askyesnocancel(title=None, message=None, **options):
-    logger.log_message(f"{title}: {message}", "ASK")
-    logger.show_temporarily()
+    lines = logger.log_message(f"{title}: {message}", "ASK")
+    logger.show_temporarily(lines=lines)
     try:
         return tk_messagebox.askyesnocancel(title, message, **options)
     except (TclError, RuntimeError):
@@ -62,8 +62,8 @@ def askyesnocancel(title=None, message=None, **options):
 
 
 def askokcancel(title=None, message=None, **options):
-    logger.log_message(f"{title}: {message}", "ASK")
-    logger.show_temporarily()
+    lines = logger.log_message(f"{title}: {message}", "ASK")
+    logger.show_temporarily(lines=lines)
     try:
         return tk_messagebox.askokcancel(title, message, **options)
     except (TclError, RuntimeError):

--- a/tests/test_log_window_resize.py
+++ b/tests/test_log_window_resize.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import tkinter as tk
+import pytest
+
+# Ensure repository root in path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from gui import logger, messagebox
+
+
+def test_log_window_expands_to_fit_message():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    logger.init_log_window(root)
+    long_message = "This is a long message " * 50
+    default_height = logger._default_height
+    messagebox.showinfo("Title", long_message)
+    root.update_idletasks()
+    display_lines = logger.log_widget.count("1.0", "end-1c", "displaylines")[0]
+    expected_height = logger._line_height * display_lines
+    assert logger.log_frame.winfo_height() == expected_height
+    assert logger.log_frame.winfo_height() > default_height
+    root.destroy()


### PR DESCRIPTION
## Summary
- resize log window when showing temporary messages so full text is visible
- return display line count from logger.log_message and use it to size temporary log windows
- add regression test for log window resizing

## Testing
- `pytest`
- `radon cc -j gui/logger.py gui/messagebox.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4eef6c89483278face1a539250082