### PR TITLE
Add diagnostics manager and unify metrics tab line chart

### DIFF
--- a/gui/metrics_tab.py
+++ b/gui/metrics_tab.py
@@ -12,57 +12,9 @@ class MetricsTab(tk.Frame):
         for c in self.canvases:
             c.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.update_plots()
-        
-    @staticmethod
-    def _line_chart_points(canvas: tk.Canvas, data):
-        h = int(canvas["height"])
-        w = int(canvas["width"])
-        max_val = max(data) if data else 0
-        if max_val == 0:
-            max_val = 1
-        step = w / max(1, len(data) - 1)
-        points: list[float] = []
-        for i, val in enumerate(data):
-            x = i * step
-            y = h - (val / max_val) * h if max_val else h
-            points.extend([x, y])
-        return points
 
-    def _draw_line_chart(self, canvas: tk.Canvas, data):
-        canvas.delete("all")
-        points = MetricsTab._line_chart_points(canvas, data)
-        if len(points) > 3:
-            canvas.create_line(*points, fill="blue")
-        canvas.create_text(5, 5, anchor="nw", text="Requirements")
-
-    def _draw_line_chart_v1(self, canvas: tk.Canvas, data):
-        MetricsTab._draw_line_chart(self, canvas, data)
-
-    def _draw_line_chart_v2(self, canvas: tk.Canvas, data):
-        canvas.delete("all")
-        points = MetricsTab._line_chart_points(canvas, data)
-        if len(points) > 3:
-            canvas.create_line(*points, fill="blue")
-        canvas.create_text(5, 5, anchor="nw", text="Requirements")
-
-    def _draw_line_chart_v3(self, canvas: tk.Canvas, data):
-        MetricsTab._draw_line_chart_v2(self, canvas, data)
-
-    def _draw_line_chart_v4(self, canvas: tk.Canvas, data):
-        canvas.delete("all")
-        h = int(canvas["height"])
-        w = int(canvas["width"])
-        max_val = max(data or [0]) or 1
-        step = w / max(1, len(data) - 1)
-        points = [
-            coord
-            for i, val in enumerate(data)
-            for coord in (i * step, h - (val / max_val) * h)
-        ]
-        if len(points) > 3:
-            canvas.create_line(*points, fill="blue")
-        canvas.create_text(5, 5, anchor="nw", text="Requirements")
-
+    # Four experimental implementations of the same line chart function.
+    # Each delegates to ``_line_chart_core`` which performs the actual work.
     def _draw_line_chart(self, canvas: tk.Canvas, data):
         self._line_chart_core(canvas, data)
 
@@ -81,6 +33,22 @@ class MetricsTab(tk.Frame):
     @staticmethod
     def _draw_line_chart_v4(_self, canvas: tk.Canvas, data):
         MetricsTab._line_chart_core(canvas, data)
+
+    @staticmethod
+    def _line_chart_core(canvas: tk.Canvas, data):
+        canvas.delete("all")
+        h = int(canvas["height"])
+        w = int(canvas["width"])
+        max_val = max(data or [0]) or 1
+        step = w / max(1, len(data) - 1)
+        points = [
+            coord
+            for i, val in enumerate(data)
+            for coord in (i * step, h - (val / max_val) * h)
+        ]
+        if len(points) > 3:
+            canvas.create_line(*points, fill="blue")
+        canvas.create_text(5, 5, anchor="nw", text="Requirements")
 
     def _draw_bar_chart(self, canvas: tk.Canvas, data):
         canvas.delete("all")

--- a/tests/test_diagnostics_manager.py
+++ b/tests/test_diagnostics_manager.py
@@ -1,0 +1,53 @@
+import asyncio
+import time
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.diagnostics_manager import (
+    AsyncDiagnosticsManager,
+    DiagnosticError,
+    EventDiagnosticsManager,
+    PassiveDiagnosticsManager,
+    PollingDiagnosticsManager,
+)
+
+
+def test_polling_manager_detects_failure() -> None:
+    manager = PollingDiagnosticsManager(interval=0.01)
+    manager.register_check("fail", lambda: False)
+    manager.start()
+    time.sleep(0.05)
+    manager.stop()
+    with pytest.raises(DiagnosticError):
+        manager.raise_errors()
+
+
+def test_event_manager_records_error() -> None:
+    manager = EventDiagnosticsManager()
+    manager.record_event("fail", False)
+    manager.process_events()
+    with pytest.raises(DiagnosticError):
+        manager.raise_errors()
+
+
+def test_passive_manager_runs_checks() -> None:
+    manager = PassiveDiagnosticsManager()
+    manager.run_check("fail", lambda: False)
+    with pytest.raises(DiagnosticError):
+        manager.raise_errors()
+
+
+def test_async_manager_detects_failure() -> None:
+    manager = AsyncDiagnosticsManager()
+
+    async def bad() -> bool:
+        return False
+
+    manager.register_check("fail", bad)
+    asyncio.run(manager.run_once())
+    with pytest.raises(DiagnosticError):
+        manager.raise_errors()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,19 @@
+"""Utility helpers for the AutoML tool."""
+
+from .diagnostics_manager import (
+    AsyncDiagnosticsManager,
+    DiagnosticError,
+    DiagnosticsManagerBase,
+    EventDiagnosticsManager,
+    PassiveDiagnosticsManager,
+    PollingDiagnosticsManager,
+)
+
+__all__ = [
+    "AsyncDiagnosticsManager",
+    "DiagnosticError",
+    "DiagnosticsManagerBase",
+    "EventDiagnosticsManager",
+    "PassiveDiagnosticsManager",
+    "PollingDiagnosticsManager",
+]

