### PR TITLE
Improve requirement table context menu and phase diagram access

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9516,14 +9516,29 @@ class AutoMLApp:
         tags = self.analysis_tree.item(item, "tags")
         if len(tags) != 2:
             parent = item
+            in_gov = False
             while parent:
                 if (
                     self.analysis_tree.item(parent, "text")
                     == "Safety & Security Governance Diagrams"
                 ):
-                    self.manage_safety_management()
-                    return
+                    in_gov = True
+                    break
                 parent = self.analysis_tree.parent(parent)
+            if not in_gov:
+                return
+            self.manage_safety_management()
+            text = self.analysis_tree.item(item, "text")
+            idx = next(
+                (
+                    i
+                    for i, d in enumerate(getattr(self, "management_diagrams", []))
+                    if (d.name or d.diag_id) == text
+                ),
+                None,
+            )
+            if idx is not None:
+                self.open_management_window(idx)
             return
         kind, ident = tags[0], tags[1]
         if kind in {"fmea", "fmeda", "hazop", "hara", "stpa", "threat", "fi2tc", "tc2fi", "jrev", "gov"}:
@@ -12719,7 +12734,7 @@ class AutoMLApp:
 
         columns = ["ID", "ASIL", "CAL", "Type", "Status", "Parent", "Trace", "Links", "Text"]
         tree_frame = ttk.Frame(win)
-        tree_frame.pack(fill=tk.BOTH, expand=True)
+        tree_frame.pack(fill=tk.BOTH)
         style = ttk.Style(tree_frame)
         style.configure("ReqEditor.Treeview", rowheight=20)
         tree = ttk.Treeview(
@@ -12729,6 +12744,7 @@ class AutoMLApp:
             selectmode="browse",
             style="ReqEditor.Treeview",
         )
+        tree.configure(height=10)
         vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=tree.yview)
         hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=tree.xview)
         tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
@@ -13010,6 +13026,77 @@ class AutoMLApp:
                 unlink_requirements(rid, relation, tid)
             refresh_tree()
 
+        def save_csv():
+            path = filedialog.asksaveasfilename(
+                defaultextension=".csv", filetypes=[("CSV", "*.csv")]
+            )
+            if not path:
+                return
+            try:
+                with open(path, "w", newline="") as fh:
+                    writer = csv.writer(fh)
+                    writer.writerow(columns)
+                    for req in global_requirements.values():
+                        rid = req.get("id", "")
+                        trace = ", ".join(_get_requirement_allocations(rid))
+                        links = ", ".join(
+                            f"{r.get('type')} {r.get('id')}" for r in req.get("relations", [])
+                        )
+                        writer.writerow(
+                            [
+                                rid,
+                                req.get("asil", ""),
+                                req.get("cal", ""),
+                                req.get("req_type", ""),
+                                req.get("status", "draft"),
+                                req.get("parent_id", ""),
+                                trace,
+                                links,
+                                req.get("text", ""),
+                            ]
+                        )
+                messagebox.showinfo(
+                    "Requirements", f"Saved {len(global_requirements)} requirements to {path}"
+                )
+            except Exception as exc:
+                messagebox.showerror("Requirements", f"Failed to save CSV:\n{exc}")
+
+        if hasattr(tree, "bind"):
+            try:
+                menu = tk.Menu(tree, tearoff=False)
+            except Exception:
+                menu = None
+            if menu:
+                menu.add_command(label="Add", command=add_req)
+                menu.add_command(label="Edit", command=edit_req)
+                menu.add_command(label="Delete", command=del_req)
+                menu.add_command(label="Link to Diagram...", command=link_to_diagram)
+                menu.add_command(label="Link Requirement...", command=link_requirement)
+                menu.add_command(label="Save CSV", command=save_csv)
+
+                def _popup(event: tk.Event) -> None:
+                    row = tree.identify_row(event.y)
+                    if row:
+                        tree.selection_set(row)
+                        tree.focus(row)
+                    try:
+                        menu.tk_popup(event.x_root, event.y_root)
+                    finally:
+                        menu.grab_release()
+
+                def _on_double(event: tk.Event) -> None:
+                    row = tree.identify_row(event.y)
+                    if row:
+                        tree.selection_set(row)
+                        tree.focus(row)
+                        edit_req()
+
+                tree.bind("<Button-3>", _popup)
+                tree.bind("<Button-2>", _popup)
+                tree.bind("<Control-Button-1>", _popup)
+                tree.bind("<Double-1>", _on_double)
+                tree.context_menu = menu
+
         btn = tk.Frame(win)
         btn.pack(fill=tk.X)
         tk.Button(btn, text="Add", command=add_req).pack(side=tk.LEFT)
