### PR TITLE
feat: highlight button icons on hover

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -34,3 +34,57 @@ def set_uniform_button_width(widget: tk.Misc) -> None:
             btn.configure(width=max_width)
         except Exception:  # pragma: no cover - defensive
             pass
+
+
+def _lighten_color(color: str, factor: float = 1.2) -> str:
+    """Return *color* lightened by *factor* while clamping to valid range."""
+    r = int(color[1:3], 16)
+    g = int(color[3:5], 16)
+    b = int(color[5:7], 16)
+    r = min(int(r * factor), 255)
+    g = min(int(g * factor), 255)
+    b = min(int(b * factor), 255)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _lighten_image(img: tk.PhotoImage, factor: float = 1.2) -> tk.PhotoImage:
+    """Return a new image with all non-black pixels lightened."""
+    w, h = img.width(), img.height()
+    new_img = tk.PhotoImage(width=w, height=h)
+    for x in range(w):
+        for y in range(h):
+            pixel = img.get(x, y)
+            # ``PhotoImage.get`` may return a tuple or an empty string for
+            # transparency.  Normalise to ``#rrggbb`` when a colour is present.
+            if isinstance(pixel, tuple):
+                if len(pixel) == 4 and pixel[3] == 0:
+                    continue
+                pixel = f"#{pixel[0]:02x}{pixel[1]:02x}{pixel[2]:02x}"
+            if not pixel:
+                continue
+            if pixel.lower() == "#000000":
+                new_img.put(pixel, (x, y))
+            else:
+                new_img.put(_lighten_color(pixel, factor), (x, y))
+    return new_img
+
+
+def add_hover_highlight(
+    button: ttk.Button, image: tk.PhotoImage, factor: float = 1.2
+) -> tk.PhotoImage:
+    """Swap *button* image to a lighter variant on hover.
+
+    The returned :class:`tk.PhotoImage` is the generated hover image.  A
+    reference to both normal and hover images is stored on the button to avoid
+    them being garbage collected.
+    """
+
+    hover_img = _lighten_image(image, factor)
+    button.configure(image=image)
+    # Preserve references so Tk does not discard the images
+    button._normal_image = image  # type: ignore[attr-defined]
+    button._hover_image = hover_img  # type: ignore[attr-defined]
+    button.bind("<Enter>", lambda _e: button.configure(image=hover_img))
+    button.bind("<Leave>", lambda _e: button.configure(image=image))
+    return hover_img
+

--- a/gui/toolboxes.py
+++ b/gui/toolboxes.py
@@ -8,6 +8,7 @@ import textwrap
 import uuid
 
 from gui.tooltip import ToolTip
+from gui.button_utils import add_hover_highlight
 from sysml.sysml_repository import SysMLRepository
 from analysis.models import (
     ReliabilityComponent,
@@ -665,6 +666,7 @@ class ReliabilityWindow(tk.Frame):
             compound=tk.LEFT,
             command=self.load_csv,
         )
+        add_hover_highlight(load_btn, self._icons["load"])
         load_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(load_btn, "Import components from a CSV Bill of Materials.")
 
@@ -675,6 +677,7 @@ class ReliabilityWindow(tk.Frame):
             compound=tk.LEFT,
             command=self.add_component,
         )
+        add_hover_highlight(add_btn, self._icons["add"])
         add_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(add_btn, "Create a new component entry manually.")
 
@@ -685,6 +688,7 @@ class ReliabilityWindow(tk.Frame):
             compound=tk.LEFT,
             command=self.configure_component,
         )
+        add_hover_highlight(cfg_btn, self._icons["cfg"])
         cfg_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(cfg_btn, "Edit parameters of the selected component.")
 
@@ -695,6 +699,7 @@ class ReliabilityWindow(tk.Frame):
             compound=tk.LEFT,
             command=self.delete_component,
         )
+        add_hover_highlight(del_comp_btn, self._icons["del"])
         del_comp_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(del_comp_btn, "Remove the selected component from the table.")
 
@@ -705,6 +710,7 @@ class ReliabilityWindow(tk.Frame):
             compound=tk.LEFT,
             command=self.calculate_fit,
         )
+        add_hover_highlight(calc_btn, self._icons["calc"])
         calc_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(
             calc_btn,
@@ -718,6 +724,7 @@ class ReliabilityWindow(tk.Frame):
             compound=tk.LEFT,
             command=self.save_analysis,
         )
+        add_hover_highlight(save_btn, self._icons["save"])
         save_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(save_btn, "Store the current analysis in the project file.")
 
@@ -728,6 +735,7 @@ class ReliabilityWindow(tk.Frame):
             compound=tk.LEFT,
             command=self.load_analysis,
         )
+        add_hover_highlight(load_an_btn, self._icons["load"])
         load_an_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(load_an_btn, "Reload a previously saved reliability analysis.")
 
@@ -738,6 +746,7 @@ class ReliabilityWindow(tk.Frame):
             compound=tk.LEFT,
             command=self.delete_analysis,
         )
+        add_hover_highlight(del_btn, self._icons["del"])
         del_btn.pack(side=tk.LEFT, padx=2, pady=2)
         ToolTip(del_btn, "Remove the selected analysis from the project.")
         self.formula_label = ttk.Label(self, text="")

--- a/tests/test_button_hover_highlight.py
+++ b/tests/test_button_hover_highlight.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.button_utils import add_hover_highlight
+
+
+def _sum_rgb(value):
+    if isinstance(value, tuple):
+        return sum(value[:3])
+    return sum(int(value[i : i + 2], 16) for i in (1, 3, 5))
+
+
+def test_add_hover_highlight_swaps_to_lighter_image():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    img = tk.PhotoImage(width=2, height=2)
+    img.put("#808080", to=(0, 0, 2, 2))
+    btn = ttk.Button(root, image=img)
+    hover_img = add_hover_highlight(btn, img)
+
+    btn.event_generate("<Enter>")
+    root.update_idletasks()
+
+    assert btn.cget("image") == str(hover_img)
+    assert _sum_rgb(hover_img.get(0, 0)) > _sum_rgb(img.get(0, 0))
+    root.destroy()
+


### PR DESCRIPTION
## Summary
- add `add_hover_highlight` to lighten button images on mouse hover
- apply hover highlight to toolbox buttons
- test hover image swap for lighter tones

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a51076ecd08327ac1037972d0df34a