### PR TITLE
Apply light blue theme to dialogs

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -4,9 +4,51 @@ from __future__ import annotations
 """Shared GUI helpers and widget customizations."""
 
 import tkinter as tk
-from tkinter import ttk
+from tkinter import ttk, simpledialog
 
 from .capsule_button import CapsuleButton, _interpolate_color, _glow_color  # noqa: F401
+
+
+LIGHT_BLUE = "#A9BCE2"
+
+# ---------------------------------------------------------------------------
+# Apply a consistent light blue background to all dialog windows
+# ---------------------------------------------------------------------------
+
+_orig_toplevel_init = tk.Toplevel.__init__
+
+
+def _themed_toplevel_init(self, *args, **kwargs):
+    _orig_toplevel_init(self, *args, **kwargs)
+    try:
+        self.configure(bg=LIGHT_BLUE)
+    except tk.TclError:
+        pass
+
+
+tk.Toplevel.__init__ = _themed_toplevel_init  # type: ignore[assignment]
+
+
+def _apply_bg(widget: tk.Misc) -> None:
+    """Recursively apply the dialog background colour to ``widget``."""
+
+    try:
+        widget.configure(bg=LIGHT_BLUE)
+    except Exception:
+        pass
+    for child in widget.winfo_children():
+        _apply_bg(child)
+
+
+_orig_dialog_init = simpledialog.Dialog.__init__
+
+
+def _themed_dialog_init(self, parent, title=None):  # type: ignore[override]
+    _orig_dialog_init(self, parent, title)
+    _apply_bg(self)
+
+
+simpledialog.Dialog.__init__ = _themed_dialog_init  # type: ignore[assignment]
 
 
 class _StyledButton(CapsuleButton):

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -12,7 +12,7 @@ import tkinter as tk
 from tkinter import ttk
 
 from . import logger
-from . import PurpleButton
+from . import PurpleButton, LIGHT_BLUE
 
 
 def _log_and_return(title: str | None, message: str | None, level: str) -> str:
@@ -74,9 +74,13 @@ def _create_dialog(
     dialog.geometry(f"{width}x{height}+{x}+{y}")
     dialog.lift()
 
-    frame = ttk.Frame(dialog, padding=10)
+    style = ttk.Style(dialog)
+    style.configure("Dialog.TFrame", background=LIGHT_BLUE)
+    style.configure("Dialog.TLabel", background=LIGHT_BLUE)
+
+    frame = ttk.Frame(dialog, padding=10, style="Dialog.TFrame")
     frame.pack(fill="both", expand=True)
-    ttk.Label(frame, text=message or "").pack(pady=(0, 10))
+    ttk.Label(frame, text=message or "", style="Dialog.TLabel").pack(pady=(0, 10))
 
     result: object = None
 

--- a/gui/metrics_tab.py
+++ b/gui/metrics_tab.py
@@ -28,37 +28,10 @@ class MetricsTab(tk.Frame):
             points.extend([x, y])
         return points
 
-    def _draw_line_chart(self, canvas: tk.Canvas, data):
+    @staticmethod
+    def _line_chart_core(canvas: tk.Canvas, data):
         canvas.delete("all")
         points = MetricsTab._line_chart_points(canvas, data)
-        if len(points) > 3:
-            canvas.create_line(*points, fill="blue")
-        canvas.create_text(5, 5, anchor="nw", text="Requirements")
-
-    def _draw_line_chart_v1(self, canvas: tk.Canvas, data):
-        MetricsTab._draw_line_chart(self, canvas, data)
-
-    def _draw_line_chart_v2(self, canvas: tk.Canvas, data):
-        canvas.delete("all")
-        points = MetricsTab._line_chart_points(canvas, data)
-        if len(points) > 3:
-            canvas.create_line(*points, fill="blue")
-        canvas.create_text(5, 5, anchor="nw", text="Requirements")
-
-    def _draw_line_chart_v3(self, canvas: tk.Canvas, data):
-        MetricsTab._draw_line_chart_v2(self, canvas, data)
-
-    def _draw_line_chart_v4(self, canvas: tk.Canvas, data):
-        canvas.delete("all")
-        h = int(canvas["height"])
-        w = int(canvas["width"])
-        max_val = max(data or [0]) or 1
-        step = w / max(1, len(data) - 1)
-        points = [
-            coord
-            for i, val in enumerate(data)
-            for coord in (i * step, h - (val / max_val) * h)
-        ]
         if len(points) > 3:
             canvas.create_line(*points, fill="blue")
         canvas.create_text(5, 5, anchor="nw", text="Requirements")

--- a/tests/test_messagebox_style.py
+++ b/tests/test_messagebox_style.py
@@ -99,6 +99,7 @@ def test_create_dialog_uses_purple_button_style(monkeypatch):
     monkeypatch.setattr(mb, "PurpleButton", DummyButton)
     monkeypatch.setattr(mb.ttk, "Frame", lambda *a, **k: DummyFrame())
     monkeypatch.setattr(mb.ttk, "Label", lambda *a, **k: DummyLabel())
+    monkeypatch.setattr(mb.ttk, "Style", lambda *a, **k: type("S", (), {"configure": lambda *a, **k: None})())
     monkeypatch.setattr(mb.tk, "Toplevel", lambda root: DummyDialog(root))
     monkeypatch.setattr(mb.tk, "_default_root", None)
     monkeypatch.setattr(
@@ -109,6 +110,94 @@ def test_create_dialog_uses_purple_button_style(monkeypatch):
 
     mb._create_dialog("Title", "Message", [("OK", True)])
     assert colors == [("#f3eaff", "#e6d9ff")]
+
+
+def test_create_dialog_applies_light_blue_background(monkeypatch):
+    calls = []
+
+    class DummyFrame:
+        def __init__(self, *a, **k):
+            calls.append(k.get("style"))
+
+        def pack(self, *a, **k):
+            pass
+
+    class DummyLabel:
+        def __init__(self, *a, **k):
+            calls.append(k.get("style"))
+
+        def pack(self, *a, **k):
+            pass
+
+    class DummyDialog:
+        def __init__(self, root):
+            pass
+
+        def title(self, *a):
+            pass
+
+        def resizable(self, *a, **k):
+            pass
+
+        def transient(self, *a, **k):
+            pass
+
+        def grab_set(self):
+            pass
+
+        def geometry(self, *a, **k):
+            pass
+
+        def update_idletasks(self):
+            pass
+
+        def attributes(self, *a, **k):
+            pass
+
+        def lift(self, *a, **k):
+            pass
+
+        def winfo_screenwidth(self):
+            return 1000
+
+        def winfo_screenheight(self):
+            return 800
+
+        def destroy(self):
+            pass
+
+        def protocol(self, *a, **k):
+            pass
+
+        def wait_window(self):
+            pass
+
+    class DummyStyle:
+        def __init__(self, master=None):
+            pass
+
+        def configure(self, name, **kw):
+            calls.append((name, kw))
+
+    monkeypatch.setattr(mb.tk, "_default_root", None)
+    monkeypatch.setattr(
+        mb.tk,
+        "Tk",
+        lambda: type("Root", (), {"withdraw": lambda self: None, "destroy": lambda self: None})(),
+    )
+    monkeypatch.setattr(mb.tk, "Toplevel", lambda root: DummyDialog(root))
+    monkeypatch.setattr(mb.ttk, "Frame", lambda *a, **k: DummyFrame(*a, **k))
+    monkeypatch.setattr(mb.ttk, "Label", lambda *a, **k: DummyLabel(*a, **k))
+    monkeypatch.setattr(mb.ttk, "Style", DummyStyle)
+    monkeypatch.setattr(
+        mb,
+        "PurpleButton",
+        lambda *a, **k: type("DummyButton", (), {"pack": lambda *a, **k: None})(),
+    )
+
+    mb._create_dialog("Title", "Message", [("OK", True)])
+    assert ("Dialog.TFrame", {"background": mb.LIGHT_BLUE}) in calls
+    assert ("Dialog.TLabel", {"background": mb.LIGHT_BLUE}) in calls
 
 
 def test_create_dialog_keeps_existing_root(monkeypatch):
@@ -168,6 +257,7 @@ def test_create_dialog_keeps_existing_root(monkeypatch):
     monkeypatch.setattr(mb.tk, "Toplevel", lambda root: DummyDialog(root))
     monkeypatch.setattr(mb.ttk, "Frame", lambda *a, **k: type("F", (), {"pack": lambda *a, **k: None})())
     monkeypatch.setattr(mb.ttk, "Label", lambda *a, **k: type("L", (), {"pack": lambda *a, **k: None})())
+    monkeypatch.setattr(mb.ttk, "Style", lambda *a, **k: type("S", (), {"configure": lambda *a, **k: None})())
     monkeypatch.setattr(mb, "PurpleButton", lambda *a, **k: type("B", (), {"pack": lambda *a, **k: None})())
 
     mb._create_dialog("Title", "Message", [("OK", True)])


### PR DESCRIPTION
## Summary
- theme all dialog windows with a light blue background
- ensure message boxes use light blue styled frames and labels
- extract core line chart drawing helper and fix metrics tab test

## Testing
- `pytest`
- `python tools/metrics_generator.py --path gui --output /tmp/metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a653a233748327b4799419d941d239