### PR TITLE
Handle unexpected listbox hover events safely

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -171,7 +171,9 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
     """
 
     def _lb_on_motion(event: tk.Event) -> None:
-        lb: tk.Listbox = event.widget  # type: ignore[assignment]
+        lb = event.widget
+        if not isinstance(lb, tk.Listbox):
+            return
         size = lb.size()
         if size == 0:
             return
@@ -192,7 +194,9 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
         lb._hover_index = index  # type: ignore[attr-defined]
 
     def _lb_on_leave(event: tk.Event) -> None:
-        lb: tk.Listbox = event.widget  # type: ignore[assignment]
+        lb = event.widget
+        if not isinstance(lb, tk.Listbox):
+            return
         prev = getattr(lb, "_hover_index", None)
         if prev is not None:
             lb.itemconfig(prev, background=getattr(lb, "_default_bg", "white"))

--- a/tests/test_listbox_hover_invalid_widget.py
+++ b/tests/test_listbox_hover_invalid_widget.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.button_utils import enable_listbox_hover_highlight
+
+
+class DummyRoot:
+    def __init__(self):
+        self.bindings = {}
+
+    def bind_class(self, cls, sequence, func, add=None):
+        self.bindings[(cls, sequence)] = func
+
+
+def test_listbox_highlight_ignores_non_listbox():
+    root = DummyRoot()
+    enable_listbox_hover_highlight(root)
+    lb_on_motion = root.bindings[("Listbox", "<Motion>")]
+    lb_on_leave = root.bindings[("Listbox", "<Leave>")]
+
+    class DummyEvent:
+        def __init__(self, widget):
+            self.widget = widget
+
+    lb_on_motion(DummyEvent("not a listbox"))
+    lb_on_leave(DummyEvent("not a listbox"))


### PR DESCRIPTION
## Summary
- guard listbox hover handlers against widgets that are not tk.Listbox
- cover invalid widget scenario with dedicated unit test

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path gui --output /tmp/metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a602b42b508327bf371cb32addd8af