### PR TITLE
feat: introduce button style variants for dialogs and toolboxes

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -256,7 +256,7 @@ from gsn.nodes import GSNNode
 from gui.closable_notebook import ClosableNotebook
 from gui.icon_factory import create_icon
 from gui.splash_screen import SplashScreen
-from gui.mac_button_style import apply_mac_button_style
+from gui.mac_button_style import apply_translucid_button_style
 from dataclasses import asdict
 from pathlib import Path
 from analysis.mechanisms import (
@@ -3023,7 +3023,7 @@ class AutoMLApp:
         nb_container = ttk.Frame(self.tools_group)
         nb_container.pack(fill=tk.BOTH, expand=True)
         style = ttk.Style()
-        apply_mac_button_style(style)
+        apply_translucid_button_style(style)
         # Create a custom notebook style so that a layout is available.  Without a
         # ``TNotebook`` suffix in the style name, ttk cannot find the default
         # layout which led to ``_tkinter.TclError: Layout ToolsNotebook not
@@ -14226,7 +14226,7 @@ class AutoMLApp:
             style.theme_use("clam")
         except tk.TclError:
             pass
-        apply_mac_button_style(style)
+        apply_translucid_button_style(style)
         style.configure(
             "FMEA.Treeview",
             font=("Segoe UI", 10),

--- a/gui/mac_button_style.py
+++ b/gui/mac_button_style.py
@@ -26,3 +26,43 @@ def apply_mac_button_style(style: ttk.Style | None = None) -> ttk.Style:
         relief=[("pressed", "sunken"), ("!pressed", "raised")],
     )
     return style
+
+
+def apply_purplish_button_style(style: ttk.Style | None = None) -> ttk.Style:
+    """Style buttons with a purple theme for message boxes."""
+
+    style = style or ttk.Style()
+    style.configure(
+        "Purple.TButton",
+        padding=(10, 5),
+        relief="raised",
+        borderwidth=1,
+        foreground="white",
+        background="#9b59b6",
+    )
+    style.map(
+        "Purple.TButton",
+        background=[("active", "#b37cc8"), ("pressed", "#8e44ad")],
+        relief=[("pressed", "sunken"), ("!pressed", "raised")],
+    )
+    return style
+
+
+def apply_translucid_button_style(style: ttk.Style | None = None) -> ttk.Style:
+    """Style buttons with a subtle, translucent look for toolboxes."""
+
+    style = style or ttk.Style()
+    style.configure(
+        "Translucid.TButton",
+        padding=(10, 5),
+        relief="flat",
+        borderwidth=1,
+        foreground="black",
+        background="#ffffff",
+    )
+    style.map(
+        "Translucid.TButton",
+        background=[("active", "#f0f0f0"), ("pressed", "#e0e0e0")],
+        relief=[("pressed", "sunken"), ("!pressed", "flat")],
+    )
+    return style

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -11,7 +11,7 @@ from tkinter import TclError
 import tkinter as tk
 from tkinter import ttk
 
-from .mac_button_style import apply_mac_button_style
+from .mac_button_style import apply_purplish_button_style
 
 from . import logger
 
@@ -62,7 +62,7 @@ def _create_dialog(
     dialog.transient(root)
     dialog.grab_set()
 
-    apply_mac_button_style()
+    apply_purplish_button_style()
 
     frame = ttk.Frame(dialog, padding=10)
     frame.pack(fill="both", expand=True)
@@ -76,9 +76,9 @@ def _create_dialog(
         dialog.destroy()
 
     for text, value in buttons:
-        ttk.Button(frame, text=text, command=lambda v=value: _set(v)).pack(
-            side="left", padx=5
-        )
+        ttk.Button(
+            frame, text=text, style="Purple.TButton", command=lambda v=value: _set(v)
+        ).pack(side="left", padx=5)
 
     dialog.protocol("WM_DELETE_WINDOW", lambda: _set(None))
     dialog.wait_window()

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -38,7 +38,7 @@ from analysis.models import (
 from analysis.safety_management import ACTIVE_TOOLBOX, SAFETY_ANALYSIS_WORK_PRODUCTS
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.constants import CHECK_MARK, CROSS_MARK
-from gui.mac_button_style import apply_mac_button_style
+from gui.mac_button_style import apply_translucid_button_style
 from gui.icon_factory import create_icon
 from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
 from gui.architecture import (
@@ -87,7 +87,7 @@ def configure_table_style(style_name: str, rowheight: int = 60) -> None:
         style.theme_use("clam")
     except tk.TclError:
         pass
-    apply_mac_button_style(style)
+    apply_translucid_button_style(style)
     border_opts = {"bordercolor": "black", "borderwidth": 1, "relief": "solid"}
     style.configure(
         style_name,

--- a/tests/test_button_styles.py
+++ b/tests/test_button_styles.py
@@ -1,0 +1,53 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from gui.mac_button_style import (
+    apply_purplish_button_style,
+    apply_translucid_button_style,
+)
+from gui import toolboxes
+
+
+class DummyStyle:
+    def __init__(self):
+        self.configured = {}
+        self.mapped = {}
+
+    def configure(self, style, **kwargs):
+        self.configured[style] = kwargs
+
+    def map(self, style, **kwargs):
+        self.mapped[style] = kwargs
+
+
+def test_apply_purplish_button_style_configures_background():
+    style = DummyStyle()
+    apply_purplish_button_style(style)
+    assert style.configured["Purple.TButton"]["background"] == "#9b59b6"
+
+
+def test_apply_translucid_button_style_sets_flat_relief():
+    style = DummyStyle()
+    apply_translucid_button_style(style)
+    assert style.configured["Translucid.TButton"]["relief"] == "flat"
+
+
+def test_configure_table_style_uses_translucid(monkeypatch):
+    called = {}
+    
+    class DummyStyle:
+        def theme_use(self, *a, **k):
+            pass
+
+        def configure(self, *a, **k):
+            pass
+
+        def map(self, *a, **k):
+            pass
+
+    def fake_apply(style):
+        called["ok"] = isinstance(style, DummyStyle)
+
+    monkeypatch.setattr(toolboxes.ttk, "Style", lambda: DummyStyle())
+    monkeypatch.setattr(toolboxes, "apply_translucid_button_style", fake_apply)
+    toolboxes.configure_table_style("TestStyle")
+    assert called.get("ok")

--- a/tests/test_messagebox_style.py
+++ b/tests/test_messagebox_style.py
@@ -27,3 +27,59 @@ def test_askokcancel_uses_custom_dialog(monkeypatch):
         return False
     monkeypatch.setattr(mb, '_create_dialog', fake_dialog)
     assert mb.askokcancel('Title', 'Message') is False
+
+
+def test_create_dialog_uses_purple_button_style(monkeypatch):
+    styles = []
+
+    class DummyButton:
+        def __init__(self, master, **kwargs):
+            styles.append(kwargs.get("style"))
+
+        def pack(self, *a, **k):
+            pass
+
+    class DummyFrame:
+        def pack(self, *a, **k):
+            pass
+
+    class DummyLabel:
+        def pack(self, *a, **k):
+            pass
+
+    class DummyDialog:
+        def __init__(self, root):
+            self.protocol = lambda *a, **k: None
+
+        def title(self, *a, **k):
+            pass
+
+        def resizable(self, *a, **k):
+            pass
+
+        def transient(self, *a, **k):
+            pass
+
+        def grab_set(self):
+            pass
+
+        def destroy(self):
+            pass
+
+        def wait_window(self):
+            pass
+
+    monkeypatch.setattr(mb.ttk, "Button", DummyButton)
+    monkeypatch.setattr(mb.ttk, "Frame", lambda *a, **k: DummyFrame())
+    monkeypatch.setattr(mb.ttk, "Label", lambda *a, **k: DummyLabel())
+    monkeypatch.setattr(
+        mb.ttk,
+        "Style",
+        lambda *a, **k: type("S", (), {"configure": lambda *a, **k: None, "map": lambda *a, **k: None})(),
+    )
+    monkeypatch.setattr(mb.tk, "Toplevel", lambda root: DummyDialog(root))
+    monkeypatch.setattr(mb.tk, "_default_root", None)
+    monkeypatch.setattr(mb.tk, "Tk", lambda: type("Root", (), {"withdraw": lambda self: None})())
+
+    mb._create_dialog("Title", "Message", [("OK", True)])
+    assert styles == ["Purple.TButton"]


### PR DESCRIPTION
## Summary
- add purple button style for message boxes
- add translucent button style for toolboxes and navigation widgets
- cover new style utilities with tests

## Testing
- `pytest -q`
- `radon cc -j gui/mac_button_style.py gui/messagebox.py gui/toolboxes.py AutoML.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4f5f98f188327b07d7b5a2d8134db