@@ -13017,6 +13104,7 @@ class AutoMLApp:
         tk.Button(btn, text="Delete", command=del_req).pack(side=tk.LEFT)
         tk.Button(btn, text="Link to Diagram...", command=link_to_diagram).pack(side=tk.LEFT)
         tk.Button(btn, text="Link Requirement...", command=link_requirement).pack(side=tk.LEFT)
+        tk.Button(btn, text="Save CSV", command=save_csv).pack(side=tk.LEFT)
 
         refresh_tree()
 

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -1,3 +1,4 @@
+import csv
 import tkinter as tk
 from tkinter import ttk, simpledialog
 import tkinter.font as tkfont
@@ -18,7 +19,6 @@ from gui.mac_button_style import apply_translucid_button_style
 from gui.icon_factory import create_icon
 from sysml.sysml_repository import SysMLRepository
 from gui.toolboxes import configure_table_style, _wrap_val
-from gui.mac_button_style import apply_translucid_button_style
 
 
 class SafetyManagementWindow(tk.Frame):
@@ -320,12 +320,13 @@ class SafetyManagementWindow(tk.Frame):
         tree_frame = ttk.Frame(frame)
         style_name = "Requirements.Treeview"
         try:
-            configure_table_style(style_name, rowheight=80)
+            configure_table_style(style_name)
             tree = ttk.Treeview(
                 tree_frame, columns=columns, show="headings", style=style_name
             )
         except Exception:
             tree = ttk.Treeview(tree_frame, columns=columns, show="headings")
+        tree.configure(height=10)  # limit table height so buttons remain visible
         for c in columns:
             tree.heading(c, text=c)
 
@@ -368,7 +369,142 @@ class SafetyManagementWindow(tk.Frame):
 
         populate(ids)
         add_treeview_scrollbars(tree, tree_frame)
