### PR TITLE
Remove Matplotlib dependency from metrics tab

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -364,7 +364,6 @@ import os
 import types
 os.environ["GS_EXECUTABLE"] = r"C:\Program Files\gs\gs10.04.0\bin\gswin64c.exe"
 import networkx as nx
-import matplotlib.pyplot as plt
 # Import ReportLab for PDF export.
 from reportlab.platypus import Table, TableStyle, SimpleDocTemplate, Paragraph, Spacer, Image as RLImage, PageBreak
 from gui.style_editor import StyleEditor
@@ -18080,19 +18079,7 @@ class AutoMLApp:
 
     def open_metrics_tab(self):
         """Open a tab displaying project metrics."""
-        import importlib
-        from gui import messagebox
-
-        if importlib.util.find_spec("matplotlib") is None:
-            msg = ("Matplotlib is required to view metrics.\n"
-                   "Install it with 'pip install matplotlib'.")
-            messagebox.showerror("Metrics unavailable", msg)
-            return
-        try:
-            from gui.metrics_tab import MetricsTab
-        except Exception as exc:  # pragma: no cover - display error in GUI
-            messagebox.showerror("Metrics unavailable", str(exc))
-            return
+        from gui.metrics_tab import MetricsTab
 
         tab = self._new_tab("Metrics")
         MetricsTab(tab, self).pack(fill=tk.BOTH, expand=True)

--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -180,6 +180,7 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
         required = {"size", "nearest", "itemconfig", "itemcget", "cget"}
         if not all(hasattr(lb, attr) for attr in required):
             return
+        size = lb.size()
         if size == 0:
             return
         index = lb.nearest(event.y)

--- a/gui/metrics_tab.py
+++ b/gui/metrics_tab.py
@@ -1,44 +1,59 @@
 import tkinter as tk
 from collections import Counter
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-import matplotlib.pyplot as plt
 
 
 class MetricsTab(tk.Frame):
-    """Tab displaying simple project metrics graphs."""
+    """Tab displaying simple project metrics graphs without Matplotlib."""
 
     def __init__(self, master, app):
         super().__init__(master)
         self.app = app
-        self.fig = plt.Figure(figsize=(9, 3))
-        self.axes = [self.fig.add_subplot(131),
-                     self.fig.add_subplot(132),
-                     self.fig.add_subplot(133)]
-        canvas = FigureCanvasTkAgg(self.fig, master=self)
-        canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
-        self.canvas = canvas
+        self.canvases = [tk.Canvas(self, width=300, height=200, bg="white") for _ in range(3)]
+        for c in self.canvases:
+            c.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.update_plots()
+
+    def _draw_line_chart(self, canvas: tk.Canvas, data):
+        canvas.delete("all")
+        h = int(canvas["height"])
+        w = int(canvas["width"])
+        max_val = max(data) if data else 1
+        step = w / max(1, len(data) - 1)
+        points = []
+        for i, val in enumerate(data):
+            x = i * step
+            y = h - (val / max_val) * h
+            points.extend([x, y])
+        if len(points) > 3:
+            canvas.create_line(*points, fill="blue")
+        canvas.create_text(5, 5, anchor="nw", text="Requirements")
+
+    def _draw_bar_chart(self, canvas: tk.Canvas, data):
+        canvas.delete("all")
+        h = int(canvas["height"])
+        w = int(canvas["width"])
+        keys = list(data.keys())
+        vals = list(data.values())
+        n = len(keys)
+        bar_w = w / max(1, n)
+        max_val = max(vals) if vals else 1
+        for i, (k, v) in enumerate(data.items()):
+            x0 = i * bar_w + 10
+            x1 = (i + 1) * bar_w - 10
+            y1 = h - (v / max_val) * h
+            canvas.create_rectangle(x0, y1, x1, h, fill="green")
+            canvas.create_text((x0 + x1) / 2, h - 5, anchor="s", text=str(k))
 
     def update_plots(self):
         req_history = getattr(self.app, "requirement_history", [])
         if not req_history:
             req_history = [len(getattr(self.app, "requirements", []))]
-        ax = self.axes[0]
-        ax.clear()
-        ax.plot(req_history)
-        ax.set_title("Requirements")
+        self._draw_line_chart(self.canvases[0], req_history)
 
         statuses = Counter(getattr(r, "status", "unknown") for r in getattr(self.app, "requirements", []))
-        ax = self.axes[1]
-        ax.clear()
-        ax.bar(list(statuses.keys()), list(statuses.values()))
-        ax.set_title("Status")
+        self._draw_bar_chart(self.canvases[1], statuses)
+        self.canvases[1].create_text(5, 5, anchor="nw", text="Status")
 
         user_metrics = getattr(self.app, "user_metrics", {})
-        ax = self.axes[2]
-        ax.clear()
-        if user_metrics:
-            ax.bar(list(user_metrics.keys()), list(user_metrics.values()))
-        ax.set_title("User Effort")
-        self.fig.tight_layout()
-        self.canvas.draw_idle()
+        self._draw_bar_chart(self.canvases[2], user_metrics)
+        self.canvases[2].create_text(5, 5, anchor="nw", text="User Effort")

--- a/tests/test_metrics_tab_missing_backend.py
+++ b/tests/test_metrics_tab_missing_backend.py
@@ -4,7 +4,7 @@ from unittest import mock
 from AutoML import AutoMLApp
 
 
-class MetricsTabMissingBackendTests(unittest.TestCase):
+class MetricsTabWithoutMatplotlibTests(unittest.TestCase):
     def test_open_metrics_tab_without_matplotlib(self):
         try:
             root = tk.Tk()
@@ -12,10 +12,9 @@ class MetricsTabMissingBackendTests(unittest.TestCase):
         except tk.TclError:
             self.skipTest("Tk not available")
         app = AutoMLApp(root)
-        with mock.patch("importlib.util.find_spec", return_value=None):
-            app.open_metrics_tab()
+        app.open_metrics_tab()
         tabs = [app.doc_nb.tab(tid, "text") for tid in app.doc_nb.tabs()]
-        self.assertNotIn("Metrics", tabs)
+        self.assertIn("Metrics", tabs)
         root.destroy()
 
 


### PR DESCRIPTION
## Summary
- Render metrics graphs on a Tk canvas to avoid the Matplotlib requirement
- Simplify metrics tab creation by dropping stub-detection logic

## Testing
- `pytest -q`
- `radon cc -j AutoML.py gui/button_utils.py gui/metrics_tab.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a641ed1110832793356f13c221fcfd