### PR TITLE
Ensure focus follows selection in list and tree views

### DIFF
--- a/gui/button_utils.py
+++ b/gui/button_utils.py
@@ -218,6 +218,25 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
             lb.itemconfig(prev, background=getattr(lb, "_default_bg", "white"))
             lb._hover_index = None  # type: ignore[attr-defined]
 
+    def _lb_on_select(event: tk.Event) -> None:
+        lb = event.widget
+        if isinstance(lb, str):
+            resolver = getattr(root, "nametowidget", lambda name: name)
+            try:
+                lb = resolver(lb)
+            except Exception:
+                return
+        if not all(hasattr(lb, attr) for attr in ("curselection", "activate", "selection_clear", "selection_set")):
+            return
+        sels = lb.curselection()
+        if sels:
+            try:
+                lb.selection_clear(0, tk.END)
+                lb.selection_set(sels[0])
+                lb.activate(sels[0])
+            except Exception:
+                pass
+
     def _tv_on_motion(event: tk.Event) -> None:
         tree_widget = event.widget
         if isinstance(tree_widget, str):
@@ -259,7 +278,24 @@ def enable_listbox_hover_highlight(root: tk.Misc) -> None:
                 tree.item(prev, tags=tags)
         tree._hover_item = None  # type: ignore[attr-defined]
 
+    def _tv_on_select(event: tk.Event) -> None:
+        tree_widget = event.widget
+        if isinstance(tree_widget, str):
+            tree_widget = root.nametowidget(tree_widget)
+        tree: ttk.Treeview = tree_widget  # type: ignore[assignment]
+        if not all(hasattr(tree, attr) for attr in ("selection", "focus", "selection_set")):
+            return
+        sels = tree.selection()
+        if sels:
+            try:
+                tree.selection_set(sels[0])
+                tree.focus(sels[0])
+            except Exception:
+                pass
+
     root.bind_class("Listbox", "<Motion>", _lb_on_motion, add="+")
     root.bind_class("Listbox", "<Leave>", _lb_on_leave, add="+")
+    root.bind_class("Listbox", "<<ListboxSelect>>", _lb_on_select, add="+")
     root.bind_class("Treeview", "<Motion>", _tv_on_motion, add="+")
     root.bind_class("Treeview", "<Leave>", _tv_on_leave, add="+")
+    root.bind_class("Treeview", "<<TreeviewSelect>>", _tv_on_select, add="+")

--- a/tests/test_selection_focus.py
+++ b/tests/test_selection_focus.py
@@ -1,0 +1,84 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.button_utils import enable_listbox_hover_highlight
+
+
+class DummyRoot:
+    def __init__(self):
+        self.bindings = {}
+        self.widgets = {}
+
+    def bind_class(self, classname, sequence, func=None, add=None):
+        if func is None:
+            return self.bindings[(classname, sequence)]
+        self.bindings[(classname, sequence)] = func
+
+    def nametowidget(self, name):
+        return self.widgets[name]
+
+
+class DummyListbox:
+    def __init__(self):
+        self.selection = ()
+        self.active = None
+
+    def curselection(self):
+        return self.selection
+
+    def activate(self, index):
+        self.active = index
+
+    def selection_clear(self, start, end):
+        self.selection = ()
+
+    def selection_set(self, index):
+        self.selection = (index,)
+
+
+class DummyTree:
+    def __init__(self):
+        self.sel = ()
+        self.focus_item = None
+
+    def selection(self):
+        return self.sel
+
+    def selection_set(self, item):
+        if isinstance(item, (list, tuple)):
+            self.sel = tuple(item)
+        else:
+            self.sel = (item,)
+
+    def focus(self, item=None):
+        if item is None:
+            return self.focus_item
+        self.focus_item = item
+
+
+def test_treeview_focus_follows_selection():
+    root = DummyRoot()
+    tree = DummyTree()
+    root.widgets["tree"] = tree
+    enable_listbox_hover_highlight(root)
+    tree.sel = ("b", "c")
+    event = SimpleNamespace(widget="tree")
+    func = root.bindings[("Treeview", "<<TreeviewSelect>>")]
+    func(event)
+    assert tree.focus_item == "b"
+    assert tree.sel == ("b",)
+
+
+def test_listbox_focus_follows_selection():
+    root = DummyRoot()
+    lb = DummyListbox()
+    root.widgets["lb"] = lb
+    enable_listbox_hover_highlight(root)
+    lb.selection = (2, 3)
+    event = SimpleNamespace(widget="lb")
+    func = root.bindings[("Listbox", "<<ListboxSelect>>")]
+    func(event)
+    assert lb.active == 2
+    assert lb.selection == (2,)


### PR DESCRIPTION
## Summary
- keep listbox and treeview focus in sync with current selection by binding `<<ListboxSelect>>` and `<<TreeviewSelect>>` events
- clear any prior selections so only the newly chosen item remains highlighted
- add tests exercising the new focus and single-selection behavior on both widgets

## Testing
- `pytest -q`
- `radon cc -s -j gui/button_utils.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a77e85b68c8327b93b3977e407d1d8