### PR TITLE
Handle string widget names in listbox hover highlight

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -171,7 +171,10 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
     """
 
     def _lb_on_motion(event: tk.Event) -> None:
-        lb: tk.Listbox = event.widget  # type: ignore[assignment]
+        lb_widget = event.widget
+        if isinstance(lb_widget, str):
+            lb_widget = root.nametowidget(lb_widget)
+        lb: tk.Listbox = lb_widget  # type: ignore[assignment]
         size = lb.size()
         if size == 0:
             return
@@ -192,14 +195,20 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
         lb._hover_index = index  # type: ignore[attr-defined]
 
     def _lb_on_leave(event: tk.Event) -> None:
-        lb: tk.Listbox = event.widget  # type: ignore[assignment]
+        lb_widget = event.widget
+        if isinstance(lb_widget, str):
+            lb_widget = root.nametowidget(lb_widget)
+        lb: tk.Listbox = lb_widget  # type: ignore[assignment]
         prev = getattr(lb, "_hover_index", None)
         if prev is not None:
             lb.itemconfig(prev, background=getattr(lb, "_default_bg", "white"))
             lb._hover_index = None  # type: ignore[attr-defined]
 
     def _tv_on_motion(event: tk.Event) -> None:
-        tree: ttk.Treeview = event.widget  # type: ignore[assignment]
+        tree_widget = event.widget
+        if isinstance(tree_widget, str):
+            tree_widget = root.nametowidget(tree_widget)
+        tree: ttk.Treeview = tree_widget  # type: ignore[assignment]
         item = tree.identify_row(event.y)
         prev = getattr(tree, "_hover_item", None)
         if prev and prev != item:
@@ -224,7 +233,10 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
             tree._hover_item = item  # type: ignore[attr-defined]
 
     def _tv_on_leave(event: tk.Event) -> None:
-        tree: ttk.Treeview = event.widget  # type: ignore[assignment]
+        tree_widget = event.widget
+        if isinstance(tree_widget, str):
+            tree_widget = root.nametowidget(tree_widget)
+        tree: ttk.Treeview = tree_widget  # type: ignore[assignment]
         prev = getattr(tree, "_hover_item", None)
         if prev and tree.exists(prev):
             tags = list(tree.item(prev, "tags"))

--- a/tests/test_listbox_class_event.py
+++ b/tests/test_listbox_class_event.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.button_utils import enable_listbox_hover_highlight, _blend_with
+
+
+class DummyListbox:
+    def __init__(self):
+        self.items = ["a", "b"]
+        self.bg = "#ffffff"
+        self.configs = {}
+        self._hover_index = None
+
+    def size(self):
+        return len(self.items)
+
+    def nearest(self, y):
+        return 0
+
+    def itemconfig(self, index, **kwargs):
+        self.configs[index] = kwargs
+
+    def itemcget(self, index, option):
+        return self.bg
+
+    def cget(self, option):
+        return self.bg
+
+
+class DummyRoot:
+    def __init__(self):
+        self.bindings = {}
+        self.widgets = {}
+
+    def bind_class(self, classname, sequence, func=None, add=None):
+        if func is None:
+            return self.bindings[(classname, sequence)]
+        self.bindings[(classname, sequence)] = func
+
+    def nametowidget(self, name):
+        return self.widgets[name]
+
+
+def test_lb_on_motion_handles_widget_path():
+    root = DummyRoot()
+    lb = DummyListbox()
+    root.widgets["lb"] = lb
+    enable_listbox_hover_highlight(root)
+    event = SimpleNamespace(widget="lb", y=0)
+    func = root.bindings[("Listbox", "<Motion>")]
+    func(event)
+    assert 0 in lb.configs
+    expected = _blend_with(lb.bg, (204, 255, 204), 0.5)
+    assert lb.configs[0]["background"] == expected


### PR DESCRIPTION
## Summary
- Fix hover highlight callbacks to resolve widget path strings to actual Listbox/Treeview instances
- Add regression test ensuring class-level bindings handle widget names

## Testing
- `pytest tests/test_listbox_class_event.py -q`
- `pytest -q`
- `radon cc -s -a -j gui/button_utils.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a602cf2ea08327a23c6ddcb6929c40