### PR TITLE
Add green-white glow to button hover images

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import ttk
 
+from .capsule_button import _lighten
+
 
 def set_uniform_button_width(widget: tk.Misc) -> None:
     """Ensure all ``ttk.Button`` children of *widget* share the same width.
@@ -35,17 +37,6 @@ def set_uniform_button_width(widget: tk.Misc) -> None:
             btn.configure(width=max_width)
         except Exception:  # pragma: no cover - defensive
             pass
-
-
-def _lighten_color(color: str, factor: float = 1.2) -> str:
-    """Return *color* lightened by *factor* while clamping to valid range."""
-    r = int(color[1:3], 16)
-    g = int(color[3:5], 16)
-    b = int(color[5:7], 16)
-    r = min(int(r * factor), 255)
-    g = min(int(g * factor), 255)
-    b = min(int(b * factor), 255)
-    return f"#{r:02x}{g:02x}{b:02x}"
 
 
 def _lighten_image(
@@ -80,7 +71,7 @@ def _lighten_image(
                 new_img.put(pixel, (x, y))
             else:
                 lf = factor * bottom_factor if y >= highlight_start else factor
-                new_img.put(_lighten_color(pixel, lf), (x, y))
+                new_img.put(_lighten(pixel, lf), (x, y))
     return new_img
 
 

--- a/tests/test_button_hover_highlight.py
+++ b/tests/test_button_hover_highlight.py
@@ -15,6 +15,12 @@ def _sum_rgb(value):
     return sum(int(value[i : i + 2], 16) for i in (1, 3, 5))
 
 
+def _get_rgb(value):
+    if isinstance(value, tuple):
+        return value[:3]
+    return tuple(int(value[i : i + 2], 16) for i in (1, 3, 5))
+
+
 def test_add_hover_highlight_swaps_to_lighter_image():
     try:
         root = tk.Tk()
@@ -34,4 +40,7 @@ def test_add_hover_highlight_swaps_to_lighter_image():
     assert _sum_rgb(hover_img.get(0, 0)) > _sum_rgb(img.get(0, 0))
     # Bottom pixels receive an extra boost creating a light glow
     assert _sum_rgb(hover_img.get(0, 1)) > _sum_rgb(hover_img.get(0, 0))
+    # Hover image gains a subtle green tint
+    r, g, b = _get_rgb(hover_img.get(0, 0))
+    assert g > r and g > b
     root.destroy()


### PR DESCRIPTION
## Summary
- Blend white and light green into button hover images for a glowing effect
- Test hover highlighting to confirm subtle green tint on hover

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a5cbdbde7083279561d30576c51017