### PR TITLE
Show 'Used By' in governance core toolbox

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -11696,8 +11696,11 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
                         r for r in sub.get("relations", []) if r not in global_rels
                     ]
         seen_rels: set[str] = set()
-        for data in defs.values():
-            _dedup_category(data, seen_rels)
+        for name, data in defs.items():
+            if name == "Governance Core":
+                _dedup_category(data)
+            else:
+                _dedup_category(data, seen_rels)
         if ai_data:
             _dedup_category(ai_data, seen_rels)
         if hasattr(self.tools_frame, "pack_forget"):

--- a/tests/test_toolbox_dynamic_relations.py
+++ b/tests/test_toolbox_dynamic_relations.py
@@ -57,12 +57,15 @@ def test_governance_core_relations_and_externals(tmp_path, monkeypatch):
     # Governance core toolbox hides Work Product and Lifecycle Phase buttons
     # but should still expose all relationships between them.
     assert core["nodes"] == []
+    relations = core["relations"]
     assert {
         "Propagate",
         "Propagate by Review",
         "Propagate by Approval",
         "Re-use",
-    } <= set(core["relations"])
+        "Used By",
+    } <= set(relations)
+    assert relations.index("Used By") < relations.index("Used after Approval")
     orig_path = architecture._CONFIG_PATH
     cfg = load_json_with_comments(orig_path)
     new_cfg = json.loads(json.dumps(cfg))


### PR DESCRIPTION
## Summary
- Ensure Governance Core toolbox includes the "Used By" relation
- Verify "Used By" appears before "Used after Approval" through new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a51999b02083279aa7efd6f36ba997