### PR TITLE
Add metrics tab and review time tracking

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2625,6 +2625,7 @@ class AutoMLApp:
             label="Light Mode",
             command=lambda: self.apply_style('pastel.xml'),
         )
+        view_menu.add_command(label="Metrics", command=self.open_metrics_tab)
 
         requirements_menu = tk.Menu(menubar, tearoff=0)
         requirements_menu.add_command(
@@ -17918,6 +17919,12 @@ class AutoMLApp:
     def open_style_editor(self):
         """Open the diagram style editor window."""
         StyleEditor(self.root)
+
+    def open_metrics_tab(self):
+        """Open a tab displaying project metrics."""
+        tab = self._new_tab("Metrics")
+        from gui.metrics_tab import MetricsTab
+        MetricsTab(tab, self).pack(fill=tk.BOTH, expand=True)
 
     def apply_style(self, filename: str) -> None:
         path = Path(__file__).resolve().parent / 'styles' / filename

--- a/gui/metrics_tab.py
+++ b/gui/metrics_tab.py
@@ -1,0 +1,44 @@
+import tkinter as tk
+from collections import Counter
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+import matplotlib.pyplot as plt
+
+
+class MetricsTab(tk.Frame):
+    """Tab displaying simple project metrics graphs."""
+
+    def __init__(self, master, app):
+        super().__init__(master)
+        self.app = app
+        self.fig = plt.Figure(figsize=(9, 3))
+        self.axes = [self.fig.add_subplot(131),
+                     self.fig.add_subplot(132),
+                     self.fig.add_subplot(133)]
+        canvas = FigureCanvasTkAgg(self.fig, master=self)
+        canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+        self.canvas = canvas
+        self.update_plots()
+
+    def update_plots(self):
+        req_history = getattr(self.app, "requirement_history", [])
+        if not req_history:
+            req_history = [len(getattr(self.app, "requirements", []))]
+        ax = self.axes[0]
+        ax.clear()
+        ax.plot(req_history)
+        ax.set_title("Requirements")
+
+        statuses = Counter(getattr(r, "status", "unknown") for r in getattr(self.app, "requirements", []))
+        ax = self.axes[1]
+        ax.clear()
+        ax.bar(list(statuses.keys()), list(statuses.values()))
+        ax.set_title("Status")
+
+        user_metrics = getattr(self.app, "user_metrics", {})
+        ax = self.axes[2]
+        ax.clear()
+        if user_metrics:
+            ax.bar(list(user_metrics.keys()), list(user_metrics.values()))
+        ax.set_title("User Effort")
+        self.fig.tight_layout()
+        self.canvas.draw_idle()

--- a/tests/test_metrics_tab_menu.py
+++ b/tests/test_metrics_tab_menu.py
@@ -1,0 +1,17 @@
+import inspect
+import unittest
+from AutoML import AutoMLApp
+
+
+class MetricsTabMenuTests(unittest.TestCase):
+    def test_app_has_open_metrics_tab(self):
+        self.assertTrue(hasattr(AutoMLApp, "open_metrics_tab"))
+
+    def test_view_menu_includes_metrics_option(self):
+        src = inspect.getsource(AutoMLApp.__init__)
+        self.assertIn('label="Metrics"', src)
+        self.assertIn('open_metrics_tab', src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_review_timer.py
+++ b/tests/test_review_timer.py
@@ -1,0 +1,50 @@
+import time
+import unittest
+import tkinter as tk
+from gui.review_toolbox import ReviewParticipant, ReviewData, ReviewToolbox
+
+
+class ReviewTimerTests(unittest.TestCase):
+    def test_mark_done_records_time(self):
+        try:
+            root = tk.Tk()
+            root.withdraw()
+        except tk.TclError:
+            self.skipTest("Tk not available")
+
+        class StubApp:
+            def __init__(self):
+                self.current_user = "alice"
+                self.review_data = ReviewData(participants=[ReviewParticipant("alice", "a@x", "reviewer")])
+                self.reviews = []
+                self.comment_target = None
+                self.selected_node = None
+
+            def update_hara_statuses(self):
+                pass
+
+            def review_is_closed(self):
+                return False
+
+            def find_node_by_id_all(self, _):
+                return None
+
+            def focus_on_node(self, _):
+                pass
+
+            def get_review_targets(self):
+                return [], {}
+
+        app = StubApp()
+        toolbox = ReviewToolbox(root, app)
+        toolbox.start_participant_timer()
+        time.sleep(0.01)
+        toolbox.mark_done()
+        p = app.review_data.participants[0]
+        self.assertTrue(p.done)
+        self.assertGreater(p.time_spent, 0)
+        root.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add Metrics view menu option and tab showing requirement counts, status distribution, and user effort graphs
- Track review participant time using start and completion timestamps
- Cover new features with tests

## Testing
- `python tools/metrics_generator.py --path gui`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_b_68a5d1b3ab688327bf03d2b1631ebc07