### PR TITLE
Fix CapsuleButton glow outline sizing

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -371,12 +371,12 @@ class CapsuleButton(tk.Canvas):
         r = self._radius
         glow_color = _lighten(self._current_color, 1.3)
         self._glow_items = [
-            self.create_arc((2, 2, 2 * r - 2, h - 2), start=90, extent=180, style=tk.ARC, outline=glow_color, width=2),
-            self.create_line(r, 2, w - r, 2, fill=glow_color, width=2),
-            self.create_arc((w - 2 * r + 2, 2, w - 2, h - 2), start=-90, extent=180, style=tk.ARC, outline=glow_color, width=2),
-            self.create_line(2, r, 2, h - r, fill=glow_color, width=2),
-            self.create_line(r, h - 2, w - r, h - 2, fill=glow_color, width=2),
-            self.create_line(w - 2, r, w - 2, h - r, fill=glow_color, width=2),
+            self.create_arc((-1, -1, 2 * r + 1, h + 1), start=90, extent=180, style=tk.ARC, outline=glow_color, width=2),
+            self.create_line(r, -1, w - r, -1, fill=glow_color, width=2),
+            self.create_arc((w - 2 * r - 1, -1, w + 1, h + 1), start=-90, extent=180, style=tk.ARC, outline=glow_color, width=2),
+            self.create_line(-1, r, -1, h - r, fill=glow_color, width=2),
+            self.create_line(r, h + 1, w - r, h + 1, fill=glow_color, width=2),
+            self.create_line(w + 1, r, w + 1, h - r, fill=glow_color, width=2),
         ]
 
     def _remove_glow(self) -> None:


### PR DESCRIPTION
## Summary
- ensure CapsuleButton glow outline matches button dimensions so highlight is not too small
- position glow drawing just outside button edges to avoid inset outlines

## Testing
- `pytest -q`
- ⚠️ `radon cc -s -j gui/capsule_button.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4f15cd394832795e5ff48090d8c49