### PR TITLE
Allow tasks to consume requirement specifications

### DIFF
--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -549,7 +549,9 @@
         "Software Component": [],
         "Standard": [],
         "System": [],
-        "Task": [],
+        "Task": [
+          "Work Product"
+        ],
         "Test Suite": [],
         "Vehicle": [],
         "Work Product": [],

--- a/tests/test_governance_task_consumes_requirement_spec.py
+++ b/tests/test_governance_task_consumes_requirement_spec.py
@@ -1,0 +1,16 @@
+import types
+
+from gui import architecture
+
+
+def test_task_consumes_requirement_specification():
+    """Tasks should consume Requirement Specification work products."""
+    architecture.reload_config()
+    win = architecture.GovernanceDiagramWindow.__new__(architecture.GovernanceDiagramWindow)
+    win.repo = types.SimpleNamespace(diagrams={})
+    win.diagram_id = "d"
+    win.repo.diagrams["d"] = types.SimpleNamespace(diag_type="Governance Diagram")
+    src = architecture.SysMLObject(1, "Action", 0, 0)
+    dst = architecture.SysMLObject(2, "Work Product", 0, 0, properties={"name": "Requirement Specification"})
+    valid, _ = architecture.GovernanceDiagramWindow.validate_connection(win, src, dst, "Consumes")
+    assert valid


### PR DESCRIPTION
## Summary
- permit tasks to consume work products in diagram rules
- add regression test ensuring tasks can consume requirement specification work products

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a5209d9de08327aab6a8f115827f2c