### PR TITLE
feat: enable table row reordering

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -19079,8 +19079,10 @@ class AutoMLApp:
         repo = SysMLRepository.get_instance()
         repo._undo_stack.clear()
         repo._redo_stack.clear()
-        self._undo_stack.clear()
-        self._redo_stack.clear()
+        if hasattr(self, "_undo_stack"):
+            self._undo_stack.clear()
+        if hasattr(self, "_redo_stack"):
+            self._redo_stack.clear()
 
     # ------------------------------------------------------------
     # Undo support

--- a/gui/safety_case_table.py
+++ b/gui/safety_case_table.py
@@ -72,6 +72,14 @@ class SafetyCaseTable(tk.Frame):
             rowheight=80,
         )
         self.controller.pack(fill=tk.BOTH, expand=True)
+        btns = tk.Frame(self)
+        btns.pack(fill=tk.X)
+        tk.Button(btns, text="Move Up", command=self.controller.move_up).pack(
+            side=tk.LEFT
+        )
+        tk.Button(btns, text="Move Down", command=self.controller.move_down).pack(
+            side=tk.LEFT
+        )
         self.tree = self.controller.tree
 
         self.tree.bind("<Double-1>", self._on_double_click, add="+")

--- a/gui/safety_management_toolbox.py
+++ b/gui/safety_management_toolbox.py
@@ -18,7 +18,7 @@ from gui import messagebox, add_treeview_scrollbars
 from gui.mac_button_style import apply_translucid_button_style
 from gui.icon_factory import create_icon
 from sysml.sysml_repository import SysMLRepository
-from gui.toolboxes import configure_table_style, _wrap_val
+from gui.toolboxes import configure_table_style, _wrap_val, enable_treeview_reorder
 
 
 class SafetyManagementWindow(tk.Frame):
@@ -368,6 +368,7 @@ class SafetyManagementWindow(tk.Frame):
             _fit_columns()
 
         populate(ids)
+        move_up, move_down = enable_treeview_reorder(tree)
         add_treeview_scrollbars(tree, tree_frame)
         tree_frame.pack(fill=tk.BOTH)  # don't expand so button bar has room
 
@@ -492,18 +493,16 @@ class SafetyManagementWindow(tk.Frame):
             btn_frame = ttk.Frame(frame)
             btn_frame.pack(fill=tk.X, pady=4)
             if hasattr(btn_frame, "configure"):
-                tk.Button(btn_frame, text="Add", command=_add).pack(
+                tk.Button(btn_frame, text="Move Up", command=move_up).pack(
                     side=tk.LEFT, padx=2
                 )
-                tk.Button(btn_frame, text="Edit", command=_edit).pack(
+                tk.Button(btn_frame, text="Move Down", command=move_down).pack(
                     side=tk.LEFT, padx=2
                 )
-                tk.Button(btn_frame, text="Remove", command=_remove).pack(
-                    side=tk.LEFT, padx=2
-                )
-                tk.Button(btn_frame, text="Save CSV", command=_save_csv).pack(
-                    side=tk.LEFT, padx=2
-                )
+                tk.Button(btn_frame, text="Add", command=_add).pack(side=tk.LEFT, padx=2)
+                tk.Button(btn_frame, text="Edit", command=_edit).pack(side=tk.LEFT, padx=2)
+                tk.Button(btn_frame, text="Remove", command=_remove).pack(side=tk.LEFT, padx=2)
+                tk.Button(btn_frame, text="Save CSV", command=_save_csv).pack(side=tk.LEFT, padx=2)
 
         frame.refresh_table = populate
         return frame

--- a/gui/table_controller.py
+++ b/gui/table_controller.py
@@ -3,7 +3,12 @@ import tkinter.font as tkfont
 from tkinter import ttk
 
 from gui import add_treeview_scrollbars
-from gui.toolboxes import EditableTreeview, configure_table_style, _wrap_val
+from gui.toolboxes import (
+    EditableTreeview,
+    configure_table_style,
+    _wrap_val,
+    enable_treeview_reorder,
+)
 
 
 class TableController(tk.Frame):
@@ -48,6 +53,9 @@ class TableController(tk.Frame):
             self.tree.column(col, width=width, stretch=True)
         add_treeview_scrollbars(self.tree, self)
         self.tree.bind("<Configure>", self._adjust_text, add="+")
+        self._move_up, self._move_down = enable_treeview_reorder(
+            self.tree, self._adjust_text
+        )
 
     # ------------------------------------------------------------------
     def clear(self) -> None:
@@ -95,3 +103,12 @@ class TableController(tk.Frame):
     def adjust_text(self) -> None:
         """Public wrapper for :meth:`_adjust_text`."""
         self._adjust_text()
+
+    # ------------------------------------------------------------------
+    def move_up(self) -> None:
+        """Move the currently selected row one position upwards."""
+        self._move_up()
+
+    def move_down(self) -> None:
+        """Move the currently selected row one position downwards."""
+        self._move_down()


### PR DESCRIPTION
## Summary
- allow drag-and-drop and button-based row reordering in table controller
- add move controls to safety case and requirement tables
- guard undo history clearing to handle minimal app instances

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a74ba1242083278a43d8d69460e55c