### PR TITLE
Enable cross-diagram clipboard sharing for SysML diagrams

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -4,6 +4,7 @@ import tkinter.font as tkFont
 import textwrap
 from tkinter import ttk, simpledialog
 from gui import messagebox, format_name_with_phase, add_treeview_scrollbars, TranslucidButton
+from gui.diagram_clipboard import DEFAULT_STRATEGY as _clipboard
 try:  # Guard against environments where the tooltip module is unavailable
     from gui.tooltip import ToolTip
 except Exception:  # pragma: no cover - fallback for minimal installs
@@ -3635,7 +3636,6 @@ class SysMLDiagramWindow(tk.Frame):
         self.conn_drag_offset: tuple[float, float] | None = None
         self.dragging_conn_mid: tuple[float, float] | None = None
         self.dragging_conn_vec: tuple[float, float] | None = None
-        self.clipboard: SysMLObject | None = None
         self.resizing_obj: SysMLObject | None = None
         self.resize_edge: str | None = None
         self.select_rect_start: tuple[float, float] | None = None
@@ -9290,17 +9290,13 @@ class SysMLDiagramWindow(tk.Frame):
     # ------------------------------------------------------------
     def copy_selected(self, _event=None):
         if self.selected_obj:
-            import copy
-
-            self.clipboard = copy.deepcopy(self.selected_obj)
+            _clipboard.copy(self.selected_obj)
 
     def cut_selected(self, _event=None):
         if self.repo.diagram_read_only(self.diagram_id):
             return
         if self.selected_obj:
-            import copy
-
-            self.clipboard = copy.deepcopy(self.selected_obj)
+            _clipboard.copy(self.selected_obj)
             self.remove_object(self.selected_obj)
             self.selected_obj = None
             self._sync_to_repository()
@@ -9310,10 +9306,9 @@ class SysMLDiagramWindow(tk.Frame):
     def paste_selected(self, _event=None):
         if self.repo.diagram_read_only(self.diagram_id):
             return
-        if self.clipboard:
-            import copy
-
-            new_obj = copy.deepcopy(self.clipboard)
+        obj = _clipboard.paste()
+        if obj:
+            new_obj = obj
             new_obj.obj_id = _get_next_id()
             new_obj.x += 20
             new_obj.y += 20

