### PR TITLE
Prevent resizing of description and password dialogs

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -228,6 +228,7 @@ import sys
 import json
 import tkinter as tk
 from tkinter import ttk, filedialog, simpledialog, scrolledtext
+from gui.dialog_utils import askstring_fixed
 from gui import messagebox, logger, add_treeview_scrollbars
 from gui.button_utils import enable_listbox_hover_highlight
 from gui.tooltip import ToolTip
@@ -18811,7 +18812,12 @@ class AutoMLApp:
 
     def edit_description(self):
         if self.selected_node:
-            new_desc = simpledialog.askstring("Edit Description", "Enter new description:", initialvalue=self.selected_node.description)
+            new_desc = askstring_fixed(
+                simpledialog,
+                "Edit Description",
+                "Enter new description:",
+                initialvalue=self.selected_node.description,
+            )
             if new_desc is not None:
                 self.selected_node.description = new_desc
                 # Propagate the updated description across clones/original.
@@ -19790,7 +19796,6 @@ class AutoMLApp:
                     "Save Model", "cryptography package is required for encrypted save."
                 )
                 return
-        from tkinter import simpledialog
         import base64
         import gzip
         import hashlib
@@ -19818,13 +19823,15 @@ class AutoMLApp:
                 with open(path, "w", encoding="utf-8") as f:
                     json.dump(data, f, indent=2)
             else:
-                from tkinter import simpledialog
                 import base64
                 import gzip
                 import hashlib
 
-                password = simpledialog.askstring(
-                    "Password", "Enter encryption password:", show="*"
+                password = askstring_fixed(
+                    simpledialog,
+                    "Password",
+                    "Enter encryption password:",
+                    show="*",
                 )
                 if password is None:
                     return
@@ -19872,14 +19879,16 @@ class AutoMLApp:
                         "Load Model", "cryptography package is required for encrypted files."
                     )
                     return
-            from tkinter import simpledialog
             import base64
             import gzip
             import hashlib
             import json
 
-            password = simpledialog.askstring(
-                "Password", "Enter decryption password:", show="*"
+            password = askstring_fixed(
+                simpledialog,
+                "Password",
+                "Enter decryption password:",
+                show="*",
             )
             if password is None:
                 return
@@ -20761,7 +20770,11 @@ class AutoMLApp:
             name = simpledialog.askstring("Review Name", "Enter unique review name:")
             if not name:
                 return
-            description = simpledialog.askstring("Description", "Enter a short description:")
+            description = askstring_fixed(
+                simpledialog,
+                "Description",
+                "Enter a short description:",
+            )
             if description is None:
                 description = ""
             if not moderators:
@@ -20816,7 +20829,11 @@ class AutoMLApp:
             name = simpledialog.askstring("Review Name", "Enter unique review name:")
             if not name:
                 return
-            description = simpledialog.askstring("Description", "Enter a short description:")
+            description = askstring_fixed(
+                simpledialog,
+                "Description",
+                "Enter a short description:",
+            )
             if description is None:
                 description = ""
             if not moderators:

--- a/gui/dialog_utils.py
+++ b/gui/dialog_utils.py
@@ -1,0 +1,26 @@
+"""Utility functions for GUI dialogs."""
+from __future__ import annotations
+
+from tkinter import simpledialog
+
+
+def askstring_fixed(sd_module: simpledialog.__class__, title: str, prompt: str, **kwargs):
+    """Display an ``askstring`` dialog with a fixed-size window.
+
+    This helper temporarily patches the dialog class used by
+    :func:`tkinter.simpledialog.askstring` so the resulting window cannot be
+    resized.  The *sd_module* parameter should be the ``simpledialog`` module
+    used by the caller so that test patches on that module remain effective.
+    """
+    original = sd_module._QueryString
+
+    class FixedQueryString(sd_module._QueryString):  # type: ignore[attr-defined]
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            self.resizable(False, False)
+
+    sd_module._QueryString = FixedQueryString  # type: ignore[attr-defined]
+    try:
+        return sd_module.askstring(title, prompt, **kwargs)
+    finally:
+        sd_module._QueryString = original  # type: ignore[attr-defined]

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -21,6 +21,7 @@ from tkinter import simpledialog, ttk
 from gui import messagebox
 from gui.mac_button_style import apply_translucid_button_style
 from gui.style_manager import StyleManager
+from gui.dialog_utils import askstring_fixed
 from dataclasses import dataclass, field
 from typing import List
 import difflib
@@ -745,7 +746,12 @@ class ReviewToolbox(tk.Frame):
             return
         self.app.review_data.moderators = moderators
         self.app.review_data.participants = participants
-        desc = simpledialog.askstring("Description", "Edit description:", initialvalue=self.app.review_data.description)
+        desc = askstring_fixed(
+            simpledialog,
+            "Description",
+            "Edit description:",
+            initialvalue=self.app.review_data.description,
+        )
         if desc is not None:
             self.app.review_data.description = desc
         due = simpledialog.askstring("Due Date", "Edit due date (YYYY-MM-DD):", initialvalue=self.app.review_data.due_date)


### PR DESCRIPTION
## Summary
- add `askstring_fixed` helper to display non-resizable prompt dialogs
- use `askstring_fixed` for description edits and encryption password prompts

## Testing
- `python tools/metrics_generator.py --path . --output metrics.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a5f22cf0c48327b003eb8980b37236