### PR TITLE
feat: add bottom highlight glow on button hover

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -419,6 +419,16 @@ class CapsuleButton(tk.Canvas):
             self.create_line(r - 1, h + 1, w - r + 1, h + 1, fill=glow_color, width=2),
             self.create_line(w + 1, r, w + 1, h - r, fill=glow_color, width=2),
         ]
+        self._glow_items.append(
+            self.create_rectangle(
+                r,
+                h - 2,
+                w - r,
+                h,
+                outline="",
+                fill=glow_color,
+            )
+        )
 
     def _remove_glow(self) -> None:
         for item in self._glow_items:

--- a/tests/test_capsule_button_glow_outline.py
+++ b/tests/test_capsule_button_glow_outline.py
@@ -38,3 +38,21 @@ def test_glow_matches_button_width():
     assert x1 == r - 1
     assert x2 == w - r + 1
     root.destroy()
+
+def test_glow_bottom_highlight():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Glow")
+    btn.pack()
+    root.update_idletasks()
+    btn._on_enter(type("E", (), {})())
+    rects = [i for i in btn._glow_items if btn.type(i) == "rectangle"]
+    assert rects, "bottom highlight not added"
+    rect_id = rects[0]
+    x1, y1, x2, y2 = btn.coords(rect_id)
+    h = int(btn["height"])
+    assert y2 == h
+    assert y2 - y1 <= 2
+    root.destroy()


### PR DESCRIPTION
## Summary
- enhance CapsuleButton glow with a bottom highlight when hovered
- cover new glow behaviour with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a5b99bac008327b6dfa09ff38dec65