### PR TITLE
Fix log popup sizing when explorer is pinned

### DIFF
--- a/gui/logger.py
+++ b/gui/logger.py
@@ -12,6 +12,9 @@ _toggle_button = None
 _default_height = 0
 _line_height = 0
 _auto_hide_id = None
+# Start and end indices of the most recently logged message
+_last_msg_start = "1.0"
+_last_msg_end = "1.0"
 
 # Mapping of log levels to the tag name that will be used for colouring
 _LEVEL_TAGS = {
@@ -179,15 +182,32 @@ def show_temporarily(duration=3000, lines: int | None = None):
     duration:
         Time in milliseconds before hiding the log window.
     lines:
-        Number of display lines to show. If provided, the log window is sized
-        to exactly fit that many lines rather than the default height.
+        If provided, explicitly size the log window for this many display lines
+        (plus an extra trailing blank).  When ``None`` the required pixel height
+        is calculated from the most recently logged message so that all of its
+        lines remain visible even when other panes alter the available width.
     """
     global _auto_hide_id
     if not log_frame:
         return
     show_log()
-    if lines:
-        log_frame.configure(height=_line_height * lines)
+    log_widget.update_idletasks()
+    height = None
+    if lines is None:
+        try:
+            height = log_widget.count(_last_msg_start, _last_msg_end, "ypixels")[0]
+        except Exception:
+            try:
+                lines = log_widget.count(
+                    _last_msg_start, _last_msg_end, "displaylines"
+                )[0]
+                height = _line_height * lines
+            except Exception:
+                pass
+    else:
+        height = _line_height * (lines + 1)
+    if height:
+        log_frame.configure(height=height)
     if _auto_hide_id:
         log_frame.after_cancel(_auto_hide_id)
     _auto_hide_id = log_frame.after(duration, lambda: hide_log(animate=True))
@@ -218,18 +238,20 @@ def log_message(message: str, level: str = "INFO") -> int:
 
     Returns the number of display lines added for the message.
     """
+    global _last_msg_start, _last_msg_end
     if not log_widget:
         return 0
     log_widget.configure(state="normal")
     tag = _LEVEL_TAGS.get(level.upper(), "info")
     start_index = log_widget.index("end-1c")
     log_widget.insert(tk.END, f"[{level}] {message}\n", tag)
-    end_index = log_widget.index("end-1c")
+    end_index = log_widget.index("end")
+    _last_msg_start, _last_msg_end = start_index, end_index
     log_widget.see(tk.END)
     log_widget.configure(state="disabled")
     _update_line_numbers()
     try:
-        return log_widget.count(start_index, end_index, "displaylines")[0]
+        return log_widget.count(start_index, end_index, "displaylines")[0] - 1
     except Exception:
         # Fallback to a simple newline count if displaylines is unsupported
         return message.count("\n") + 1

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -28,8 +28,8 @@ def _log_and_return(title: str | None, message: str | None, level: str) -> str:
         Log level to associate with the message.
     """
 
-    lines = logger.log_message(f"{title}: {message}", level)
-    logger.show_temporarily(lines=lines)
+    logger.log_message(f"{title}: {message}", level)
+    logger.show_temporarily()
     return "ok"
 
 
@@ -98,8 +98,8 @@ def _create_dialog(
 
 
 def askyesno(title=None, message=None, **options):
-    lines = logger.log_message(f"{title}: {message}", "ASK")
-    logger.show_temporarily(lines=lines)
+    logger.log_message(f"{title}: {message}", "ASK")
+    logger.show_temporarily()
     try:
         return bool(
             _create_dialog(title, message, [("Yes", True), ("No", False)])
@@ -109,8 +109,8 @@ def askyesno(title=None, message=None, **options):
 
 
 def askyesnocancel(title=None, message=None, **options):
-    lines = logger.log_message(f"{title}: {message}", "ASK")
-    logger.show_temporarily(lines=lines)
+    logger.log_message(f"{title}: {message}", "ASK")
+    logger.show_temporarily()
     try:
         return _create_dialog(
             title, message, [("Yes", True), ("No", False), ("Cancel", None)]
@@ -120,8 +120,8 @@ def askyesnocancel(title=None, message=None, **options):
 
 
 def askokcancel(title=None, message=None, **options):
-    lines = logger.log_message(f"{title}: {message}", "ASK")
-    logger.show_temporarily(lines=lines)
+    logger.log_message(f"{title}: {message}", "ASK")
+    logger.show_temporarily()
     try:
         return bool(
             _create_dialog(title, message, [("OK", True), ("Cancel", False)])

--- a/tests/test_log_window_resize.py
+++ b/tests/test_log_window_resize.py
@@ -6,6 +6,7 @@ import pytest
 # Ensure repository root in path
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from gui import logger, messagebox
+from AutoML import AutoMLApp
 
 
 def test_log_window_expands_to_fit_message():
@@ -18,9 +19,8 @@ def test_log_window_expands_to_fit_message():
     default_height = logger._default_height
     messagebox.showinfo("Title", long_message)
     root.update_idletasks()
-    display_lines = logger.log_widget.count("1.0", "end-1c", "displaylines")[0]
-    expected_height = logger._line_height * display_lines
-    assert logger.log_frame.winfo_height() == expected_height
+    pixels = logger.log_widget.count("1.0", "end", "ypixels")[0]
+    assert logger.log_frame.winfo_height() == pixels
     assert logger.log_frame.winfo_height() > default_height
     root.destroy()
 
@@ -34,7 +34,22 @@ def test_log_window_shrinks_to_message_lines():
     short_message = "short"
     messagebox.showinfo("Title", short_message)
     root.update_idletasks()
-    expected_height = logger._line_height
-    assert logger.log_frame.winfo_height() == expected_height
-    assert expected_height < logger._default_height
+    pixels = logger.log_widget.count("1.0", "end", "ypixels")[0]
+    assert logger.log_frame.winfo_height() == pixels
+    assert pixels < logger._default_height
+    root.destroy()
+
+
+def test_log_window_resizes_with_pinned_explorer():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    app = AutoMLApp(root)
+    app.toggle_explorer_pin()
+    long_message = "Pinned panel message " * 40
+    messagebox.showinfo("Title", long_message)
+    root.update_idletasks()
+    pixels = logger.log_widget.count("1.0", "end", "ypixels")[0]
+    assert logger.log_frame.winfo_height() == pixels
     root.destroy()


### PR DESCRIPTION
## Summary
- compute popup height in pixels from the last log message so pinned panels no longer crop text
- track message end index including trailing newline
- validate log window sizing with pixel-based tests

## Testing
- `python tools/metrics_generator.py --output metrics.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a50a8a89f48327912217ee8eb8344b