### PR TITLE
Preserve work product positions when moving boundaries

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -5099,10 +5099,15 @@ class SysMLDiagramWindow(tk.Frame):
                         offy = float(o.properties.get("py", o.y - old_y))
                         o.x = self.selected_obj.x + offx
                         o.y = self.selected_obj.y + offy
-                        self._constrain_to_parent(o, self.selected_obj)
+                        o.properties["px"] = str(offx)
+                        o.properties["py"] = str(offy)
                     elif o.properties.get("boundary") == str(self.selected_obj.obj_id):
-                        o.x += dx
-                        o.y += dy
+                        offx = float(o.properties.get("px", o.x - old_x))
+                        offy = float(o.properties.get("py", o.y - old_y))
+                        o.x = self.selected_obj.x + offx
+                        o.y = self.selected_obj.y + offy
+                        o.properties["px"] = str(offx)
+                        o.properties["py"] = str(offy)
             boundary = self.get_ibd_boundary()
             if boundary:
                 ensure_boundary_contains_parts(boundary, self.objects)

--- a/tests/test_work_product_process_area_lock.py
+++ b/tests/test_work_product_process_area_lock.py
@@ -60,6 +60,41 @@ class WorkProductProcessAreaLockTests(unittest.TestCase):
         win._sync_to_repository = lambda: None
         return win, boundary, wp
 
+    def _create_window_with_parent(self):
+        repo = self.repo
+        diag = SysMLDiagram(diag_id="d", diag_type="Governance Diagram")
+        repo.diagrams[diag.diag_id] = diag
+        win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+        win.repo = repo
+        win.diagram_id = diag.diag_id
+        win.objects = []
+        win.connections = []
+        win.canvas = self.DummyCanvas()
+        win.zoom = 1.0
+        win.current_tool = "Select"
+        win.selected_obj = None
+        win.drag_offset = (0, 0)
+        win.resizing_obj = None
+        win.start = None
+        win.select_rect_start = None
+        win.dragging_point_index = None
+        win.dragging_endpoint = None
+        win.conn_drag_offset = None
+        win.endpoint_drag_pos = None
+        win.app = None
+        win.selected_conn = None
+        win._constrain_horizontal_movement = SysMLDiagramWindow._constrain_horizontal_movement.__get__(win)
+        win.get_object = SysMLDiagramWindow.get_object.__get__(win)
+        win.get_ibd_boundary = SysMLDiagramWindow.get_ibd_boundary.__get__(win)
+        win.find_boundary_for_obj = SysMLDiagramWindow.find_boundary_for_obj.__get__(win)
+        win._object_within = SysMLDiagramWindow._object_within.__get__(win)
+        win.redraw = lambda: None
+        win._sync_to_repository = lambda: None
+        area = win._place_process_area("Risk Assessment", 0.0, 0.0)
+        wp = win._place_work_product("Risk Assessment", 10.0, 10.0, area=area)
+        win.selected_obj = area
+        return win, area, wp
+
     def test_work_product_remains_in_process_area(self):
         win, boundary, wp = self._create_window()
         win.on_left_drag(self.DummyEvent(200, 0))
@@ -67,6 +102,14 @@ class WorkProductProcessAreaLockTests(unittest.TestCase):
         self.assertEqual(wp.properties.get("boundary"), "1")
         expected_x = boundary.x + boundary.width / 2 - wp.width / 2
         self.assertEqual((wp.x, wp.y), (expected_x, boundary.y))
+
+    def test_work_product_position_preserved_on_boundary_move(self):
+        win, boundary, wp = self._create_window_with_parent()
+        offx = wp.x - boundary.x
+        offy = wp.y - boundary.y
+        win.on_left_drag(self.DummyEvent(100, 50))
+        win.on_left_release(self.DummyEvent(100, 50))
+        self.assertEqual((wp.x - boundary.x, wp.y - boundary.y), (offx, offy))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep work products fixed relative to boundaries during drag
- verify boundary movement preserves work product offsets

## Testing
- `pytest`
- `pip install radon` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a70d29b1e48327b2e6f1bb47897440