### PR TITLE
Add crash report logging

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from tools.crash_report_logger import install_best
 
 # Hint PyInstaller to bundle AutoML and its dependencies (e.g. gui package)
 if False:  # pragma: no cover
@@ -117,6 +118,7 @@ def ensure_packages() -> None:
 
 def main() -> None:
     """Entry point used by both source and bundled executions."""
+    install_best()
     ensure_packages()
     ensure_ghostscript()
     base_path = Path(getattr(sys, "_MEIPASS", Path(__file__).parent))

--- a/tests/test_crash_report_logger.py
+++ b/tests/test_crash_report_logger.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repository root is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.crash_report_logger import (
+    crash_handler_v1,
+    crash_handler_v2,
+    CrashLoggerV3,
+    CrashLoggerV4,
+)
+
+
+def _raise(exception):
+    try:
+        raise exception
+    except Exception:
+        return sys.exc_info()
+
+
+def test_crash_handler_v1(tmp_path):
+    path = tmp_path / "v1.log"
+    exc_info = _raise(ValueError("boom"))
+    crash_handler_v1(*exc_info, path=path)
+    assert path.exists()
+    assert "ValueError: boom" in path.read_text()
+
+
+def test_crash_handler_v2(tmp_path):
+    path = tmp_path / "v2.log"
+    exc_info = _raise(RuntimeError("oops"))
+    crash_handler_v2(*exc_info, path=path)
+    assert path.exists()
+    assert "RuntimeError: oops" in path.read_text()
+
+
+def test_crash_handler_v3(tmp_path):
+    path = tmp_path / "v3.log"
+    handler = CrashLoggerV3(path)
+    handler(*_raise(KeyError("missing")))
+    assert path.exists()
+    assert "KeyError: 'missing'" in path.read_text()
+
+
+def test_crash_handler_v4(tmp_path):
+    directory = tmp_path / "logs"
+    handler = CrashLoggerV4(directory)
+    handler(*_raise(Exception("crash")))
+    files = list(directory.glob("crash_*.log"))
+    assert files, "log file not created"
+    assert "Exception: crash" in files[0].read_text()

--- a/tools/crash_report_logger.py
+++ b/tools/crash_report_logger.py
@@ -1,0 +1,99 @@
+"""Crash report logging utilities with multiple implementations."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import sys
+import traceback
+from pathlib import Path
+
+# Default directory for crash logs
+LOG_DIR = Path(__file__).resolve().parent
+
+
+def crash_handler_v1(exc_type, exc, tb, path: Path | None = None) -> Path:
+    """Write traceback to a fixed file using basic file IO."""
+    log_path = path or LOG_DIR / "crash_v1.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "w", encoding="utf-8") as fh:
+        traceback.print_exception(exc_type, exc, tb, file=fh)
+    return log_path
+
+
+def crash_handler_v2(exc_type, exc, tb, path: Path | None = None) -> Path:
+    """Use :mod:`logging` to persist the crash details."""
+    log_path = path or LOG_DIR / "crash_v2.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(filename=log_path, level=logging.ERROR, force=True)
+    logging.error("Unhandled exception", exc_info=(exc_type, exc, tb))
+    return log_path
+
+
+class CrashLoggerV3:
+    """Callable class writing traceback to a provided path."""
+
+    def __init__(self, path: Path | str):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def __call__(self, exc_type, exc, tb) -> Path:
+        with open(self.path, "w", encoding="utf-8") as fh:
+            fh.write("Unhandled exception\n")
+            traceback.print_exception(exc_type, exc, tb, file=fh)
+        return self.path
+
+
+def crash_handler_v3(exc_type, exc, tb, path: Path | None = None) -> Path:
+    """Helper using :class:`CrashLoggerV3` for a default path."""
+    return CrashLoggerV3(path or LOG_DIR / "crash_v3.log")(exc_type, exc, tb)
+
+
+class CrashLoggerV4:
+    """Timestamped crash logger producing unique files."""
+
+    def __init__(self, directory: Path | str = LOG_DIR):
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+    def __call__(self, exc_type, exc, tb) -> Path:
+        timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        log_path = self.directory / f"crash_{timestamp}.log"
+        with open(log_path, "w", encoding="utf-8") as fh:
+            fh.write(f"Timestamp: {timestamp}\n")
+            fh.write("Unhandled exception\n")
+            traceback.print_exception(exc_type, exc, tb, file=fh)
+        return log_path
+
+
+def install_v1() -> None:
+    sys.excepthook = crash_handler_v1
+
+
+def install_v2() -> None:
+    sys.excepthook = crash_handler_v2
+
+
+def install_v3() -> None:
+    sys.excepthook = crash_handler_v3
+
+
+def install_v4(directory: Path | str = LOG_DIR) -> None:
+    sys.excepthook = CrashLoggerV4(directory)
+
+
+# The most complete implementation is version 4
+install_best = install_v4
+
+__all__ = [
+    "crash_handler_v1",
+    "crash_handler_v2",
+    "CrashLoggerV3",
+    "crash_handler_v3",
+    "CrashLoggerV4",
+    "install_v1",
+    "install_v2",
+    "install_v3",
+    "install_v4",
+    "install_best",
+]


### PR DESCRIPTION
## Summary
- add four crash logger implementations and expose the most complete version as default
- hook crash logger into launcher so unhandled exceptions are captured
- add tests covering all crash logger variants

## Testing
- `pytest`
- `radon cc -s -a -j tools/crash_report_logger.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a78598a120832789e5ad87b533eacc