-        tree_frame.pack(fill=tk.BOTH, expand=True)
+        tree_frame.pack(fill=tk.BOTH)  # don't expand so button bar has room
+
+        def _selected_rid() -> str | None:
+            item = tree.focus()
+            if not item:
+                return None
+            try:
+                return tree.item(item, "values")[0]
+            except Exception:
+                return None
+
+        def _add() -> None:
+            text = simpledialog.askstring("Requirement", "Requirement text:")
+            if not text:
+                return
+            req_type = (
+                simpledialog.askstring(
+                    "Requirement", "Requirement type:", initialvalue="organizational"
+                )
+                or "organizational"
+            )
+            rid = self._add_requirement(text, req_type=req_type)
+            ids.append(rid)
+            populate(ids)
+
+        def _edit() -> None:
+            rid = _selected_rid()
+            if not rid:
+                return
+            req = global_requirements.get(rid, {})
+            text = simpledialog.askstring(
+                "Requirement", "Requirement text:", initialvalue=req.get("text", "")
+            )
+            if text is None:
+                return
+            req["text"] = text
+            req_type = simpledialog.askstring(
+                "Requirement", "Requirement type:", initialvalue=req.get("req_type", "")
+            )
+            if req_type:
+                req["req_type"] = req_type
+            populate(ids)
+
+        def _remove() -> None:
+            rid = _selected_rid()
+            if not rid:
+                return
+            if not messagebox.askyesno("Remove Requirement", f"Delete {rid}?"):
+                return
+            try:
+                ids.remove(rid)
+            except ValueError:
+                pass
+            global_requirements.pop(rid, None)
+            populate(ids)
+
+        def _save_csv() -> None:
+            path = simpledialog.askstring(
+                "Save CSV", "File path:", initialvalue="requirements.csv"
+            )
+            if not path:
+                return
+            try:
+                with open(path, "w", newline="") as fh:
+                    writer = csv.writer(fh)
+                    writer.writerow(columns)
+                    for rid in ids:
+                        req = global_requirements.get(rid, {})
+                        writer.writerow(
+                            [
+                                rid,
+                                req.get("req_type", ""),
+                                req.get("text", ""),
+                                req.get("phase") or "",
+                                req.get("status", ""),
+                            ]
+                        )
+                messagebox.showinfo(
+                    "Requirements", f"Saved {len(ids)} requirements to {path}"
+                )
+            except Exception as exc:
+                messagebox.showerror("Requirements", f"Failed to save CSV:\n{exc}")
+
+        if hasattr(tree, "bind"):
+            try:
+                menu = tk.Menu(tree, tearoff=False)
+            except Exception:
+                menu = None
+            if menu:
+                menu.add_command(label="Add", command=_add)
+                menu.add_command(label="Edit", command=_edit)
+                menu.add_command(label="Remove", command=_remove)
+                menu.add_command(label="Save CSV", command=_save_csv)
+
+                def _popup(event: tk.Event) -> None:
+                    row = tree.identify_row(event.y)
+                    if row:
+                        tree.selection_set(row)
+                        tree.focus(row)
+                    try:
+                        menu.tk_popup(event.x_root, event.y_root)
+                    finally:
+                        menu.grab_release()
+
+                def _on_double_click(event: tk.Event) -> None:
+                    row = tree.identify_row(event.y)
+                    if row:
+                        tree.selection_set(row)
+                        tree.focus(row)
+                        _edit()
+
+                # support right-click across platforms and trackpads
+                tree.bind("<Button-3>", _popup)
+                tree.bind("<Button-2>", _popup)
+                tree.bind("<Control-Button-1>", _popup)
+                tree.bind("<Double-1>", _on_double_click)
+                # keep a reference so the menu isn't garbage collected
+                tree.context_menu = menu
+
+        if hasattr(ttk.Frame, "grid"):
+            btn_frame = ttk.Frame(frame)
+            btn_frame.pack(fill=tk.X, pady=4)
+            if hasattr(btn_frame, "configure"):
+                tk.Button(btn_frame, text="Add", command=_add).pack(
+                    side=tk.LEFT, padx=2
+                )
+                tk.Button(btn_frame, text="Edit", command=_edit).pack(
+                    side=tk.LEFT, padx=2
+                )
+                tk.Button(btn_frame, text="Remove", command=_remove).pack(
+                    side=tk.LEFT, padx=2
+                )
+                tk.Button(btn_frame, text="Save CSV", command=_save_csv).pack(
+                    side=tk.LEFT, padx=2
+                )
+
         frame.refresh_table = populate
         return frame
 

--- a/tests/test_safety_management.py
+++ b/tests/test_safety_management.py
@@ -1989,6 +1989,47 @@ def test_folder_double_click_opens_safety_management_explorer():
     assert called["explorer"]
 
 
+def test_diagram_double_click_opens_directly():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    diag.name = "Gov1"
+
+    class DummyTree:
+        def __init__(self):
+            self._focus = "d"
+            self.items = {
+                "g": {"parent": "", "text": "Safety & Security Governance Diagrams", "tags": ()},
+                "p": {"parent": "g", "text": "Phase", "tags": ()},
+                "d": {"parent": "p", "text": "Gov1", "tags": ()},
+            }
+
+        def item(self, iid, option):
+            meta = self.items[iid]
+            return meta.get(option)
+
+        def parent(self, iid):
+            return self.items[iid]["parent"]
+
+        def focus(self, iid=None):
+            if iid is None:
+                return self._focus
+            self._focus = iid
+
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.analysis_tree = DummyTree()
+    app.management_diagrams = [diag]
+
+    called = {"explorer": False, "opened": False}
+    app.manage_safety_management = lambda: called.__setitem__("explorer", True)
+    app.open_management_window = lambda idx: called.__setitem__("opened", idx == 0)
+
+    app.on_analysis_tree_double_click(None)
+
+    assert called["explorer"]
+    assert called["opened"]
+
+
 def test_add_work_product_uses_half_width(monkeypatch):
     SysMLRepository._instance = None
     repo = SysMLRepository.get_instance()


### PR DESCRIPTION
## Summary
- Support right-click context menu across platforms and retain menu reference
- Bind double-clicks to open the requirement editor
- Limit Requirements editor table height so controls are visible
- Add CSV export with matching context menu entries
- Open governance diagrams within lifecycle phases directly on double-click

## Testing
- `pytest -q`
- `radon cc -s -j gui/safety_management_toolbox.py AutoML.py` *(fails: command not found; `pip install radon` failed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a5ffc8a0d4832792cade61b8877ab5