### PR TITLE
Show logs window by default

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2923,16 +2923,17 @@ class AutoMLApp:
         self.main_pane = tk.PanedWindow(self.top_frame, orient=tk.HORIZONTAL)
         self.main_pane.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
 
-        # Initialise the log window but keep it hidden by default.
-        self.log_frame = logger.init_log_window(root, height=7)
+        # Initialise the log window and show it by default.
+        self.log_frame = logger.init_log_window(root, height=10)
         # Status bar showing lifecycle phase and object metadata
         self.status_frame = ttk.Frame(root)
         self.status_frame.pack(side=tk.BOTTOM, fill=tk.X)
         self.toggle_log_button = ttk.Button(
-            root, text="Show Logs", command=self.toggle_logs
+            root, text="Hide Logs", command=self.toggle_logs
         )
         self.toggle_log_button.pack(side=tk.BOTTOM, fill=tk.X)
         logger.set_toggle_button(self.toggle_log_button)
+        logger.show_log()
         self.style.configure(
             "Phase.TLabel",
             background="#4a6ea9",
@@ -10546,6 +10547,8 @@ class AutoMLApp:
             self._cancel_explorer_hide()
         else:
             self._schedule_explorer_hide()
+        # Ensure the log window and toggle button remain visible
+        logger.show_log()
 
     def _limit_explorer_size(self):
         """Ensure the explorer pane does not exceed the maximum width."""

--- a/gui/logger.py
+++ b/gui/logger.py
@@ -24,7 +24,7 @@ _LEVEL_TAGS = {
 }
 
 
-def init_log_window(root, height=7, dark_mode: bool = True):
+def init_log_window(root, height=10, dark_mode: bool = True):
     """Create and return an un-packed styled log window in *root*.
 
     Parameters
@@ -111,29 +111,29 @@ def set_toggle_button(button):
 
 
 def show_log():
-    """Display the log frame and update the toggle button text."""
+    """Display the log frame and ensure related widgets stay visible."""
     global _auto_hide_id
-    if not log_frame or log_frame.winfo_manager():
-        if log_frame and _auto_hide_id:
-            log_frame.after_cancel(_auto_hide_id)
-            _auto_hide_id = None
+    if not log_frame:
         return
+    if _auto_hide_id:
+        log_frame.after_cancel(_auto_hide_id)
+        _auto_hide_id = None
     log_frame.configure(height=_default_height)
-    # Pack the log frame below all other widgets so the toggle button
-    # remains visible even when additional panels (like the explorer)
-    # are pinned and consume vertical space.  By omitting the ``before``
-    # argument the log frame is placed at the very bottom, leaving the
-    # toggle button immediately above it.
-    log_frame.pack(side=tk.BOTTOM, fill=tk.X)
+    if not log_frame.winfo_manager():
+        # Pack the log frame below the toggle button so the button remains
+        # immediately accessible even when the explorer pane is pinned and
+        # alters the available vertical space.
+        if _toggle_button:
+            log_frame.pack(side=tk.BOTTOM, fill=tk.X, before=_toggle_button)
+        else:
+            log_frame.pack(side=tk.BOTTOM, fill=tk.X)
     if _toggle_button:
         _toggle_button.config(text="Hide Logs")
         # Ensure the toggle button remains visible when other panels
         # (such as a pinned explorer) might overlap it by raising it
         # to the top of the stacking order.
         _raise_widget(_toggle_button)
-    if _auto_hide_id:
-        log_frame.after_cancel(_auto_hide_id)
-        _auto_hide_id = None
+    _raise_widget(log_frame)
 
 
 def _animate_hide(height):

--- a/tests/test_log_button_visibility.py
+++ b/tests/test_log_button_visibility.py
@@ -5,6 +5,7 @@ import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from AutoML import AutoMLApp
+from gui import logger
 
 
 def test_log_toggle_button_visible_with_pinned_explorer():
@@ -15,8 +16,12 @@ def test_log_toggle_button_visible_with_pinned_explorer():
     app = AutoMLApp(root)
     # Pin the explorer pane which previously caused the toggle button to be hidden
     app.toggle_explorer_pin()
-    app.toggle_logs()  # show logs
+    # Logs are shown by default; ensure the toggle button remains visible
     root.update_idletasks()
     button_bottom = app.toggle_log_button.winfo_y() + app.toggle_log_button.winfo_height()
     assert button_bottom <= root.winfo_height()
+    # The log frame should sit directly beneath the toggle button at its
+    # default height even when the explorer pane is pinned.
+    assert logger.log_frame.winfo_y() >= button_bottom
+    assert logger.log_frame.winfo_height() == logger._default_height
     root.destroy()

--- a/tests/test_log_window_resize.py
+++ b/tests/test_log_window_resize.py
@@ -69,3 +69,20 @@ def test_log_window_resizes_with_pinned_explorer():
     expected_height = logger._line_height * display_lines
     assert logger.log_frame.winfo_height() == expected_height
     root.destroy()
+
+
+def test_log_window_visible_by_default_and_with_pinned_explorer():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    app = AutoMLApp(root)
+    root.update_idletasks()
+    assert logger.log_frame.winfo_manager() == "pack"
+    assert logger.log_frame.winfo_height() == logger._default_height
+    assert logger._default_height == logger._line_height * 10
+    app.toggle_explorer_pin()
+    root.update_idletasks()
+    assert logger.log_frame.winfo_manager() == "pack"
+    assert logger.log_frame.winfo_height() == logger._default_height
+    root.destroy()


### PR DESCRIPTION
## Summary
- Keep log frame beneath the toggle button so both remain visible even with a pinned explorer pane
- Verify toggle button and log frame layout with new regression test

## Testing
- `pytest -q`
- `radon cc . -s -j` *(fails: command not found; `pip install radon` reports 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a51a7570148327a3218cfadeb48206