### PR TITLE
Fix capsule button glow size

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -371,12 +371,26 @@ class CapsuleButton(tk.Canvas):
         r = self._radius
         glow_color = _lighten(self._current_color, 1.3)
         self._glow_items = [
-            self.create_arc((2, 2, 2 * r - 2, h - 2), start=90, extent=180, style=tk.ARC, outline=glow_color, width=2),
-            self.create_line(r, 2, w - r, 2, fill=glow_color, width=2),
-            self.create_arc((w - 2 * r + 2, 2, w - 2, h - 2), start=-90, extent=180, style=tk.ARC, outline=glow_color, width=2),
-            self.create_line(2, r, 2, h - r, fill=glow_color, width=2),
-            self.create_line(r, h - 2, w - r, h - 2, fill=glow_color, width=2),
-            self.create_line(w - 2, r, w - 2, h - r, fill=glow_color, width=2),
+            self.create_arc(
+                (1, 1, 2 * r - 1, h - 1),
+                start=90,
+                extent=180,
+                style=tk.ARC,
+                outline=glow_color,
+                width=2,
+            ),
+            self.create_line(r, 1, w - r, 1, fill=glow_color, width=2),
+            self.create_arc(
+                (w - 2 * r + 1, 1, w - 1, h - 1),
+                start=-90,
+                extent=180,
+                style=tk.ARC,
+                outline=glow_color,
+                width=2,
+            ),
+            self.create_line(1, r, 1, h - r, fill=glow_color, width=2),
+            self.create_line(r, h - 1, w - r, h - 1, fill=glow_color, width=2),
+            self.create_line(w - 1, r, w - 1, h - r, fill=glow_color, width=2),
         ]
 
     def _remove_glow(self) -> None:

--- a/tests/test_capsule_button_effects.py
+++ b/tests/test_capsule_button_effects.py
@@ -51,3 +51,18 @@ def test_glow_on_hover_and_press():
     btn._on_release(type("E", (), {"x":1,"y":1})())
     assert btn._glow_items
     root.destroy()
+
+
+def test_glow_outline_matches_button_size():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Glow", width=120, height=40)
+    btn.pack()
+    root.update_idletasks()
+    btn._on_enter(type("E", (), {})())
+    w, h = int(btn["width"]), int(btn["height"])
+    bbox = btn.bbox(*btn._glow_items)
+    assert bbox == (0, 0, w, h)
+    root.destroy()


### PR DESCRIPTION
## Summary
- ensure capsule button hover glow outlines match the button's dimensions
- add regression test verifying glow outline uses full width and height

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path gui --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a4f15cd394832795e5ff48090d8c49