### PR TITLE
style: apply consistent dialog background

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -4,7 +4,30 @@ from __future__ import annotations
 """Shared GUI helpers and widget customizations."""
 
 import tkinter as tk
-from tkinter import ttk
+from tkinter import ttk, simpledialog
+
+# Default background color for all dialog windows
+DIALOG_BG_COLOR = "#A9BCE2"
+
+
+_orig_dialog_init = simpledialog.Dialog.__init__
+
+
+def _dialog_init_with_color(self, parent, title=None):
+    """Apply light blue background to every dialog window."""
+    _orig_dialog_init(self, parent, title)
+    try:
+        self.configure(bg=DIALOG_BG_COLOR)
+        for child in self.winfo_children():
+            try:
+                child.configure(bg=DIALOG_BG_COLOR)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+simpledialog.Dialog.__init__ = _dialog_init_with_color
 
 from .capsule_button import CapsuleButton, _interpolate_color, _glow_color  # noqa: F401
 
@@ -15,7 +38,9 @@ class _StyledButton(CapsuleButton):
     def __init__(self, *args, **kwargs):
         gradient = kwargs.pop("gradient", None)
         hover_gradient = kwargs.pop("hover_gradient", None)
-        super().__init__(*args, gradient=gradient, hover_gradient=hover_gradient, **kwargs)
+        super().__init__(
+            *args, gradient=gradient, hover_gradient=hover_gradient, **kwargs
+        )
 
 
 class TranslucidButton(_StyledButton):
@@ -34,7 +59,9 @@ class PurpleButton(_StyledButton):
 
     def __init__(self, *args, **kwargs):
         bg = kwargs.setdefault("bg", "#f3eaff")
-        gradient = kwargs.setdefault("gradient", ["#f8f6ff", "#e7ddff", "#d9c2ff", "#f3eaff"])
+        gradient = kwargs.setdefault(
+            "gradient", ["#f8f6ff", "#e7ddff", "#d9c2ff", "#f3eaff"]
+        )
         kwargs.setdefault("hover_bg", _glow_color(bg))
         kwargs.setdefault("hover_gradient", [_glow_color(c) for c in gradient])
         super().__init__(*args, **kwargs)
@@ -97,6 +124,7 @@ class HoverListbox(tk.Listbox):
 
 tk.Listbox = HoverListbox  # type: ignore[assignment]
 
+
 def format_name_with_phase(name: str, phase: str | None) -> str:
     """Return ``name`` with ``" (phase)"`` appended when ``phase")" is set."""
 
@@ -105,7 +133,9 @@ def format_name_with_phase(name: str, phase: str | None) -> str:
     return name
 
 
