### PR TITLE
Add depth and glow to splash screen

### DIFF
--- a/tests/test_splash_screen_visuals.py
+++ b/tests/test_splash_screen_visuals.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import tkinter as tk
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from gui.splash_screen import SplashScreen
+
+
+def test_splash_screen_visual_elements():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    root.withdraw()
+    splash = SplashScreen(root, auto_start=False)
+    splash._draw_gear()
+    splash._draw_cube()
+    horizon = splash.canvas.find_withtag("horizon")
+    glow = splash.canvas.find_withtag("gear_glow")
+    faces = splash.canvas.find_withtag("cube_face")
+    splash.destroy()
+    root.destroy()
+    assert horizon, "Horizon line missing"
+    assert glow, "Gear glow missing"
+    assert faces, "Cube faces missing"


### PR DESCRIPTION
## Summary
- add optional auto-start parameter to SplashScreen for easier testing
- render horizon gradient, glowing gear and shiny transparent cube in splash screen
- test splash screen visual elements for presence of horizon, gear glow and cube faces

## Testing
- `pytest tests/test_splash_screen_visuals.py -q`
- `pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a5b4da44988327b5f8342c226e8aca