### PR TITLE
Fix treeview hover handling for deleted items

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -194,10 +194,12 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
         item = tree.identify_row(event.y)
         prev = getattr(tree, "_hover_item", None)
         if prev and prev != item:
-            tags = list(tree.item(prev, "tags"))
-            if "hover" in tags:
-                tags.remove("hover")
-                tree.item(prev, tags=tags)
+            if tree.exists(prev):
+                tags = list(tree.item(prev, "tags"))
+                if "hover" in tags:
+                    tags.remove("hover")
+                    tree.item(prev, tags=tags)
+            tree._hover_item = None  # type: ignore[attr-defined]
         if item:
             if not getattr(tree, "_hover_tagged", False):
                 style = ttk.Style(tree)
@@ -215,12 +217,12 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
     def _tv_on_leave(event: tk.Event) -> None:
         tree: ttk.Treeview = event.widget  # type: ignore[assignment]
         prev = getattr(tree, "_hover_item", None)
-        if prev:
+        if prev and tree.exists(prev):
             tags = list(tree.item(prev, "tags"))
             if "hover" in tags:
                 tags.remove("hover")
                 tree.item(prev, tags=tags)
-            tree._hover_item = None  # type: ignore[attr-defined]
+        tree._hover_item = None  # type: ignore[attr-defined]
 
     root.bind_class("Listbox", "<Motion>", _lb_on_motion, add="+")
     root.bind_class("Listbox", "<Leave>", _lb_on_leave, add="+")

--- a/tests/test_treeview_hover_highlight.py
+++ b/tests/test_treeview_hover_highlight.py
@@ -38,3 +38,32 @@ def test_treeview_row_highlight_on_hover():
     root.update_idletasks()
     assert not tree.tag_has("hover", "0")
     root.destroy()
+
+
+def test_treeview_hover_after_item_deleted():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    enable_listbox_hover_highlight(root)
+    tree = ttk.Treeview(root, columns=("c",), show="headings")
+    tree.insert("", "end", iid="0", values=("a",))
+    tree.insert("", "end", iid="1", values=("b",))
+    tree.pack()
+    root.update_idletasks()
+
+    x0, y0, _, _ = tree.bbox("0")
+    tree.event_generate("<Motion>", x=x0 + 1, y=y0 + 1)
+    root.update_idletasks()
+    assert getattr(tree, "_hover_item", None) == "0"
+
+    tree.delete("0")
+    root.update_idletasks()
+
+    x1, y1, _, _ = tree.bbox("1")
+    tree.event_generate("<Motion>", x=x1 + 1, y=y1 + 1)
+    root.update_idletasks()
+    assert getattr(tree, "_hover_item", None) == "1"
+    assert tree.tag_has("hover", "1")
+    root.destroy()


### PR DESCRIPTION
## Summary
- prevent TclError when hovering Treeview after item deletion
- test Treeview hover resilience

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path gui --output metrics.json`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a5f25ea9488327b5e64d1bfc6a5ff4