### PR TITLE
Add minimal matplotlib backend stub and robust listbox hover

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -172,7 +172,17 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
 
     def _lb_on_motion(event: tk.Event) -> None:
         lb = event.widget
-        if not isinstance(lb, tk.Listbox):
+        if isinstance(lb, str):  # widget path names may be provided by events
+            resolver = getattr(root, "nametowidget", None)
+            if resolver is None:
+                return
+            try:
+                lb = resolver(lb)
+            except Exception:
+                return
+        # ``tk.Listbox`` isn't available in tests; fall back to duck-typing.
+        required = ("size", "nearest", "itemconfig")
+        if not all(hasattr(lb, attr) for attr in required):
             return
         size = lb.size()
         if size == 0:
@@ -195,7 +205,15 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
 
     def _lb_on_leave(event: tk.Event) -> None:
         lb = event.widget
-        if not isinstance(lb, tk.Listbox):
+        if isinstance(lb, str):
+            resolver = getattr(root, "nametowidget", None)
+            if resolver is None:
+                return
+            try:
+                lb = resolver(lb)
+            except Exception:
+                return
+        if not hasattr(lb, "itemconfig"):
             return
         prev = getattr(lb, "_hover_index", None)
         if prev is not None:

--- a/matplotlib/backends/__init__.py
+++ b/matplotlib/backends/__init__.py
@@ -1,0 +1,12 @@
+"""Minimal ``matplotlib.backends`` package for testing.
+
+This stub package provides only the pieces required by the project.  It is
+*not* a full-featured backend implementation.  Only the TkAgg canvas is
+implemented to allow the metrics tab to create a drawing surface when the
+real Matplotlib library is unavailable.
+"""
+
+from .backend_tkagg import FigureCanvasTkAgg  # noqa: F401
+
+__all__ = ["FigureCanvasTkAgg"]
+

--- a/matplotlib/backends/backend_tkagg.py
+++ b/matplotlib/backends/backend_tkagg.py
@@ -1,0 +1,37 @@
+"""TkAgg backend stub for the minimal Matplotlib substitute.
+
+Only the small subset of functionality exercised by the tests is provided.
+The real Matplotlib project offers a rich drawing API; this lightweight
+implementation merely supplies the :class:`FigureCanvasTkAgg` class with the
+methods used by the GUI metrics tab.
+"""
+
+try:  # pragma: no cover - best effort import
+    import tkinter as tk
+except Exception:  # pragma: no cover - fallback when Tk is unavailable
+    tk = None  # type: ignore
+
+
+class FigureCanvasTkAgg:
+    """Very small stand-in for Matplotlib's canvas widget."""
+
+    def __init__(self, figure, master=None):
+        self.figure = figure
+        if tk and master is not None:
+            self._tk_widget = tk.Frame(master)
+        else:  # pragma: no cover - Tk not available
+            class _Dummy:
+                def pack(self, *args, **kwargs):
+                    pass
+
+            self._tk_widget = _Dummy()
+
+    def get_tk_widget(self):  # pragma: no cover - trivial
+        return self._tk_widget
+
+    def draw_idle(self):  # pragma: no cover - trivial
+        pass
+
+
+__all__ = ["FigureCanvasTkAgg"]
+

--- a/matplotlib/pyplot.py
+++ b/matplotlib/pyplot.py
@@ -1,5 +1,43 @@
+class Axes:
+    """Minimal stand-in for :class:`matplotlib.axes.Axes`."""
+
+    def clear(self):
+        pass
+
+    def plot(self, *args, **kwargs):
+        pass
+
+    def set_title(self, *args, **kwargs):
+        pass
+
+    def bar(self, *args, **kwargs):
+        pass
+
+
+class Figure:
+    """Very small substitute for :class:`matplotlib.figure.Figure`.
+
+    The real ``matplotlib`` library exposes a ``Figure`` class used to
+    create and manage subplots.  The GUI's metrics tab imports this class via
+    ``plt.Figure``.  The testing environment only requires enough behaviour
+    to satisfy those imports, so this stub tracks created axes and exposes a
+    ``tight_layout`` no-op.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.axes = []
+
+    def add_subplot(self, *args, **kwargs):  # pragma: no cover - trivial
+        ax = Axes()
+        self.axes.append(ax)
+        return ax
+
+    def tight_layout(self, *args, **kwargs):  # pragma: no cover - trivial
+        pass
+
+
 def figure(*args, **kwargs):
-    pass
+    return Figure(*args, **kwargs)
 
 def title(*args, **kwargs):
     pass


### PR DESCRIPTION
## Summary
- provide matplotlib backends and Figure stubs so metrics tab works without full matplotlib
- handle widget path strings in listbox hover highlighting

## Testing
- `pytest`
- `python tools/metrics_generator.py --path analysis --output metrics.json --plots`


------
https://chatgpt.com/codex/tasks/task_b_68a637a3795c8327922814567cf18051