### PR TITLE
Fix glow outline width to fully surround capsule buttons

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -372,10 +372,13 @@ class CapsuleButton(tk.Canvas):
         glow_color = _lighten(self._current_color, 1.3)
         self._glow_items = [
             self.create_arc((-1, -1, 2 * r + 1, h + 1), start=90, extent=180, style=tk.ARC, outline=glow_color, width=2),
-            self.create_line(r, -1, w - r, -1, fill=glow_color, width=2),
+            # Offset the horizontal glow lines by one pixel so the caps extend
+            # beyond the button edge.  Without this adjustment the highlight
+            # appears slightly narrower than the button itself.
+            self.create_line(r - 1, -1, w - r + 1, -1, fill=glow_color, width=2),
             self.create_arc((w - 2 * r - 1, -1, w + 1, h + 1), start=-90, extent=180, style=tk.ARC, outline=glow_color, width=2),
             self.create_line(-1, r, -1, h - r, fill=glow_color, width=2),
-            self.create_line(r, h + 1, w - r, h + 1, fill=glow_color, width=2),
+            self.create_line(r - 1, h + 1, w - r + 1, h + 1, fill=glow_color, width=2),
             self.create_line(w + 1, r, w + 1, h - r, fill=glow_color, width=2),
         ]
 

--- a/tests/test_capsule_button_glow_outline.py
+++ b/tests/test_capsule_button_glow_outline.py
@@ -20,3 +20,21 @@ def test_glow_edges_only():
     item_types = {btn.type(i) for i in btn._glow_items}
     assert "oval" not in item_types
     root.destroy()
+
+
+def test_glow_matches_button_width():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Glow")
+    btn.pack()
+    root.update_idletasks()
+    btn._on_enter(type("E", (), {})())
+    w = int(btn["width"])
+    r = btn._radius
+    top_line = btn._glow_items[1]
+    x1, _y1, x2, _y2 = btn.coords(top_line)
+    assert x1 == r - 1
+    assert x2 == w - r + 1
+    root.destroy()


### PR DESCRIPTION
## Summary
- ensure capsule button glow lines extend one pixel beyond edges so highlight matches button width
- add regression test verifying glow outline spans entire button

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path . --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a4fae6ca308327ad80980c8222a50c