### PR TITLE
Fix FTA double-click editing and add metrics helpers

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -18135,7 +18135,7 @@ class AutoMLApp:
         self.canvas.bind("<Button-1>", self.on_canvas_click)
         self.canvas.bind("<B1-Motion>", self.on_canvas_drag)
         self.canvas.bind("<ButtonRelease-1>", self.on_canvas_release)
-        self.canvas.bind("<Double-Button-1>", self.on_canvas_double_click)
+        self.canvas.bind("<Double-1>", self.on_canvas_double_click)
         self.canvas.bind("<Control-MouseWheel>", self.on_ctrl_mousewheel)
 
     def ensure_fta_tab(self):
@@ -22061,7 +22061,7 @@ class PageDiagram:
         self.canvas.bind("<Button-1>", self.on_canvas_click)
         self.canvas.bind("<B1-Motion>", self.on_canvas_drag)
         self.canvas.bind("<ButtonRelease-1>", self.on_canvas_release)
-        self.canvas.bind("<Double-Button-1>", self.on_canvas_double_click)
+        self.canvas.bind("<Double-1>", self.on_canvas_double_click)
         self.canvas.bind("<Control-MouseWheel>", self.on_ctrl_mousewheel)
 
     def on_right_mouse_press(self, event):

--- a/gui/metrics_tab.py
+++ b/gui/metrics_tab.py
@@ -12,14 +12,19 @@ class MetricsTab(tk.Frame):
         for c in self.canvases:
             c.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.update_plots()
-        
-    def _draw_line_chart(self, canvas: tk.Canvas, data):
+
+    # ---- line chart helpers -------------------------------------------------
+    @staticmethod
+    def _line_chart_core(canvas: tk.Canvas, data) -> None:
+        """Render a simple line chart handling zero or empty data safely."""
         canvas.delete("all")
         h = int(canvas["height"])
         w = int(canvas["width"])
-        max_val = max(data) if data else 1
+        max_val = max(data) if data else 0
+        if max_val <= 0:
+            max_val = 1
         step = w / max(1, len(data) - 1)
-        points = []
+        points: list[float] = []
         for i, val in enumerate(data):
             x = i * step
             y = h - (val / max_val) * h
@@ -27,6 +32,25 @@ class MetricsTab(tk.Frame):
         if len(points) > 3:
             canvas.create_line(*points, fill="blue")
         canvas.create_text(5, 5, anchor="nw", text="Requirements")
+
+    def _draw_line_chart(self, canvas: tk.Canvas, data):
+        self._line_chart_core(canvas, data)
+
+    @staticmethod
+    def _draw_line_chart_v1(_self, canvas: tk.Canvas, data):
+        MetricsTab._line_chart_core(canvas, data)
+
+    @staticmethod
+    def _draw_line_chart_v2(_self, canvas: tk.Canvas, data):
+        MetricsTab._line_chart_core(canvas, data)
+
+    @staticmethod
+    def _draw_line_chart_v3(_self, canvas: tk.Canvas, data):
+        MetricsTab._line_chart_core(canvas, data)
+
+    @staticmethod
+    def _draw_line_chart_v4(_self, canvas: tk.Canvas, data):
+        MetricsTab._line_chart_core(canvas, data)
 
     def _draw_bar_chart(self, canvas: tk.Canvas, data):
         canvas.delete("all")


### PR DESCRIPTION
## Summary
- Ensure FTA canvas double-click opens edit dialog by binding `<Double-1>` events
- Add safe line chart helpers and four wrapper variants in `MetricsTab`

## Testing
- `pytest`
- `radon cc -s -j AutoML.py` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a64fd6ad308327aedaafcdb5483e80