### PR TITLE
Ensure application exits when main window closes

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -18931,6 +18931,8 @@ class AutoMLApp:
                     os.remove(path)
             except OSError:
                 pass
+        # Ensure the Tk event loop terminates and all windows are destroyed
+        self.root.quit()
         self.root.destroy()
 
     def show_about(self):

--- a/tests/test_confirm_close_quits.py
+++ b/tests/test_confirm_close_quits.py
@@ -1,0 +1,28 @@
+import tkinter as tk
+from unittest.mock import MagicMock
+
+import pytest
+
+from AutoML import AutoMLApp
+
+
+def test_confirm_close_quits_and_destroys():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter GUI not available")
+    root.withdraw()
+    quit_spy = MagicMock(wraps=root.quit)
+    destroy_spy = MagicMock(wraps=root.destroy)
+    root.quit = quit_spy
+    root.destroy = destroy_spy
+
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.root = root
+    app.has_unsaved_changes = lambda: False
+    app._loaded_model_paths = []
+
+    app.confirm_close()
+
+    assert quit_spy.called
+    assert destroy_spy.called


### PR DESCRIPTION
## Summary
- Ensure Tk event loop quits when exiting to fully close the application
- Add regression test confirming application calls `quit` and `destroy`

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a4f759d7e883279d604b20e53d16e3