### PR TITLE
feat: use purplish buttons on welcome dialogs

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -241,7 +241,7 @@ from gui.review_toolbox import (
     ParticipantDialog,
     EmailConfigDialog,
     ReviewScopeDialog,
-    UserSelectDialog,
+    UserSelectDialog as ReviewUserSelectDialog,
     ReviewDocumentDialog,
     VersionCompareDialog,
 )
@@ -258,7 +258,10 @@ from gsn.nodes import GSNNode
 from gui.closable_notebook import ClosableNotebook
 from gui.icon_factory import create_icon
 from gui.splash_screen import SplashScreen
-from gui.mac_button_style import apply_translucid_button_style
+from gui.mac_button_style import (
+    apply_translucid_button_style,
+    apply_purplish_button_style,
+)
 from dataclasses import asdict
 from pathlib import Path
 from analysis.mechanisms import (
@@ -491,6 +494,27 @@ class UserInfoDialog(simpledialog.Dialog):
     def apply(self):
         self.result = (self.name_var.get().strip(), self.email_var.get().strip())
 
+    def buttonbox(self):
+        box = ttk.Frame(self)
+        apply_purplish_button_style()
+        ttk.Button(
+            box,
+            text="OK",
+            width=10,
+            command=self.ok,
+            style="Purple.TButton",
+        ).pack(side=tk.LEFT, padx=5, pady=5)
+        ttk.Button(
+            box,
+            text="Cancel",
+            width=10,
+            command=self.cancel,
+            style="Purple.TButton",
+        ).pack(side=tk.LEFT, padx=5, pady=5)
+        self.bind("<Return>", self.ok)
+        self.bind("<Escape>", self.cancel)
+        box.pack()
+
 
 class UserSelectDialog(simpledialog.Dialog):
     """Prompt to select a user from a list."""
@@ -526,6 +550,27 @@ class UserSelectDialog(simpledialog.Dialog):
 
     def apply(self):
         self.result = (self.name_var.get(), self.email_var.get().strip())
+
+    def buttonbox(self):
+        box = ttk.Frame(self)
+        apply_purplish_button_style()
+        ttk.Button(
+            box,
+            text="OK",
+            width=10,
+            command=self.ok,
+            style="Purple.TButton",
+        ).pack(side=tk.LEFT, padx=5, pady=5)
+        ttk.Button(
+            box,
+            text="Cancel",
+            width=10,
+            command=self.cancel,
+            style="Purple.TButton",
+        ).pack(side=tk.LEFT, padx=5, pady=5)
+        self.bind("<Return>", self.ok)
+        self.bind("<Escape>", self.cancel)
+        box.pack()
 
 
 # Target PMHF limits per ASIL level (events per hour)
@@ -21640,7 +21685,7 @@ class AutoMLApp:
             messagebox.showwarning("User", "Start a review first")
             return
         parts = self.review_data.participants + self.review_data.moderators
-        dlg = UserSelectDialog(self.root, parts, initial_name=self.current_user)
+        dlg = ReviewUserSelectDialog(self.root, parts, initial_name=self.current_user)
         if not dlg.result:
             return
         name, _ = dlg.result

--- a/tests/test_user_dialog_buttons.py
+++ b/tests/test_user_dialog_buttons.py
@@ -1,0 +1,49 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import AutoML as automl
+
+
+def _collect_button_styles(dialog_cls, monkeypatch):
+    styles = []
+    applied = {"called": 0}
+
+    class DummyButton:
+        def __init__(self, master, **kwargs):
+            styles.append(kwargs.get("style"))
+        def pack(self, *a, **k):
+            pass
+
+    class DummyFrame:
+        def __init__(self, *a, **k):
+            pass
+        def pack(self, *a, **k):
+            pass
+
+    class DummyDialog:
+        def bind(self, *a, **k):
+            pass
+        ok = lambda self, *a, **k: None
+        cancel = lambda self, *a, **k: None
+
+    def fake_apply(style=None):
+        applied["called"] += 1
+
+    monkeypatch.setattr(automl.ttk, "Button", DummyButton)
+    monkeypatch.setattr(automl.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(automl, "apply_purplish_button_style", fake_apply)
+
+    dlg = DummyDialog()
+    dialog_cls.buttonbox(dlg)
+    return styles, applied["called"]
+
+
+def test_user_info_dialog_purplish_buttons(monkeypatch):
+    styles, called = _collect_button_styles(automl.UserInfoDialog, monkeypatch)
+    assert styles == ["Purple.TButton", "Purple.TButton"]
+    assert called == 1
+
+
+def test_user_select_dialog_purplish_buttons(monkeypatch):
+    styles, called = _collect_button_styles(automl.UserSelectDialog, monkeypatch)
+    assert styles == ["Purple.TButton", "Purple.TButton"]
+    assert called == 1


### PR DESCRIPTION
## Summary
- apply purple-themed button style on user info and selection dialogs
- avoid name clash with review user selector
- test that welcome dialogs create Purple.TButton widgets

## Testing
- `pytest`
- `python tools/metrics_generator.py --path . --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a63bde58a48327942f5f6da01f547e