### PR TITLE
Improve white-green hover glow for button images

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -48,19 +48,33 @@ def _lighten_color(color: str, factor: float = 1.2) -> str:
     return f"#{r:02x}{g:02x}{b:02x}"
 
 
+def _blend_with(color: str, overlay: tuple[int, int, int], alpha: float) -> str:
+    """Blend *color* towards *overlay* by *alpha*."""
+    r = int(color[1:3], 16)
+    g = int(color[3:5], 16)
+    b = int(color[5:7], 16)
+    r = int(r + (overlay[0] - r) * alpha)
+    g = int(g + (overlay[1] - g) * alpha)
+    b = int(b + (overlay[2] - b) * alpha)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
 def _lighten_image(
     img: tk.PhotoImage,
-    factor: float = 1.2,
+    factor: float = 1.4,
     *,
-    bottom_factor: float = 1.4,
+    bottom_factor: float = 1.8,
     bottom_ratio: float = 0.3,
+    top_alpha: float = 0.5,
+    bottom_alpha: float = 0.5,
 ) -> tk.PhotoImage:
-    """Return a new image with all non-black pixels lightened.
+    """Return a new image with all pixels lightened.
 
-    A subtle "lighting" effect is added to the lower portion of the image by
-    applying a stronger lightening factor to the bottom *bottom_ratio* of
-    pixels.  This creates the impression of a light source shining on the base
-    of the button when hovered.
+    The default factors intentionally apply a strong boost so the hover image is
+    visually distinct.  The bottom portion receives both a higher lightening
+    factor and a green-tinted blend, creating a pronounced glow effect.  Even
+    fully black capsules are brightened so the hover state is immediately
+    noticeable.
     """
     w, h = img.width(), img.height()
     new_img = tk.PhotoImage(width=w, height=h)
@@ -76,16 +90,26 @@ def _lighten_image(
                 pixel = f"#{pixel[0]:02x}{pixel[1]:02x}{pixel[2]:02x}"
             if not pixel:
                 continue
+            lf = factor * bottom_factor if y >= highlight_start else factor
+            overlay = (179, 255, 179) if y >= highlight_start else (255, 255, 255)
+            alpha = bottom_alpha if y >= highlight_start else top_alpha
+
             if pixel.lower() == "#000000":
-                new_img.put(pixel, (x, y))
+                # Seed black pixels with a blend first so the lightening factor
+                # can meaningfully brighten them, producing a visibly lighter
+                # capsule image.
+                blended = _blend_with(pixel, overlay, alpha)
+                light = _lighten_color(blended, lf)
             else:
-                lf = factor * bottom_factor if y >= highlight_start else factor
-                new_img.put(_lighten_color(pixel, lf), (x, y))
+                light = _lighten_color(pixel, lf)
+                light = _blend_with(light, overlay, alpha)
+
+            new_img.put(light, (x, y))
     return new_img
 
 
 def add_hover_highlight(
-    button: ttk.Button, image: tk.PhotoImage, factor: float = 1.2
+    button: ttk.Button, image: tk.PhotoImage, factor: float = 1.4
 ) -> tk.PhotoImage:
     """Swap *button* image to a lighter variant on hover.
 

--- a/tests/test_button_hover_highlight.py
+++ b/tests/test_button_hover_highlight.py
@@ -31,7 +31,53 @@ def test_add_hover_highlight_swaps_to_lighter_image():
 
     assert btn.cget("image") == str(hover_img)
     # Entire image should be lighter
-    assert _sum_rgb(hover_img.get(0, 0)) > _sum_rgb(img.get(0, 0))
+    assert _sum_rgb(hover_img.get(0, 0)) >= _sum_rgb(img.get(0, 0)) + 60
     # Bottom pixels receive an extra boost creating a light glow
-    assert _sum_rgb(hover_img.get(0, 1)) > _sum_rgb(hover_img.get(0, 0))
+    assert _sum_rgb(hover_img.get(0, 1)) >= _sum_rgb(hover_img.get(0, 0)) + 20
+    root.destroy()
+
+
+def test_add_hover_highlight_blends_white_and_green():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    img = tk.PhotoImage(width=2, height=2)
+    img.put("#808080", to=(0, 0, 2, 2))
+    btn = ttk.Button(root, image=img)
+    hover_img = add_hover_highlight(btn, img)
+
+    bottom = hover_img.get(0, 1)
+    top = hover_img.get(0, 0)
+
+    def _rgb(value):
+        if isinstance(value, tuple):
+            return value[:3]
+        return tuple(int(value[i : i + 2], 16) for i in (1, 3, 5))
+
+    br, bg, bb = _rgb(bottom)
+    tr, tg, tb = _rgb(top)
+
+    assert bg > br and bg > bb
+    assert abs(tr - tg) < 5 and abs(tg - tb) < 5
+    root.destroy()
+
+
+def test_add_hover_highlight_lightens_black_pixels():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    img = tk.PhotoImage(width=2, height=2)
+    img.put("#000000", to=(0, 0, 2, 2))
+    btn = ttk.Button(root, image=img)
+    hover_img = add_hover_highlight(btn, img)
+
+    top = _sum_rgb(hover_img.get(0, 0))
+    bottom = _sum_rgb(hover_img.get(0, 1))
+
+    assert top > 0
+    assert bottom > top
     root.destroy()


### PR DESCRIPTION
## Summary
- brighten the entire capsule image on hover by blending and lightening even black pixels
- add regression test ensuring black button images brighten and bottom pixels glow green

## Testing
- `pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a5cbdbde7083279561d30576c51017