### PR TITLE
docs: add quick start overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,27 @@ version: 0.1.6
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
-AutoML is an automotive modeling and analysis tool built around a SysML-based metamodel. The language lets you model items, operating scenarios, functions, structure and interfaces in a single environment.
+AutoML is an automotive modeling and analysis tool built around a SysML-based metamodel. It lets you describe items, operating scenarios, functions, structure and interfaces in a single environment.
 
-The metamodel weaves together concepts from key automotive standards—ISO 26262 for functional safety, ISO 21448 for SOTIF, ISO 21434 for cybersecurity and ISO 8800 for safety and AI—so one project can address safety, cybersecurity and assurance requirements side by side.
+The metamodel blends concepts from key automotive standards—ISO 26262 (functional safety), ISO 21448 (SOTIF), ISO 21434 (cybersecurity) and ISO 8800 (safety and AI)—so one project can address safety, cybersecurity and assurance requirements side by side.
 
-Recent updates add a **Review Toolbox** supporting peer and joint review workflows. The explorer pane now includes an **Analyses** tab organized into *System Design (Item Definition)*, *Hazard Analysis*, *Risk Assessment* and *Safety Analysis* sections so documents and diagrams can be opened directly. Architecture objects can be resized either by editing width and height values or by dragging the red handles that appear when an item is selected. Fork and join bars keep a constant thickness so only their length changes. **Deleting objects on a diagram now asks whether to remove them from the model or only from the current view. Removing from the model also deletes any part elements referencing it so names can be reused.** New FMEDA functionality automatically fills the violated safety goal from chosen malfunctions, supports selecting multiple malfunction effects and prevents assigning one malfunction to more than one top level event. Malfunctions can be added or removed via **Add** and **Delete** buttons in the FMEA/FMEDA dialogs, but deletion is blocked for malfunctions currently used in analyses or FTAs.
+## Quick Start
 
-## Index
+1. Install the required Python packages:
+
+   ```
+   pip install pillow openpyxl networkx matplotlib reportlab adjustText
+   ```
+
+2. Launch the application:
+
+   ```
+   python AutoML.py
+   ```
+
+3. Create a new project via **File → New Project** and begin modeling. Detailed workflows—HAZOP, risk assessment, fault trees and more—are described in the sections below.
+
+## Contents
 
 - [Governance Diagrams](#governance-diagrams)
 - [Workflow Overview](#workflow-overview)


### PR DESCRIPTION
## Summary
- clarify AutoML's purpose in README
- add Quick Start section with installation and launch instructions

## Testing
- `pytest`
- `radon cc -j .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a5beb5533883278ba7c0f291780871