### PR TITLE
Add cybersecurity reporting templates and rename safety case

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -12864,7 +12864,7 @@ class AutoMLApp:
 
         ttk.Label(
             win,
-            text="Technical Safety Concept Description & Assumptions:",
+            text="Technical & Cybersecurity Concept Description & Assumptions:",
         ).pack(anchor="w")
         t_frame = ttk.Frame(win)
         t_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
@@ -12873,11 +12873,6 @@ class AutoMLApp:
         self._tsc_text.configure(yscrollcommand=t_scroll.set)
         self._tsc_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         t_scroll.pack(side=tk.RIGHT, fill=tk.Y)
-
-        ttk.Label(
-            win,
-            text="Cybersecurity Concept Description & Assumptions:",
-        ).pack(anchor="w")
         c_frame = ttk.Frame(win)
         c_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
         self._csc_text = tk.Text(c_frame, height=8, wrap="word")

--- a/analysis/safety_case.py
+++ b/analysis/safety_case.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Data structures for safety & security cases."""
+"""Data structures for safety & security reports."""
 
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -12,7 +12,7 @@ from config import load_report_template
 
 @dataclass
 class SafetyCase:
-    """Representation of a safety & security case derived from a GSN diagram."""
+    """Representation of a safety & security report derived from a GSN diagram."""
 
     name: str
     diagram: GSNDiagram
@@ -23,10 +23,12 @@ class SafetyCase:
         self.solutions = [n for n in self.diagram.nodes if n.node_type == "Solution"]
 
     def build_report_template(self) -> dict:
-        """Return safety case report template filtered by referenced work products."""
+        """Return safety & security report template filtered by referenced work products."""
 
         base = load_report_template(
-            Path(__file__).resolve().parents[1] / "config" / "safety_case_template.json"
+            Path(__file__).resolve().parents[1]
+            / "config"
+            / "safety_security_report_template.json"
         )
 
         # map lower-case keywords to (element placeholder, section title)

--- a/config/field_monitoring_template.json
+++ b/config/field_monitoring_template.json
@@ -1,0 +1,8 @@
+{
+  "elements": {
+    "field_monitoring_requirements": "field_monitoring_requirements"
+  },
+  "sections": [
+    {"title": "Field Monitoring Requirements", "content": "<field_monitoring_requirements>"}
+  ]
+}

--- a/config/production_service_decommissioning_template.json
+++ b/config/production_service_decommissioning_template.json
@@ -1,0 +1,12 @@
+{
+  "elements": {
+    "production_requirements": "req_production",
+    "service_requirements": "req_service",
+    "decommissioning_instructions": "decommissioning_instructions"
+  },
+  "sections": [
+    {"title": "Production Requirements", "content": "<production_requirements>"},
+    {"title": "Service Requirements", "content": "<service_requirements>"},
+    {"title": "Decommissioning Instructions", "content": "<decommissioning_instructions>"}
+  ]
+}

--- a/config/report_template.json
+++ b/config/report_template.json
@@ -160,7 +160,7 @@
       "content": "<cbn>"
     },
     {
-      "title": "Safety Case",
+      "title": "Safety & Security Report",
       "content": "<safety_case>"
     },
     {

--- a/config/safety_security_management_template.json
+++ b/config/safety_security_management_template.json
@@ -1,0 +1,14 @@
+{
+  "elements": {
+    "governance_diagrams": "governance_diagrams",
+    "gsn_diagrams": "gsn_diagrams",
+    "organizational_requirements": "organizational_requirements",
+    "legal_requirements": "legal_requirements"
+  },
+  "sections": [
+    {"title": "Governance Diagrams", "content": "<governance_diagrams>"},
+    {"title": "GSN Diagrams", "content": "<gsn_diagrams>"},
+    {"title": "Organizational Requirements", "content": "<organizational_requirements>"},
+    {"title": "Legal Requirements", "content": "<legal_requirements>"}
+  ]
+}

--- a/config/safety_security_report_template.json
+++ b/config/safety_security_report_template.json
@@ -1,7 +1,7 @@
 {
   "elements": {
     "gsr_argument": "gsr_argument",
-    "safety_cases": "safety_cases",
+    "safety_security_reports": "safety_security_reports",
     "fta_diagrams": "analysis:fault_tree",
     "hazard_analysis_diagrams": "analysis:hazard",
     "fmea_diagrams": "analysis:fmea",
@@ -12,7 +12,7 @@
   },
   "sections": [
     {"title": "GSR Argumentation", "content": "<gsr_argument>"},
-    {"title": "Related Safety Cases", "content": "<safety_cases>"},
+    {"title": "Related Safety & Security Reports", "content": "<safety_security_reports>"},
     {"title": "SPI Table", "content": "<spi_table>"},
     {"title": "Work Products and Evidence", "content": "<work_products>"}
   ]

--- a/config/technical_cybersecurity_concept_template.json
+++ b/config/technical_cybersecurity_concept_template.json
@@ -3,6 +3,8 @@
     "internal_block_diagrams": "diagram:internal block",
     "req_matrix": "req_matrix_alloc",
     "req_technical_safety": "req_technical_safety",
+    "req_cybersecurity": "req_cybersecurity",
+    "req_ai_safety": "req_ai_safety",
     "trace_matrix_fsc": "trace_matrix_fsc",
     "fta_diagrams": "analysis:fault_tree",
     "fmea_diagrams": "analysis:fmea",
@@ -43,6 +45,14 @@
     {
       "title": "Functional Modifications",
       "content": "<functional_modifications>"
+    },
+    {
+      "title": "Cybersecurity Requirements",
+      "content": "<req_cybersecurity>"
+    },
+    {
+      "title": "AI Safety Requirements",
+      "content": "<req_ai_safety>"
     },
     {
       "title": "Technical Safety Requirements",

--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -81,7 +81,9 @@ class SafetyCaseExplorer(tk.Frame):
             c = style.get_color(name)
             return default if c == "#FFFFFF" else c
 
-        self.case_icon = self._create_icon("shield", _color("Safety Case", "#b8860b"))
+        self.case_icon = self._create_icon(
+            "shield", _color("Safety & Security Report", "#b8860b")
+        )
         self.solution_icon = self._create_icon("shield_check", _color("Solution", "#1e90ff"))
         self.item_map: Dict[str, Tuple[str, object]] = {}
 
@@ -90,7 +92,7 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def populate(self):
-        """Fill the tree with safety cases and their solutions."""
+        """Fill the tree with safety & security reports and their solutions."""
         self.item_map.clear()
         self.tree.delete(*self.tree.get_children(""))
         for case in self.library.list_cases():
@@ -118,7 +120,7 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def _available_diagrams(self):
-        """Return GSN diagrams visible to the safety case."""
+        """Return GSN diagrams visible to the safety & security report."""
         if not self.app:
             return []
 
@@ -156,12 +158,14 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def new_case(self):
-        """Create a new safety case derived from a GSN diagram."""
+        """Create a new safety & security report derived from a GSN diagram."""
         diagrams = self._available_diagrams()
         if not diagrams:
             messagebox.showerror("New Case", "No GSN diagrams available")
             return
-        name = simpledialog.askstring("New Safety Case", "Name:", parent=self)
+        name = simpledialog.askstring(
+            "New Safety & Security Report", "Name:", parent=self
+        )
         if not name:
             return
         diag_names = [d.root.user_name for d in diagrams]
@@ -178,7 +182,7 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def edit_case(self):
-        """Rename the selected safety case or change its diagram."""
+        """Rename the selected safety & security report or change its diagram."""
         sel = self.tree.selection()
         if not sel:
             return
@@ -186,7 +190,10 @@ class SafetyCaseExplorer(tk.Frame):
         if typ != "case":
             return
         new_name = simpledialog.askstring(
-            "Rename Safety Case", "Name:", initialvalue=obj.name, parent=self
+            "Rename Safety & Security Report",
+            "Name:",
+            initialvalue=obj.name,
+            parent=self,
         )
         if not new_name:
             return
@@ -226,13 +233,13 @@ class SafetyCaseExplorer(tk.Frame):
             return
         typ, obj = self.item_map.get(sel[0], (None, None))
         if typ == "case":
-            # Prefer opening safety cases within the application's document
-            # notebook so they appear as a new tab in the main working area
-            # instead of a separate window.  The ``SafetyCaseTable`` already
-            # provides scrollbars via its internal ``TableController`` so users
-            # can navigate large cases easily.
+            # Prefer opening reports within the application's document notebook
+            # so they appear as a new tab in the main working area instead of a
+            # separate window. The ``SafetyCaseTable`` already provides
+            # scrollbars via its internal ``TableController`` so users can
+            # navigate large reports easily.
             if self.app and hasattr(self.app, "_new_tab"):
-                tab = self.app._new_tab(f"Safety Case: {obj.name}")
+                tab = self.app._new_tab(f"Safety & Security Report: {obj.name}")
                 table = SafetyCaseTable(tab, obj, app=self.app)
                 table.pack(fill=tk.BOTH, expand=True)
             else:  # Fallback to a new toplevel window if no app context

--- a/gui/safety_case_table.py
+++ b/gui/safety_case_table.py
@@ -31,7 +31,7 @@ class SafetyCaseTable(tk.Frame):
         self.app = app
         self._node_lookup = {}
         if isinstance(master, tk.Toplevel):
-            master.title(f"Safety Case: {case.name}")
+            master.title(f"Safety & Security Report: {case.name}")
             master.geometry("900x300")
             self.pack(fill=tk.BOTH, expand=True)
 

--- a/tests/test_safety_case_tab.py
+++ b/tests/test_safety_case_tab.py
@@ -39,7 +39,7 @@ def test_open_case_uses_app_tab(monkeypatch):
 
     safety_case_explorer.SafetyCaseExplorer.open_item(explorer)
 
-    assert called["title"] == "Safety Case: MyCase"
+    assert called["title"] == "Safety & Security Report: MyCase"
     assert called["master"].packed is False
     assert called["case"] is case
     assert called.get("packed") is True

--- a/tests/test_safety_report_templates.py
+++ b/tests/test_safety_report_templates.py
@@ -49,8 +49,8 @@ def test_functional_safety_concept_template_valid():
     } <= titles
 
 
-def test_technical_safety_concept_template_valid():
-    data = _load("technical_safety_concept_template.json")
+def test_technical_cybersecurity_concept_template_valid():
+    data = _load("technical_cybersecurity_concept_template.json")
     titles = {sec["title"] for sec in data["sections"]}
     assert {
         "Internal Block Diagrams",
@@ -60,6 +60,8 @@ def test_technical_safety_concept_template_valid():
         "Reliability Analysis",
         "Mission Profile",
         "Functional Modifications",
+        "Cybersecurity Requirements",
+        "AI Safety Requirements",
         "Technical Safety Requirements",
         "Requirements Allocation Matrix",
         "Traceability to Functional Safety Concept",
@@ -82,7 +84,7 @@ def test_pdf_report_template_includes_diagram_sections():
         "FMEA Analyses",
         "FMEDA Analyses",
         "Reliability Analysis",
-        "Safety Case",
+        "Safety & Security Report",
     } <= set(titles)
 
 
@@ -100,12 +102,12 @@ def test_report_template_includes_odd_and_scenario_sections():
     assert {"ODD Library", "Scenario Library"} <= titles
 
 
-def test_safety_case_template_valid():
-    data = _load("safety_case_template.json")
+def test_safety_security_report_template_valid():
+    data = _load("safety_security_report_template.json")
     titles = {sec["title"] for sec in data["sections"]}
     assert {
         "GSR Argumentation",
-        "Related Safety Cases",
+        "Related Safety & Security Reports",
         "SPI Table",
         "Work Products and Evidence",
     } <= titles
@@ -117,6 +119,33 @@ def test_report_template_includes_trigger_and_insufficiency_sections():
         "Triggering Conditions",
         "Functional Insufficiencies",
         "Functional Modifications",
+    } <= titles
+
+
+def test_production_service_decommissioning_template_valid():
+    data = _load("production_service_decommissioning_template.json")
+    titles = {sec["title"] for sec in data["sections"]}
+    assert {
+        "Production Requirements",
+        "Service Requirements",
+        "Decommissioning Instructions",
+    } <= titles
+
+
+def test_field_monitoring_template_valid():
+    data = _load("field_monitoring_template.json")
+    titles = {sec["title"] for sec in data["sections"]}
+    assert {"Field Monitoring Requirements"} <= titles
+
+
+def test_safety_security_management_template_valid():
+    data = _load("safety_security_management_template.json")
+    titles = {sec["title"] for sec in data["sections"]}
+    assert {
+        "Governance Diagrams",
+        "GSN Diagrams",
+        "Organizational Requirements",
+        "Legal Requirements",
     } <= titles
 
 def test_safety_case_dynamic_sections():


### PR DESCRIPTION
## Summary
- expand technical safety concept into a Technical & Cybersecurity Concept including AI safety and cybersecurity requirements
- introduce templates for Production/Service/Decommissioning, Field Monitoring, and Safety & Security Management
- rename Safety Case to Safety & Security Report across templates and GUI labels

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon)*
- `radon cc analysis/safety_case.py gui/safety_case_explorer.py gui/safety_case_table.py AutoML.py -j` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a78ccd49788327a09a382f17203ead