### PR TITLE
Fix undo history after load and cross-diagram copy

### DIFF
--- a/sysml/sysml_repository.py
+++ b/sysml/sysml_repository.py
@@ -546,11 +546,22 @@ class SysMLRepository:
         with open(path, "w", encoding="utf-8") as f:
             f.write(self.serialize())
 
-    def load(self, path: str) -> None:
+    def load(self, path: str, strategy: str = "v4") -> None:
         if not os.path.exists(path):
             return
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
+        self._load_data(data)
+        if strategy == "v1":
+            self._reset_history_v1()
+        elif strategy == "v2":
+            self._reset_history_v2()
+        elif strategy == "v3":
+            self._reset_history_v3()
+        else:
+            self._reset_history_v4()
+
+    def _load_data(self, data: dict) -> None:
         self.elements.clear()
         self.relationships.clear()
         self.diagrams.clear()
@@ -571,6 +582,31 @@ class SysMLRepository:
                 break
         if self.root_package is None:
             self.root_package = self.create_element("Package", name="Root")
+
+    def _reset_history_v1(self) -> None:
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+
+    def _reset_history_v2(self) -> None:
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+        self.push_undo_state()
+
+    def _reset_history_v3(self) -> None:
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+        self._last_move_base = None
+        self._move_run_length = 0
+        self.push_undo_state()
+
+    def _reset_history_v4(self) -> None:
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+        self._last_move_base = None
+        self._move_run_length = 0
+        self.push_undo_state()
+        if self._undo_stack:
+            self._undo_stack[0] = self._undo_stack[0]
 
     def create_relationship(
         self,

--- a/tests/test_gsn_copy_paste_between_diagrams.py
+++ b/tests/test_gsn_copy_paste_between_diagrams.py
@@ -1,0 +1,71 @@
+import unittest
+import types
+import os
+import sys
+
+# Provide dummy PIL modules
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp, FaultTreeNode
+from gsn import GSNNode, GSNDiagram
+from gui import messagebox
+
+class DummyTree:
+    def selection(self):
+        return ()
+    def item(self, iid, attr):
+        return None
+
+class GSNMultiDiagramCopyPasteTests(unittest.TestCase):
+    def setUp(self):
+        self.app = AutoMLApp.__new__(AutoMLApp)
+        self.app.analysis_tree = DummyTree()
+        self.app.top_events = []
+        self.app.update_views = lambda: None
+        self.app.root_node = FaultTreeNode("root", "TOP EVENT")
+        self.app.clipboard_node = None
+        self.app.cut_mode = False
+
+        root1 = GSNNode("G1", "Goal")
+        child1 = GSNNode("S1", "Strategy")
+        root1.add_child(child1)
+        diag1 = GSNDiagram(root1)
+        diag1.add_node(child1)
+
+        root2 = GSNNode("G2", "Goal")
+        target2 = GSNNode("S2", "Strategy")
+        root2.add_child(target2)
+        diag2 = GSNDiagram(root2)
+        diag2.add_node(target2)
+
+        self.app.gsn_diagrams = [diag1, diag2]
+        self.diag1 = diag1
+        self.diag2 = diag2
+        self.child1 = child1
+        self.target2 = target2
+        self.app.selected_node = child1
+
+        # suppress message boxes
+        self._orig_info = messagebox.showinfo
+        self._orig_warn = messagebox.showwarning
+        messagebox.showinfo = lambda *a, **k: None
+        messagebox.showwarning = lambda *a, **k: None
+
+    def tearDown(self):
+        messagebox.showinfo = self._orig_info
+        messagebox.showwarning = self._orig_warn
+
+    def test_copy_between_same_type_diagrams(self):
+        self.app.copy_node()
+        self.app.selected_node = self.target2
+        self.app.paste_node()
+        self.assertEqual(len(self.diag2.nodes), 3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_load_undo_preserves_project.py
+++ b/tests/test_load_undo_preserves_project.py
@@ -1,0 +1,29 @@
+import unittest
+import tempfile
+from pathlib import Path
+from sysml.sysml_repository import SysMLRepository
+
+class LoadUndoPreservesProjectTests(unittest.TestCase):
+    def _create_project(self, path: Path):
+        repo = SysMLRepository.get_instance()
+        blk = repo.create_element("Block", name="A")
+        repo.save(path)
+        return blk.elem_id
+
+    def test_undo_after_load_keeps_elements(self):
+        for strat in ("v1", "v2", "v3", "v4"):
+            with self.subTest(strategy=strat):
+                SysMLRepository.reset_instance()
+                repo = SysMLRepository.get_instance()
+                with tempfile.TemporaryDirectory() as td:
+                    file = Path(td)/"model.json"
+                    elem_id = self._create_project(file)
+                    SysMLRepository.reset_instance()
+                    repo = SysMLRepository.get_instance()
+                    repo.load(str(file), strategy=strat)
+                    self.assertIn(elem_id, repo.elements)
+                    repo.undo()
+                    self.assertIn(elem_id, repo.elements)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure repository load resets history and offers four strategies
- test that undo after loading keeps project elements
- test copying between same-type diagrams

## Testing
- `pytest`
- `pip install radon` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a71537f9088327a6e6cce8e09e2747