### PR TITLE
Center GUI message boxes and fix size

### DIFF
--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -65,6 +65,15 @@ def _create_dialog(
     dialog.transient(root)
     dialog.grab_set()
 
+    # Ensure dialog appears above all other windows and is centered on screen
+    dialog.attributes("-topmost", True)
+    dialog.update_idletasks()
+    width, height = 300, 150
+    x = int(dialog.winfo_screenwidth() / 2 - width / 2)
+    y = int(dialog.winfo_screenheight() / 2 - height / 2)
+    dialog.geometry(f"{width}x{height}+{x}+{y}")
+    dialog.lift()
+
     frame = ttk.Frame(dialog, padding=10)
     frame.pack(fill="both", expand=True)
     ttk.Label(frame, text=message or "").pack(pady=(0, 10))

--- a/tests/test_messagebox_style.py
+++ b/tests/test_messagebox_style.py
@@ -1,6 +1,6 @@
 import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from gui import messagebox
+from gui import messagebox as mb
 
 
 def test_askyesno_uses_custom_dialog(monkeypatch):
@@ -53,16 +53,44 @@ def test_create_dialog_uses_purple_button_style(monkeypatch):
         def pack(self, *a, **k):
             pass
 
-    class DummyTop:
+    class DummyDialog:
         def __init__(self, root):
             pass
+
         def title(self, *a):
+            pass
+
+        def resizable(self, *a, **k):
+            pass
+
+        def transient(self, *a, **k):
             pass
 
         def grab_set(self):
             pass
 
+        def geometry(self, *a, **k):
+            pass
+
+        def update_idletasks(self):
+            pass
+
+        def attributes(self, *a, **k):
+            pass
+
+        def lift(self, *a, **k):
+            pass
+
+        def winfo_screenwidth(self):
+            return 1000
+
+        def winfo_screenheight(self):
+            return 800
+
         def destroy(self):
+            pass
+
+        def protocol(self, *a, **k):
             pass
 
         def wait_window(self):
@@ -103,14 +131,37 @@ def test_create_dialog_keeps_existing_root(monkeypatch):
 
         def resizable(self, *a, **k):
             pass
+
         def transient(self, *a, **k):
             pass
+
         def grab_set(self):
             pass
+
+        def geometry(self, *a, **k):
+            pass
+
+        def update_idletasks(self):
+            pass
+
+        def attributes(self, *a, **k):
+            pass
+
+        def lift(self, *a, **k):
+            pass
+
+        def winfo_screenwidth(self):
+            return 1000
+
+        def winfo_screenheight(self):
+            return 800
+
         def destroy(self):
             pass
+
         def protocol(self, *a, **k):
             pass
+
         def wait_window(self):
             pass
 


### PR DESCRIPTION
## Summary
- Center message box dialogs on screen with fixed size and topmost display
- Update message box tests to use simplified dummy dialogs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a506f09b1483279ad84a34bf93ed68