### PR TITLE
Fix drag undo handling in diagram windows

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -108,6 +108,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
         self.edges = []  # (line_id, src, dst)
         self.edge_start = None
         self.drag_node = None
+        self._drag_state_saved = False
+        self._drag_moved = False
         self.selected_node = None
         self.selection_rect = None
         self.temp_edge_line = None
@@ -371,12 +373,10 @@ class CausalBayesianNetworkWindow(tk.Frame):
             self._highlight_node(None)
         else:  # Select tool
             name = self._find_node(event.x, event.y)
-            if name:
-                undo = getattr(self.app, "push_undo_state", None)
-                if undo:
-                    undo()
             self.drag_node = name
             self.drag_offset = (0, 0)
+            self._drag_state_saved = False
+            self._drag_moved = False
             self._highlight_node(name)
             if name:
                 x, y = doc.positions.get(name, (0, 0))
@@ -388,6 +388,12 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if not doc:
             return
         if self.current_tool == "Select" and self.drag_node:
+            if not getattr(self, "_drag_state_saved", False):
+                app = getattr(self, "app", None)
+                undo = getattr(app, "push_undo_state", None)
+                if undo:
+                    undo()
+                self._drag_state_saved = True
             name = self.drag_node
             old_x, old_y = doc.positions.get(name, (0, 0))
             x, y = event.x + self.drag_offset[0], event.y + self.drag_offset[1]
@@ -414,6 +420,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
             if self.selected_node == name and self.selection_rect:
                 self.canvas.coords(self.selection_rect, x - r, y - r, x + r, y + r)
             self._update_scroll_region()
+            self._drag_moved = True
         elif self.current_tool == "Relationship" and self.edge_start:
             x1, y1 = doc.positions.get(self.edge_start, (0, 0))
             if self.temp_edge_line is None:
@@ -433,6 +440,8 @@ class CausalBayesianNetworkWindow(tk.Frame):
             return
         if self.current_tool == "Select":
             self.drag_node = None
+            self._drag_state_saved = False
+            self._drag_moved = False
         elif self.current_tool == "Relationship" and self.edge_start:
             dst = self._find_node(event.x, event.y)
             src = self.edge_start

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -218,6 +218,8 @@ class GSNDiagramWindow(tk.Frame):
         self._selected_connection: Optional[tuple[GSNNode, GSNNode]] = None
         self._drag_node: Optional[GSNNode] = None
         self._drag_offset = (0, 0)
+        self._drag_state_saved = False
+        self._drag_moved = False
         self._connect_mode: Optional[str] = None
         self._connect_parent: Optional[GSNNode] = None
         self.zoom = 1.0
@@ -409,14 +411,13 @@ class GSNDiagramWindow(tk.Frame):
                 app.selected_node = None
             self.refresh()
             return
-        undo = getattr(app, "push_undo_state", None)
-        if undo:
-            undo()
         self.selected_node = node
         self._selected_connection = None
         self._drag_node = node
         sx, sy = node.x * self.zoom, node.y * self.zoom
         self._drag_offset = (cx - sx, cy - sy)
+        self._drag_state_saved = False
+        self._drag_moved = False
         if app:
             app.selected_node = node
         self.refresh()
@@ -468,6 +469,12 @@ class GSNDiagramWindow(tk.Frame):
             return
         if not self._drag_node:
             return
+        if not getattr(self, "_drag_state_saved", False):
+            app = getattr(self, "app", None)
+            undo = getattr(app, "push_undo_state", None)
+            if undo:
+                undo()
+            self._drag_state_saved = True
         nx = (cx - self._drag_offset[0]) / self.zoom
         ny = (cy - self._drag_offset[1]) / self.zoom
         dx = nx - self._drag_node.x
@@ -475,6 +482,7 @@ class GSNDiagramWindow(tk.Frame):
         # Move the dragged node along with all of its children so the
         # relative layout of the subtree remains intact.
         self._move_subtree(self._drag_node, dx, dy)
+        self._drag_moved = True
         self.refresh()
 
     def _on_release(self, event):  # pragma: no cover - requires tkinter
@@ -510,6 +518,8 @@ class GSNDiagramWindow(tk.Frame):
             self.refresh()
             return
         self._drag_node = None
+        self._drag_state_saved = False
+        self._drag_moved = False
 
     def _animate_temp_connection(self):  # pragma: no cover - requires tkinter
         find = getattr(self.canvas, "find_withtag", None)

