### PR TITLE
Manage tab data loading based on focus

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -19079,8 +19079,10 @@ class AutoMLApp:
         repo = SysMLRepository.get_instance()
         repo._undo_stack.clear()
         repo._redo_stack.clear()
-        self._undo_stack.clear()
-        self._redo_stack.clear()
+        if hasattr(self, "_undo_stack"):
+            self._undo_stack.clear()
+        if hasattr(self, "_redo_stack"):
+            self._redo_stack.clear()
 
     # ------------------------------------------------------------
     # Undo support

--- a/tests/test_tab_data_loading.py
+++ b/tests/test_tab_data_loading.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.closable_notebook import ClosableNotebook
+
+
+class DummyTab:
+    def __init__(self):
+        self.methods = []
+        self.events = []
+
+    def load_data(self):
+        self.methods.append("load")
+
+    def unload_data(self):
+        self.methods.append("unload")
+
+    def event_generate(self, name):
+        self.events.append(name)
+
+
+@pytest.mark.parametrize("strategy", [1, 2, 3, 4])
+def test_tab_data_loading(strategy):
+    nb = ClosableNotebook.__new__(ClosableNotebook)
+    nb._data_strategy = strategy
+    nb._focused_tab = None
+
+    tabs = {"t1": DummyTab(), "t2": DummyTab()}
+
+    def select():
+        return nb._current
+
+    nb.select = select
+    nb.nametowidget = lambda widget_id: tabs[widget_id]
+    nb._get_widget = lambda widget_id: tabs.get(widget_id)
+    nb._call_method = ClosableNotebook._call_method.__get__(nb)
+
+    nb._current = "t1"
+    nb._handle_tab_focus()
+    nb._current = "t2"
+    nb._handle_tab_focus()
+
+    t1, t2 = tabs["t1"], tabs["t2"]
+
+    if strategy == 1:
+        assert t1.methods == ["load"]
+        assert t1.events == []
+        assert t2.methods == ["load"]
+    elif strategy == 2:
+        assert t1.methods == ["load", "unload"]
+        assert t1.events == []
+        assert t2.methods == ["load"]
+    elif strategy == 3:
+        assert t1.methods == []
+        assert t1.events == ["<<TabLoaded>>", "<<TabUnloaded>>"]
+        assert t2.events == ["<<TabLoaded>>"]
+    else:
+        assert t1.methods == ["load", "unload"]
+        assert t1.events == ["<<TabLoaded>>", "<<TabUnloaded>>"]
+        assert t2.methods == ["load"]
+        assert t2.events == ["<<TabLoaded>>"]


### PR DESCRIPTION
## Summary
- add strategy-based data loading/unloading for notebook tabs with four selectable modes
- guard AutoML undo history cleanup for partially initialized apps
- cover strategies with unit tests

## Testing
- `pytest tests/test_tab_data_loading.py`
- `pytest`
- `pip install radon` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a74c46dac08327814f89bd08c75798