### PR TITLE
Handle zero max in metrics line chart

### DIFF
--- a/gui/metrics_tab.py
+++ b/gui/metrics_tab.py
@@ -13,11 +13,14 @@ class MetricsTab(tk.Frame):
             c.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.update_plots()
 
-    def _draw_line_chart(self, canvas: tk.Canvas, data):
+    def _draw_line_chart_v1(self, canvas: tk.Canvas, data):
+        """Version 1: guard against max value of zero by fallback to 1."""
         canvas.delete("all")
         h = int(canvas["height"])
         w = int(canvas["width"])
         max_val = max(data) if data else 1
+        if max_val == 0:
+            max_val = 1
         step = w / max(1, len(data) - 1)
         points = []
         for i, val in enumerate(data):
@@ -27,6 +30,64 @@ class MetricsTab(tk.Frame):
         if len(points) > 3:
             canvas.create_line(*points, fill="blue")
         canvas.create_text(5, 5, anchor="nw", text="Requirements")
+
+    def _draw_line_chart_v2(self, canvas: tk.Canvas, data):
+        """Version 2: use Python's 'or' to ensure non-zero max value."""
+        canvas.delete("all")
+        h = int(canvas["height"])
+        w = int(canvas["width"])
+        max_val = max(data or [1]) or 1
+        step = w / max(1, len(data) - 1)
+        points = []
+        for i, val in enumerate(data):
+            x = i * step
+            y = h - (val / max_val) * h
+            points.extend([x, y])
+        if len(points) > 3:
+            canvas.create_line(*points, fill="blue")
+        canvas.create_text(5, 5, anchor="nw", text="Requirements")
+
+    def _draw_line_chart_v3(self, canvas: tk.Canvas, data):
+        """Version 3: handle empty and non-positive data via try/except."""
+        canvas.delete("all")
+        h = int(canvas["height"])
+        w = int(canvas["width"])
+        try:
+            max_val = max(data)
+            if max_val <= 0:
+                max_val = 1
+        except ValueError:
+            max_val = 1
+        step = w / max(1, len(data) - 1)
+        points = []
+        for i, val in enumerate(data):
+            x = i * step
+            y = h - (val / max_val) * h
+            points.extend([x, y])
+        if len(points) > 3:
+            canvas.create_line(*points, fill="blue")
+        canvas.create_text(5, 5, anchor="nw", text="Requirements")
+
+    def _draw_line_chart_v4(self, canvas: tk.Canvas, data):
+        """Version 4: pre-compute scaling factor avoiding division by zero."""
+        canvas.delete("all")
+        h = int(canvas["height"])
+        w = int(canvas["width"])
+        max_val = max(data) if data else 1
+        scale = h / max_val if max_val else 0
+        step = w / max(1, len(data) - 1)
+        points = []
+        for i, val in enumerate(data):
+            x = i * step
+            y = h - val * scale
+            points.extend([x, y])
+        if len(points) > 3:
+            canvas.create_line(*points, fill="blue")
+        canvas.create_text(5, 5, anchor="nw", text="Requirements")
+
+    def _draw_line_chart(self, canvas: tk.Canvas, data):
+        """Final implementation selecting the most complete version."""
+        self._draw_line_chart_v4(canvas, data)
 
     def _draw_bar_chart(self, canvas: tk.Canvas, data):
         canvas.delete("all")
@@ -50,7 +111,9 @@ class MetricsTab(tk.Frame):
             req_history = [len(getattr(self.app, "requirements", []))]
         self._draw_line_chart(self.canvases[0], req_history)
 
-        statuses = Counter(getattr(r, "status", "unknown") for r in getattr(self.app, "requirements", []))
+        statuses = Counter(
+            getattr(r, "status", "unknown") for r in getattr(self.app, "requirements", [])
+        )
         self._draw_bar_chart(self.canvases[1], statuses)
         self.canvases[1].create_text(5, 5, anchor="nw", text="Status")
 

--- a/tests/test_metrics_tab_zero_division.py
+++ b/tests/test_metrics_tab_zero_division.py
@@ -1,0 +1,60 @@
+import unittest
+import sys
+import types
+import os
+import importlib.util
+from pathlib import Path
+
+try:  # pragma: no cover - only executed when tkinter missing
+    import tkinter  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for headless envs
+    class _Frame:
+        pass
+
+    class _Canvas:
+        pass
+
+    tk_stub = types.SimpleNamespace(
+        Canvas=_Canvas, Frame=_Frame, LEFT=0, BOTH=0, ttk=types.SimpleNamespace(), font=types.SimpleNamespace()
+    )
+    sys.modules["tkinter"] = tk_stub
+
+module_path = Path(__file__).resolve().parents[1] / "gui" / "metrics_tab.py"
+spec = importlib.util.spec_from_file_location("metrics_tab", module_path)
+metrics_tab = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(metrics_tab)
+MetricsTab = metrics_tab.MetricsTab
+
+
+class DummyCanvas:
+    def __getitem__(self, key):
+        return {"width": 300, "height": 200}[key]
+
+    def delete(self, *args, **kwargs):
+        pass
+
+    def create_line(self, *args, **kwargs):
+        pass
+
+    def create_text(self, *args, **kwargs):
+        pass
+
+    def create_rectangle(self, *args, **kwargs):
+        pass
+
+
+class MetricsTabZeroDivisionTests(unittest.TestCase):
+    def test_line_chart_variants_handle_zero_max(self):
+        canvas = DummyCanvas()
+        data = [0, 0, 0]
+        for name in [
+            "_draw_line_chart_v1",
+            "_draw_line_chart_v2",
+            "_draw_line_chart_v3",
+            "_draw_line_chart_v4",
+        ]:
+            getattr(MetricsTab, name)(None, canvas, data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add four alternate line-chart renderers and use the safest version to avoid division by zero when requirements history is all zeroes
- Provide unit tests exercising all renderer variants even in headless environments

## Testing
- `python3 tests/test_metrics_tab_zero_division.py`
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'tkinter')*
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*


------
https://chatgpt.com/codex/tasks/task_b_68a647d569a88327b60dfd83e20e4802