### PR TITLE
Improve node selection in CBN diagrams

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -18826,6 +18826,11 @@ class AutoMLApp:
             self.selected_node = node
             self.cut_mode = False
             return
+        win = getattr(self, "_cbn_window", None)
+        if win and getattr(win, "selected_node", None):
+            if getattr(win, "copy_selected", None):
+                win.copy_selected()
+                return
         win = getattr(self, "active_arch_window", None)
         if win and getattr(win, "selected_obj", None):
             if getattr(win, "copy_selected", None):
@@ -18853,6 +18858,11 @@ class AutoMLApp:
             self.selected_node = node
             self.cut_mode = True
             return
+        win = getattr(self, "_cbn_window", None)
+        if win and getattr(win, "selected_node", None):
+            if getattr(win, "cut_selected", None):
+                win.cut_selected()
+                return
         win = getattr(self, "active_arch_window", None)
         if win and getattr(win, "selected_obj", None):
             if getattr(win, "cut_selected", None):
@@ -18938,8 +18948,14 @@ class AutoMLApp:
             )
             self.update_views()
             return
-        win = getattr(self, "active_arch_window", None)
         clip_type = getattr(self, "diagram_clipboard_type", None)
+        win = getattr(self, "_cbn_window", None)
+        if win and getattr(self, "diagram_clipboard", None):
+            if not clip_type or clip_type == "Causal Bayesian Network":
+                if getattr(win, "paste_selected", None):
+                    win.paste_selected()
+                    return
+        win = getattr(self, "active_arch_window", None)
         if (
             (not win or (clip_type and self._get_diag_type(win) != clip_type))
             and ARCH_WINDOWS

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -3,6 +3,8 @@ import tkinter.font as tkfont
 from tkinter import ttk, simpledialog
 from itertools import product
 import re
+import copy
+import json
 
 from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
 from gui import messagebox, TranslucidButton
@@ -840,10 +842,64 @@ class CausalBayesianNetworkWindow(tk.Frame):
         return [n.strip() for n in sel.split(",") if n.strip() in mals]
 
     # ------------------------------------------------------------------
-    def _find_node(self, x: float, y: float) -> str | None:
-        ids = self.canvas.find_overlapping(x, y, x, y)
+    def _find_node_strategy1(self, x: float, y: float) -> str | None:
+        """Locate a node by checking overlapping canvas items."""
+        canvasx = getattr(self.canvas, "canvasx", lambda v: v)
+        canvasy = getattr(self.canvas, "canvasy", lambda v: v)
+        cx, cy = canvasx(x), canvasy(y)
+        ids = self.canvas.find_overlapping(cx - 1, cy - 1, cx + 1, cy + 1)
         for i in ids:
             name = self.id_to_node.get(i)
+            if name:
+                return name
+        return None
+
+    def _find_node_strategy2(self, x: float, y: float) -> str | None:
+        """Locate a node using the closest canvas item."""
+        canvasx = getattr(self.canvas, "canvasx", lambda v: v)
+        canvasy = getattr(self.canvas, "canvasy", lambda v: v)
+        cx, cy = canvasx(x), canvasy(y)
+        ids = self.canvas.find_closest(cx, cy)
+        for i in ids:
+            name = self.id_to_node.get(i)
+            if name:
+                return name
+        return None
+
+    def _find_node_strategy3(self, x: float, y: float) -> str | None:
+        """Locate a node by checking drawn ovals' bounding boxes."""
+        canvasx = getattr(self.canvas, "canvasx", lambda v: v)
+        canvasy = getattr(self.canvas, "canvasy", lambda v: v)
+        cx, cy = canvasx(x), canvasy(y)
+        for name, (oval_id, _, _) in self.nodes.items():
+            x1, y1, x2, y2 = self.canvas.coords(oval_id)
+            if x1 <= cx <= x2 and y1 <= cy <= y2:
+                return name
+        return None
+
+    def _find_node_strategy4(self, x: float, y: float) -> str | None:
+        """Locate a node using stored positions and a radius check."""
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc:
+            return None
+        canvasx = getattr(self.canvas, "canvasx", lambda v: v)
+        canvasy = getattr(self.canvas, "canvasy", lambda v: v)
+        cx, cy = canvasx(x), canvasy(y)
+        r = self.NODE_RADIUS
+        for name, (nx, ny) in doc.positions.items():
+            if (cx - nx) ** 2 + (cy - ny) ** 2 <= r ** 2:
+                return name
+        return None
+
+    def _find_node(self, x: float, y: float) -> str | None:
+        """Find a node at the given canvas coordinates using multiple strategies."""
+        for strat in (
+            self._find_node_strategy1,
+            self._find_node_strategy2,
+            self._find_node_strategy3,
+            self._find_node_strategy4,
+        ):
+            name = strat(x, y)
             if name:
                 return name
         return None
@@ -1037,4 +1093,161 @@ class CausalBayesianNetworkWindow(tk.Frame):
         for child, parents in doc.network.parents.items():
             if new in parents and child != new:
                 self._rebuild_table(child)
+
+    # ------------------------------------------------------------------
+    def _clone_node_strategy1(self, name: str) -> dict | None:
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc or name not in doc.network.nodes:
+            return None
+        x, y = doc.positions.get(name, (0.0, 0.0))
+        return {
+            "name": name,
+            "parents": list(doc.network.parents.get(name, [])),
+            "cpd": copy.deepcopy(doc.network.cpds.get(name)),
+            "x": x,
+            "y": y,
+            "kind": doc.types.get(name, "variable"),
+        }
+
+    def _clone_node_strategy2(self, name: str) -> dict | None:
+        snap = self._clone_node_strategy1(name)
+        if snap:
+            snap["cpd"] = json.loads(json.dumps(snap["cpd"]))
+        return snap
+
+    def _clone_node_strategy3(self, name: str) -> dict | None:
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc or name not in doc.network.nodes:
+            return None
+        parents = tuple(doc.network.parents.get(name, []))
+        cpd = doc.network.cpds.get(name)
+        if isinstance(cpd, dict):
+            cpd = {tuple(k): v for k, v in cpd.items()}
+        x, y = doc.positions.get(name, (0.0, 0.0))
+        return {
+            "name": name,
+            "parents": list(parents),
+            "cpd": copy.deepcopy(cpd),
+            "x": x,
+            "y": y,
+            "kind": doc.types.get(name, "variable"),
+        }
+
+    def _clone_node_strategy4(self, name: str) -> dict | None:
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc or name not in doc.network.nodes:
+            return None
+        x, y = doc.positions.get(name, (0.0, 0.0))
+        cpd = doc.network.cpds.get(name)
+        return {
+            "name": str(name),
+            "parents": [p for p in doc.network.parents.get(name, [])],
+            "cpd": copy.deepcopy(cpd),
+            "x": float(x),
+            "y": float(y),
+            "kind": str(doc.types.get(name, "variable")),
+        }
+
+    def _clone_node(self, name: str) -> dict | None:
+        for strat in (
+            self._clone_node_strategy1,
+            self._clone_node_strategy2,
+            self._clone_node_strategy3,
+            self._clone_node_strategy4,
+        ):
+            snap = strat(name)
+            if snap:
+                return snap
+        return None
+
+    def _reconstruct_node_strategy1(self, snap: dict, doc, offset=(20, 20)) -> str:
+        name = snap["name"]
+        new_name = name
+        while new_name in doc.network.nodes:
+            idx = sum(1 for n in doc.network.nodes if n.startswith(name + "_")) + 1
+            new_name = f"{name}_{idx}"
+        doc.network.add_node(new_name, parents=snap["parents"], cpd=copy.deepcopy(snap["cpd"]))
+        doc.positions[new_name] = (snap["x"] + offset[0], snap["y"] + offset[1])
+        doc.types[new_name] = snap["kind"]
+        return new_name
+
+    def _reconstruct_node_strategy2(self, snap: dict, doc, offset=(20, 20)) -> str:
+        name = snap["name"]
+        new_name = name
+        while new_name in doc.network.nodes:
+            idx = sum(1 for n in doc.network.nodes if n.startswith(name + "_")) + 1
+            new_name = f"{name}_{idx}"
+        doc.network.nodes.append(new_name)
+        doc.network.parents[new_name] = list(snap["parents"])
+        doc.network.cpds[new_name] = copy.deepcopy(snap["cpd"])
+        doc.positions[new_name] = (snap["x"] + offset[0], snap["y"] + offset[1])
+        doc.types[new_name] = snap["kind"]
+        return new_name
+
+    def _reconstruct_node_strategy3(self, snap: dict, doc, offset=(20, 20)) -> str:
+        clone = copy.deepcopy(snap)
+        clone["cpd"] = json.loads(json.dumps(clone["cpd"]))
+        return self._reconstruct_node_strategy1(clone, doc, offset)
+
+    def _reconstruct_node_strategy4(self, snap: dict, doc, offset=(20, 20)) -> str:
+        name = snap["name"]
+        new_name = name
+        while new_name in doc.network.nodes:
+            idx = sum(1 for n in doc.network.nodes if n.startswith(name + "_")) + 1
+            new_name = f"{name}_{idx}"
+        parents = [p for p in snap.get("parents", [])]
+        cpd = snap.get("cpd")
+        if isinstance(cpd, dict):
+            cpd = {tuple(k): v for k, v in cpd.items()}
+        doc.network.add_node(new_name, parents=parents, cpd=cpd)
+        doc.positions[new_name] = (snap.get("x", 0) + offset[0], snap.get("y", 0) + offset[1])
+        doc.types[new_name] = snap.get("kind", "variable")
+        return new_name
+
+    def _reconstruct_node(self, snap: dict, doc) -> str | None:
+        for strat in (
+            self._reconstruct_node_strategy1,
+            self._reconstruct_node_strategy2,
+            self._reconstruct_node_strategy3,
+            self._reconstruct_node_strategy4,
+        ):
+            try:
+                return strat(snap, doc)
+            except Exception:
+                continue
+        return None
+
+    def copy_selected(self, _event=None) -> None:
+        if not self.app or not self.selected_node:
+            return
+        snap = self._clone_node(self.selected_node)
+        if snap:
+            self.app.diagram_clipboard = snap
+            self.app.diagram_clipboard_type = "Causal Bayesian Network"
+
+    def cut_selected(self, _event=None) -> None:
+        if not self.app or not self.selected_node:
+            return
+        self.copy_selected()
+        self._delete_node(self.selected_node)
+        self.selected_node = None
+
+    def paste_selected(self, _event=None) -> None:
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc or not self.app or not getattr(self.app, "diagram_clipboard", None):
+            return
+        clip_type = getattr(self.app, "diagram_clipboard_type", None)
+        if clip_type and clip_type != "Causal Bayesian Network":
+            messagebox.showwarning("Paste", "Clipboard contains incompatible diagram element.")
+            return
+        snap = copy.deepcopy(self.app.diagram_clipboard)
+        name = self._reconstruct_node(snap, doc)
+        if not name:
+            return
+        x, y = doc.positions[name]
+        kind = doc.types.get(name)
+        self._draw_node(name, x, y, kind)
+        for parent in doc.network.parents.get(name, []):
+            if parent in doc.network.nodes:
+                self._draw_edge(parent, name)
 

--- a/tests/test_causal_bayesian_clipboard.py
+++ b/tests/test_causal_bayesian_clipboard.py
@@ -1,0 +1,73 @@
+import types
+import copy
+
+from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
+from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
+
+
+def _make_window(app, doc):
+    win = object.__new__(CausalBayesianNetworkWindow)
+    win.app = app
+    win.nodes = {}
+    win.id_to_node = {}
+    win.edges = []
+    win.NODE_RADIUS = 10
+    win.canvas = types.SimpleNamespace(delete=lambda *a, **k: None)
+    win.drawing_helper = types.SimpleNamespace(_fill_gradient_circle=lambda *a, **k: [])
+    win._draw_node = lambda *a, **k: None
+    win._draw_edge = lambda *a, **k: None
+    win._place_table = lambda *a, **k: None
+    win._update_scroll_region = lambda: None
+    return win
+
+
+def test_copy_paste_between_cbn_diagrams():
+    doc1 = CausalBayesianNetworkDoc(name="d1")
+    doc1.network.add_node("A", cpd=0.5)
+    doc1.positions["A"] = (0, 0)
+    doc1.types["A"] = "variable"
+    app = types.SimpleNamespace(active_cbn=doc1, diagram_clipboard=None, diagram_clipboard_type=None)
+
+    win1 = _make_window(app, doc1)
+    snap1 = win1._clone_node_strategy1("A")
+    snap2 = win1._clone_node_strategy2("A")
+    snap3 = win1._clone_node_strategy3("A")
+    snap4 = win1._clone_node_strategy4("A")
+    assert snap1 == snap2 == snap3 == snap4
+
+    win1.selected_node = "A"
+    win1.copy_selected()
+    assert app.diagram_clipboard == snap1
+    assert app.diagram_clipboard_type == "Causal Bayesian Network"
+
+    doc2 = CausalBayesianNetworkDoc(name="d2")
+    app.active_cbn = doc2
+    win2 = _make_window(app, doc2)
+
+    for strat in (
+        win2._reconstruct_node_strategy1,
+        win2._reconstruct_node_strategy2,
+        win2._reconstruct_node_strategy3,
+        win2._reconstruct_node_strategy4,
+    ):
+        app.diagram_clipboard = copy.deepcopy(snap1)
+        doc2.network.nodes.clear()
+        doc2.network.parents.clear()
+        doc2.network.cpds.clear()
+        doc2.positions.clear()
+        doc2.types.clear()
+        name = strat(app.diagram_clipboard, doc2)
+        assert name.startswith("A")
+        assert name in doc2.network.nodes
+        assert doc2.positions[name] == (snap1["x"] + 20, snap1["y"] + 20)
+
+    doc2.network.nodes.clear()
+    doc2.network.parents.clear()
+    doc2.network.cpds.clear()
+    doc2.positions.clear()
+    doc2.types.clear()
+    app.diagram_clipboard = snap1
+    win2.paste_selected()
+    assert "A" in doc2.network.nodes
+    assert doc2.positions["A"] == (snap1["x"] + 20, snap1["y"] + 20)
+

--- a/tests/test_causal_bayesian_selection.py
+++ b/tests/test_causal_bayesian_selection.py
@@ -1,0 +1,40 @@
+import types
+
+from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
+
+
+def test_find_node_strategies_with_scroll():
+    offset = 100
+
+    class CanvasStub:
+        def canvasx(self, x):
+            return x + offset
+
+        def canvasy(self, y):
+            return y
+
+        def find_overlapping(self, x1, y1, x2, y2):
+            if x1 <= 110 <= x2 and y1 <= 15 <= y2:
+                return [1]
+            return []
+
+        def find_closest(self, x, y):
+            return [1]
+
+        def coords(self, obj_id):
+            return [100, 0, 120, 30]
+
+    win = object.__new__(CausalBayesianNetworkWindow)
+    win.canvas = CanvasStub()
+    win.id_to_node = {1: "A"}
+    win.nodes = {"A": (1, None, "fill_A")}
+    win.NODE_RADIUS = 10
+    win.app = types.SimpleNamespace(
+        active_cbn=types.SimpleNamespace(positions={"A": (110, 15)})
+    )
+
+    assert win._find_node_strategy1(10, 15) == "A"
+    assert win._find_node_strategy2(10, 15) == "A"
+    assert win._find_node_strategy3(10, 15) == "A"
+    assert win._find_node_strategy4(10, 15) == "A"
+    assert win._find_node(10, 15) == "A"


### PR DESCRIPTION
## Summary
- enhance node hit-testing in Causal Bayesian Network diagrams
- add comprehensive selection strategies and corresponding tests
- restore cross-diagram clipboard support with multi-strategy node cloning

## Testing
- `pytest`
- `radon cc -s -j gui/causal_bayesian_network_window.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7a7f825108327afe10dbc69f508ef