### PR TITLE
feat: add bottom highlight glow on button hover

### DIFF
--- a/gui/capsule_button.py
+++ b/gui/capsule_button.py
@@ -408,6 +408,7 @@ class CapsuleButton(tk.Canvas):
         w, h = int(self["width"]), int(self["height"])
         r = self._radius
         glow_color = _lighten(self._current_color, 1.3)
+        bottom_color = _lighten(self._current_color, 1.6)
         self._glow_items = [
             self.create_arc((-1, -1, 2 * r + 1, h + 1), start=90, extent=180, style=tk.ARC, outline=glow_color, width=2),
             # Offset the horizontal glow lines by one pixel so the caps extend
@@ -419,6 +420,16 @@ class CapsuleButton(tk.Canvas):
             self.create_line(r - 1, h + 1, w - r + 1, h + 1, fill=glow_color, width=2),
             self.create_line(w + 1, r, w + 1, h - r, fill=glow_color, width=2),
         ]
+        self._glow_items.append(
+            self.create_rectangle(
+                r,
+                h - 2,
+                w - r,
+                h,
+                outline="",
+                fill=bottom_color,
+            )
+        )
 
     def _remove_glow(self) -> None:
         for item in self._glow_items:

--- a/tests/test_capsule_button_glow_outline.py
+++ b/tests/test_capsule_button_glow_outline.py
@@ -5,7 +5,7 @@ import tkinter as tk
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from gui.capsule_button import CapsuleButton
+from gui.capsule_button import CapsuleButton, _lighten
 
 
 def test_glow_edges_only():
@@ -37,4 +37,24 @@ def test_glow_matches_button_width():
     x1, _y1, x2, _y2 = btn.coords(top_line)
     assert x1 == r - 1
     assert x2 == w - r + 1
+    root.destroy()
+
+def test_glow_bottom_highlight():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    btn = CapsuleButton(root, text="Glow")
+    btn.pack()
+    root.update_idletasks()
+    btn._on_enter(type("E", (), {})())
+    rects = [i for i in btn._glow_items if btn.type(i) == "rectangle"]
+    assert rects, "bottom highlight not added"
+    rect_id = rects[0]
+    x1, y1, x2, y2 = btn.coords(rect_id)
+    h = int(btn["height"])
+    assert y2 == h
+    assert y2 - y1 <= 2
+    expected_color = _lighten(btn._current_color, 1.6)
+    assert btn.itemcget(rect_id, "fill") == expected_color
     root.destroy()


### PR DESCRIPTION
## Summary
- enhance CapsuleButton glow with a brighter bottom highlight for clearer hover feedback
- verify bottom glow color and placement in tests

## Testing
- `pytest -q`
- `pip install radon -q` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a5b99bac008327b6dfa09ff38dec65