### PR TITLE
Handle zero value line charts and verify governance activation for additional analyses

### DIFF
--- a/gui/metrics_tab.py
+++ b/gui/metrics_tab.py
@@ -13,17 +13,52 @@ class MetricsTab(tk.Frame):
             c.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.update_plots()
         
-    def _draw_line_chart(self, canvas: tk.Canvas, data):
-        canvas.delete("all")
+    @staticmethod
+    def _line_chart_points(canvas: tk.Canvas, data):
         h = int(canvas["height"])
         w = int(canvas["width"])
-        max_val = max(data) if data else 1
+        max_val = max(data) if data else 0
+        if max_val == 0:
+            max_val = 1
         step = w / max(1, len(data) - 1)
         points = []
         for i, val in enumerate(data):
             x = i * step
             y = h - (val / max_val) * h
             points.extend([x, y])
+        return points
+
+    def _draw_line_chart(self, canvas: tk.Canvas, data):
+        canvas.delete("all")
+        points = MetricsTab._line_chart_points(canvas, data)
+        if len(points) > 3:
+            canvas.create_line(*points, fill="blue")
+        canvas.create_text(5, 5, anchor="nw", text="Requirements")
+
+    def _draw_line_chart_v1(self, canvas: tk.Canvas, data):
+        MetricsTab._draw_line_chart(self, canvas, data)
+
+    def _draw_line_chart_v2(self, canvas: tk.Canvas, data):
+        canvas.delete("all")
+        points = MetricsTab._line_chart_points(canvas, data)
+        if len(points) > 3:
+            canvas.create_line(*points, fill="blue")
+        canvas.create_text(5, 5, anchor="nw", text="Requirements")
+
+    def _draw_line_chart_v3(self, canvas: tk.Canvas, data):
+        MetricsTab._draw_line_chart_v2(self, canvas, data)
+
+    def _draw_line_chart_v4(self, canvas: tk.Canvas, data):
+        canvas.delete("all")
+        h = int(canvas["height"])
+        w = int(canvas["width"])
+        max_val = max(data or [0]) or 1
+        step = w / max(1, len(data) - 1)
+        points = [
+            coord
+            for i, val in enumerate(data)
+            for coord in (i * step, h - (val / max_val) * h)
+        ]
         if len(points) > 3:
             canvas.create_line(*points, fill="blue")
         canvas.create_text(5, 5, anchor="nw", text="Requirements")

--- a/tests/test_governance_group_activation.py
+++ b/tests/test_governance_group_activation.py
@@ -48,6 +48,8 @@ class DummyMenu:
         ("FMEA", "Qualitative Analysis"),
         ("FMEDA", "Quantitative Analysis"),
         ("Causal Bayesian Network Analysis", "Quantitative Analysis"),
+        ("Mission Profile", "Quantitative Analysis"),
+        ("Reliability Analysis", "Quantitative Analysis"),
     ],
 )
 def test_work_product_groups_follow_phase(work_product, parent):


### PR DESCRIPTION
## Summary
- prevent division by zero in MetricsTab line charts and add four safe variants
- test that mission profile and reliability analysis menus activate under governance

## Testing
- `pytest`
- `pip install radon` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a6504a83008327905200cc859bdca1