### PR TITLE
feat: use purplish buttons on all dialogs

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -241,7 +241,7 @@ from gui.review_toolbox import (
     ParticipantDialog,
     EmailConfigDialog,
     ReviewScopeDialog,
-    UserSelectDialog,
+    UserSelectDialog as ReviewUserSelectDialog,
     ReviewDocumentDialog,
     VersionCompareDialog,
 )
@@ -258,7 +258,10 @@ from gsn.nodes import GSNNode
 from gui.closable_notebook import ClosableNotebook
 from gui.icon_factory import create_icon
 from gui.splash_screen import SplashScreen
-from gui.mac_button_style import apply_translucid_button_style
+from gui.mac_button_style import (
+    apply_translucid_button_style,
+    apply_purplish_button_style,
+)
 from dataclasses import asdict
 from pathlib import Path
 from analysis.mechanisms import (
@@ -1874,11 +1877,23 @@ class EditNodeDialog(simpledialog.Dialog):
             pass  # ASIL recalculated when joint review closes
 
     def buttonbox(self):
-        box = tk.Frame(self)
-        ok_button = tk.Button(box, text="OK", width=10, command=self.ok, default=tk.ACTIVE)
-        ok_button.pack(side=tk.LEFT, padx=5, pady=5)
-        cancel_button = tk.Button(box, text="Cancel", width=10, command=self.cancel)
-        cancel_button.pack(side=tk.LEFT, padx=5, pady=5)
+        box = ttk.Frame(self)
+        apply_purplish_button_style()
+        ttk.Button(
+            box,
+            text="OK",
+            width=10,
+            command=self.ok,
+            style="Purple.TButton",
+            default=tk.ACTIVE,
+        ).pack(side=tk.LEFT, padx=5, pady=5)
+        ttk.Button(
+            box,
+            text="Cancel",
+            width=10,
+            command=self.cancel,
+            style="Purple.TButton",
+        ).pack(side=tk.LEFT, padx=5, pady=5)
         self.bind("<Escape>", lambda event: self.cancel())
         box.pack()
 
@@ -21640,7 +21655,7 @@ class AutoMLApp:
             messagebox.showwarning("User", "Start a review first")
             return
         parts = self.review_data.participants + self.review_data.moderators
-        dlg = UserSelectDialog(self.root, parts, initial_name=self.current_user)
+        dlg = ReviewUserSelectDialog(self.root, parts, initial_name=self.current_user)
         if not dlg.result:
             return
         name, _ = dlg.result

--- a/gui/mac_button_style.py
+++ b/gui/mac_button_style.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import tkinter as tk
-from tkinter import ttk
+from tkinter import simpledialog, ttk
 
 
 def apply_mac_button_style(style: ttk.Style | None = None) -> ttk.Style:
@@ -75,3 +75,36 @@ def apply_translucid_button_style(style: ttk.Style | None = None) -> ttk.Style:
         relief=[("pressed", "sunken"), ("!pressed", "flat")],
     )
     return style
+
+
+def _purplish_buttonbox(self) -> None:
+    """Default ``simpledialog`` button box with purple-themed buttons."""
+
+    box = ttk.Frame(self)
+    apply_purplish_button_style()
+    ttk.Button(
+        box,
+        text="OK",
+        width=10,
+        command=self.ok,
+        style="Purple.TButton",
+    ).pack(side=tk.LEFT, padx=5, pady=5)
+    ttk.Button(
+        box,
+        text="Cancel",
+        width=10,
+        command=self.cancel,
+        style="Purple.TButton",
+    ).pack(side=tk.LEFT, padx=5, pady=5)
+    self.bind("<Return>", self.ok)
+    self.bind("<Escape>", self.cancel)
+    box.pack()
+
+
+def enable_purplish_dialog_buttons() -> None:
+    """Monkeypatch ``simpledialog.Dialog`` to use purple buttons everywhere."""
+
+    simpledialog.Dialog.buttonbox = _purplish_buttonbox
+
+
+enable_purplish_dialog_buttons()

--- a/gui/threat_dialog.py
+++ b/gui/threat_dialog.py
@@ -2,6 +2,8 @@
 import tkinter as tk
 from tkinter import ttk, simpledialog
 
