### PR TITLE
Add white-green hover glow for button images

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -48,6 +48,17 @@ def _lighten_color(color: str, factor: float = 1.2) -> str:
     return f"#{r:02x}{g:02x}{b:02x}"
 
 
+def _blend_with(color: str, overlay: tuple[int, int, int], alpha: float) -> str:
+    """Blend *color* towards *overlay* by *alpha*."""
+    r = int(color[1:3], 16)
+    g = int(color[3:5], 16)
+    b = int(color[5:7], 16)
+    r = int(r + (overlay[0] - r) * alpha)
+    g = int(g + (overlay[1] - g) * alpha)
+    b = int(b + (overlay[2] - b) * alpha)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
 def _lighten_image(
     img: tk.PhotoImage,
     factor: float = 1.2,
@@ -80,7 +91,12 @@ def _lighten_image(
                 new_img.put(pixel, (x, y))
             else:
                 lf = factor * bottom_factor if y >= highlight_start else factor
-                new_img.put(_lighten_color(pixel, lf), (x, y))
+                light = _lighten_color(pixel, lf)
+                if y >= highlight_start:
+                    blend = _blend_with(light, (179, 255, 179), 0.3)
+                else:
+                    blend = _blend_with(light, (255, 255, 255), 0.3)
+                new_img.put(blend, (x, y))
     return new_img
 
 

--- a/tests/test_button_hover_highlight.py
+++ b/tests/test_button_hover_highlight.py
@@ -35,3 +35,30 @@ def test_add_hover_highlight_swaps_to_lighter_image():
     # Bottom pixels receive an extra boost creating a light glow
     assert _sum_rgb(hover_img.get(0, 1)) > _sum_rgb(hover_img.get(0, 0))
     root.destroy()
+
+
+def test_add_hover_highlight_blends_white_and_green():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    img = tk.PhotoImage(width=2, height=2)
+    img.put("#808080", to=(0, 0, 2, 2))
+    btn = ttk.Button(root, image=img)
+    hover_img = add_hover_highlight(btn, img)
+
+    bottom = hover_img.get(0, 1)
+    top = hover_img.get(0, 0)
+
+    def _rgb(value):
+        if isinstance(value, tuple):
+            return value[:3]
+        return tuple(int(value[i : i + 2], 16) for i in (1, 3, 5))
+
+    br, bg, bb = _rgb(bottom)
+    tr, tg, tb = _rgb(top)
+
+    assert bg > br and bg > bb
+    assert abs(tr - tg) < 5 and abs(tg - tb) < 5
+    root.destroy()


### PR DESCRIPTION
## Summary
- blend button hover images with white and light green to produce a glow effect
- add regression test for white-green hover blending

## Testing
- `pytest -q`
- `pip install radon` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a5cbdbde7083279561d30576c51017