### PR TITLE
Allow constrained by relation between work products

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -482,7 +482,8 @@
           "Guideline",
           "Policy",
           "Principle",
-          "Standard"
+          "Standard",
+          "Work Product"
         ],
         "AI Database": [
           "Guideline",

--- a/tests/test_governance_constrained_by_rules.py
+++ b/tests/test_governance_constrained_by_rules.py
@@ -11,3 +11,10 @@ def test_constrained_by_rules() -> None:
     rules = cfg["connection_rules"]["Governance Diagram"]["Constrained by"]
     assert set(rules["Organization"]) == {"Policy"}
     assert set(rules["Business Unit"]) == {"Principle"}
+    assert set(rules["Work Product"]) == {
+        "Guideline",
+        "Policy",
+        "Principle",
+        "Standard",
+        "Work Product",
+    }

--- a/tests/test_governance_element_connection_rules.py
+++ b/tests/test_governance_element_connection_rules.py
@@ -18,3 +18,10 @@ def test_governance_element_connection_rules():
     assert set(rules["Used By"]["Principle"]) == {"Lifecycle Phase"}
     assert set(rules["Used By"]["Standard"]) == {"Lifecycle Phase"}
     assert set(rules["Constrained by"]["Organization"]) == {"Policy"}
+    assert set(rules["Constrained by"]["Work Product"]) == {
+        "Guideline",
+        "Policy",
+        "Principle",
+        "Standard",
+        "Work Product",
+    }


### PR DESCRIPTION
## Summary
- permit Work Product-to-Work Product connections via "Constrained by" rules
- verify rule via governance connection tests

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path . --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a51a32e99483278f9646eaf9e6c493