### PR TITLE
feat: add installer packaging for executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1608,8 +1608,7 @@ dependency-checking launcher:
 - **Windows:** run `bin\build_exe.bat`
 
 You can invoke these scripts from any directory; they locate the repository
-root automatically. Both generate `AutoML.exe` inside the `bin` directory.
-After building you can launch the application directly or use
+root automatically. Both generate `AutoML.exe` and an installer archive `AutoML_installer.zip` inside the `bin` directory. After building you can launch the application directly or use
 `bin/run_automl.sh` on Unix-like systems or `bin\run_automl.bat` on
 Windows. The bundled executable executes `launcher.py` internally so it
 performs the same dependency installation when run from source.

--- a/bin/build_exe.bat
+++ b/bin/build_exe.bat
@@ -57,4 +57,6 @@ rmdir /S /Q build 2>nul
 rmdir /S /Q dist 2>nul
 if exist AutoML.spec del AutoML.spec
 
-echo Executable created at %BIN_DIR%AutoML.exe
+python tools\create_installer.py --exe "%BIN_DIR%AutoML.exe" --output "%BIN_DIR%AutoML_installer.zip"
+
+echo Executable and installer created in %BIN_DIR%

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -50,7 +50,10 @@ pyinstaller --noconfirm --onefile --windowed \
 # Move the resulting executable to the bin directory
 mkdir -p bin
 mv -f dist/AutoML.exe bin/
+# Create installer archive with executable and docs
+python tools/create_installer.py --exe bin/AutoML.exe --output bin/AutoML_installer.zip
+
 # Clean up build artifacts
 rm -rf build dist __pycache__ AutoML.spec
 
-echo "Executable created at bin/AutoML.exe"
+echo "Executable and installer created in bin/"

