### PR TITLE
Highlight capsule button icons on hover

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -40,6 +40,25 @@ def _interpolate_color(c1: str, c2: str, t: float) -> str:
     return _rgb_to_hex((r, g, b))
 
 
+def _lighten_image(img: tk.PhotoImage, factor: float = 1.2) -> tk.PhotoImage:
+    """Return a lightened copy of *img* preserving transparency."""
+    w, h = img.width(), img.height()
+    new = tk.PhotoImage(width=w, height=h)
+    for x in range(w):
+        for y in range(h):
+            pixel = img.get(x, y)
+            if pixel in ("", "{}", None):
+                # Transparent pixel; copy as-is
+                new.put(pixel, (x, y))
+                continue
+            if isinstance(pixel, tuple):
+                color = _rgb_to_hex(pixel[:3])
+            else:
+                color = pixel
+            new.put(_lighten(color, factor), (x, y))
+    return new
+
+
 class CapsuleButton(tk.Canvas):
     """A capsule-shaped button that lightens on hover and appears recessed.
 
@@ -87,7 +106,9 @@ class CapsuleButton(tk.Canvas):
         kwargs.pop("compound", None)
         self._text = text
         self._image = image
+        self._hover_image = _lighten_image(image) if image else None
         self._compound = compound
+        self._current_image = self._image
         req_width = max(width, self._content_width(height))
         init_kwargs["width"] = req_width
         init_kwargs.update(kwargs)
@@ -264,19 +285,19 @@ class CapsuleButton(tk.Canvas):
         # are recreated when drawing the button.
         self._image_item = None
         self._icon_highlight_item = None
-        if self._image and self._text and self._compound == tk.LEFT:
+        if self._current_image and self._text and self._compound == tk.LEFT:
             font = tkfont.nametofont("TkDefaultFont")
             text_w = font.measure(self._text)
-            img_w = self._image.width()
+            img_w = self._current_image.width()
             spacing = 4
             total = text_w + img_w + spacing
             start = (w - total) // 2
             img_x = start + img_w // 2
             text_x = start + img_w + spacing + text_w // 2
-            self._image_item = self.create_image(img_x, cy, image=self._image)
+            self._image_item = self.create_image(img_x, cy, image=self._current_image)
             self._text_item = self.create_text(text_x, cy, text=self._text)
-        elif self._image:
-            self._image_item = self.create_image(cx, cy, image=self._image)
+        elif self._current_image:
+            self._image_item = self.create_image(cx, cy, image=self._current_image)
         else:
             self._text_item = self.create_text(cx, cy, text=self._text)
 
@@ -409,11 +430,17 @@ class CapsuleButton(tk.Canvas):
     def _on_enter(self, _event: tk.Event) -> None:
         if "disabled" not in self._state:
             self._set_color(self._hover_color)
+            if self._image_item and self._hover_image:
+                self.itemconfigure(self._image_item, image=self._hover_image)
+                self._current_image = self._hover_image
             self._add_glow()
 
     def _on_leave(self, _event: tk.Event) -> None:
         if "disabled" not in self._state:
             self._set_color(self._normal_color)
+            if self._image_item and self._hover_image:
+                self.itemconfigure(self._image_item, image=self._image)
+                self._current_image = self._image
             self._remove_glow()
 
     def _on_press(self, _event: tk.Event) -> None:
@@ -502,6 +529,8 @@ class CapsuleButton(tk.Canvas):
         changed = False
         if image is not None:
             self._image = image
+            self._hover_image = _lighten_image(image)
+            self._current_image = self._image
             changed = True
         if compound is not None:
             self._compound = compound

--- a/tests/test_capsule_button_hover_icon.py
+++ b/tests/test_capsule_button_hover_icon.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+import tkinter as tk
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.capsule_button import CapsuleButton, _lighten
+
+
+def test_capsule_button_lightens_icon_on_hover():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    img = tk.PhotoImage(width=1, height=1)
+    img.put("#808080", to=(0, 0, 1, 1))
+    btn = CapsuleButton(root, image=img)
+    btn.pack()
+    root.update_idletasks()
+    # hover image should be a lighter tone of original
+    assert btn._hover_image.get(0, 0) == _lighten("#808080")
+    btn._on_enter(type("E", (), {})())
+    assert btn.itemcget(btn._image_item, "image") == str(btn._hover_image)
+    btn._on_leave(type("E", (), {})())
+    assert btn.itemcget(btn._image_item, "image") == str(btn._image)
+    root.destroy()
+
+
+def test_capsule_button_preserves_transparency_on_hover():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    img = tk.PhotoImage(width=2, height=1)
+    img.put("#808080", to=(0, 0, 1, 1))
+    btn = CapsuleButton(root, image=img)
+    btn.pack()
+    root.update_idletasks()
+    assert btn._image.get(1, 0) == "{}"
+    assert btn._hover_image.get(1, 0) == btn._image.get(1, 0)
+    btn._on_enter(type("E", (), {})())
+    assert btn.itemcget(btn._image_item, "image") == str(btn._hover_image)
+    btn._on_leave(type("E", (), {})())
+    assert btn.itemcget(btn._image_item, "image") == str(btn._image)
+    root.destroy()


### PR DESCRIPTION
## Summary
- Lighten button icons when hovered by generating a brighter image variant
- Switch between normal and lightened images on mouse enter/leave
- Preserve icon transparency when lightening for hover and test this behaviour

## Testing
- `pytest -q`
- ⚠️ `pip install radon` *(403 ProxyError)*
- ⚠️ `radon cc -j gui/capsule_button.py` *(command not found: radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a51076ecd08327ac1037972d0df34a