### PR TITLE
Add operational safety and decommissioning requirement sections

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -9211,6 +9211,7 @@ class AutoMLApp:
         requirement_element_map = {
             "req_vehicle": ("vehicle", "Vehicle"),
             "req_operational": ("operational", "Operational"),
+            "req_operational_safety": ("operational safety", "Operational Safety"),
             "req_functional_safety": ("functional safety", "Functional Safety"),
             "req_technical_safety": ("technical safety", "Technical Safety"),
             "req_ai_safety": ("AI safety", "AI Safety"),
@@ -9218,6 +9219,7 @@ class AutoMLApp:
             "req_cybersecurity": ("cybersecurity", "Cybersecurity"),
             "req_production": ("production", "Production"),
             "req_service": ("service", "Service"),
+            "req_decommissioning": ("decommissioning", "Decommissioning"),
             "req_product": ("product", "Product"),
             "req_legal": ("legal", "Legal"),
             "req_organizational": ("organizational", "Organizational"),
@@ -12852,7 +12854,7 @@ class AutoMLApp:
         win = self._safety_concept_tab
         ttk.Label(
             win,
-            text="Functional Safety Concept Description and Assumptions:",
+            text="Functional & Cybersecurity Concept Description and Assumptions:",
         ).pack(anchor="w")
         f_frame = ttk.Frame(win)
         f_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
@@ -12864,7 +12866,7 @@ class AutoMLApp:
 
         ttk.Label(
             win,
-            text="Technical Safety Concept Description & Assumptions:",
+            text="Technical & Cybersecurity Concept Description & Assumptions:",
         ).pack(anchor="w")
         t_frame = ttk.Frame(win)
         t_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
@@ -12873,11 +12875,6 @@ class AutoMLApp:
         self._tsc_text.configure(yscrollcommand=t_scroll.set)
         self._tsc_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         t_scroll.pack(side=tk.RIGHT, fill=tk.Y)
-
-        ttk.Label(
-            win,
-            text="Cybersecurity Concept Description & Assumptions:",
-        ).pack(anchor="w")
         c_frame = ttk.Frame(win)
         c_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
         self._csc_text = tk.Text(c_frame, height=8, wrap="word")

--- a/analysis/safety_case.py
+++ b/analysis/safety_case.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Data structures for safety & security cases."""
+"""Data structures for safety & security reports."""
 
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -12,7 +12,7 @@ from config import load_report_template
 
 @dataclass
 class SafetyCase:
-    """Representation of a safety & security case derived from a GSN diagram."""
+    """Representation of a safety & security report derived from a GSN diagram."""
 
     name: str
     diagram: GSNDiagram
@@ -23,10 +23,12 @@ class SafetyCase:
         self.solutions = [n for n in self.diagram.nodes if n.node_type == "Solution"]
 
     def build_report_template(self) -> dict:
-        """Return safety case report template filtered by referenced work products."""
+        """Return safety & security report template filtered by referenced work products."""
 
         base = load_report_template(
-            Path(__file__).resolve().parents[1] / "config" / "safety_case_template.json"
+            Path(__file__).resolve().parents[1]
+            / "config"
+            / "safety_security_report_template.json"
         )
 
         # map lower-case keywords to (element placeholder, section title)

--- a/config/diagram_rules.json
+++ b/config/diagram_rules.json
@@ -3707,6 +3707,33 @@
       ],
       "subject": "Safety manager"
     },
+    "production requirements": {
+      "action": "define production requirements",
+      "relations": [
+        "Plans",
+        "Develops",
+        "Produces"
+      ],
+      "subject": "Production manager"
+    },
+    "service requirements": {
+      "action": "define service requirements",
+      "relations": [
+        "Plans",
+        "Develops",
+        "Produces"
+      ],
+      "subject": "Service manager"
+    },
+    "decommissioning requirements": {
+      "action": "define decommissioning requirements",
+      "relations": [
+        "Plans",
+        "Develops",
+        "Produces"
+      ],
+      "subject": "Safety manager"
+    },
     "deployment readiness": {
       "action": "verify deployment readiness",
       "relations": [

--- a/config/field_monitoring_template.json
+++ b/config/field_monitoring_template.json
@@ -1,0 +1,8 @@
+{
+  "elements": {
+    "field_monitoring_requirements": "field_monitoring_requirements"
+  },
+  "sections": [
+    {"title": "Field Monitoring Requirements", "content": "<field_monitoring_requirements>"}
+  ]
+}

--- a/config/functional_cybersecurity_concept_template.json
+++ b/config/functional_cybersecurity_concept_template.json
@@ -5,9 +5,13 @@
     "product_goals": "product_goals",
     "fsc_info": "fsc_info",
     "req_functional_safety": "req_functional_safety",
+    "req_operational_safety": "req_operational_safety",
+    "req_cybersecurity": "req_cybersecurity",
     "trace_matrix_pg_fsr": "trace_matrix_pg_fsr",
     "fta_diagrams": "analysis:fault_tree",
     "threat_analysis_diagrams": "analysis:threat",
+    "bayesian_network_diagrams": "analysis:bayesian_network",
+    "stpa_diagrams": "analysis:stpa",
     "fi2tc": "fi2tc",
     "tc2fi": "tc2fi",
     "triggering_conditions": "triggering_conditions",
@@ -21,7 +25,7 @@
       "content": "<product_goals>"
     },
     {
-      "title": "Functional Safety Concept",
+      "title": "Functional & Cybersecurity Concept",
       "content": "<fsc_info>"
     },
     {
@@ -45,6 +49,14 @@
       "content": "<threat_analysis_diagrams>"
     },
     {
+      "title": "Bayesian Network Analysis",
+      "content": "<bayesian_network_diagrams>"
+    },
+    {
+      "title": "STPA Analyses",
+      "content": "<stpa_diagrams>"
+    },
+    {
       "title": "FI2TC Mapping",
       "content": "<fi2tc>"
     },
@@ -63,6 +75,14 @@
     {
       "title": "Functional Safety Requirements",
       "content": "<req_functional_safety>"
+    },
+    {
+      "title": "Operational Safety Requirements",
+      "content": "<req_operational_safety>"
+    },
+    {
+      "title": "Cybersecurity Requirements",
+      "content": "<req_cybersecurity>"
     },
     {
       "title": "Requirements Allocation Matrix",

--- a/config/item_definition_template.json
+++ b/config/item_definition_template.json
@@ -8,6 +8,7 @@
     "internal_block_diagrams": "diagram:internal block",
     "req_product": "req_product",
     "req_vehicle": "req_vehicle",
+    "req_operational": "req_operational",
     "activity_actions": "activity_actions"
   },
   "sections": [
@@ -19,6 +20,7 @@
     {"title": "Internal Block Diagrams", "content": "<internal_block_diagrams>"},
     {"title": "Product Requirements", "content": "<req_product>"},
     {"title": "Vehicle Requirements", "content": "<req_vehicle>"},
+    {"title": "Operational Requirements", "content": "<req_operational>"},
     {"title": "Activity Actions", "content": "<activity_actions>"}
   ]
 }

--- a/config/production_service_decommissioning_template.json
+++ b/config/production_service_decommissioning_template.json
@@ -1,0 +1,12 @@
+{
+  "elements": {
+    "production_requirements": "req_production",
+    "service_requirements": "req_service",
+    "decommissioning_requirements": "req_decommissioning"
+  },
+  "sections": [
+    {"title": "Production Requirements", "content": "<production_requirements>"},
+    {"title": "Service Requirements", "content": "<service_requirements>"},
+    {"title": "Decommissioning Requirements", "content": "<decommissioning_requirements>"}
+  ]
+}

--- a/config/report_template.json
+++ b/config/report_template.json
@@ -21,6 +21,7 @@
     "common_cause": "common_cause",
     "req_vehicle": "req_vehicle",
     "req_operational": "req_operational",
+    "req_operational_safety": "req_operational_safety",
     "req_functional_safety": "req_functional_safety",
     "req_technical_safety": "req_technical_safety",
     "req_ai_safety": "req_ai_safety",
@@ -29,6 +30,7 @@
     "req_cybersecurity": "req_cybersecurity",
     "req_production": "req_production",
     "req_service": "req_service",
+    "req_decommissioning": "req_decommissioning",
     "req_product": "req_product",
     "req_legal": "req_legal",
     "req_organizational": "req_organizational",
@@ -160,7 +162,7 @@
       "content": "<cbn>"
     },
     {
-      "title": "Safety Case",
+      "title": "Safety & Security Report",
       "content": "<safety_case>"
     },
     {
@@ -170,6 +172,10 @@
     {
       "title": "Operational Requirements",
       "content": "<req_operational>"
+    },
+    {
+      "title": "Operational Safety Requirements",
+      "content": "<req_operational_safety>"
     },
     {
       "title": "Functional Safety Requirements",
@@ -202,6 +208,10 @@
     {
       "title": "Service Requirements",
       "content": "<req_service>"
+    },
+    {
+      "title": "Decommissioning Requirements",
+      "content": "<req_decommissioning>"
     },
     {
       "title": "Product Requirements",

--- a/config/safety_security_management_template.json
+++ b/config/safety_security_management_template.json
@@ -1,0 +1,14 @@
+{
+  "elements": {
+    "governance_diagrams": "governance_diagrams",
+    "gsn_diagrams": "gsn_diagrams",
+    "organizational_requirements": "organizational_requirements",
+    "legal_requirements": "legal_requirements"
+  },
+  "sections": [
+    {"title": "Governance Diagrams", "content": "<governance_diagrams>"},
+    {"title": "GSN Diagrams", "content": "<gsn_diagrams>"},
+    {"title": "Organizational Requirements", "content": "<organizational_requirements>"},
+    {"title": "Legal Requirements", "content": "<legal_requirements>"}
+  ]
+}

--- a/config/safety_security_report_template.json
+++ b/config/safety_security_report_template.json
@@ -1,7 +1,7 @@
 {
   "elements": {
     "gsr_argument": "gsr_argument",
-    "safety_cases": "safety_cases",
+    "safety_security_reports": "safety_security_reports",
     "fta_diagrams": "analysis:fault_tree",
     "hazard_analysis_diagrams": "analysis:hazard",
     "fmea_diagrams": "analysis:fmea",
@@ -12,7 +12,7 @@
   },
   "sections": [
     {"title": "GSR Argumentation", "content": "<gsr_argument>"},
-    {"title": "Related Safety Cases", "content": "<safety_cases>"},
+    {"title": "Related Safety & Security Reports", "content": "<safety_security_reports>"},
     {"title": "SPI Table", "content": "<spi_table>"},
     {"title": "Work Products and Evidence", "content": "<work_products>"}
   ]

--- a/config/technical_cybersecurity_concept_template.json
+++ b/config/technical_cybersecurity_concept_template.json
@@ -3,6 +3,8 @@
     "internal_block_diagrams": "diagram:internal block",
     "req_matrix": "req_matrix_alloc",
     "req_technical_safety": "req_technical_safety",
+    "req_cybersecurity": "req_cybersecurity",
+    "req_ai_safety": "req_ai_safety",
     "trace_matrix_fsc": "trace_matrix_fsc",
     "fta_diagrams": "analysis:fault_tree",
     "fmea_diagrams": "analysis:fmea",
@@ -45,6 +47,14 @@
       "content": "<functional_modifications>"
     },
     {
+      "title": "Cybersecurity Requirements",
+      "content": "<req_cybersecurity>"
+    },
+    {
+      "title": "AI Safety Requirements",
+      "content": "<req_ai_safety>"
+    },
+    {
       "title": "Technical Safety Requirements",
       "content": "<req_technical_safety>"
     },
@@ -53,7 +63,7 @@
       "content": "<req_matrix>"
     },
     {
-      "title": "Traceability to Functional Safety Concept",
+      "title": "Traceability to Functional & Cybersecurity Concept",
       "content": "<trace_matrix_fsc>"
     },
     {

--- a/gui/safety_case_explorer.py
+++ b/gui/safety_case_explorer.py
@@ -81,7 +81,9 @@ class SafetyCaseExplorer(tk.Frame):
             c = style.get_color(name)
             return default if c == "#FFFFFF" else c
 
-        self.case_icon = self._create_icon("shield", _color("Safety Case", "#b8860b"))
+        self.case_icon = self._create_icon(
+            "shield", _color("Safety & Security Report", "#b8860b")
+        )
         self.solution_icon = self._create_icon("shield_check", _color("Solution", "#1e90ff"))
         self.item_map: Dict[str, Tuple[str, object]] = {}
 
@@ -90,7 +92,7 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def populate(self):
-        """Fill the tree with safety cases and their solutions."""
+        """Fill the tree with safety & security reports and their solutions."""
         self.item_map.clear()
         self.tree.delete(*self.tree.get_children(""))
         for case in self.library.list_cases():
@@ -118,7 +120,7 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def _available_diagrams(self):
-        """Return GSN diagrams visible to the safety case."""
+        """Return GSN diagrams visible to the safety & security report."""
         if not self.app:
             return []
 
@@ -156,12 +158,14 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def new_case(self):
-        """Create a new safety case derived from a GSN diagram."""
+        """Create a new safety & security report derived from a GSN diagram."""
         diagrams = self._available_diagrams()
         if not diagrams:
             messagebox.showerror("New Case", "No GSN diagrams available")
             return
-        name = simpledialog.askstring("New Safety Case", "Name:", parent=self)
+        name = simpledialog.askstring(
+            "New Safety & Security Report", "Name:", parent=self
+        )
         if not name:
             return
         diag_names = [d.root.user_name for d in diagrams]
@@ -178,7 +182,7 @@ class SafetyCaseExplorer(tk.Frame):
 
     # ------------------------------------------------------------------
     def edit_case(self):
-        """Rename the selected safety case or change its diagram."""
+        """Rename the selected safety & security report or change its diagram."""
         sel = self.tree.selection()
         if not sel:
             return
@@ -186,7 +190,10 @@ class SafetyCaseExplorer(tk.Frame):
         if typ != "case":
             return
         new_name = simpledialog.askstring(
-            "Rename Safety Case", "Name:", initialvalue=obj.name, parent=self
+            "Rename Safety & Security Report",
+            "Name:",
+            initialvalue=obj.name,
+            parent=self,
         )
         if not new_name:
             return
@@ -226,13 +233,13 @@ class SafetyCaseExplorer(tk.Frame):
             return
         typ, obj = self.item_map.get(sel[0], (None, None))
         if typ == "case":
-            # Prefer opening safety cases within the application's document
-            # notebook so they appear as a new tab in the main working area
-            # instead of a separate window.  The ``SafetyCaseTable`` already
-            # provides scrollbars via its internal ``TableController`` so users
-            # can navigate large cases easily.
+            # Prefer opening reports within the application's document notebook
+            # so they appear as a new tab in the main working area instead of a
+            # separate window. The ``SafetyCaseTable`` already provides
+            # scrollbars via its internal ``TableController`` so users can
+            # navigate large reports easily.
             if self.app and hasattr(self.app, "_new_tab"):
-                tab = self.app._new_tab(f"Safety Case: {obj.name}")
+                tab = self.app._new_tab(f"Safety & Security Report: {obj.name}")
                 table = SafetyCaseTable(tab, obj, app=self.app)
                 table.pack(fill=tk.BOTH, expand=True)
             else:  # Fallback to a new toplevel window if no app context

--- a/gui/safety_case_table.py
+++ b/gui/safety_case_table.py
@@ -31,7 +31,7 @@ class SafetyCaseTable(tk.Frame):
         self.app = app
         self._node_lookup = {}
         if isinstance(master, tk.Toplevel):
-            master.title(f"Safety Case: {case.name}")
+            master.title(f"Safety & Security Report: {case.name}")
             master.geometry("900x300")
             self.pack(fill=tk.BOTH, expand=True)
 

--- a/tests/test_safety_case_tab.py
+++ b/tests/test_safety_case_tab.py
@@ -39,7 +39,7 @@ def test_open_case_uses_app_tab(monkeypatch):
 
     safety_case_explorer.SafetyCaseExplorer.open_item(explorer)
 
-    assert called["title"] == "Safety Case: MyCase"
+    assert called["title"] == "Safety & Security Report: MyCase"
     assert called["master"].packed is False
     assert called["case"] is case
     assert called.get("packed") is True

--- a/tests/test_safety_report_templates.py
+++ b/tests/test_safety_report_templates.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 
 from config import load_report_template
 from gsn import GSNDiagram, GSNNode
@@ -24,33 +25,38 @@ def test_item_definition_template_valid():
         "Internal Block Diagrams",
         "Product Requirements",
         "Vehicle Requirements",
+        "Operational Requirements",
         "Activity Actions",
     } <= titles
 
 
-def test_functional_safety_concept_template_valid():
-    data = _load("functional_safety_concept_template.json")
+def test_functional_cybersecurity_concept_template_valid():
+    data = _load("functional_cybersecurity_concept_template.json")
     titles = {sec["title"] for sec in data["sections"]}
     assert {
         "Product Goals",
-        "Functional Safety Concept",
+        "Functional & Cybersecurity Concept",
         "ODD Library",
         "Scenario Library",
         "Internal Block Diagrams",
         "Fault Tree Analyses (FTA)",
         "Threat Analysis",
+        "Bayesian Network Analysis",
+        "STPA Analyses",
         "FI2TC Mapping",
         "TC2FI Mapping",
         "Triggering Conditions",
         "Functional Insufficiencies",
         "Functional Safety Requirements",
+        "Operational Safety Requirements",
+        "Cybersecurity Requirements",
         "Requirements Allocation Matrix",
         "Traceability Matrix",
     } <= titles
 
 
-def test_technical_safety_concept_template_valid():
-    data = _load("technical_safety_concept_template.json")
+def test_technical_cybersecurity_concept_template_valid():
+    data = _load("technical_cybersecurity_concept_template.json")
     titles = {sec["title"] for sec in data["sections"]}
     assert {
         "Internal Block Diagrams",
@@ -60,9 +66,11 @@ def test_technical_safety_concept_template_valid():
         "Reliability Analysis",
         "Mission Profile",
         "Functional Modifications",
+        "Cybersecurity Requirements",
+        "AI Safety Requirements",
         "Technical Safety Requirements",
         "Requirements Allocation Matrix",
-        "Traceability to Functional Safety Concept",
+        "Traceability to Functional & Cybersecurity Concept",
         "PMHF Results",
         "SPFM Results",
         "LPFM Results",
@@ -82,7 +90,7 @@ def test_pdf_report_template_includes_diagram_sections():
         "FMEA Analyses",
         "FMEDA Analyses",
         "Reliability Analysis",
-        "Safety Case",
+        "Safety & Security Report",
     } <= set(titles)
 
 
@@ -100,12 +108,18 @@ def test_report_template_includes_odd_and_scenario_sections():
     assert {"ODD Library", "Scenario Library"} <= titles
 
 
-def test_safety_case_template_valid():
-    data = _load("safety_case_template.json")
+def test_report_template_includes_operational_safety_and_decommissioning_sections():
+    data = _load("report_template.json")
+    titles = {sec["title"] for sec in data["sections"]}
+    assert {"Operational Safety Requirements", "Decommissioning Requirements"} <= titles
+
+
+def test_safety_security_report_template_valid():
+    data = _load("safety_security_report_template.json")
     titles = {sec["title"] for sec in data["sections"]}
     assert {
         "GSR Argumentation",
-        "Related Safety Cases",
+        "Related Safety & Security Reports",
         "SPI Table",
         "Work Products and Evidence",
     } <= titles
@@ -118,6 +132,45 @@ def test_report_template_includes_trigger_and_insufficiency_sections():
         "Functional Insufficiencies",
         "Functional Modifications",
     } <= titles
+
+
+def test_production_service_decommissioning_template_valid():
+    data = _load("production_service_decommissioning_template.json")
+    titles = {sec["title"] for sec in data["sections"]}
+    assert {
+        "Production Requirements",
+        "Service Requirements",
+        "Decommissioning Requirements",
+    } <= titles
+
+
+def test_field_monitoring_template_valid():
+    data = _load("field_monitoring_template.json")
+    titles = {sec["title"] for sec in data["sections"]}
+    assert {"Field Monitoring Requirements"} <= titles
+
+
+def test_safety_security_management_template_valid():
+    data = _load("safety_security_management_template.json")
+    titles = {sec["title"] for sec in data["sections"]}
+    assert {
+        "Governance Diagrams",
+        "GSN Diagrams",
+        "Organizational Requirements",
+        "Legal Requirements",
+    } <= titles
+
+
+def test_diagram_rules_include_lifecycle_requirements():
+    path = BASE_DIR / "config" / "diagram_rules.json"
+    with path.open() as fh:
+        data = json.load(fh)
+    sequences = set(data.get("requirement_sequences", {}))
+    assert {
+        "production requirements",
+        "service requirements",
+        "decommissioning requirements",
+    } <= sequences
 
 def test_safety_case_dynamic_sections():
     root = GSNNode("G", "Goal")


### PR DESCRIPTION
## Summary
- add operational safety and decommissioning requirement types to PDF templates and requirement mapping
- include operational requirements in item definition and expand Functional & Cybersecurity Concept with STPA analyses and operational safety requirements
- extend Production/Service/Decommissioning report with decommissioning requirements and lifecycle governance sequences

## Testing
- `pytest`
- `pip install radon` *(fails: Could not find a version that satisfies the requirement radon (from versions: none))*
- `radon cc analysis/safety_case.py gui/safety_case_explorer.py gui/safety_case_table.py AutoML.py -j` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a78ccd49788327a09a382f17203ead