--- a/tests/test_cbn_drag_undo.py
+++ b/tests/test_cbn_drag_undo.py
@@ -1,0 +1,98 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure repository root on path and provide dummy PIL modules
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+
+from AutoML import AutoMLApp
+from analysis import CausalBayesianNetwork, CausalBayesianNetworkDoc
+from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
+
+
+def _setup_app(doc):
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.cbn_docs = [doc]
+    app.active_cbn = doc
+    app.update_views = lambda: None
+    app._undo_stack = []
+    app._redo_stack = []
+
+    def export_model_data(include_versions: bool = False):
+        return {
+            "cbn_docs": [
+                {
+                    "name": d.name,
+                    "nodes": list(d.network.nodes),
+                    "parents": {k: list(v) for k, v in d.network.parents.items()},
+                    "cpds": d.network.cpds,
+                    "positions": {k: tuple(v) for k, v in d.positions.items()},
+                    "types": dict(d.types),
+                }
+                for d in app.cbn_docs
+            ]
+        }
+
+    def apply_model_data(data):
+        app.cbn_docs = []
+        for d in data.get("cbn_docs", []):
+            net = CausalBayesianNetwork()
+            net.nodes = d.get("nodes", [])
+            net.parents = {k: list(v) for k, v in d.get("parents", {}).items()}
+            net.cpds = d.get("cpds", {})
+            positions = {k: tuple(v) for k, v in d.get("positions", {}).items()}
+            types = dict(d.get("types", {}))
+            app.cbn_docs.append(CausalBayesianNetworkDoc(d.get("name", "CBN"), network=net, positions=positions, types=types))
+        app.active_cbn = app.cbn_docs[0] if app.cbn_docs else None
+
+    app.export_model_data = export_model_data
+    app.apply_model_data = apply_model_data
+    app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+    app.undo = AutoMLApp.undo.__get__(app)
+    app.redo = AutoMLApp.redo.__get__(app)
+    return app
+
+
+def test_cbn_node_drag_records_single_undo_step():
+    doc = CausalBayesianNetworkDoc("CBN")
+    doc.network.add_node("A", cpd=0.5)
+    doc.positions["A"] = (0, 0)
+    doc.types["A"] = "variable"
+
+    win = CausalBayesianNetworkWindow.__new__(CausalBayesianNetworkWindow)
+    win.nodes = {"A": (None, None, "fill")}
+    win.edges = []
+    win.canvas = types.SimpleNamespace(canvasx=lambda v: v, canvasy=lambda v: v, move=lambda *a: None, coords=lambda *a: None)
+    win._position_table = lambda *a: None
+    win._highlight_node = lambda *a: None
+    win._find_node = lambda x, y: "A"
+    win.current_tool = "Select"
+    win.drag_node = None
+    win.selected_node = None
+    win.selection_rect = None
+
+    app = _setup_app(doc)
+    win.app = app
+
+    press = types.SimpleNamespace(x=0, y=0)
+    drag1 = types.SimpleNamespace(x=10, y=20)
+    drag2 = types.SimpleNamespace(x=20, y=30)
+
+    win.on_click(press)
+    win.on_drag(drag1)
+    win.on_drag(drag2)
+    win.on_release(drag2)
+
+    assert len(app._undo_stack) == 1
+    assert app.cbn_docs[0].positions["A"] == (20, 30)
+
+    app.undo()
+    assert app.cbn_docs[0].positions["A"] == (0, 0)
+
+    app.redo()
+    assert app.cbn_docs[0].positions["A"] == (20, 30)

--- a/tests/test_gsn_drag_undo.py
+++ b/tests/test_gsn_drag_undo.py
@@ -1,0 +1,77 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure repository root on path and provide dummy PIL modules
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+
+from AutoML import AutoMLApp
+from gsn import GSNNode, GSNDiagram
+from gui.gsn_diagram_window import GSNDiagramWindow
+
+
+def _setup_app(diagram):
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.gsn_diagrams = [diagram]
+    app.gsn_modules = []
+    app.update_views = lambda: None
+    app._undo_stack = []
+    app._redo_stack = []
+
+    def export_model_data(include_versions: bool = False):
+        return {
+            "gsn_diagrams": [d.to_dict() for d in app.gsn_diagrams],
+            "gsn_modules": [m.to_dict() for m in app.gsn_modules],
+        }
+
+    def apply_model_data(data):
+        app.gsn_diagrams = [GSNDiagram.from_dict(d) for d in data.get("gsn_diagrams", [])]
+        app.gsn_modules = []
+
+    app.export_model_data = export_model_data
+    app.apply_model_data = apply_model_data
+    app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)
+    app.undo = AutoMLApp.undo.__get__(app)
+    app.redo = AutoMLApp.redo.__get__(app)
+    return app
+
+
+def test_gsn_node_drag_records_single_undo_step():
+    root = GSNNode("Root", "Goal", x=0, y=0)
+    diagram = GSNDiagram(root)
+
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.diagram = diagram
+    win.canvas = types.SimpleNamespace(canvasx=lambda v: v, canvasy=lambda v: v)
+    win.refresh = lambda: None
+    win.zoom = 1
+    win._node_at = lambda x, y: root
+    win._connection_at = lambda x, y: None
+    win._connect_mode = None
+    win._connect_parent = None
+
+    app = _setup_app(diagram)
+    win.app = app
+
+    click = types.SimpleNamespace(x=0, y=0)
+    drag1 = types.SimpleNamespace(x=10, y=20)
+    drag2 = types.SimpleNamespace(x=20, y=30)
+
+    win._on_click(click)
+    win._on_drag(drag1)
+    win._on_drag(drag2)
+    win._on_release(drag2)
+
+    assert len(app._undo_stack) == 1
+    assert app.gsn_diagrams[0].root.x == 20 and app.gsn_diagrams[0].root.y == 30
+
+    app.undo()
+    assert app.gsn_diagrams[0].root.x == 0 and app.gsn_diagrams[0].root.y == 0
+
+    app.redo()
+    assert app.gsn_diagrams[0].root.x == 20 and app.gsn_diagrams[0].root.y == 30


### PR DESCRIPTION
## Summary
- ensure GSN diagram drag only records initial position and state
- add similar undo recording for CBN diagram drag operations
- test undo/redo after drag for both GSN and CBN diagrams

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path gui --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a70cf290c883279f6f463b4ebde7e0