### PR TITLE
Enhance splash screen with horizon shadow and translucent cube

### DIFF
--- a/gui/splash_screen.py
+++ b/gui/splash_screen.py
@@ -47,6 +47,7 @@ class SplashScreen(tk.Toplevel):
         )
         self.canvas.pack()
         self._draw_gradient()
+        self._draw_floor()
         self._center()
         # Initialize cube geometry
         self.angle = 0.0
@@ -64,6 +65,14 @@ class SplashScreen(tk.Toplevel):
             (0, 1), (1, 2), (2, 3), (3, 0),
             (4, 5), (5, 6), (6, 7), (7, 4),
             (0, 4), (1, 5), (2, 6), (3, 7),
+        ]
+        self.faces = [
+            (0, 1, 2, 3),
+            (4, 5, 6, 7),
+            (0, 1, 5, 4),
+            (2, 3, 7, 6),
+            (1, 2, 6, 5),
+            (0, 3, 7, 4),
         ]
         # Text at bottom center
         self.canvas.create_text(
@@ -159,6 +168,17 @@ class SplashScreen(tk.Toplevel):
             color = f"#{r:02x}{g:02x}{b:02x}"
             self.canvas.create_line(0, i, self.canvas_size, i, fill=color)
 
+    def _draw_floor(self):
+        """Add a darkening gradient at the bottom to mimic a horizon."""
+        horizon = int(self.canvas_size * 0.6)
+        steps = self.canvas_size - horizon
+        for i in range(steps):
+            ratio = i / steps
+            level = int(40 * (1 - ratio))
+            color = f"#{level:02x}{level:02x}{level:02x}"
+            y = horizon + i
+            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="floor")
+
     def _project(self, x, y, z):
         """Project 3D point onto 2D canvas."""
         distance = 5
@@ -170,6 +190,7 @@ class SplashScreen(tk.Toplevel):
     def _draw_cube(self):
         self.canvas.delete("cube")
         self.canvas.delete("shadow")
+        self.canvas.delete("cube_face")
         # Simple oval shadow to give cube a floating appearance
         shadow_w = 80
         shadow_h = 20
@@ -189,6 +210,7 @@ class SplashScreen(tk.Toplevel):
         cos_a = math.cos(angle)
         sin_a = math.sin(angle)
         points = []
+        points3d = []
         for x, y, z in self.vertices:
             # rotate around Y axis
             x1 = x * cos_a - z * sin_a
@@ -196,11 +218,50 @@ class SplashScreen(tk.Toplevel):
             # rotate around X axis for slight 3D
             y1 = y * cos_a - z1 * sin_a
             z2 = y * sin_a + z1 * cos_a
+            points3d.append((x1, y1, z2))
             points.append(self._project(x1, y1, z2))
+
+        faces_to_draw = []
+        light_dir = (0, 0, 1)
+        for face in self.faces:
+            pts2d = [points[i] for i in face]
+            pts3d = [points3d[i] for i in face]
+            z_avg = sum(p[2] for p in pts3d) / len(pts3d)
+            # compute normal for basic shading
+            u = (
+                pts3d[1][0] - pts3d[0][0],
+                pts3d[1][1] - pts3d[0][1],
+                pts3d[1][2] - pts3d[0][2],
+            )
+            v = (
+                pts3d[2][0] - pts3d[0][0],
+                pts3d[2][1] - pts3d[0][1],
+                pts3d[2][2] - pts3d[0][2],
+            )
+            nx = u[1] * v[2] - u[2] * v[1]
+            ny = u[2] * v[0] - u[0] * v[2]
+            nz = u[0] * v[1] - u[1] * v[0]
+            norm = math.sqrt(nx * nx + ny * ny + nz * nz) or 1
+            nx /= norm
+            ny /= norm
+            nz /= norm
+            brightness = max(0, nx * light_dir[0] + ny * light_dir[1] + nz * light_dir[2])
+            col_val = int(155 + 100 * brightness)
+            color = f"#00{col_val:02x}{col_val:02x}"
+            faces_to_draw.append((z_avg, pts2d, color))
+
+        for z_avg, pts2d, color in sorted(faces_to_draw, key=lambda item: item[0]):
+            self.canvas.create_polygon(
+                pts2d,
+                fill=color,
+                outline="",
+                tags="cube_face",
+                stipple="gray25",
+            )
+
         for i, j in self.edges:
             x1, y1 = points[i]
             x2, y2 = points[j]
-            # Bright cyan edges for visibility against black
             self.canvas.create_line(
                 x1,
                 y1,


### PR DESCRIPTION
## Summary
- Add floor gradient to splash screen to suggest a horizon
- Render cube with translucent shaded faces for shiny effect

## Testing
- `pytest -q`
- `radon cc -s -j gui/splash_screen.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5b8de54948327b446bb08d18da71c