### PR TITLE
Guard metrics tab against missing matplotlib

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -18080,18 +18080,21 @@ class AutoMLApp:
 
     def open_metrics_tab(self):
         """Open a tab displaying project metrics."""
-        import importlib
         from gui import messagebox
 
-        if importlib.util.find_spec("matplotlib") is None:
-            msg = ("Matplotlib is required to view metrics.\n"
-                   "Install it with 'pip install matplotlib'.")
-            messagebox.showerror("Metrics unavailable", msg)
-            return
         try:
+            import matplotlib
+            # Detect the lightweight testing stub by comparing paths.  The real
+            # Matplotlib package resides outside the repository.
+            if Path(matplotlib.__file__).resolve().parent == Path(__file__).resolve().parent / "matplotlib":
+                raise ImportError
             from gui.metrics_tab import MetricsTab
         except Exception as exc:  # pragma: no cover - display error in GUI
-            messagebox.showerror("Metrics unavailable", str(exc))
+            msg = (
+                "Matplotlib is required to view metrics.\n"
+                "Install it with 'pip install matplotlib'."
+            )
+            messagebox.showerror("Metrics unavailable", msg if isinstance(exc, ImportError) else str(exc))
             return
 
         tab = self._new_tab("Metrics")

--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -180,6 +180,7 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
         required = {"size", "nearest", "itemconfig", "itemcget", "cget"}
         if not all(hasattr(lb, attr) for attr in required):
             return
+        size = lb.size()
         if size == 0:
             return
         index = lb.nearest(event.y)


### PR DESCRIPTION
## Summary
- Detect repository's matplotlib stub and warn users instead of opening a blank Metrics tab
- Fix listbox hover handler by computing listbox size before use

## Testing
- `pytest -q`
- `radon cc -j AutoML.py gui/button_utils.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a641ed1110832793356f13c221fcfd