--- a/tools/diagnostics_manager.py
+++ b/tools/diagnostics_manager.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+"""Background diagnostics utilities for monitoring tool integrity.
+
+This module provides several experimental diagnostics manager
+implementations.  Each variant offers a different strategy for detecting
+integrity issues in running operations.  The intent is to evaluate which
+approach best fits the tool before wider integration.
+
+The following managers are available:
+
+* :class:`PollingDiagnosticsManager` -- periodically executes registered
+  check callables on a background thread.
+* :class:`EventDiagnosticsManager` -- collects explicit success/failure
+  events from the application.
+* :class:`PassiveDiagnosticsManager` -- exposes a simple ``run_check``
+  method for ad-hoc validation.
+* :class:`AsyncDiagnosticsManager` -- awaits registered asynchronous
+  check coroutines.
+
+Each manager raises :class:`DiagnosticError` when one or more checks
+fail, allowing callers to decide how to handle integrity issues.
+"""
+
+from dataclasses import dataclass, field
+import asyncio
+import queue
+import threading
+import time
+from typing import Awaitable, Callable, Dict, List, Optional
+
+
+class DiagnosticError(RuntimeError):
+    """Raised when a diagnostics check reports failure."""
+
+
+@dataclass
+class DiagnosticsManagerBase:
+    """Common interface for diagnostics managers."""
+
+    errors: List[str] = field(default_factory=list)
+
+    def raise_errors(self) -> None:
+        """Raise :class:`DiagnosticError` if any errors were collected."""
+        if self.errors:
+            raise DiagnosticError("; ".join(self.errors))
+
+
+class PollingDiagnosticsManager(DiagnosticsManagerBase):
+    """Polls registered checks on a background thread."""
+
+    def __init__(self, interval: float = 0.1) -> None:
+        super().__init__()
+        self.interval = interval
+        self._checks: Dict[str, Callable[[], bool]] = {}
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    def register_check(self, name: str, func: Callable[[], bool]) -> None:
+        self._checks[name] = func
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            for name, func in list(self._checks.items()):
+                try:
+                    if not func():
+                        self.errors.append(name)
+                except Exception as exc:  # pragma: no cover - rare
+                    self.errors.append(f"{name}: {exc}")
+            time.sleep(self.interval)
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join()
+
+
+class EventDiagnosticsManager(DiagnosticsManagerBase):
+    """Collects explicit success/failure events from the application."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._queue: "queue.Queue[tuple[str, bool]]" = queue.Queue()
+
+    def record_event(self, name: str, ok: bool) -> None:
+        self._queue.put((name, ok))
+
+    def process_events(self) -> None:
+        while True:
+            try:
+                name, ok = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if not ok:
+                self.errors.append(name)
+
+
+class PassiveDiagnosticsManager(DiagnosticsManagerBase):
+    """Runs checks on demand without background activity."""
+
+    def run_check(self, name: str, func: Callable[[], bool]) -> None:
+        try:
+            if not func():
+                self.errors.append(name)
+        except Exception as exc:  # pragma: no cover - rare
+            self.errors.append(f"{name}: {exc}")
+
+
+class AsyncDiagnosticsManager(DiagnosticsManagerBase):
+    """Await registered asynchronous checks."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._checks: Dict[str, Callable[[], Awaitable[bool]]] = {}
+
+    def register_check(self, name: str, coro: Callable[[], Awaitable[bool]]) -> None:
+        self._checks[name] = coro
+
+    async def run_once(self) -> None:
+        for name, coro in list(self._checks.items()):
+            try:
+                if not await coro():
+                    self.errors.append(name)
+            except Exception as exc:  # pragma: no cover - rare
+                self.errors.append(f"{name}: {exc}")
+
+
+__all__ = [
+    "DiagnosticError",
+    "DiagnosticsManagerBase",
+    "PollingDiagnosticsManager",
+    "EventDiagnosticsManager",
+    "PassiveDiagnosticsManager",
+    "AsyncDiagnosticsManager",
+]


### PR DESCRIPTION
## Summary
- add a diagnostics manager module with polling, event, passive and async variants to monitor tool integrity
- expose diagnostics helpers from tools package and exercise them via tests
- streamline metrics tab line chart drawing through a shared core function to avoid zero-division errors

## Testing
- `pytest -q`
- `pytest tests/test_diagnostics_manager.py tests/test_metrics_tab_zero_division.py -q`
- `radon cc tools/diagnostics_manager.py -s -j` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a6530298888327b3d8af904af9b469