--- a/tests/test_create_installer.py
+++ b/tests/test_create_installer.py
@@ -1,0 +1,55 @@
+import zipfile
+import tarfile
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tools import create_installer as ci
+
+
+def setup_files(tmp_path: Path):
+    exe = tmp_path / "AutoML.exe"
+    exe.write_text("exe")
+    extra = tmp_path / "README.md"
+    extra.write_text("readme")
+    return exe, [extra]
+
+
+def test_create_installer_zip(tmp_path, monkeypatch):
+    exe, extras = setup_files(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    output = tmp_path / "installer.zip"
+    ci.create_installer_zip(exe, output, extras)
+    with zipfile.ZipFile(output) as zf:
+        assert "AutoML.exe" in zf.namelist()
+        assert "README.md" in zf.namelist()
+
+
+def test_create_installer_tar(tmp_path, monkeypatch):
+    exe, extras = setup_files(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    output = tmp_path / "installer.tar.gz"
+    ci.create_installer_tar(exe, output, extras)
+    with tarfile.open(output) as tf:
+        names = tf.getnames()
+        assert "AutoML.exe" in names
+        assert "README.md" in names
+
+
+def test_create_installer_shutil_zip(tmp_path, monkeypatch):
+    exe, extras = setup_files(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    archive = ci.create_installer_shutil_zip(exe, tmp_path, extras)
+    with zipfile.ZipFile(archive) as zf:
+        assert "AutoML.exe" in zf.namelist()
+        assert "README.md" in zf.namelist()
+
+
+def test_create_installer_shutil_targz(tmp_path, monkeypatch):
+    exe, extras = setup_files(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    archive = ci.create_installer_shutil_targz(exe, tmp_path, extras)
+    with tarfile.open(archive) as tf:
+        names = [Path(n).name for n in tf.getnames()]
+        assert "AutoML.exe" in names
+        assert "README.md" in names

--- a/tools/create_installer.py
+++ b/tools/create_installer.py
@@ -1,0 +1,132 @@
+"""Utilities to package the AutoML executable into installable archives.
+
+Four different packaging strategies are provided so that the build
+process can choose the most appropriate installer format.  The
+``create_installer_zip`` function is used by default by the build
+scripts, but the other strategies are available for comparison and
+testing.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Iterable
+
+
+def _collect_files(exe: Path, extras: Iterable[Path]) -> list[Path]:
+    """Return a flat list of files to be included in the installer.
+
+    Parameters
+    ----------
+    exe:
+        Path to the built executable.
+    extras:
+        Iterable of additional files or directories.
+    """
+    files: list[Path] = [exe]
+    for item in extras:
+        path = Path(item)
+        if path.is_dir():
+            files.extend(p for p in path.rglob("*") if p.is_file())
+        elif path.is_file():
+            files.append(path)
+    return files
+
+
+def create_installer_zip(exe: str | os.PathLike, output: str | os.PathLike,
+                         extras: Iterable[str | os.PathLike] = ()) -> Path:
+    """Create a ``.zip`` archive containing the executable and extras.
+
+    This implementation uses :class:`zipfile.ZipFile` directly.
+    """
+    exe_path = Path(exe)
+    files = _collect_files(exe_path, [Path(x) for x in extras])
+    output_path = Path(output)
+    root = Path.cwd()
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for file in files:
+            zf.write(file, file.relative_to(root))
+    return output_path
+
+
+def create_installer_tar(exe: str | os.PathLike, output: str | os.PathLike,
+                         extras: Iterable[str | os.PathLike] = ()) -> Path:
+    """Create a ``.tar.gz`` archive containing the executable and extras.
+
+    This implementation uses :class:`tarfile.TarFile`.
+    """
+    exe_path = Path(exe)
+    files = _collect_files(exe_path, [Path(x) for x in extras])
+    output_path = Path(output)
+    root = Path.cwd()
+    with tarfile.open(output_path, "w:gz") as tf:
+        for file in files:
+            tf.add(file, arcname=file.relative_to(root))
+    return output_path
+
+
+def create_installer_shutil_zip(exe: str | os.PathLike,
+                                output_dir: str | os.PathLike,
+                                extras: Iterable[str | os.PathLike] = ()) -> Path:
+    """Create a ``.zip`` archive using :func:`shutil.make_archive`."""
+    exe_path = Path(exe)
+    staging = exe_path.parent / "_installer_tmp"
+    staging.mkdir(exist_ok=True)
+    try:
+        for file in _collect_files(exe_path, [Path(x) for x in extras]):
+            dest = staging / file.name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file, dest)
+        archive = shutil.make_archive(str(Path(output_dir) / "AutoML_installer"),
+                                      "zip", staging)
+    finally:
+        shutil.rmtree(staging)
+    return Path(archive)
+
+
+def create_installer_shutil_targz(exe: str | os.PathLike,
+                                  output_dir: str | os.PathLike,
+                                  extras: Iterable[str | os.PathLike] = ()) -> Path:
+    """Create a ``.tar.gz`` archive using :func:`shutil.make_archive`."""
+    exe_path = Path(exe)
+    staging = exe_path.parent / "_installer_tmp"
+    staging.mkdir(exist_ok=True)
+    try:
+        for file in _collect_files(exe_path, [Path(x) for x in extras]):
+            dest = staging / file.name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(file, dest)
+        archive = shutil.make_archive(str(Path(output_dir) / "AutoML_installer"),
+                                      "gztar", staging)
+    finally:
+        shutil.rmtree(staging)
+    return Path(archive)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Package AutoML executable")
+    parser.add_argument("--exe", default="bin/AutoML.exe",
+                        help="Path to the built AutoML executable")
+    parser.add_argument("--output", default="bin/AutoML_installer.zip",
+                        help="Output path for the installer archive")
+    parser.add_argument("--method", choices=["zip", "tar", "szip", "star"],
+                        default="zip", help="Packaging method")
+    args = parser.parse_args()
+
+    extras = ["README.md", "LICENSE"]
+    method_map = {
+        "zip": create_installer_zip,
+        "tar": create_installer_tar,
+        "szip": lambda exe, out, extras: create_installer_shutil_zip(exe, Path(out).parent, extras),
+        "star": lambda exe, out, extras: create_installer_shutil_targz(exe, Path(out).parent, extras),
+    }
+    path = method_map[args.method](args.exe, args.output, extras)
+    print(f"Installer created at {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `create_installer` utility with four packaging strategies
- integrate installer archive creation into build scripts
- document new installer output in README
- test installer creation for all packaging variants

## Testing
- `pytest tests/test_create_installer.py -q`
- `pytest -q`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*

------
https://chatgpt.com/codex/tasks/task_b_68a78bdfba088327bc5f59b3664e3fc4