### PR TITLE
feat: add translucent and purple button styles

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -8,11 +8,25 @@ from tkinter import ttk
 
 from .capsule_button import CapsuleButton  # noqa: F401
 
+
+def _translucid_button(*args, **kwargs):
+    """Return a :class:`CapsuleButton` with a subtle translucent palette.
+
+    All toolboxes across the application use this factory to provide a
+    consistent, low‑key appearance.  Callers may override the colours by
+    supplying ``bg``/``hover_bg`` in *kwargs*.
+    """
+
+    kwargs.setdefault("bg", "#ffffff")
+    kwargs.setdefault("hover_bg", "#f0f0f0")
+    return CapsuleButton(*args, **kwargs)
+
+
 # Use CapsuleButton for all button instances across the GUI.  Monkeypatching
 # both ``ttk.Button`` and the classic ``tk.Button`` ensures the custom hover
 # highlight is applied consistently without modifying every call site.
-ttk.Button = CapsuleButton  # type: ignore[assignment]
-tk.Button = CapsuleButton  # type: ignore[assignment]
+ttk.Button = _translucid_button  # type: ignore[assignment]
+tk.Button = _translucid_button  # type: ignore[assignment]
 
 def format_name_with_phase(name: str, phase: str | None) -> str:
     """Return ``name`` with ``" (phase)"`` appended when ``phase")" is set."""

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -81,7 +81,11 @@ def _create_dialog(
 
     for text, value in buttons:
         ttk.Button(
-            frame, text=text, style="Purple.TButton", command=lambda v=value: _set(v)
+            frame,
+            text=text,
+            bg="#9b59b6",
+            hover_bg="#b37cc8",
+            command=lambda v=value: _set(v),
         ).pack(side="left", padx=5)
 
     dialog.protocol("WM_DELETE_WINDOW", lambda: _set(None))

--- a/tests/test_messagebox_style.py
+++ b/tests/test_messagebox_style.py
@@ -30,11 +30,11 @@ def test_askokcancel_uses_custom_dialog(monkeypatch):
 
 
 def test_create_dialog_uses_purple_button_style(monkeypatch):
-    styles = []
+    colors = []
 
     class DummyButton:
         def __init__(self, master, **kwargs):
-            styles.append(kwargs.get("style"))
+            colors.append((kwargs.get("bg"), kwargs.get("hover_bg")))
 
         def pack(self, *a, **k):
             pass
@@ -94,7 +94,7 @@ def test_create_dialog_uses_purple_button_style(monkeypatch):
     )
 
     mb._create_dialog("Title", "Message", [("OK", True)])
-    assert styles == ["Purple.TButton"]
+    assert colors == [("#9b59b6", "#b37cc8")]
 
 
 def test_create_dialog_keeps_existing_root(monkeypatch):


### PR DESCRIPTION
## Summary
- make CapsuleButton default to a translucent palette across the GUI
- style message box buttons with a purple theme
- adjust tests for updated button coloring

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*
- `radon cc -j gui/messagebox.py gui/__init__.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a4fcdb73fc8327ad4d55f6166dff0a