### PR TITLE
Prompt to save before loading AutoML projects

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -20291,6 +20291,15 @@ class AutoMLApp:
     def load_model(self):
         import json
 
+        if self.has_unsaved_changes():
+            result = messagebox.askyesnocancel(
+                "Unsaved Changes", "Save changes before loading a project?"
+            )
+            if result is None:
+                return
+            if result:
+                self.save_model()
+
         path = filedialog.askopenfilename(
             defaultextension=".autml",
             filetypes=[("AutoML Project", "*.autml"), ("JSON", "*.json")],


### PR DESCRIPTION
## Summary
- warn users about unsaved changes before loading a new project and allow cancel
- add regression tests for load_model unsaved-change prompt

## Testing
- `pytest -q`
- `pip install radon` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a756fba9ac8327b78b122a2218ccd6