### PR TITLE
Fix governance diagram double-click handling

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9512,7 +9512,14 @@ class AutoMLApp:
             self.open_page_diagram(node)
 
     def on_analysis_tree_double_click(self, event):
-        item = self.analysis_tree.focus()
+        item = (
+            self.analysis_tree.identify_row(event.y)
+            if event is not None
+            else self.analysis_tree.focus()
+        )
+        if not item:
+            return
+        self.analysis_tree.focus(item)
         tags = self.analysis_tree.item(item, "tags")
         if len(tags) != 2:
             parent = item

--- a/gui/safety_management_explorer.py
+++ b/gui/safety_management_explorer.py
@@ -95,8 +95,10 @@ class SafetyManagementExplorer(tk.Frame):
                 _add_module(sub_id, sub)
             for name in mod.diagrams:
                 plain = _strip_phase_suffix(name)
-                diag_id = self.tree.insert(parent, "end", text=plain, image=self.diagram_icon)
-                self.item_map[diag_id] = ("diagram", plain)
+                diag_iid = self.tree.insert(parent, "end", text=plain, image=self.diagram_icon)
+                # Store the full diagram name so lookups succeed even when the
+                # displayed label omits phase information.
+                self.item_map[diag_iid] = ("diagram", name)
 
         for mod in self.toolbox.modules:
             label = _strip_phase_suffix(mod.name)
@@ -112,7 +114,9 @@ class SafetyManagementExplorer(tk.Frame):
                 iid = self.tree.insert(
                     self.root_iid, "end", text=label, image=self.diagram_icon
                 )
-                self.item_map[iid] = ("diagram", label)
+                # As above, keep the real name mapped to the tree item so
+                # actions can resolve the diagram identifier.
+                self.item_map[iid] = ("diagram", name)
 
     # ------------------------------------------------------------------
     def refresh(self):

--- a/tests/test_safety_management_double_click.py
+++ b/tests/test_safety_management_double_click.py
@@ -1,0 +1,97 @@
+import types
+
+from gui.safety_management_explorer import SafetyManagementExplorer
+from analysis.safety_management import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+from AutoML import AutoMLApp
+
+
+def test_double_click_opens_diagram_with_phase(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    toolbox = SafetyManagementToolbox()
+    diag_id = toolbox.create_diagram("Gov (Phase1)")
+
+    explorer = SafetyManagementExplorer.__new__(SafetyManagementExplorer)
+
+    class DummyTree:
+        def __init__(self):
+            self.items = {}
+            self.counter = 0
+            self.selection_item = None
+
+        def delete(self, *items):
+            self.items = {}
+
+        def get_children(self, item=""):
+            return [iid for iid, meta in self.items.items() if meta["parent"] == item]
+
+        def insert(self, parent, index, text="", image=None, **_kwargs):
+            iid = f"i{self.counter}"
+            self.counter += 1
+            self.items[iid] = {"parent": parent, "text": text}
+            return iid
+
+        def parent(self, item):
+            return self.items[item]["parent"]
+
+        def selection(self):
+            return (self.selection_item,) if self.selection_item else ()
+
+    explorer.tree = DummyTree()
+    explorer.toolbox = toolbox
+    explorer.item_map = {}
+    explorer.folder_icon = None
+    explorer.diagram_icon = None
+    calls = []
+    explorer.app = types.SimpleNamespace(open_arch_window=lambda _id: calls.append(_id))
+
+    SafetyManagementExplorer.populate(explorer)
+
+    # locate diagram iid
+    for iid, (typ, obj) in explorer.item_map.items():
+        if typ == "diagram" and obj == "Gov (Phase1)":
+            explorer.tree.selection_item = iid
+            break
+
+    explorer.open_item()
+    assert calls == [diag_id]
+
+
+def test_analysis_tree_double_click_opens_diagram(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    repo.create_diagram("Governance Diagram", name="Gov")
+    app = AutoMLApp.__new__(AutoMLApp)
+
+    class DummyTree:
+        def __init__(self):
+            self.items = {
+                "root": {"text": "Safety & Security Governance Diagrams", "tags": (), "parent": ""},
+                "d1": {"text": "Gov", "tags": ("gov", "0"), "parent": "root"},
+            }
+            self._focus = "root"
+
+        def focus(self, item=None):
+            if item is None:
+                return self._focus
+            self._focus = item
+
+        def identify_row(self, _y):
+            return "d1"
+
+        def item(self, iid, opt):
+            return self.items[iid][opt]
+
+        def parent(self, iid):
+            return self.items[iid]["parent"]
+
+    app.analysis_tree = DummyTree()
+    called = {"open": None, "explorer": False}
+    app.open_management_window = lambda idx: called.__setitem__("open", idx)
+    app.manage_safety_management = lambda: called.__setitem__("explorer", True)
+
+    app.on_analysis_tree_double_click(types.SimpleNamespace(y=10))
+
+    assert called["open"] == 0
+    assert not called["explorer"]


### PR DESCRIPTION
## Summary
- use event location to identify analysis tree items so governance diagrams open directly on first double-click
- add regression test ensuring analysis tree double-click opens diagram without launching explorer

## Testing
- `pytest`
- `radon cc -j AutoML.py tests/test_safety_management_double_click.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a62ef41ba88327b7ec717e4d16e6cf