+from gui.mac_button_style import apply_purplish_button_style
+
 from gui import messagebox, add_treeview_scrollbars
 from gui.toolboxes import configure_table_style
 from analysis.models import (
@@ -564,12 +566,24 @@ class ThreatDialog(simpledialog.Dialog):
 
         box = ttk.Frame(self)
         box.pack(fill=tk.X, padx=5, pady=5)
+        apply_purplish_button_style()
 
         ok_btn = ttk.Button(
-            box, text="OK", width=10, command=self.ok, default=tk.ACTIVE
+            box,
+            text="OK",
+            width=10,
+            command=self.ok,
+            default=tk.ACTIVE,
+            style="Purple.TButton",
         )
         ok_btn.pack(side=tk.RIGHT, padx=5)
-        cancel_btn = ttk.Button(box, text="Cancel", width=10, command=self.cancel)
+        cancel_btn = ttk.Button(
+            box,
+            text="Cancel",
+            width=10,
+            command=self.cancel,
+            style="Purple.TButton",
+        )
         cancel_btn.pack(side=tk.RIGHT, padx=5)
 
         ok_btn.focus_set()

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -2,6 +2,8 @@
 import tkinter as tk
 from tkinter import simpledialog, ttk
 
+from gui.mac_button_style import apply_purplish_button_style
+
 from gui import messagebox
 from gui.toolboxes import ToolTip
 from gui.table_controller import TableController
@@ -217,12 +219,24 @@ class ThreatWindow(tk.Frame):
 
             box = ttk.Frame(self)
             box.pack(fill=tk.X, padx=5, pady=5)
+            apply_purplish_button_style()
 
             ok_btn = ttk.Button(
-                box, text="OK", width=10, command=self.ok, default=tk.ACTIVE
+                box,
+                text="OK",
+                width=10,
+                command=self.ok,
+                default=tk.ACTIVE,
+                style="Purple.TButton",
             )
             ok_btn.pack(side=tk.RIGHT, padx=5)
-            cancel_btn = ttk.Button(box, text="Cancel", width=10, command=self.cancel)
+            cancel_btn = ttk.Button(
+                box,
+                text="Cancel",
+                width=10,
+                command=self.cancel,
+                style="Purple.TButton",
+            )
             cancel_btn.pack(side=tk.RIGHT, padx=5)
 
             ok_btn.focus_set()

--- a/tests/test_user_dialog_buttons.py
+++ b/tests/test_user_dialog_buttons.py
@@ -1,0 +1,60 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import AutoML as automl
+
+
+def _collect_button_styles(dialog_cls, monkeypatch):
+    styles = []
+    applied = {"called": 0}
+
+    class DummyButton:
+        def __init__(self, master, **kwargs):
+            styles.append(kwargs.get("style"))
+        def pack(self, *a, **k):
+            pass
+
+    class DummyFrame:
+        def __init__(self, *a, **k):
+            pass
+        def pack(self, *a, **k):
+            pass
+
+    class DummyDialog:
+        def bind(self, *a, **k):
+            pass
+        ok = lambda self, *a, **k: None
+        cancel = lambda self, *a, **k: None
+
+    def fake_apply(style=None):
+        applied["called"] += 1
+
+    import gui.mac_button_style as mbs
+
+    monkeypatch.setattr(automl.ttk, "Button", DummyButton)
+    monkeypatch.setattr(automl.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(mbs.ttk, "Button", DummyButton)
+    monkeypatch.setattr(mbs.ttk, "Frame", DummyFrame)
+    monkeypatch.setattr(automl, "apply_purplish_button_style", fake_apply)
+    monkeypatch.setattr(mbs, "apply_purplish_button_style", fake_apply)
+
+    dlg = DummyDialog()
+    dialog_cls.buttonbox(dlg)
+    return styles, applied["called"]
+
+
+def test_user_info_dialog_purplish_buttons(monkeypatch):
+    styles, called = _collect_button_styles(automl.UserInfoDialog, monkeypatch)
+    assert styles == ["Purple.TButton", "Purple.TButton"]
+    assert called == 1
+
+
+def test_user_select_dialog_purplish_buttons(monkeypatch):
+    styles, called = _collect_button_styles(automl.UserSelectDialog, monkeypatch)
+    assert styles == ["Purple.TButton", "Purple.TButton"]
+    assert called == 1
+
+
+def test_base_dialog_purplish_buttons(monkeypatch):
+    styles, called = _collect_button_styles(automl.simpledialog.Dialog, monkeypatch)
+    assert styles == ["Purple.TButton", "Purple.TButton"]
+    assert called == 1


### PR DESCRIPTION
## Summary
- globally patch tkinter simpledialog dialogs to use the shared Purple.TButton style
- update custom dialog button boxes to apply purple-themed ttk buttons
- verify default and custom dialogs create Purple.TButton widgets

## Testing
- `pytest`
- `python tools/metrics_generator.py --path . --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68a63bde58a48327942f5f6da01f547e