### PR TITLE
Preserve work product layout when process areas move or resize

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -23,6 +23,7 @@ from config import load_diagram_rules, load_json_with_comments
 import json
 from gui.icon_factory import create_icon
 from gui.button_utils import set_uniform_button_width
+import os
 
 from sysml.sysml_spec import SYSML_PROPERTIES
 from analysis.models import (
@@ -67,6 +68,8 @@ _CONFIG = load_diagram_rules(_CONFIG_PATH)
 _REQ_PATTERN_PATH = (
     Path(__file__).resolve().parents[1] / "config/requirement_patterns.json"
 )
+
+RESIZE_STRATEGY = os.getenv("ARCH_WP_RESIZE_STRATEGY", "corner_ratio")
 
 
 def _load_requirement_relations(path: Path = _REQ_PATTERN_PATH) -> list[str]:
@@ -5006,9 +5009,13 @@ class SysMLDiagramWindow(tk.Frame):
                         text_h = self.font.metrics("linespace") * len(label_lines)
                         min_w = max(min_w, (text_w + 10 * self.zoom) / self.zoom)
                         min_h = max(min_h, (text_h + 10 * self.zoom) / self.zoom)
-            left = obj.x - obj.width / 2
+            old_left = obj.x - obj.width / 2
+            old_top = obj.y - obj.height / 2
+            old_w = obj.width
+            old_h = obj.height
+            left = old_left
             right = obj.x + obj.width / 2
-            top = obj.y - obj.height / 2
+            top = old_top
             bottom = obj.y + obj.height / 2
             if "e" in self.resize_edge:
                 new_right = x / self.zoom
@@ -5045,6 +5052,12 @@ class SysMLDiagramWindow(tk.Frame):
             obj.y = (top + bottom) / 2
             obj.width = new_w
             obj.height = new_h
+            if obj.obj_type == "System Boundary":
+                self._reposition_work_products(
+                    obj,
+                    (old_left, old_top, old_w, old_h),
+                    (left, top, new_w, new_h),
+                )
             if obj.obj_type == "Part":
                 update_ports_for_part(obj, self.objects)
             if obj.obj_type == "Block Boundary":
@@ -5090,17 +5103,19 @@ class SysMLDiagramWindow(tk.Frame):
                                 p.x += dx
                                 p.y += dy
             if self.selected_obj.obj_type == "System Boundary":
+                width = self.selected_obj.width
+                height = self.selected_obj.height
+                old_left = old_x - width / 2
+                old_top = old_y - height / 2
+                new_left = self.selected_obj.x - width / 2
+                new_top = self.selected_obj.y - height / 2
+                self._reposition_work_products(
+                    self.selected_obj,
+                    (old_left, old_top, width, height),
+                    (new_left, new_top, width, height),
+                )
                 for o in self.objects:
-                    if (
-                        o.obj_type == "Work Product"
-                        and o.properties.get("parent") == str(self.selected_obj.obj_id)
-                    ):
-                        offx = float(o.properties.get("px", o.x - old_x))
-                        offy = float(o.properties.get("py", o.y - old_y))
-                        o.x = self.selected_obj.x + offx
-                        o.y = self.selected_obj.y + offy
-                        self._constrain_to_parent(o, self.selected_obj)
-                    elif o.properties.get("boundary") == str(self.selected_obj.obj_id):
+                    if o.properties.get("boundary") == str(self.selected_obj.obj_id):
                         o.x += dx
                         o.y += dy
             boundary = self.get_ibd_boundary()
@@ -12028,8 +12043,50 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
         # Clamp coordinates to the process area so work products cannot escape.
         obj.x = min(max(obj.x, left), right)
         obj.y = min(max(obj.y, top), bottom)
-        obj.properties["px"] = str(obj.x - area.x)
-        obj.properties["py"] = str(obj.y - area.y)
+        area_left = area.x - area.width / 2
+        area_top = area.y - area.height / 2
+        obj.properties["px"] = str((obj.x - area_left) / area.width)
+        obj.properties["py"] = str((obj.y - area_top) / area.height)
+
+    def _reposition_work_products(
+        self,
+        area: SysMLObject,
+        old: tuple[float, float, float, float],
+        new: tuple[float, float, float, float],
+        strategy: str = RESIZE_STRATEGY,
+    ) -> None:
+        old_left, old_top, old_w, old_h = old
+        new_left, new_top, new_w, new_h = new
+        old_cx = old_left + old_w / 2
+        old_cy = old_top + old_h / 2
+        new_cx = new_left + new_w / 2
+        new_cy = new_top + new_h / 2
+        for o in self.objects:
+            if (
+                o.obj_type == "Work Product"
+                and o.properties.get("parent") == str(area.obj_id)
+            ):
+                if strategy == "center_ratio":
+                    rx = (o.x - old_cx) / old_w if old_w else 0.0
+                    ry = (o.y - old_cy) / old_h if old_h else 0.0
+                    o.x = new_cx + rx * new_w
+                    o.y = new_cy + ry * new_h
+                elif strategy == "center_offset":
+                    dx = o.x - old_cx
+                    dy = o.y - old_cy
+                    o.x = new_cx + dx
+                    o.y = new_cy + dy
+                elif strategy == "corner_offset":
+                    dx = o.x - old_left
+                    dy = o.y - old_top
+                    o.x = new_left + dx
+                    o.y = new_top + dy
+                else:  # corner_ratio
+                    rx = (o.x - old_left) / old_w if old_w else 0.0
+                    ry = (o.y - old_top) / old_h if old_h else 0.0
+                    o.x = new_left + rx * new_w
+                    o.y = new_top + ry * new_h
+                self._constrain_to_parent(o, area)
 
     def on_left_press(self, event):  # pragma: no cover - requires tkinter
         if self.repo.diagram_read_only(self.diagram_id):

--- a/tests/test_work_product_process_area_containment.py
+++ b/tests/test_work_product_process_area_containment.py
@@ -35,8 +35,10 @@ def test_work_product_clamped_to_process_area():
     bottom = area.y + area.height / 2 - wp.height / 2
     assert math.isclose(wp.x, right)
     assert math.isclose(wp.y, bottom)
-    assert wp.properties.get("px") == str(wp.x - area.x)
-    assert wp.properties.get("py") == str(wp.y - area.y)
+    exp_px = (wp.x - (area.x - area.width / 2)) / area.width
+    exp_py = (wp.y - (area.y - area.height / 2)) / area.height
+    assert math.isclose(float(wp.properties.get("px")), exp_px)
+    assert math.isclose(float(wp.properties.get("py")), exp_py)
 
 
 def test_add_work_product_existing_area_click():
@@ -183,10 +185,68 @@ def test_process_area_drag_moves_work_product():
     win.on_left_drag(Event())
 
     assert win.find_boundary_for_obj(wp) == area
-    assert wp.x == area.x + 10
-    assert wp.y == area.y
-    assert wp.properties.get("px") == "10.0"
-    assert wp.properties.get("py") == "0.0"
+    assert math.isclose(wp.x, area.x + 10)
+    assert math.isclose(wp.y, area.y)
+    assert math.isclose(float(wp.properties.get("px")), 0.55)
+    assert math.isclose(float(wp.properties.get("py")), 0.5)
+
+
+def test_process_area_resize_keeps_work_product_ratio():
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram")
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.app = None
+
+    area = win._place_process_area("Risk Assessment", 0.0, 0.0)
+    wp = win._place_work_product("Risk Assessment", 10.0, 0.0, area=area)
+    relx = float(wp.properties.get("px"))
+    rely = float(wp.properties.get("py"))
+
+    class DummyCanvas:
+        def canvasx(self, x):
+            return x
+
+        def canvasy(self, y):
+            return y
+
+    win.canvas = DummyCanvas()
+    win.selected_obj = area
+    win.current_tool = "Select"
+    win.resizing_obj = area
+    win.resize_edge = "e"
+    win.drag_offset = (0, 0)
+    win.start = None
+    win.select_rect_start = None
+    win.dragging_conn_mid = None
+    win.selected_conn = None
+    win.dragging_endpoint = None
+    win.dragging_point_index = None
+
+    class Event:
+        x = 200
+        y = 0
+
+    win.on_left_drag(Event())
+
+    left = area.x - area.width / 2
+    top = area.y - area.height / 2
+    new_relx = (wp.x - left) / area.width
+    new_rely = (wp.y - top) / area.height
+    assert math.isclose(new_relx, relx)
+    assert math.isclose(new_rely, rely)
+    assert math.isclose(float(wp.properties.get("px")), relx)
+    assert math.isclose(float(wp.properties.get("py")), rely)
+    assert wp.width == 60.0
+    assert wp.height == 80.0
 
 
 def test_process_area_multiple_drags_keep_work_product_offset():
@@ -241,7 +301,7 @@ def test_process_area_multiple_drags_keep_work_product_offset():
     win.on_left_drag(Event2())
 
     assert win.find_boundary_for_obj(wp) == area
-    assert wp.x == area.x + 10
-    assert wp.y == area.y
-    assert wp.properties.get("px") == "10.0"
-    assert wp.properties.get("py") == "0.0"
+    assert math.isclose(wp.x, area.x + 10)
+    assert math.isclose(wp.y, area.y)
+    assert math.isclose(float(wp.properties.get("px")), 0.55)
+    assert math.isclose(float(wp.properties.get("py")), 0.5)


### PR DESCRIPTION
## Summary
- keep work products at proportional coordinates within their process area
- support multiple strategies for child repositioning during area resize
- test work product containment and resizing behavior

## Testing
- `ARCH_WP_RESIZE_STRATEGY=corner_ratio pytest`
- `ARCH_WP_RESIZE_STRATEGY=center_ratio pytest`
- `ARCH_WP_RESIZE_STRATEGY=corner_offset pytest` *(fails: assert False)*
- `ARCH_WP_RESIZE_STRATEGY=center_offset pytest` *(fails: assert False)*
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a7157872d4832780685531557171c9