### PR TITLE
Deduplicate governance core toolbox relations

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -356,6 +356,25 @@ def _external_relations_for(nodes: list[str]) -> dict[str, dict[str, list[str]]]
     return result
 
 
+def _dedup_category(data: dict) -> None:
+    """Remove duplicate relations within ``data`` and its externals."""
+
+    seen: set[str] = set()
+    rels: list[str] = []
+    for r in data.get("relations", []) or []:
+        if r not in seen:
+            seen.add(r)
+            rels.append(r)
+    data["relations"] = rels
+    for sub in data.get("externals", {}).values():
+        sub_rels: list[str] = []
+        for r in sub.get("relations", []) or []:
+            if r not in seen:
+                seen.add(r)
+                sub_rels.append(r)
+        sub["relations"] = sub_rels
+
+
 def _toolbox_defs() -> dict[str, dict[str, list[str] | dict]]:
     """Return mapping of toolbox name to node/relation lists."""
     defs: dict[str, dict[str, list[str] | dict]] = {}
@@ -378,11 +397,13 @@ def _toolbox_defs() -> dict[str, dict[str, list[str] | dict]]:
         # inserted via dedicated actions rather than direct toolbox buttons.
         # Still derive their relationships so users can connect existing
         # boundary elements.
-        defs["Governance Core"] = {
+        core = {
             "nodes": [],
             "relations": _relations_for(GOV_CORE_NODES),
             "externals": _external_relations_for(GOV_CORE_NODES),
         }
+        _dedup_category(core)
+        defs["Governance Core"] = core
     return defs
 
 
@@ -11638,23 +11659,6 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                     sub["relations"] = [
                         r for r in sub.get("relations", []) if r not in global_rels
                     ]
-
-        def _dedup_category(data: dict) -> None:
-            seen: set[str] = set()
-            rels = []
-            for r in data.get("relations", []) or []:
-                if r not in seen:
-                    seen.add(r)
-                    rels.append(r)
-            data["relations"] = rels
-            for sub in data.get("externals", {}).values():
-                sub_rels = []
-                for r in sub.get("relations", []) or []:
-                    if r not in seen:
-                        seen.add(r)
-                        sub_rels.append(r)
-                sub["relations"] = sub_rels
-
         for data in defs.values():
             _dedup_category(data)
         if ai_data:

--- a/tests/test_governance_toolbox_relation_dedup.py
+++ b/tests/test_governance_toolbox_relation_dedup.py
@@ -139,3 +139,79 @@ def test_category_relations_deduplicated(monkeypatch):
     assert art["relations"] == ["Approves"]
     assert art["externals"]["Roles"]["relations"] == ["Manage"]
     assert art["externals"]["Processes"]["relations"] == []
+
+
+def test_governance_core_relations_deduplicated(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+
+    defs_data = {
+        "Governance Core": {
+            "nodes": [],
+            "relations": ["Propagate", "Propagate", "Re-use"],
+            "externals": {
+                "Artifacts": {"nodes": [], "relations": ["Propagate", "Re-use", "Re-use"]},
+                "Entities": {"nodes": [], "relations": ["Propagate"]},
+            },
+        }
+    }
+    monkeypatch.setattr(arch, "_toolbox_defs", lambda: defs_data)
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def pack_forget(self, *a, **k):
+            pass
+
+        def bind(self, *a, **k):
+            pass
+
+        def configure(self, *a, **k):
+            pass
+
+        def destroy(self, *a, **k):
+            pass
+
+    def fake_sysml_init(
+        self,
+        master,
+        title,
+        tools,
+        diagram_id=None,
+        app=None,
+        history=None,
+        relation_tools=None,
+        tool_groups=None,
+    ):
+        self.app = app
+        self.repo = repo
+        self.diagram_id = diagram_id
+        self.toolbox = DummyWidget()
+        self.tools_frame = DummyWidget()
+        self.rel_frame = DummyWidget()
+        self.toolbox_selector = DummyWidget()
+        self.toolbox_var = types.SimpleNamespace(get=lambda: "", set=lambda v: None)
+        self.relation_tools = relation_tools or []
+        self._toolbox_frames = {}
+        self.canvas = types.SimpleNamespace(master=DummyWidget())
+
+    monkeypatch.setattr(arch.SysMLDiagramWindow, "__init__", fake_sysml_init)
+    monkeypatch.setattr(arch, "draw_icon", lambda *a, **k: None)
+    monkeypatch.setattr(
+        arch.GovernanceDiagramWindow, "refresh_from_repository", lambda self: None
+    )
+    monkeypatch.setattr(arch.ttk, "Combobox", DummyWidget)
+    monkeypatch.setattr(arch.ttk, "Frame", DummyWidget)
+    monkeypatch.setattr(arch.ttk, "LabelFrame", DummyWidget)
+    monkeypatch.setattr(arch.ttk, "Button", DummyWidget)
+
+    GovernanceDiagramWindow(None, None, diagram_id=diag.diag_id)
+    core = defs_data["Governance Core"]
+    assert core["relations"] == ["Propagate", "Re-use"]
+    assert core["externals"]["Artifacts"]["relations"] == []
+    assert core["externals"]["Entities"]["relations"] == []


### PR DESCRIPTION
## Summary
- add helper to remove duplicate relations from toolbox data
- deduplicate governance core relations when building toolboxes
- test governance core toolbox for relation deduplication

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a4f6d7e0d083279b860e0d2ad213a2