### PR TITLE
Ensure unique GSN node names

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -31,9 +31,23 @@ class GSNDiagram:
             self.nodes.append(self.root)
 
     # ------------------------------------------------------------------
+    def ensure_unique_name(self, name: str, self_node: GSNNode | None = None) -> str:
+        """Return a unique node name based on ``name`` within the diagram."""
+        if not name:
+            return name
+        existing = {n.user_name for n in self.nodes if n is not self_node and n.user_name}
+        base = name
+        suffix = 1
+        while name in existing:
+            name = f"{base}_{suffix}"
+            suffix += 1
+        return name
+
     def add_node(self, node: GSNNode) -> None:
         """Register *node* with the diagram without connecting it."""
-        if node not in self.nodes:
+        if all(existing is not node for existing in self.nodes):
+            if getattr(node, "is_primary_instance", True):
+                node.user_name = self.ensure_unique_name(node.user_name, node)
             self.nodes.append(node)
 
     # ------------------------------------------------------------------

--- a/tests/test_gsn_unique_node_names.py
+++ b/tests/test_gsn_unique_node_names.py
@@ -1,0 +1,17 @@
+from gsn.nodes import GSNNode
+from gsn.diagram import GSNDiagram
+
+def test_gsn_unique_node_names():
+    root = GSNNode("Goal", "Goal")
+    diagram = GSNDiagram(root)
+    # clone should retain name
+    clone = root.clone()
+    diagram.add_node(clone)
+    assert clone.user_name == "Goal"
+    # new nodes with same name should be renamed
+    n1 = GSNNode("Goal", "Goal")
+    diagram.add_node(n1)
+    n2 = GSNNode("Goal", "Goal")
+    diagram.add_node(n2)
+    assert n1.user_name == "Goal_1"
+    assert n2.user_name == "Goal_2"


### PR DESCRIPTION
## Summary
- enforce unique node names when adding to GSN diagrams
- test GSN diagrams auto rename duplicate node names

## Testing
- `python -m pytest -q` *(fails: AttributeError: 'CanvasStub' object has no attribute 'find_closest')*


------
https://chatgpt.com/codex/tasks/task_b_68a7b06a8bfc8327b49d434637cb626c