### PR TITLE
Add gradient shading for work product shapes in governance diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -8256,14 +8256,57 @@ class SysMLDiagramWindow(tk.Frame):
                 color = "#d5e8d4"
             else:
                 color = "#ffffff"
+            radius = 8 * self.zoom
+            self._draw_gradient_rect(x - w, y - h, x + w, y + h, color, obj.obj_id)
+            bg = StyleManager.get_instance().get_canvas_color()
+            self.canvas.create_arc(
+                x - w,
+                y - h,
+                x - w + 2 * radius,
+                y - h + 2 * radius,
+                start=90,
+                extent=90,
+                fill=bg,
+                outline="",
+            )
+            self.canvas.create_arc(
+                x + w - 2 * radius,
+                y - h,
+                x + w,
+                y - h + 2 * radius,
+                start=0,
+                extent=90,
+                fill=bg,
+                outline="",
+            )
+            self.canvas.create_arc(
+                x + w - 2 * radius,
+                y + h - 2 * radius,
+                x + w,
+                y + h,
+                start=270,
+                extent=90,
+                fill=bg,
+                outline="",
+            )
+            self.canvas.create_arc(
+                x - w,
+                y + h - 2 * radius,
+                x - w + 2 * radius,
+                y + h,
+                start=180,
+                extent=90,
+                fill=bg,
+                outline="",
+            )
             self._create_round_rect(
                 x - w,
                 y - h,
                 x + w,
                 y + h,
-                radius=8 * self.zoom,
+                radius=radius,
                 outline=outline,
-                fill=color,
+                fill="",
             )
             fold = 10 * self.zoom
             fold_color = "#fdfdfd"

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -79,6 +79,9 @@ class DummyCanvas:
     def create_polygon(self, *args, **kwargs):
         self.polygon_calls.append((args, kwargs))
 
+    def create_arc(self, *args, **kwargs):
+        pass
+
     def canvasx(self, x):
         return x
 
@@ -2024,7 +2027,8 @@ def test_work_product_color_and_text_wrapping():
     win.zoom = 1.0
     win.canvas = DummyCanvas()
     win.font = None
-    win._draw_gradient_rect = lambda *args, **kwargs: None
+    colors = []
+    win._draw_gradient_rect = lambda *args, **kwargs: colors.append(args[4])
     win.selected_objs = []
 
     obj = SysMLObject(
@@ -2037,8 +2041,7 @@ def test_work_product_color_and_text_wrapping():
         properties={"name": "Architecture Diagram"},
     )
     win.draw_object(obj)
-    _, poly_kwargs = win.canvas.polygon_calls[0]
-    assert poly_kwargs["fill"] == "#cfe2f3"
+    assert colors[0] == "#cfe2f3"
     assert win.canvas.text_calls[0][2]["width"] == 60.0
     assert win.canvas.text_calls[0][2]["text"] == "Architecture\nDiagram"
 
@@ -2046,8 +2049,7 @@ def test_work_product_color_and_text_wrapping():
     win.canvas.text_calls.clear()
     obj.properties["name"] = "HAZOP"
     win.draw_object(obj)
-    _, poly_kwargs = win.canvas.polygon_calls[0]
-    assert poly_kwargs["fill"] == "#d5e8d4"
+    assert colors[1] == "#d5e8d4"
 
 
 def test_work_product_shapes_fixed_size():

--- a/tests/test_work_product_shading.py
+++ b/tests/test_work_product_shading.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import types
+from gui.architecture import GovernanceDiagramWindow, SysMLObject
+
+class DummyCanvas:
+    def create_polygon(self, *a, **k):
+        pass
+    def create_line(self, *a, **k):
+        pass
+    def create_text(self, *a, **k):
+        pass
+    def create_arc(self, *a, **k):
+        pass
+    def create_image(self, *a, **k):
+        pass
+
+
+def test_work_product_shape_uses_gradient():
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.canvas = DummyCanvas()
+    win.zoom = 1
+    win.font = None
+    win.selected_objs = []
+    win.repo = types.SimpleNamespace(get_linked_diagram=lambda x: None, diagrams={})
+    captured = []
+    win._draw_gradient_rect = lambda *args, **kwargs: captured.append(args)
+    obj = SysMLObject(obj_id=1, obj_type="Work Product", x=0, y=0, properties={})
+    win.draw_object(obj)
+    assert captured, "Work Product shape should use gradient fill"


### PR DESCRIPTION
## Summary
- Shade governance work product shapes with a white-to-color gradient and masked rounded corners
- Test that governance work products render with gradient shading
- Adjust safety management tests for gradient-based work product styling

## Testing
- `pytest tests/test_work_product_shading.py -q`
- `pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a4efa5542883278fd4c1706cc37afc