### PR TITLE
Ensure explorer opens and returns diagram windows

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -13189,9 +13189,12 @@ class ArchitectureManagerDialog(tk.Frame):
             self.app.open_arch_window(diag_id)
             tab = self.app.diagram_tabs.get(diag_id)
             if tab and tab.winfo_exists():
-                for child in tab.winfo_children():
-                    if isinstance(child, SysMLDiagramWindow):
-                        return child
+                stack = list(tab.winfo_children())
+                while stack:
+                    widget = stack.pop()
+                    if isinstance(widget, SysMLDiagramWindow):
+                        return widget
+                    stack.extend(getattr(widget, "winfo_children", lambda: [])())
             return None
 
         master = self.master if self.master else self

--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -171,8 +171,11 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
     """
 
     def _lb_on_motion(event: tk.Event) -> None:
-        lb = event.widget
-        if not isinstance(lb, tk.Listbox):
+        lb_widget = event.widget
+        if isinstance(lb_widget, str) and hasattr(root, "nametowidget"):
+            lb_widget = root.nametowidget(lb_widget)
+        lb = lb_widget
+        if not hasattr(lb, "size"):
             return
         size = lb.size()
         if size == 0:
@@ -194,8 +197,11 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
         lb._hover_index = index  # type: ignore[attr-defined]
 
     def _lb_on_leave(event: tk.Event) -> None:
-        lb = event.widget
-        if not isinstance(lb, tk.Listbox):
+        lb_widget = event.widget
+        if isinstance(lb_widget, str) and hasattr(root, "nametowidget"):
+            lb_widget = root.nametowidget(lb_widget)
+        lb = lb_widget
+        if not hasattr(lb, "itemconfig"):
             return
         prev = getattr(lb, "_hover_index", None)
         if prev is not None:

--- a/tests/test_architecture_open_diagram.py
+++ b/tests/test_architecture_open_diagram.py
@@ -24,3 +24,35 @@ def test_open_diagram_uses_diag_id():
     explorer.open_diagram(diag.diag_id)
 
     assert called == [diag.diag_id]
+
+
+def test_open_diagram_returns_window(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Use Case Diagram", name="UC")
+
+    class StubWindow:
+        def winfo_children(self):
+            return []
+
+    class FakeTab:
+        def __init__(self, child):
+            self.child = child
+
+        def winfo_exists(self):
+            return True
+
+        def winfo_children(self):
+            return [self.child]
+
+    app = types.SimpleNamespace(diagram_tabs={}, open_arch_window=lambda d: app.diagram_tabs.update({d: FakeTab(StubWindow())}))
+
+    explorer = ArchitectureManagerDialog.__new__(ArchitectureManagerDialog)
+    explorer.repo = repo
+    explorer.app = app
+    explorer.master = None
+
+    monkeypatch.setattr("gui.architecture.SysMLDiagramWindow", StubWindow)
+
+    win = explorer.open_diagram(diag.diag_id)
+    assert isinstance(win, StubWindow)


### PR DESCRIPTION
## Summary
- Search entire tab when opening diagrams to return the created window
- Allow listbox hover helper to resolve widget names to objects
- Cover diagram window retrieval with a regression test

## Testing
- `PYTHONPATH=. pytest tests/test_architecture_open_diagram.py -q`
- `PYTHONPATH=. pytest tests/test_listbox_class_event.py::test_lb_on_motion_handles_widget_path -q`
- `PYTHONPATH=. pytest tests/test_listbox_hover_invalid_widget.py::test_listbox_highlight_ignores_non_listbox -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a62c1fdf9083278e5a1d90512fba53