### PR TITLE
Improve white-green hover glow for button images

### DIFF
--- a/tests/test_button_hover_highlight.py
+++ b/tests/test_button_hover_highlight.py
@@ -31,7 +31,34 @@ def test_add_hover_highlight_swaps_to_lighter_image():
 
     assert btn.cget("image") == str(hover_img)
     # Entire image should be lighter
-    assert _sum_rgb(hover_img.get(0, 0)) > _sum_rgb(img.get(0, 0))
+    assert _sum_rgb(hover_img.get(0, 0)) >= _sum_rgb(img.get(0, 0)) + 60
     # Bottom pixels receive an extra boost creating a light glow
-    assert _sum_rgb(hover_img.get(0, 1)) > _sum_rgb(hover_img.get(0, 0))
+    assert _sum_rgb(hover_img.get(0, 1)) >= _sum_rgb(hover_img.get(0, 0)) + 20
+    root.destroy()
+
+
+def test_add_hover_highlight_blends_white_and_green():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    img = tk.PhotoImage(width=2, height=2)
+    img.put("#808080", to=(0, 0, 2, 2))
+    btn = ttk.Button(root, image=img)
+    hover_img = add_hover_highlight(btn, img)
+
+    bottom = hover_img.get(0, 1)
+    top = hover_img.get(0, 0)
+
+    def _rgb(value):
+        if isinstance(value, tuple):
+            return value[:3]
+        return tuple(int(value[i : i + 2], 16) for i in (1, 3, 5))
+
+    br, bg, bb = _rgb(bottom)
+    tr, tg, tb = _rgb(top)
+
+    assert bg > br and bg > bb
+    assert abs(tr - tg) < 5 and abs(tg - tb) < 5
     root.destroy()


### PR DESCRIPTION
## Summary
- amplify hover lightening so bottom pixels glow green and top pixels brighten to white
- tighten regression tests to ensure the hover image visibly differs from the base image

## Testing
- `pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a5cbdbde7083279561d30576c51017