-def add_treeview_scrollbars(tree: ttk.Treeview, container: ttk.Widget | None = None) -> None:
+def add_treeview_scrollbars(
+    tree: ttk.Treeview, container: ttk.Widget | None = None
+) -> None:
     """Attach both vertical and horizontal scrollbars to ``tree``.
 
     Parameters
@@ -137,6 +167,7 @@ _orig_heading = ttk.Treeview.heading
 def _sortable_heading(self, column, option=None, **kw):
     """Add ascending/descending sort behavior when a column header is clicked."""
     if option is None and kw and "command" not in kw:
+
         def sort_column(col=column):
             data = [(self.set(k, col), k) for k in self.get_children("")]
 
@@ -150,7 +181,9 @@ def _sortable_heading(self, column, option=None, **kw):
             numeric = all(_is_number(v) for v, _ in data if v not in ("", None))
             if numeric:
                 data.sort(
-                    key=lambda t: float(t[0]) if t[0] not in ("", None) else float("-inf")
+                    key=lambda t: (
+                        float(t[0]) if t[0] not in ("", None) else float("-inf")
+                    )
                 )
             else:
                 data.sort(key=lambda t: str(t[0]).lower())

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -11,7 +11,7 @@ from tkinter import TclError
 import tkinter as tk
 from tkinter import ttk
 
-from . import logger
+from . import logger, DIALOG_BG_COLOR
 from . import PurpleButton
 
 
@@ -60,6 +60,10 @@ def _create_dialog(
         temp_root = True
 
     dialog = tk.Toplevel(root)
+    try:
+        dialog.configure(bg=DIALOG_BG_COLOR)
+    except Exception:
+        pass
     dialog.title(title or "")
     dialog.resizable(False, False)
     dialog.transient(root)
@@ -101,9 +105,7 @@ def askyesno(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ASK")
     logger.show_temporarily()
     try:
-        return bool(
-            _create_dialog(title, message, [("Yes", True), ("No", False)])
-        )
+        return bool(_create_dialog(title, message, [("Yes", True), ("No", False)]))
     except (TclError, RuntimeError):
         return False
 
@@ -123,8 +125,6 @@ def askokcancel(title=None, message=None, **options):
     logger.log_message(f"{title}: {message}", "ASK")
     logger.show_temporarily()
     try:
-        return bool(
-            _create_dialog(title, message, [("OK", True), ("Cancel", False)])
-        )
+        return bool(_create_dialog(title, message, [("OK", True), ("Cancel", False)]))
     except (TclError, RuntimeError):
         return False

--- a/gui/metrics_tab.py
+++ b/gui/metrics_tab.py
@@ -8,11 +8,13 @@ class MetricsTab(tk.Frame):
     def __init__(self, master, app):
         super().__init__(master)
         self.app = app
-        self.canvases = [tk.Canvas(self, width=300, height=200, bg="white") for _ in range(3)]
+        self.canvases = [
+            tk.Canvas(self, width=300, height=200, bg="white") for _ in range(3)
+        ]
         for c in self.canvases:
             c.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.update_plots()
-        
+
     @staticmethod
     def _line_chart_points(canvas: tk.Canvas, data):
         h = int(canvas["height"])
@@ -63,25 +65,6 @@ class MetricsTab(tk.Frame):
             canvas.create_line(*points, fill="blue")
         canvas.create_text(5, 5, anchor="nw", text="Requirements")
 
-    def _draw_line_chart(self, canvas: tk.Canvas, data):
-        self._line_chart_core(canvas, data)
-
-    @staticmethod
-    def _draw_line_chart_v1(_self, canvas: tk.Canvas, data):
-        MetricsTab._line_chart_core(canvas, data)
-
-    @staticmethod
-    def _draw_line_chart_v2(_self, canvas: tk.Canvas, data):
-        MetricsTab._line_chart_core(canvas, data)
-
-    @staticmethod
-    def _draw_line_chart_v3(_self, canvas: tk.Canvas, data):
-        MetricsTab._line_chart_core(canvas, data)
-
-    @staticmethod
-    def _draw_line_chart_v4(_self, canvas: tk.Canvas, data):
-        MetricsTab._line_chart_core(canvas, data)
-
     def _draw_bar_chart(self, canvas: tk.Canvas, data):
         canvas.delete("all")
         h = int(canvas["height"])
@@ -104,7 +87,10 @@ class MetricsTab(tk.Frame):
             req_history = [len(getattr(self.app, "requirements", []))]
         self._draw_line_chart(self.canvases[0], req_history)
 
-        statuses = Counter(getattr(r, "status", "unknown") for r in getattr(self.app, "requirements", []))
+        statuses = Counter(
+            getattr(r, "status", "unknown")
+            for r in getattr(self.app, "requirements", [])
+        )
         self._draw_bar_chart(self.canvases[1], statuses)
         self.canvases[1].create_text(5, 5, anchor="nw", text="Status")
 


### PR DESCRIPTION
## Summary
- globally apply light blue (`#A9BCE2`) background to all Tk dialog windows
- update custom message box to honor new dialog color
- remove duplicate line-chart helpers from metrics tab

## Testing
- `pytest`
- `pip install radon` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a653a233748327b4799419d941d239