### PR TITLE
Enable runtime mitigation to clear diagnostics errors

### DIFF
--- a/tests/test_diagnostics_manager.py
+++ b/tests/test_diagnostics_manager.py
@@ -81,7 +81,71 @@ def test_nonrecoverable_fault_mitigates_and_notifies() -> None:
         return "degraded mode"
 
     manager.run_check("n1", check, mitigate=mitigate, recoverable=False)
-    with pytest.raises(DiagnosticError):
-        manager.raise_errors()
+    manager.raise_errors()  # should not raise because mitigated
     assert mitigated["called"]
     assert "degraded mode" in manager.notifications
+
+
+def test_polling_failed_recovery_triggers_mitigation() -> None:
+    manager = PollingDiagnosticsManager(interval=0.01)
+    manager.register_check(
+        "p1",
+        lambda: False,
+        recover=lambda: False,
+        mitigate=lambda: "fallback",
+        recoverable=True,
+    )
+    manager.start()
+    time.sleep(0.05)
+    manager.stop()
+    manager.raise_errors()  # mitigated
+    assert "fallback" in manager.notifications
+
+
+def test_event_failed_recovery_triggers_mitigation() -> None:
+    manager = EventDiagnosticsManager()
+    manager.register_check(
+        "e1",
+        recover=lambda: False,
+        mitigate=lambda: "fallback",
+        recoverable=True,
+    )
+    manager.record_event("e1", False)
+    manager.process_events()
+    manager.raise_errors()  # mitigated
+    assert "fallback" in manager.notifications
+
+
+def test_passive_failed_recovery_triggers_mitigation() -> None:
+    manager = PassiveDiagnosticsManager()
+
+    def check() -> bool:
+        return False
+
+    manager.run_check(
+        "s1",
+        check,
+        recover=lambda: False,
+        mitigate=lambda: "fallback",
+        recoverable=True,
+    )
+    manager.raise_errors()  # mitigated
+    assert "fallback" in manager.notifications
+
+
+def test_async_failed_recovery_triggers_mitigation() -> None:
+    manager = AsyncDiagnosticsManager()
+
+    async def bad() -> bool:
+        return False
+
+    manager.register_check(
+        "a1",
+        bad,
+        recover=lambda: False,
+        mitigate=lambda: "fallback",
+        recoverable=True,
+    )
+    asyncio.run(manager.run_once())
+    manager.raise_errors()  # mitigated
+    assert "fallback" in manager.notifications


### PR DESCRIPTION
## Summary
- treat successful mitigation as resolving runtime diagnostics failures
- update diagnostics tests to ensure mitigated faults do not raise errors

## Testing
- `pytest tests/test_diagnostics_manager.py::test_nonrecoverable_fault_mitigates_and_notifies tests/test_diagnostics_manager.py::test_polling_failed_recovery_triggers_mitigation tests/test_diagnostics_manager.py::test_event_failed_recovery_triggers_mitigation tests/test_diagnostics_manager.py::test_passive_failed_recovery_triggers_mitigation tests/test_diagnostics_manager.py::test_async_failed_recovery_triggers_mitigation -q`
- `python tools/metrics_generator.py --path tools --output metrics_after.json >/tmp/metrics_after.log && tail -n 20 /tmp/metrics_after.log`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a65ea352b48327a31e61e39c53b9d2