### PR TITLE
Ensure consistent styling for message box dialogs

### DIFF
--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -8,7 +8,10 @@ decision is needed.
 """
 
 from tkinter import TclError
-import tkinter.messagebox as tk_messagebox
+import tkinter as tk
+from tkinter import ttk
+
+from .mac_button_style import apply_mac_button_style
 
 from . import logger
 
@@ -43,11 +46,52 @@ def showerror(title=None, message=None, **options):
     return _log_and_return(title, message, "ERROR")
 
 
+def _create_dialog(
+    title: str | None,
+    message: str | None,
+    buttons: list[tuple[str, object]],
+) -> object:
+    """Create a simple ``ttk`` dialog returning the associated button value."""
+
+    root = tk._default_root or tk.Tk()
+    root.withdraw()
+
+    dialog = tk.Toplevel(root)
+    dialog.title(title or "")
+    dialog.resizable(False, False)
+    dialog.transient(root)
+    dialog.grab_set()
+
+    apply_mac_button_style()
+
+    frame = ttk.Frame(dialog, padding=10)
+    frame.pack(fill="both", expand=True)
+    ttk.Label(frame, text=message or "").pack(pady=(0, 10))
+
+    result: object = None
+
+    def _set(value: object) -> None:
+        nonlocal result
+        result = value
+        dialog.destroy()
+
+    for text, value in buttons:
+        ttk.Button(frame, text=text, command=lambda v=value: _set(v)).pack(
+            side="left", padx=5
+        )
+
+    dialog.protocol("WM_DELETE_WINDOW", lambda: _set(None))
+    dialog.wait_window()
+    return result
+
+
 def askyesno(title=None, message=None, **options):
     lines = logger.log_message(f"{title}: {message}", "ASK")
     logger.show_temporarily(lines=lines)
     try:
-        return tk_messagebox.askyesno(title, message, **options)
+        return bool(
+            _create_dialog(title, message, [("Yes", True), ("No", False)])
+        )
     except (TclError, RuntimeError):
         return False
 
@@ -56,7 +100,9 @@ def askyesnocancel(title=None, message=None, **options):
     lines = logger.log_message(f"{title}: {message}", "ASK")
     logger.show_temporarily(lines=lines)
     try:
-        return tk_messagebox.askyesnocancel(title, message, **options)
+        return _create_dialog(
+            title, message, [("Yes", True), ("No", False), ("Cancel", None)]
+        )
     except (TclError, RuntimeError):
         return None
 
@@ -65,6 +111,8 @@ def askokcancel(title=None, message=None, **options):
     lines = logger.log_message(f"{title}: {message}", "ASK")
     logger.show_temporarily(lines=lines)
     try:
-        return tk_messagebox.askokcancel(title, message, **options)
+        return bool(
+            _create_dialog(title, message, [("OK", True), ("Cancel", False)])
+        )
     except (TclError, RuntimeError):
         return False

--- a/tests/test_messagebox_noninteractive.py
+++ b/tests/test_messagebox_noninteractive.py
@@ -1,28 +1,40 @@
 from gui import messagebox
 
 
-def _was_called(monkeypatch, func_name):
+def test_showinfo_does_not_popup(monkeypatch):
     called = False
 
-    def fake(*args, **kwargs):
+    def fake(*args, **kwargs):  # pragma: no cover - simple flag setter
         nonlocal called
         called = True
 
-    monkeypatch.setattr(messagebox.tk_messagebox, func_name, fake)
-    getattr(messagebox, func_name)("T", "M")
-    return called
-
-
-def test_showinfo_does_not_popup(monkeypatch):
-    assert _was_called(monkeypatch, "showinfo") is False
+    monkeypatch.setattr(messagebox, "_create_dialog", fake)
+    messagebox.showinfo("T", "M")
+    assert called is False
 
 
 def test_showwarning_does_not_popup(monkeypatch):
-    assert _was_called(monkeypatch, "showwarning") is False
+    called = False
+
+    def fake(*args, **kwargs):  # pragma: no cover - simple flag setter
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(messagebox, "_create_dialog", fake)
+    messagebox.showwarning("T", "M")
+    assert called is False
 
 
 def test_showerror_does_not_popup(monkeypatch):
-    assert _was_called(monkeypatch, "showerror") is False
+    called = False
+
+    def fake(*args, **kwargs):  # pragma: no cover - simple flag setter
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(messagebox, "_create_dialog", fake)
+    messagebox.showerror("T", "M")
+    assert called is False
 
 
 def test_askyesno_displays_popup(monkeypatch):
@@ -33,6 +45,6 @@ def test_askyesno_displays_popup(monkeypatch):
         called = True
         return True
 
-    monkeypatch.setattr(messagebox.tk_messagebox, "askyesno", fake)
+    monkeypatch.setattr(messagebox, "_create_dialog", fake)
     assert messagebox.askyesno("T", "M") is True
     assert called is True

--- a/tests/test_messagebox_style.py
+++ b/tests/test_messagebox_style.py
@@ -1,0 +1,29 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from gui import messagebox as mb
+
+
+def test_askyesno_uses_custom_dialog(monkeypatch):
+    called = {}
+    def fake_dialog(title, message, buttons):
+        called['buttons'] = buttons
+        return True
+    monkeypatch.setattr(mb, '_create_dialog', fake_dialog)
+    assert mb.askyesno('Title', 'Message') is True
+    assert called['buttons'] == [('Yes', True), ('No', False)]
+
+
+def test_askyesnocancel_uses_custom_dialog(monkeypatch):
+    def fake_dialog(title, message, buttons):
+        assert buttons == [('Yes', True), ('No', False), ('Cancel', None)]
+        return None
+    monkeypatch.setattr(mb, '_create_dialog', fake_dialog)
+    assert mb.askyesnocancel('Title', 'Message') is None
+
+
+def test_askokcancel_uses_custom_dialog(monkeypatch):
+    def fake_dialog(title, message, buttons):
+        assert buttons == [('OK', True), ('Cancel', False)]
+        return False
+    monkeypatch.setattr(mb, '_create_dialog', fake_dialog)
+    assert mb.askokcancel('Title', 'Message') is False


### PR DESCRIPTION
## Summary
- replace tkinter messagebox prompts with custom ttk dialogs styled like the rest of the GUI
- avoid pop-ups for non-interactive messages and test dialog button layouts

## Testing
- `pytest`
- `radon cc -j gui/messagebox.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4f29d848483278fe356ef5605e3d4