--- a/gui/diagram_clipboard.py
+++ b/gui/diagram_clipboard.py
@@ -1,0 +1,92 @@
+"""Clipboard strategies for SysML diagram operations.
+
+This module provides multiple implementations for storing and
+retrieving diagram objects when copying, cutting and pasting.
+Each strategy offers a different mechanism.  The default strategy is
+:class:`ClassClipboardStrategy`, which keeps the clipboard at the class
+level and allows sharing between diagram instances of the same type.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import copy
+import pickle
+from typing import Any, Protocol
+
+try:
+    import tkinter as tk
+except Exception:  # pragma: no cover - environments without Tk
+    tk = None  # type: ignore
+
+
+class ClipboardStrategy(Protocol):
+    """Protocol for clipboard behaviour."""
+
+    def copy(self, obj: Any) -> None:
+        """Store ``obj`` in the clipboard."""
+
+    def paste(self) -> Any:
+        """Return a deep copy of the clipboard contents."""
+
+
+@dataclass
+class ModuleClipboardStrategy:
+    """Simple module level clipboard using a global variable."""
+
+    _clipboard: Any | None = None
+
+    def copy(self, obj: Any) -> None:  # pragma: no cover - trivial
+        self._clipboard = copy.deepcopy(obj)
+
+    def paste(self) -> Any:  # pragma: no cover - trivial
+        return copy.deepcopy(self._clipboard)
+
+
+@dataclass
+class ClassClipboardStrategy:
+    """Clipboard stored on the strategy class itself."""
+
+    _clipboard: Any | None = None
+
+    def copy(self, obj: Any) -> None:
+        type(self)._clipboard = copy.deepcopy(obj)
+
+    def paste(self) -> Any:
+        return copy.deepcopy(type(self)._clipboard)
+
+
+@dataclass
+class TkClipboardStrategy:
+    """Clipboard using the Tk root clipboard with pickle serialisation."""
+
+    root: tk.Misc
+
+    def copy(self, obj: Any) -> None:
+        data = pickle.dumps(obj)
+        self.root.clipboard_clear()
+        self.root.clipboard_append(data.decode("latin1"))
+
+    def paste(self) -> Any:
+        try:
+            data = self.root.clipboard_get().encode("latin1")
+            return pickle.loads(data)
+        except Exception:  # pragma: no cover - clipboard unavailable
+            return None
+
+
+@dataclass
+class RepositoryClipboardStrategy:
+    """Clipboard stored on a repository-like object."""
+
+    repo: Any
+
+    def copy(self, obj: Any) -> None:
+        self.repo._clipboard = copy.deepcopy(obj)
+
+    def paste(self) -> Any:
+        return copy.deepcopy(getattr(self.repo, "_clipboard", None))
+
+
+# Expose all strategies for testing, default to class-level
+DEFAULT_STRATEGY = ClassClipboardStrategy()

--- a/tests/test_diagram_clipboard_strategies.py
+++ b/tests/test_diagram_clipboard_strategies.py
@@ -1,0 +1,62 @@
+import unittest
+import types
+
+# Provide dummy PIL modules to satisfy imports when AutoML modules are imported
+import sys
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+from gui.diagram_clipboard import (
+    ModuleClipboardStrategy,
+    ClassClipboardStrategy,
+    RepositoryClipboardStrategy,
+    TkClipboardStrategy,
+)
+
+
+class Dummy:
+    pass
+
+
+class DummyRepo:
+    pass
+
+
+class ClipboardStrategyTests(unittest.TestCase):
+    def setUp(self):
+        self.obj = Dummy()
+
+    def _assert_copy_paste(self, strategy):
+        strategy.copy(self.obj)
+        pasted = strategy.paste()
+        self.assertIsInstance(pasted, Dummy)
+        self.assertIsNot(pasted, self.obj)
+
+    def test_module_strategy(self):
+        self._assert_copy_paste(ModuleClipboardStrategy())
+
+    def test_class_strategy(self):
+        self._assert_copy_paste(ClassClipboardStrategy())
+
+    def test_repository_strategy(self):
+        self._assert_copy_paste(RepositoryClipboardStrategy(DummyRepo()))
+
+    def test_tk_strategy(self):
+        import tkinter as tk
+
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            self.skipTest("Tk not available")
+        root.withdraw()
+        try:
+            self._assert_copy_paste(TkClipboardStrategy(root))
+        finally:
+            root.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sysml_cross_diagram_clipboard.py
+++ b/tests/test_sysml_cross_diagram_clipboard.py
@@ -1,0 +1,47 @@
+import unittest
+import types
+import sys
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+import tkinter as tk
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+from sysml.sysml_repository import SysMLRepository
+
+
+class CrossDiagramClipboardTests(unittest.TestCase):
+    def setUp(self):
+        SysMLRepository.reset_instance()
+        try:
+            self.root = tk.Tk()
+        except tk.TclError:
+            self.skipTest("Tk not available")
+        self.root.withdraw()
+        self.win1 = SysMLDiagramWindow(self.root, "Diag1", [])
+        self.win2 = SysMLDiagramWindow(self.root, "Diag2", [])
+        obj = SysMLObject(obj_id=1, obj_type="Block", x=0, y=0)
+        self.win1.objects.append(obj)
+        self.win1.selected_obj = obj
+
+    def tearDown(self):
+        self.root.destroy()
+
+    def test_copy_between_diagrams(self):
+        self.win1.copy_selected()
+        self.win2.paste_selected()
+        self.assertEqual(len(self.win2.objects), 1)
+
+    def test_cut_between_diagrams(self):
+        self.win1.cut_selected()
+        self.assertEqual(len(self.win1.objects), 0)
+        self.win2.paste_selected()
+        self.assertEqual(len(self.win2.objects), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cc_metrics.py
+++ b/tools/cc_metrics.py
@@ -1,0 +1,41 @@
+import ast
+import json
+import sys
+
+
+class ComplexityVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.count = 1
+
+    def generic_visit(self, node):
+        if isinstance(
+            node,
+            (ast.If, ast.For, ast.While, ast.And, ast.Or, ast.ExceptHandler, ast.With, ast.Try, ast.BoolOp),
+        ):
+            self.count += 1
+        super().generic_visit(node)
+
+
+def function_complexity(node: ast.AST) -> int:
+    visitor = ComplexityVisitor()
+    visitor.visit(node)
+    return visitor.count
+
+
+def file_complexity(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read())
+    result = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            result[node.name] = function_complexity(node)
+    return result
+
+
+def main(paths: list[str]) -> None:
+    results = {path: file_complexity(path) for path in paths}
+    print(json.dumps(results))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add clipboard strategies with class-level default shared across diagrams
- use shared clipboard in SysML diagram window copy/cut/paste operations
- add tests for clipboard strategies and cross-diagram clipboard behavior
- include simple cyclomatic complexity metric script

## Testing
- `python tools/cc_metrics.py gui/diagram_clipboard.py gui/architecture.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a709517c348327a3215a5baf8e9803