### PR TITLE
Limit Requirements Editor row height for visibility

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12786,7 +12786,7 @@ class AutoMLApp:
                         text,
                     ],
                 )
-            style.configure("ReqEditor.Treeview", rowheight=20 * max_lines)
+            style.configure("ReqEditor.Treeview", rowheight=min(80, 20 * max_lines))
 
         class ReqDialog(simpledialog.Dialog):
             def __init__(self, parent, title, initial=None):


### PR DESCRIPTION
## Summary
- cap Requirements Editor table row height so bottom action buttons stay visible

## Testing
- `pytest`
- ❌ `radon cc -s -j AutoML.py` *(failed: ProxyError: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a5f714bb008327b015f71df3c19bbc