### PR TITLE
feat: ensure Ghostscript installation

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -7,6 +7,7 @@ executable the dependencies are already bundled so the installation step
 is skipped.
 """
 import importlib
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -14,6 +15,7 @@ from pathlib import Path
 # Hint PyInstaller to bundle AutoML and its dependencies (e.g. gui package)
 if False:  # pragma: no cover
     import AutoML  # noqa: F401
+    Path(r"C:\\Program Files\\gs\\gs10.04.0\\bin\\gswin64c.exe")
 
 REQUIRED_PACKAGES = [
     "pillow",
@@ -23,6 +25,81 @@ REQUIRED_PACKAGES = [
     "reportlab",
     "adjustText",
 ]
+
+GS_PATH = Path(r"C:\\Program Files\\gs\\gs10.04.0\\bin\\gswin64c.exe")
+
+
+def _install_ghostscript_via_winget() -> bool:
+    """Attempt installation using winget."""
+    try:
+        subprocess.check_call([
+            "winget",
+            "install",
+            "--id",
+            "Ghostscript.Ghostscript",
+            "-e",
+            "--silent",
+        ])
+        return True
+    except Exception:
+        return False
+
+
+def _install_ghostscript_via_choco() -> bool:
+    """Attempt installation using Chocolatey."""
+    try:
+        subprocess.check_call(["choco", "install", "ghostscript", "-y"])
+        return True
+    except Exception:
+        return False
+
+
+def _install_ghostscript_via_powershell() -> bool:
+    """Download and install Ghostscript via PowerShell."""
+    url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10040/gs10040w64.exe"
+    script = (
+        f"Invoke-WebRequest -Uri {url} -OutFile gs.exe;"
+        "Start-Process gs.exe -ArgumentList '/S' -NoNewWindow -Wait"
+    )
+    try:
+        subprocess.check_call(["powershell", "-Command", script])
+        return True
+    except Exception:
+        return False
+
+
+def _install_ghostscript_via_pip() -> bool:
+    """Fallback installation using pip ghostscript wrapper."""
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "ghostscript"])
+        return True
+    except Exception:
+        return False
+
+
+def ensure_ghostscript() -> None:
+    """Ensure Ghostscript is available on Windows systems.
+
+    The function attempts four different installation mechanisms to provide
+    robustness across environments.  If all methods fail, a ``RuntimeError``
+    is raised to signal the missing dependency.
+    """
+    if os.name != "nt":
+        return
+    if GS_PATH.exists():
+        return
+    installers = [
+        _install_ghostscript_via_winget,
+        _install_ghostscript_via_choco,
+        _install_ghostscript_via_powershell,
+        _install_ghostscript_via_pip,
+    ]
+    for installer in installers:
+        if installer():
+            if GS_PATH.exists():
+                return
+    raise RuntimeError("Ghostscript installation failed")
+
 
 def ensure_packages() -> None:
     """Install any missing runtime dependencies.
@@ -41,6 +118,7 @@ def ensure_packages() -> None:
 def main() -> None:
     """Entry point used by both source and bundled executions."""
     ensure_packages()
+    ensure_ghostscript()
     base_path = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))
     if str(base_path) not in sys.path:
         sys.path.insert(0, str(base_path))

--- a/tests/test_ghostscript_installation.py
+++ b/tests/test_ghostscript_installation.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest import mock
+
+import launcher
+
+
+def test_ensure_ghostscript_non_windows():
+    with mock.patch.object(launcher, "os") as m_os:
+        m_os.name = "posix"
+        launcher.ensure_ghostscript()
+
+
+def test_ensure_ghostscript_already_present():
+    with mock.patch.object(launcher, "os") as m_os:
+        m_os.name = "nt"
+        with mock.patch.object(launcher, "GS_PATH") as gs_path:
+            gs_path.exists.return_value = True
+            launcher.ensure_ghostscript()
+            gs_path.exists.assert_called_once()
+
+
+def test_ensure_ghostscript_installs():
+    with mock.patch.object(launcher, "os") as m_os:
+        m_os.name = "nt"
+        with mock.patch.object(launcher, "GS_PATH") as gs_path:
+            gs_path.exists.side_effect = [False, True]
+            calls = []
+
+            def fake_check_call(cmd, *args, **kwargs):
+                calls.append(cmd)
+                if cmd and cmd[0] == "winget":
+                    return 0
+                raise FileNotFoundError
+
+            with mock.patch.object(launcher, "subprocess") as m_sub:
+                m_sub.check_call.side_effect = fake_check_call
+                launcher.ensure_ghostscript()
+            assert calls[0][0] == "winget"
+
+
+def test_ensure_ghostscript_failure():
+    with mock.patch.object(launcher, "os") as m_os:
+        m_os.name = "nt"
+        with mock.patch.object(launcher, "GS_PATH") as gs_path:
+            gs_path.exists.return_value = False
+            def fail(*args, **kwargs):
+                raise FileNotFoundError
+            with mock.patch.object(launcher.subprocess, "check_call", side_effect=fail):
+                with pytest.raises(RuntimeError):
+                    launcher.ensure_ghostscript()


### PR DESCRIPTION
## Summary
- install Ghostscript on Windows via winget, choco, PowerShell download or pip fallback
- exercise Ghostscript installer logic with dedicated tests

## Testing
- `pytest`
- `python tools/metrics_generator.py --path . --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a77d846f508327a6fa065d8a34bf14