### PR TITLE
Deduplicate governance core toolbox relationships

### DIFF
--- a/tests/test_toolbox_dynamic_relations.py
+++ b/tests/test_toolbox_dynamic_relations.py
@@ -105,3 +105,9 @@ def test_bidirectional_external_relations(tmp_path, monkeypatch):
     finally:
         monkeypatch.setattr(architecture, "_CONFIG_PATH", orig_path)
         architecture.reload_config()
+
+def test_governance_core_has_unique_relations():
+    defs = architecture._toolbox_defs()
+    core = defs["Governance Core"]
+    all_rels = core["relations"] + [r for sub in core["externals"].values() for r in sub["relations"]]
+    assert len(all_rels) == len(set(all_rels))


### PR DESCRIPTION
## Summary
- deduplicate governance core toolbox relations to avoid repeated entries
- add tests ensuring governance core relations are unique

## Testing
- `python tools/metrics_generator.py --path gui --output metrics.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4f6d7e0d083279b860e0d2ad213a2