### PR TITLE
fix: correct comply-with requirement handling

### DIFF
--- a/analysis/governance.py
+++ b/analysis/governance.py
@@ -24,7 +24,7 @@ def _is_ai_specific_relation(conn_type: str | None) -> bool:
         return False
     lowered = conn_type.lower()
     return conn_type in _AI_RELATIONS and any(
-        key in lowered for key in ("train", "curat")
+        re.search(rf"\b{key}\w*", lowered) for key in ("train", "curat")
     )
 
 # Map relationship labels or connection types to requirement actions.  Each

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -3493,9 +3493,7 @@
       "action": "communicate with"
     },
     "complies with": {
-      "action": "comply with",
-      "constraint": true,
-      "subject": "Engineering team"
+      "action": "comply with"
     },
     "composite aggregation": {
       "action": "compose"

--- a/tests/test_governance_requirements_generator.py
+++ b/tests/test_governance_requirements_generator.py
@@ -160,3 +160,33 @@ def test_generic_ai_relation_defaults_to_organizational():
     reqs = diagram.generate_requirements()
     assess_req = next(r for r in reqs if r.action == "assess" and r.subject == "Role1")
     assert assess_req.req_type == "organizational"
+
+
+def test_complies_with_between_work_products():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Requirement Specification", node_type="Work Product")
+    diagram.add_task("Operational Requirement", node_type="Work Product")
+    diagram.add_relationship(
+        "Requirement Specification", "Operational Requirement", conn_type="Complies with"
+    )
+
+    reqs = diagram.generate_requirements()
+    comp_req = next(r for r in reqs if r.action == "comply with")
+    assert comp_req.subject == "Requirement Specification"
+    assert comp_req.obj == "Operational Requirement"
+    assert comp_req.req_type == "organizational"
+
+
+def test_constrained_by_between_work_products():
+    diagram = GovernanceDiagram()
+    diagram.add_task("Requirement Specification", node_type="Work Product")
+    diagram.add_task("Operational Requirement", node_type="Work Product")
+    diagram.add_relationship(
+        "Requirement Specification", "Operational Requirement", conn_type="Constrained by"
+    )
+
+    reqs = diagram.generate_requirements()
+    comp_req = next(r for r in reqs if r.action == "comply with")
+    assert comp_req.subject == "Requirement Specification"
+    assert comp_req.constraint == "Operational Requirement"
+    assert comp_req.req_type == "organizational"


### PR DESCRIPTION
## Summary
- refine AI-specific relation detection to avoid false positives like "Constrained by"
- test that "Constrained by" between work products yields organizational requirement

## Testing
- `pytest`
- `python tools/metrics_generator.py --path analysis --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a5b3965c28832784045d70e4bd6650