### PR TITLE
Avoid empty FTA tab on project reset

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -10365,9 +10365,8 @@ class AutoMLApp:
                 except tk.TclError:
                     pass
 
-        # Recreate the FTA tab and canvas
-        self._create_fta_tab()
-        self.canvas.delete("all")
+        # Reset FTA state without recreating the tab
+        self._reset_fta_state()
 
         global AutoML_Helper, unique_node_id_counter
         # Reset all repositories and model data
@@ -10406,7 +10405,8 @@ class AutoMLApp:
         self.analysis_tree.delete(*self.analysis_tree.get_children())
         self.update_views()
         self.set_last_saved_state()
-        self.canvas.update()
+        if self.canvas:
+            self.canvas.update()
 
     def compute_occurrence_counts(self):
         counts = {}
@@ -18164,6 +18164,15 @@ class AutoMLApp:
         self.canvas.bind("<Double-1>", self.on_canvas_double_click)
         self.canvas.bind("<Control-MouseWheel>", self.on_ctrl_mousewheel)
 
+    def _reset_fta_state(self):
+        """Clear references to the FTA tab and its canvas."""
+        self.canvas_tab = None
+        self.canvas_frame = None
+        self.canvas = None
+        self.hbar = None
+        self.vbar = None
+        self.page_diagram = None
+
     def ensure_fta_tab(self):
         """Recreate the FTA tab if it was closed."""
         if not getattr(self, "canvas_tab", None) or not self.canvas_tab.winfo_exists():
@@ -20284,9 +20293,7 @@ class AutoMLApp:
         if getattr(self, "analysis_tree", None):
             self.analysis_tree.delete(*self.analysis_tree.get_children())
 
-        self._create_fta_tab()
-        if getattr(self, "canvas", None):
-            self.canvas.delete("all")
+        self._reset_fta_state()
 
     def load_model(self):
         import json

--- a/tests/test_no_empty_fta_tab.py
+++ b/tests/test_no_empty_fta_tab.py
@@ -1,0 +1,84 @@
+import sys, types, pathlib
+from unittest.mock import MagicMock
+
+# Ensure repository root on path
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Stub PIL modules for AutoML import
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+from AutoML import AutoMLApp
+import AutoML
+
+class DummyNotebook:
+    def __init__(self):
+        self._tabs = ["t1"]
+        self._closing_tab = None
+
+    def tabs(self):
+        return list(self._tabs)
+
+    def event_generate(self, _):
+        pass
+
+    def forget(self, tab_id):
+        if tab_id in self._tabs:
+            self._tabs.remove(tab_id)
+
+
+def _base_app(monkeypatch):
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.doc_nb = DummyNotebook()
+    app.analysis_tree = MagicMock()
+    app.analysis_tree.get_children.return_value = []
+    app.analysis_tree.delete = MagicMock()
+    app.close_page_diagram = MagicMock()
+    app.page_diagram = object()
+    app.use_case_windows = [MagicMock()]
+    app.activity_windows = [MagicMock()]
+    app.block_windows = [MagicMock()]
+    app.ibd_windows = [MagicMock()]
+    app._undo_stack = []
+    app._redo_stack = []
+    app.diagram_font = MagicMock()
+    app.hara_docs = []
+    app.hazop_docs = []
+    app.fmea_entries = []
+    app.fmeas = []
+    app.fmedas = []
+    app.safety_mgmt_toolbox = MagicMock()
+    app.safety_mgmt_toolbox.doc_phases = {}
+    app.safety_mgmt_toolbox.active_module = None
+    app.safety_mgmt_toolbox.register_created_work_product = MagicMock()
+
+    monkeypatch.setattr(AutoML, "SysMLRepository", MagicMock())
+    monkeypatch.setattr(AutoML, "AutoMLHelper", MagicMock())
+    monkeypatch.setattr(AutoML, "AutoML_Helper", MagicMock(), raising=False)
+    monkeypatch.setattr(AutoML, "update_probability_tables", lambda *a, **k: None)
+    monkeypatch.setattr(AutoML.messagebox, "askyesnocancel", lambda *a, **k: False)
+    return app
+
+
+def test_new_model_no_fta_tab(monkeypatch):
+    app = _base_app(monkeypatch)
+    app.has_unsaved_changes = MagicMock(return_value=False)
+    app.apply_model_data = MagicMock()
+    app.set_last_saved_state = MagicMock()
+    app._create_fta_tab = MagicMock()
+
+    app.new_model()
+    app._create_fta_tab.assert_not_called()
+    assert "FTA" not in app.doc_nb.tabs()
+
+
+def test_reset_on_load_no_fta_tab(monkeypatch):
+    app = _base_app(monkeypatch)
+    app._create_fta_tab = MagicMock()
+
+    app._reset_on_load()
+    app._create_fta_tab.assert_not_called()
+    assert app.doc_nb.tabs() == []


### PR DESCRIPTION
## Summary
- prevent AutoML from spawning a blank FTA tab when starting a new model or loading a project
- centralize FTA tab cleanup via new `_reset_fta_state`
- add regression tests to ensure tabs are not created spuriously

## Testing
- `pytest`
- `pip install radon` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a758b07fb48327b767fd509bfd53e8