### PR TITLE
Fix copy/cut/paste for diagram selections

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -18638,8 +18638,38 @@ class AutoMLApp:
         elif diag.diag_type == "Control Flow Diagram":
             ControlFlowDiagramWindow(tab, self, diagram_id=diag.diag_id)
         self.refresh_all()
-        
+
+    def _clipboard_widget(self):
+        def search(widget):
+            stack = [widget] if widget else []
+            while stack:
+                w = stack.pop()
+                if any(
+                    hasattr(w, m) for m in ("copy_selected", "cut_selected", "paste_selected")
+                ):
+                    return w
+                stack.extend(getattr(w, "winfo_children", lambda: [])())
+            return None
+
+        widget = getattr(self, "root", None)
+        if widget:
+            hit = search(widget.focus_get())
+            if hit:
+                return hit
+        if hasattr(self, "doc_nb"):
+            try:
+                tab = self.doc_nb.nametowidget(self.doc_nb.select())
+            except Exception:
+                tab = None
+            if tab:
+                return search(tab)
+        return None
+
     def copy_node(self):
+        widget = self._clipboard_widget()
+        if widget and hasattr(widget, "copy_selected"):
+            widget.copy_selected()
+            return
         node = self.selected_node
         if (node is None or node == self.root_node) and hasattr(self, "analysis_tree"):
             sel = self.analysis_tree.selection()
@@ -18656,6 +18686,10 @@ class AutoMLApp:
 
     def cut_node(self):
         """Store the currently selected node for a cut & paste operation."""
+        widget = self._clipboard_widget()
+        if widget and hasattr(widget, "cut_selected"):
+            widget.cut_selected()
+            return
         node = self.selected_node
         if (node is None or node == self.root_node) and hasattr(self, "analysis_tree"):
             sel = self.analysis_tree.selection()
@@ -18671,6 +18705,10 @@ class AutoMLApp:
             messagebox.showwarning("Cut", "Select a non-root node to cut.")
 
     def paste_node(self):
+        widget = self._clipboard_widget()
+        if widget and hasattr(widget, "paste_selected"):
+            widget.paste_selected()
+            return
         # 1) Ensure clipboard is not empty.
         if not self.clipboard_node:
             messagebox.showwarning("Paste", "Clipboard is empty.")

--- a/tests/test_diagram_copy_cut_paste.py
+++ b/tests/test_diagram_copy_cut_paste.py
@@ -1,0 +1,42 @@
+import types
+import unittest
+
+from AutoML import AutoMLApp
+
+
+class DummyWindow:
+    def __init__(self):
+        self.copied = False
+        self.cut = False
+        self.pasted = False
+
+    def copy_selected(self):
+        self.copied = True
+
+    def cut_selected(self):
+        self.cut = True
+
+    def paste_selected(self):
+        self.pasted = True
+
+
+class DiagramClipboardDelegationTests(unittest.TestCase):
+    def setUp(self):
+        self.app = AutoMLApp.__new__(AutoMLApp)
+        self.win = DummyWindow()
+        self.app.root = types.SimpleNamespace(focus_get=lambda: self.win)
+        self.app.selected_node = None
+        self.app.clipboard_node = None
+        self.app.root_node = None
+
+    def test_copy_cut_paste_delegate_to_window(self):
+        self.app.copy_node()
+        self.app.cut_node()
+        # Put something on clipboard for paste
+        self.app.clipboard_node = object()
+        self.app.paste_node()
+        assert self.win.copied and self.win.cut and self.win.pasted
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- delegate global copy/cut/paste to focused diagram window
- add regression test ensuring delegation

## Testing
- `pytest` *(fails: tests/test_governance_undo.py::test_governance_diagram_undo_redo_work_product, tests/test_repo_push_undo_fallback.py::test_push_undo_state_falls_back_when_strategy_missing, tests/test_undo_move_ignore_modified.py::UndoMoveIgnoreModifiedTests::test_modified_fields_do_not_create_extra_states)*

------
https://chatgpt.com/codex/tasks/task_b_68a7436f23248327a7add0136e3b3195