### PR TITLE
Enhance splash screen gear and title styling

### DIFF
--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -29,9 +29,16 @@ class SplashScreenTests(unittest.TestCase):
     def test_title_background(self):
         bg_items = self.splash.canvas.find_withtag("title_bg")
         text_items = self.splash.canvas.find_withtag("title_text")
-        self.assertEqual(len(bg_items), 1)
+        self.assertGreater(len(bg_items), 1)
         self.assertEqual(len(text_items), 2)
-        self.assertEqual(self.splash.canvas.itemcget(bg_items[0], "fill"), "black")
+        bbox = self.splash.canvas.bbox("title_bg")
+        self.assertEqual(bbox[0], 0)
+        self.assertEqual(bbox[2], self.splash.canvas_size)
+        top_color = self.splash.canvas.itemcget(bg_items[0], "fill")
+        bottom_color = self.splash.canvas.itemcget(bg_items[-1], "fill")
+        expected_bottom = self.splash._floor_color_at(int(bbox[3]))
+        self.assertEqual(top_color, "#000000")
+        self.assertEqual(bottom_color, expected_bottom)
         for t in text_items:
             self.assertEqual(self.splash.canvas.itemcget(t, "fill"), "white")
 


### PR DESCRIPTION
## Summary
- Give splash screen gear a gold appearance with glow
- Extend splash title background across full width and blend with floor gradient
- Update splash screen tests for new gradient background

## Testing
- `PYTHONPATH=. pytest tests/test_splash_screen.py`
- `pytest` *(fails: AttributeError: type object 'QAbstractItemView' has no attribute 'NoEditTriggers')*
- `radon cc -j gui/splash_screen.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7979c9d4483279903119d5b75028c