### PR TITLE
Enable Scenario Library to serve as HAZOP input

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -54,6 +54,7 @@ ALLOWED_ANALYSIS_USAGE: set[tuple[str, str]] = {
     ("Reliability Analysis", "FMEA"),
     ("Reliability Analysis", "FMEDA"),
     ("ODD", "Scenario Library"),
+    ("Scenario Library", "HAZOP"),
     ("GSN Argumentation", "Safety & Security Case"),
 }
 
@@ -95,6 +96,7 @@ ALLOWED_USAGE.update(
         ("Mission Profile", "FTA"),
         ("Requirement Specification", "HAZOP"),
         ("ODD", "Scenario Library"),
+        ("Scenario Library", "HAZOP"),
         ("Reliability Analysis", "FMEA"),
         ("Reliability Analysis", "FMEDA"),
         ("GSN Argumentation", "Safety & Security Case"),

--- a/tests/test_governance_trace_relationship.py
+++ b/tests/test_governance_trace_relationship.py
@@ -245,6 +245,36 @@ class GovernanceTraceRelationshipTests(unittest.TestCase):
             )
             self.assertTrue(valid)
 
+    def test_used_allows_scenario_library_to_hazop(self):
+        repo = self.repo
+        diag = repo.create_diagram("Governance Diagram", name="Gov")
+        e1 = repo.create_element("Block", name="E1")
+        e2 = repo.create_element("Block", name="E2")
+        scenario_lib = SysMLObject(
+            1,
+            "Work Product",
+            0,
+            0,
+            element_id=e1.elem_id,
+            properties={"name": "Scenario Library"},
+        )
+        hazop = SysMLObject(
+            2,
+            "Work Product",
+            0,
+            100,
+            element_id=e2.elem_id,
+            properties={"name": "HAZOP"},
+        )
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        for rel in ["Used By", "Used after Review", "Used after Approval"]:
+            valid, _ = GovernanceDiagramWindow.validate_connection(
+                win, scenario_lib, hazop, rel
+            )
+            self.assertTrue(valid)
+
     def test_used_disallows_scenario_library_to_odd(self):
         repo = self.repo
         diag = repo.create_diagram("Governance Diagram", name="Gov")


### PR DESCRIPTION
## Summary
- allow Scenario Library to connect to HAZOP via Used By/Review/Approval relationships
- exercise Scenario Library->HAZOP usage in governance and visibility tests

## Testing
- `pytest -q`
- Attempted: `radon cc analysis/safety_management.py -j` *(failed: command not found / proxy error)*

------
https://chatgpt.com/codex/tasks/task_b_68a4f494204c8327a2caece61f55fa61