### PR TITLE
Enable requirements menu via governance and fix listbox hover

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -2841,6 +2841,12 @@ def link_requirements(src_id: str, relation: str, dst_id: str) -> None:
     dst = global_requirements.get(dst_id)
     if not src or not dst:
         return
+    from analysis import safety_management as _sm
+    toolbox = getattr(_sm, "ACTIVE_TOOLBOX", None)
+    if toolbox and not toolbox.can_link_requirements(
+        src.get("req_type", ""), dst.get("req_type", ""), relation
+    ):
+        return
     rel = {"type": relation, "id": dst_id}
     rels = src.setdefault("relations", [])
     if rel not in rels:

--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -172,7 +172,13 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
 
     def _lb_on_motion(event: tk.Event) -> None:
         lb = event.widget
-        if not isinstance(lb, tk.Listbox):
+        if isinstance(lb, str):
+            resolver = getattr(root, "nametowidget", lambda name: name)
+            lb = resolver(lb)
+        # Accept any object implementing the listbox API so tests can supply
+        # lightweight stand-ins without requiring a full tk.Listbox instance.
+        required = {"size", "nearest", "itemconfig", "itemcget", "cget"}
+        if not all(hasattr(lb, attr) for attr in required):
             return
         size = lb.size()
         if size == 0:
@@ -195,7 +201,10 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
 
     def _lb_on_leave(event: tk.Event) -> None:
         lb = event.widget
-        if not isinstance(lb, tk.Listbox):
+        if isinstance(lb, str):
+            resolver = getattr(root, "nametowidget", lambda name: name)
+            lb = resolver(lb)
+        if not hasattr(lb, "itemconfig"):
             return
         prev = getattr(lb, "_hover_index", None)
         if prev is not None:

--- a/tests/test_requirement_relations.py
+++ b/tests/test_requirement_relations.py
@@ -48,6 +48,15 @@ def test_link_requirements_creates_bidirectional_relation():
     assert {"type": "satisfies", "id": "R1"} in global_requirements["R2"].get("relations", [])
 
 
+def test_link_requirements_respects_governance():
+    setup_toolbox()
+    global_requirements.clear()
+    global_requirements["R1"] = {"id": "R1", "req_type": "vehicle"}
+    global_requirements["R2"] = {"id": "R2", "req_type": "vehicle"}
+    link_requirements("R1", "derived from", "R2")
+    assert "relations" not in global_requirements["R1"]
+
+
 def test_non_requirement_work_product_ignored():
     SysMLRepository.reset_instance()
     repo = SysMLRepository.get_instance()

--- a/tests/test_requirements_menu_activation.py
+++ b/tests/test_requirements_menu_activation.py
@@ -1,0 +1,40 @@
+import tkinter as tk
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from AutoML import AutoMLApp
+from analysis.models import REQUIREMENT_WORK_PRODUCTS
+
+class DummyMenu:
+    def __init__(self):
+        self.states = {}
+    def entryconfig(self, idx, state=tk.DISABLED):
+        self.states[idx] = state
+
+class DummyToolbox:
+    work_products = [1]
+    active_module = None
+    def enabled_products(self):
+        return {"Vehicle Requirement Specification"}
+
+def test_requirement_menu_enabled_with_any_work_product():
+    menu = DummyMenu()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.tool_listboxes = {}
+    app.tool_categories = {}
+    app.tool_actions = {}
+    app.enable_process_area = lambda area: None
+    app.update_views = lambda: None
+    app.work_product_menus = {}
+    app.enabled_work_products = set()
+    app.WORK_PRODUCT_INFO = AutoMLApp.WORK_PRODUCT_INFO
+    app.WORK_PRODUCT_PARENTS = AutoMLApp.WORK_PRODUCT_PARENTS
+    app.tool_to_work_product = {}
+    app.safety_mgmt_toolbox = DummyToolbox()
+    for wp in REQUIREMENT_WORK_PRODUCTS:
+        app.work_product_menus.setdefault(wp, []).append((menu, 0))
+    AutoMLApp.enable_work_product(app, "Vehicle Requirement Specification", refresh=False)
+    AutoMLApp.refresh_tool_enablement(app)
+    assert menu.states[0] == tk.NORMAL


### PR DESCRIPTION
## Summary
- Aggregate work-product menu states so any requirement specification activates matrix, editor, and explorer
- Gate requirement linking through the active governance toolbox to enforce allowed relations
- Cover requirement menu activation and trace governance with new tests

## Testing
- `pytest -q`
- `pip install radon -q` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a63ae897448327a8de7a392ca74cb4