### PR TITLE
Enable requirements menu via governance and fix listbox hover

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -2237,6 +2237,14 @@ class AutoMLApp:
         "ODD": "Scenario Library",
     }
 
+    # Ensure all requirement work products activate the top-level Requirements
+    # menu.  Each specific requirement specification (e.g. vehicle, functional
+    # safety) is treated as a child of the generic "Requirements" category so
+    # that declaring any of them on a governance diagram enables the
+    # corresponding menu items.
+    for _wp in REQUIREMENT_WORK_PRODUCTS:
+        WORK_PRODUCT_PARENTS.setdefault(_wp, "Requirements")
+
     def __init__(self, root):
         self.root = root
         self.top_events = []
@@ -2856,6 +2864,9 @@ class AutoMLApp:
         menubar.add_cascade(label="Search", menu=search_menu)
         menubar.add_cascade(label="View", menu=view_menu)
         menubar.add_cascade(label="Requirements", menu=requirements_menu)
+        idx = menubar.index("end")
+        self.work_product_menus.setdefault("Requirements", []).append((menubar, idx))
+        menubar.entryconfig(idx, state=tk.DISABLED)
         menubar.add_cascade(label="Architecture", menu=architecture_menu)
         idx = menubar.index("end")
         self.work_product_menus.setdefault("Architecture Diagram", []).append((menubar, idx))
@@ -10134,17 +10145,21 @@ class AutoMLApp:
         info = self.WORK_PRODUCT_INFO.get(name)
         if info:
             area, tool_name, _ = info
-            if tool_name and not any(
-                self.WORK_PRODUCT_INFO.get(wp)[1] == tool_name
-                for wp in self.enabled_work_products
-            ):
-                lb = self.tool_listboxes.get(area)
-                if lb:
-                    for i in range(lb.size()):
-                        if lb.get(i) == tool_name:
-                            lb.delete(i)
-                            break
-                self.tool_actions.pop(tool_name, None)
+            if tool_name:
+                still_in_use = False
+                for wp in self.enabled_work_products:
+                    wp_info = self.WORK_PRODUCT_INFO.get(wp)
+                    if wp_info and wp_info[1] == tool_name:
+                        still_in_use = True
+                        break
+                if not still_in_use:
+                    lb = self.tool_listboxes.get(area)
+                    if lb:
+                        for i in range(lb.size()):
+                            if lb.get(i) == tool_name:
+                                lb.delete(i)
+                                break
+                    self.tool_actions.pop(tool_name, None)
         parent = self.WORK_PRODUCT_PARENTS.get(name)
         if parent and parent in self.enabled_work_products:
             if not any(

--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -172,7 +172,13 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
 
     def _lb_on_motion(event: tk.Event) -> None:
         lb = event.widget
-        if not isinstance(lb, tk.Listbox):
+        if isinstance(lb, str):
+            resolver = getattr(root, "nametowidget", lambda name: name)
+            lb = resolver(lb)
+        # Accept any object implementing the listbox API so tests can supply
+        # lightweight stand-ins without requiring a full tk.Listbox instance.
+        required = {"size", "nearest", "itemconfig", "itemcget", "cget"}
+        if not all(hasattr(lb, attr) for attr in required):
             return
         size = lb.size()
         if size == 0:
@@ -195,7 +201,10 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
 
     def _lb_on_leave(event: tk.Event) -> None:
         lb = event.widget
-        if not isinstance(lb, tk.Listbox):
+        if isinstance(lb, str):
+            resolver = getattr(root, "nametowidget", lambda name: name)
+            lb = resolver(lb)
+        if not hasattr(lb, "itemconfig"):
             return
         prev = getattr(lb, "_hover_index", None)
         if prev is not None:


### PR DESCRIPTION
## Summary
- Activate Requirements menu when requirement work products are declared in governance diagrams
- Harden listbox hover highlighting to support widget paths and gracefully ignore non-listbox widgets
- Safely remove toolbox actions when disabling work products without metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a63ae897448327a8de7a392ca74cb4