### PR TITLE
feat(gui): make status bar slightly transparent

### DIFF
--- a/gui/faults_gui.py
+++ b/gui/faults_gui.py
@@ -526,6 +526,12 @@ class FaultsWindow(QMainWindow):
         btn_row.addStretch(1)
 
         self.status = QStatusBar()
+        pal = self.status.palette()
+        color = pal.color(QPalette.ColorRole.Window)
+        color.setAlpha(230)
+        pal.setColor(QPalette.ColorRole.Window, color)
+        self.status.setPalette(pal)
+        self.status.setAutoFillBackground(True)
         self.setStatusBar(self.status)
 
         # Menus / toolbar

--- a/tests/test_statusbar_transparency.py
+++ b/tests/test_statusbar_transparency.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+PyQt6 = pytest.importorskip("PyQt6")
+from PyQt6.QtWidgets import QApplication
+from gui.faults_gui import FaultsWindow
+
+
+@pytest.fixture(scope="module")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def test_status_bar_transparency(app):
+    win = FaultsWindow()
+    alpha = win.status.palette().color(win.status.backgroundRole()).alpha()
+    assert alpha < 255
+    win.close()


### PR DESCRIPTION
## Summary
- make GUI status bar slightly translucent so desktop is faintly visible
- cover status bar transparency with a test (skipped if PyQt6 unavailable)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4ef5a4d6083278ce82451c83ab4a0