### PR TITLE
Deduplicate governance toolbox relations across categories

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -356,10 +356,17 @@ def _external_relations_for(nodes: list[str]) -> dict[str, dict[str, list[str]]]
     return result
 
 
-def _dedup_category(data: dict) -> None:
-    """Remove duplicate relations within ``data`` and its externals."""
+def _dedup_category(data: dict, seen: set[str] | None = None) -> None:
+    """Remove duplicate relations within ``data`` and its externals.
 
-    seen: set[str] = set()
+    When ``seen`` is provided the set is used to track relationships across
+    categories so each relationship only appears once in the toolbox overall.
+    Any relations kept in ``data`` or its externals are added to ``seen`` for
+    subsequent calls.
+    """
+
+    if seen is None:
+        seen = set()
     rels: list[str] = []
     for r in data.get("relations", []) or []:
         if r not in seen:
@@ -11659,10 +11666,11 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                     sub["relations"] = [
                         r for r in sub.get("relations", []) if r not in global_rels
                     ]
+        seen_rels: set[str] = set()
         for data in defs.values():
-            _dedup_category(data)
+            _dedup_category(data, seen_rels)
         if ai_data:
-            _dedup_category(ai_data)
+            _dedup_category(ai_data, seen_rels)
         if hasattr(self.tools_frame, "pack_forget"):
             self.tools_frame.pack_forget()
         if getattr(self, "rel_frame", None) and hasattr(self.rel_frame, "pack_forget"):

--- a/tests/test_governance_toolbox_relation_dedup.py
+++ b/tests/test_governance_toolbox_relation_dedup.py
@@ -215,3 +215,71 @@ def test_governance_core_relations_deduplicated(monkeypatch):
     assert core["relations"] == ["Propagate", "Re-use"]
     assert core["externals"]["Artifacts"]["relations"] == []
     assert core["externals"]["Entities"]["relations"] == []
+
+
+def test_relations_deduplicated_across_categories(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+
+    defs_data = {
+        "First": {"nodes": [], "relations": ["Link"], "externals": {}},
+        "Second": {"nodes": [], "relations": ["Link", "Trace"], "externals": {}},
+    }
+    monkeypatch.setattr(arch, "_toolbox_defs", lambda: defs_data)
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def pack_forget(self, *a, **k):
+            pass
+
+        def bind(self, *a, **k):
+            pass
+
+        def configure(self, *a, **k):
+            pass
+
+        def destroy(self, *a, **k):
+            pass
+
+    def fake_sysml_init(
+        self,
+        master,
+        title,
+        tools,
+        diagram_id=None,
+        app=None,
+        history=None,
+        relation_tools=None,
+        tool_groups=None,
+    ):
+        self.app = app
+        self.repo = repo
+        self.diagram_id = diagram_id
+        self.toolbox = DummyWidget()
+        self.tools_frame = DummyWidget()
+        self.rel_frame = DummyWidget()
+        self.toolbox_selector = DummyWidget()
+        self.toolbox_var = types.SimpleNamespace(get=lambda: "", set=lambda v: None)
+        self.relation_tools = relation_tools or []
+        self._toolbox_frames = {}
+        self.canvas = types.SimpleNamespace(master=DummyWidget())
+
+    monkeypatch.setattr(arch.SysMLDiagramWindow, "__init__", fake_sysml_init)
+    monkeypatch.setattr(arch, "draw_icon", lambda *a, **k: None)
+    monkeypatch.setattr(
+        arch.GovernanceDiagramWindow, "refresh_from_repository", lambda self: None
+    )
+    monkeypatch.setattr(arch.ttk, "Combobox", DummyWidget)
+    monkeypatch.setattr(arch.ttk, "Frame", DummyWidget)
+    monkeypatch.setattr(arch.ttk, "LabelFrame", DummyWidget)
+    monkeypatch.setattr(arch.ttk, "Button", DummyWidget)
+
+    GovernanceDiagramWindow(None, None, diagram_id=diag.diag_id)
+    assert defs_data["First"]["relations"] == ["Link"]
+    assert defs_data["Second"]["relations"] == ["Trace"]


### PR DESCRIPTION
## Summary
- ensure governance toolbox relationships appear only once across categories
- allow `_dedup_category` to track previously seen relations
- test cross-category relationship deduplication

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_b_68a4fa75f49083279b7dff0d7fd60c79