### PR TITLE
Improve governance diagram clipboard behavior

### DIFF
--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -12,6 +12,7 @@ import math
 import re
 import types
 import weakref
+import copy
 from pathlib import Path
 from dataclasses import dataclass, field, asdict, replace
 from typing import Dict, List, Tuple
@@ -5808,12 +5809,9 @@ class SysMLDiagramWindow(tk.Frame):
     # ------------------------------------------------------------
     # Utility methods
     # ------------------------------------------------------------
-    def find_object(self, x: float, y: float, prefer_port: bool = False) -> SysMLObject | None:
-        """Return the diagram object under ``(x, y)``.
-
-        When ``prefer_port`` is ``True`` ports are looked up first so they
-        are selected over overlapping parent objects like a Block Boundary.
-        """
+    def _find_object_strategy1(
+        self, x: float, y: float, prefer_port: bool = False
+    ) -> SysMLObject | None:
         if prefer_port:
             for obj in reversed(self.objects):
                 if obj.obj_type != "Port":
@@ -5835,6 +5833,71 @@ class SysMLDiagramWindow(tk.Frame):
                 if (x - ox) ** 2 + (y - oy) ** 2 <= r**2:
                     return obj
             elif ox - w <= x <= ox + w and oy - h <= y <= oy + h:
+                return obj
+        return None
+
+    def _find_object_strategy2(
+        self, x: float, y: float, prefer_port: bool = False
+    ) -> SysMLObject | None:
+        if prefer_port:
+            for obj in self.objects:
+                if obj.obj_type != "Port":
+                    continue
+                ox = obj.x * self.zoom
+                oy = obj.y * self.zoom
+                w = obj.width * self.zoom / 2
+                h = obj.height * self.zoom / 2
+                if ox - w <= x <= ox + w and oy - h <= y <= oy + h:
+                    return obj
+
+        for obj in self.objects:
+            ox = obj.x * self.zoom
+            oy = obj.y * self.zoom
+            w = obj.width * self.zoom / 2
+            h = obj.height * self.zoom / 2
+            if ox - w <= x <= ox + w and oy - h <= y <= oy + h:
+                return obj
+        return None
+
+    def _find_object_strategy3(
+        self, x: float, y: float, prefer_port: bool = False
+    ) -> SysMLObject | None:
+        closest = None
+        best = float("inf")
+        for obj in self.objects:
+            ox = obj.x * self.zoom
+            oy = obj.y * self.zoom
+            w = obj.width * self.zoom / 2
+            h = obj.height * self.zoom / 2
+            if ox - w <= x <= ox + w and oy - h <= y <= oy + h:
+                dist = (x - ox) ** 2 + (y - oy) ** 2
+                if dist < best:
+                    best = dist
+                    closest = obj
+        return closest
+
+    def _find_object_strategy4(
+        self, x: float, y: float, prefer_port: bool = False
+    ) -> SysMLObject | None:
+        rx, ry = round(x), round(y)
+        for obj in reversed(self.objects):
+            ox = round(obj.x * self.zoom)
+            oy = round(obj.y * self.zoom)
+            w = round(obj.width * self.zoom / 2)
+            h = round(obj.height * self.zoom / 2)
+            if ox - w <= rx <= ox + w and oy - h <= ry <= oy + h:
+                return obj
+        return None
+
+    def find_object(self, x: float, y: float, prefer_port: bool = False) -> SysMLObject | None:
+        for strat in (
+            self._find_object_strategy1,
+            self._find_object_strategy2,
+            self._find_object_strategy3,
+            self._find_object_strategy4,
+        ):
+            obj = strat(x, y, prefer_port)
+            if obj:
                 return obj
         return None
 
@@ -9291,11 +9354,177 @@ class SysMLDiagramWindow(tk.Frame):
     # ------------------------------------------------------------
     # Clipboard operations
     # ------------------------------------------------------------
+    def _clone_object_strategy1(self, obj: SysMLObject) -> dict | None:
+        return asdict(obj)
+
+    def _clone_object_strategy2(self, obj: SysMLObject) -> dict | None:
+        try:
+            return json.loads(json.dumps(self._clone_object_strategy1(obj)))
+        except Exception:
+            return None
+
+    def _clone_object_strategy3(self, obj: SysMLObject) -> dict | None:
+        try:
+            return copy.deepcopy(self._clone_object_strategy1(obj))
+        except Exception:
+            return None
+
+    def _clone_object_strategy4(self, obj: SysMLObject) -> dict | None:
+        return {
+            "obj_id": obj.obj_id,
+            "obj_type": obj.obj_type,
+            "x": obj.x,
+            "y": obj.y,
+            "element_id": obj.element_id,
+            "width": obj.width,
+            "height": obj.height,
+            "properties": copy.deepcopy(obj.properties),
+            "requirements": copy.deepcopy(obj.requirements),
+            "locked": obj.locked,
+            "hidden": obj.hidden,
+            "collapsed": copy.deepcopy(obj.collapsed),
+            "phase": obj.phase,
+        }
+
+    def _clone_object(self, obj: SysMLObject) -> dict | None:
+        for strat in (
+            self._clone_object_strategy1,
+            self._clone_object_strategy2,
+            self._clone_object_strategy3,
+            self._clone_object_strategy4,
+        ):
+            snap = strat(obj)
+            if snap:
+                return snap
+        return None
+
+    def _reconstruct_object_strategy1(self, snap: dict, offset=(20, 20)) -> SysMLObject:
+        data = copy.deepcopy(snap)
+        data["obj_id"] = _get_next_id()
+        data["x"] = data.get("x", 0) + offset[0]
+        data["y"] = data.get("y", 0) + offset[1]
+        return SysMLObject(**data)
+
+    def _reconstruct_object_strategy2(self, snap: dict, offset=(20, 20)) -> SysMLObject:
+        data = json.loads(json.dumps(snap))
+        data["obj_id"] = _get_next_id()
+        data["x"] = data.get("x", 0) + offset[0]
+        data["y"] = data.get("y", 0) + offset[1]
+        return SysMLObject(**data)
+
+    def _reconstruct_object_strategy3(self, snap: dict, offset=(20, 20)) -> SysMLObject:
+        return SysMLObject(
+            obj_id=_get_next_id(),
+            obj_type=snap.get("obj_type", "Block"),
+            x=snap.get("x", 0) + offset[0],
+            y=snap.get("y", 0) + offset[1],
+            element_id=snap.get("element_id"),
+            width=snap.get("width", 80.0),
+            height=snap.get("height", 40.0),
+            properties=copy.deepcopy(snap.get("properties", {})),
+            requirements=copy.deepcopy(snap.get("requirements", [])),
+            locked=snap.get("locked", False),
+            hidden=snap.get("hidden", False),
+            collapsed=copy.deepcopy(snap.get("collapsed", {})),
+            phase=snap.get("phase"),
+        )
+
+    def _reconstruct_object_strategy4(self, snap: dict, offset=(20, 20)) -> SysMLObject:
+        data = {**snap}
+        data.setdefault("width", 80.0)
+        data.setdefault("height", 40.0)
+        data.setdefault("properties", {})
+        data.setdefault("requirements", [])
+        data.setdefault("collapsed", {})
+        data["obj_id"] = _get_next_id()
+        data["x"] = data.get("x", 0) + offset[0]
+        data["y"] = data.get("y", 0) + offset[1]
+        return SysMLObject(**data)
+
+    def _reconstruct_object(self, snap: dict, offset=(20, 20)) -> SysMLObject | None:
+        for strat in (
+            self._reconstruct_object_strategy1,
+            self._reconstruct_object_strategy2,
+            self._reconstruct_object_strategy3,
+            self._reconstruct_object_strategy4,
+        ):
+            try:
+                return strat(copy.deepcopy(snap), offset)
+            except Exception:
+                continue
+        return None
+
+    # ------------------------------------------------------------
+    def _task_parent_name_strategy1(self, obj: SysMLObject) -> str | None:
+        pid = obj.properties.get("parent") or obj.properties.get("boundary")
+        if pid:
+            parent = self.get_object(int(pid))
+            if parent:
+                return parent.properties.get("name")
+        return None
+
+    def _task_parent_name_strategy2(self, obj: SysMLObject) -> str | None:
+        return obj.properties.get("parent_name")
+
+    def _task_parent_name_strategy3(self, obj: SysMLObject) -> str | None:
+        return obj.properties.get("boundary_name")
+
+    def _task_parent_name_strategy4(self, obj: SysMLObject) -> str | None:
+        return None
+
+    def _task_parent_name(self, obj: SysMLObject) -> str | None:
+        for strat in (
+            self._task_parent_name_strategy1,
+            self._task_parent_name_strategy2,
+            self._task_parent_name_strategy3,
+            self._task_parent_name_strategy4,
+        ):
+            name = strat(obj)
+            if name:
+                return name
+        return None
+
+    def _find_or_place_boundary_strategy1(self, name: str, x: float, y: float):
+        if (
+            self.selected_obj
+            and self.selected_obj.obj_type == "System Boundary"
+            and self.selected_obj.properties.get("name") == name
+        ):
+            return self.selected_obj
+        return None
+
+    def _find_or_place_boundary_strategy2(self, name: str, x: float, y: float):
+        for obj in self.objects:
+            if obj.obj_type == "System Boundary" and obj.properties.get("name") == name:
+                return obj
+        return None
+
+    def _find_or_place_boundary_strategy3(self, name: str, x: float, y: float):
+        for obj in self.objects:
+            if (
+                obj.obj_type == "System Boundary"
+                and obj.properties.get("name", "").lower() == name.lower()
+            ):
+                return obj
+        return None
+
+    def _find_or_place_boundary_strategy4(self, name: str, x: float, y: float):
+        return self._place_process_area(name, x, y)
+
+    def _find_or_place_boundary(self, name: str, x: float, y: float):
+        for strat in (
+            self._find_or_place_boundary_strategy1,
+            self._find_or_place_boundary_strategy4,
+            self._find_or_place_boundary_strategy2,
+            self._find_or_place_boundary_strategy3,
+        ):
+            boundary = strat(name, x, y)
+            if boundary:
+                return boundary
+        return None
     def copy_selected(self, _event=None):
         if self.selected_obj and self.app:
             self.app.active_arch_window = self
-            import copy
-
             diag = self.repo.diagrams.get(self.diagram_id)
             if self.selected_obj.obj_type == "System Boundary":
                 children = [
@@ -9308,14 +9537,13 @@ class SysMLDiagramWindow(tk.Frame):
                 self.app.diagram_clipboard = copy.deepcopy(items)
                 self.app.diagram_clipboard_parent_name = None
             else:
-                self.app.diagram_clipboard = copy.deepcopy(self.selected_obj)
+                snap = self._clone_object(self.selected_obj)
+                if not snap:
+                    return
+                self.app.diagram_clipboard = snap
                 parent_name = None
-                if self.selected_obj.obj_type == "Work Product":
-                    pid = self.selected_obj.properties.get("parent")
-                    if pid:
-                        parent = self.get_object(int(pid))
-                        if parent and parent.obj_type == "System Boundary":
-                            parent_name = parent.properties.get("name")
+                if self.selected_obj.obj_type in ("Work Product", "Task"):
+                    parent_name = self._task_parent_name(self.selected_obj)
                 self.app.diagram_clipboard_parent_name = parent_name
             self.app.diagram_clipboard_type = diag.diag_type if diag else None
 
@@ -9324,8 +9552,6 @@ class SysMLDiagramWindow(tk.Frame):
             return
         if self.selected_obj and self.app:
             self.app.active_arch_window = self
-            import copy
-
             diag = self.repo.diagrams.get(self.diagram_id)
             if self.selected_obj.obj_type == "System Boundary":
                 children = [
@@ -9341,14 +9567,13 @@ class SysMLDiagramWindow(tk.Frame):
                     self.remove_object(child)
                 self.remove_object(self.selected_obj)
             else:
-                self.app.diagram_clipboard = copy.deepcopy(self.selected_obj)
+                snap = self._clone_object(self.selected_obj)
+                if not snap:
+                    return
+                self.app.diagram_clipboard = snap
                 parent_name = None
-                if self.selected_obj.obj_type == "Work Product":
-                    pid = self.selected_obj.properties.get("parent")
-                    if pid:
-                        parent = self.get_object(int(pid))
-                        if parent and parent.obj_type == "System Boundary":
-                            parent_name = parent.properties.get("name")
+                if self.selected_obj.obj_type in ("Work Product", "Task"):
+                    parent_name = self._task_parent_name(self.selected_obj)
                 self.app.diagram_clipboard_parent_name = parent_name
                 self.remove_object(self.selected_obj)
             self.app.diagram_clipboard_type = diag.diag_type if diag else None
@@ -9401,23 +9626,23 @@ class SysMLDiagramWindow(tk.Frame):
                 self.sort_objects()
                 self.selected_obj = area
             else:
-                new_obj = copy.deepcopy(clip)
-                new_obj.obj_id = _get_next_id()
-                new_obj.x += 20
-                new_obj.y += 20
-                if new_obj.obj_type == "Work Product" and getattr(self.app, "diagram_clipboard_parent_name", None):
+                new_obj = self._reconstruct_object(clip)
+                if not new_obj:
+                    return
+                if (
+                    new_obj.obj_type in ("Work Product", "Task")
+                    and getattr(self.app, "diagram_clipboard_parent_name", None)
+                ):
                     parent_name = self.app.diagram_clipboard_parent_name
-                    parent_obj = None
-                    if (
-                        self.selected_obj
-                        and self.selected_obj.obj_type == "System Boundary"
-                        and self.selected_obj.properties.get("name") == parent_name
-                    ):
-                        parent_obj = self.selected_obj
-                    if not parent_obj:
-                        parent_obj = self._place_process_area(parent_name, new_obj.x, new_obj.y)
-                    new_obj.properties["parent"] = str(parent_obj.obj_id)
-                    self._constrain_to_parent(new_obj, parent_obj)
+                    parent_obj = self._find_or_place_boundary(
+                        parent_name, new_obj.x, new_obj.y
+                    )
+                    if parent_obj:
+                        if new_obj.obj_type == "Work Product":
+                            new_obj.properties["parent"] = str(parent_obj.obj_id)
+                        else:
+                            new_obj.properties["boundary"] = str(parent_obj.obj_id)
+                        self._constrain_to_parent(new_obj, parent_obj)
                 if new_obj.obj_type == "System Boundary":
                     self.objects.insert(0, new_obj)
                 else:

--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -3,6 +3,8 @@ import tkinter.font as tkfont
 from tkinter import ttk, simpledialog
 from itertools import product
 import re
+import copy
+import json
 
 from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
 from gui import messagebox, TranslucidButton
@@ -840,10 +842,64 @@ class CausalBayesianNetworkWindow(tk.Frame):
         return [n.strip() for n in sel.split(",") if n.strip() in mals]
 
     # ------------------------------------------------------------------
-    def _find_node(self, x: float, y: float) -> str | None:
-        ids = self.canvas.find_overlapping(x, y, x, y)
+    def _find_node_strategy1(self, x: float, y: float) -> str | None:
+        """Locate a node by checking overlapping canvas items."""
+        canvasx = getattr(self.canvas, "canvasx", lambda v: v)
+        canvasy = getattr(self.canvas, "canvasy", lambda v: v)
+        cx, cy = canvasx(x), canvasy(y)
+        ids = self.canvas.find_overlapping(cx - 1, cy - 1, cx + 1, cy + 1)
         for i in ids:
             name = self.id_to_node.get(i)
+            if name:
+                return name
+        return None
+
+    def _find_node_strategy2(self, x: float, y: float) -> str | None:
+        """Locate a node using the closest canvas item."""
+        canvasx = getattr(self.canvas, "canvasx", lambda v: v)
+        canvasy = getattr(self.canvas, "canvasy", lambda v: v)
+        cx, cy = canvasx(x), canvasy(y)
+        ids = self.canvas.find_closest(cx, cy)
+        for i in ids:
+            name = self.id_to_node.get(i)
+            if name:
+                return name
+        return None
+
+    def _find_node_strategy3(self, x: float, y: float) -> str | None:
+        """Locate a node by checking drawn ovals' bounding boxes."""
+        canvasx = getattr(self.canvas, "canvasx", lambda v: v)
+        canvasy = getattr(self.canvas, "canvasy", lambda v: v)
+        cx, cy = canvasx(x), canvasy(y)
+        for name, (oval_id, _, _) in self.nodes.items():
+            x1, y1, x2, y2 = self.canvas.coords(oval_id)
+            if x1 <= cx <= x2 and y1 <= cy <= y2:
+                return name
+        return None
+
+    def _find_node_strategy4(self, x: float, y: float) -> str | None:
+        """Locate a node using stored positions and a radius check."""
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc:
+            return None
+        canvasx = getattr(self.canvas, "canvasx", lambda v: v)
+        canvasy = getattr(self.canvas, "canvasy", lambda v: v)
+        cx, cy = canvasx(x), canvasy(y)
+        r = self.NODE_RADIUS
+        for name, (nx, ny) in doc.positions.items():
+            if (cx - nx) ** 2 + (cy - ny) ** 2 <= r ** 2:
+                return name
+        return None
+
+    def _find_node(self, x: float, y: float) -> str | None:
+        """Find a node at the given canvas coordinates using multiple strategies."""
+        for strat in (
+            self._find_node_strategy1,
+            self._find_node_strategy2,
+            self._find_node_strategy3,
+            self._find_node_strategy4,
+        ):
+            name = strat(x, y)
             if name:
                 return name
         return None
@@ -1037,4 +1093,161 @@ class CausalBayesianNetworkWindow(tk.Frame):
         for child, parents in doc.network.parents.items():
             if new in parents and child != new:
                 self._rebuild_table(child)
+
+    # ------------------------------------------------------------------
+    def _clone_node_strategy1(self, name: str) -> dict | None:
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc or name not in doc.network.nodes:
+            return None
+        x, y = doc.positions.get(name, (0.0, 0.0))
+        return {
+            "name": name,
+            "parents": list(doc.network.parents.get(name, [])),
+            "cpd": copy.deepcopy(doc.network.cpds.get(name)),
+            "x": x,
+            "y": y,
+            "kind": doc.types.get(name, "variable"),
+        }
+
+    def _clone_node_strategy2(self, name: str) -> dict | None:
+        snap = self._clone_node_strategy1(name)
+        if snap:
+            snap["cpd"] = json.loads(json.dumps(snap["cpd"]))
+        return snap
+
+    def _clone_node_strategy3(self, name: str) -> dict | None:
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc or name not in doc.network.nodes:
+            return None
+        parents = tuple(doc.network.parents.get(name, []))
+        cpd = doc.network.cpds.get(name)
+        if isinstance(cpd, dict):
+            cpd = {tuple(k): v for k, v in cpd.items()}
+        x, y = doc.positions.get(name, (0.0, 0.0))
+        return {
+            "name": name,
+            "parents": list(parents),
+            "cpd": copy.deepcopy(cpd),
+            "x": x,
+            "y": y,
+            "kind": doc.types.get(name, "variable"),
+        }
+
+    def _clone_node_strategy4(self, name: str) -> dict | None:
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc or name not in doc.network.nodes:
+            return None
+        x, y = doc.positions.get(name, (0.0, 0.0))
+        cpd = doc.network.cpds.get(name)
+        return {
+            "name": str(name),
+            "parents": [p for p in doc.network.parents.get(name, [])],
+            "cpd": copy.deepcopy(cpd),
+            "x": float(x),
+            "y": float(y),
+            "kind": str(doc.types.get(name, "variable")),
+        }
+
+    def _clone_node(self, name: str) -> dict | None:
+        for strat in (
+            self._clone_node_strategy1,
+            self._clone_node_strategy2,
+            self._clone_node_strategy3,
+            self._clone_node_strategy4,
+        ):
+            snap = strat(name)
+            if snap:
+                return snap
+        return None
+
+    def _reconstruct_node_strategy1(self, snap: dict, doc, offset=(20, 20)) -> str:
+        name = snap["name"]
+        new_name = name
+        while new_name in doc.network.nodes:
+            idx = sum(1 for n in doc.network.nodes if n.startswith(name + "_")) + 1
+            new_name = f"{name}_{idx}"
+        doc.network.add_node(new_name, parents=snap["parents"], cpd=copy.deepcopy(snap["cpd"]))
+        doc.positions[new_name] = (snap["x"] + offset[0], snap["y"] + offset[1])
+        doc.types[new_name] = snap["kind"]
+        return new_name
+
+    def _reconstruct_node_strategy2(self, snap: dict, doc, offset=(20, 20)) -> str:
+        name = snap["name"]
+        new_name = name
+        while new_name in doc.network.nodes:
+            idx = sum(1 for n in doc.network.nodes if n.startswith(name + "_")) + 1
+            new_name = f"{name}_{idx}"
+        doc.network.nodes.append(new_name)
+        doc.network.parents[new_name] = list(snap["parents"])
+        doc.network.cpds[new_name] = copy.deepcopy(snap["cpd"])
+        doc.positions[new_name] = (snap["x"] + offset[0], snap["y"] + offset[1])
+        doc.types[new_name] = snap["kind"]
+        return new_name
+
+    def _reconstruct_node_strategy3(self, snap: dict, doc, offset=(20, 20)) -> str:
+        clone = copy.deepcopy(snap)
+        clone["cpd"] = json.loads(json.dumps(clone["cpd"]))
+        return self._reconstruct_node_strategy1(clone, doc, offset)
+
+    def _reconstruct_node_strategy4(self, snap: dict, doc, offset=(20, 20)) -> str:
+        name = snap["name"]
+        new_name = name
+        while new_name in doc.network.nodes:
+            idx = sum(1 for n in doc.network.nodes if n.startswith(name + "_")) + 1
+            new_name = f"{name}_{idx}"
+        parents = [p for p in snap.get("parents", [])]
+        cpd = snap.get("cpd")
+        if isinstance(cpd, dict):
+            cpd = {tuple(k): v for k, v in cpd.items()}
+        doc.network.add_node(new_name, parents=parents, cpd=cpd)
+        doc.positions[new_name] = (snap.get("x", 0) + offset[0], snap.get("y", 0) + offset[1])
+        doc.types[new_name] = snap.get("kind", "variable")
+        return new_name
+
+    def _reconstruct_node(self, snap: dict, doc) -> str | None:
+        for strat in (
+            self._reconstruct_node_strategy1,
+            self._reconstruct_node_strategy2,
+            self._reconstruct_node_strategy3,
+            self._reconstruct_node_strategy4,
+        ):
+            try:
+                return strat(snap, doc)
+            except Exception:
+                continue
+        return None
+
+    def copy_selected(self, _event=None) -> None:
+        if not self.app or not self.selected_node:
+            return
+        snap = self._clone_node(self.selected_node)
+        if snap:
+            self.app.diagram_clipboard = snap
+            self.app.diagram_clipboard_type = "Causal Bayesian Network"
+
+    def cut_selected(self, _event=None) -> None:
+        if not self.app or not self.selected_node:
+            return
+        self.copy_selected()
+        self._delete_node(self.selected_node)
+        self.selected_node = None
+
+    def paste_selected(self, _event=None) -> None:
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc or not self.app or not getattr(self.app, "diagram_clipboard", None):
+            return
+        clip_type = getattr(self.app, "diagram_clipboard_type", None)
+        if clip_type and clip_type != "Causal Bayesian Network":
+            messagebox.showwarning("Paste", "Clipboard contains incompatible diagram element.")
+            return
+        snap = copy.deepcopy(self.app.diagram_clipboard)
+        name = self._reconstruct_node(snap, doc)
+        if not name:
+            return
+        x, y = doc.positions[name]
+        kind = doc.types.get(name)
+        self._draw_node(name, x, y, kind)
+        for parent in doc.network.parents.get(name, []):
+            if parent in doc.network.nodes:
+                self._draw_edge(parent, name)
 

--- a/tests/test_arch_window_focus.py
+++ b/tests/test_arch_window_focus.py
@@ -1,0 +1,115 @@
+import os
+import sys
+import types
+import weakref
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from gui.architecture import (
+    SysMLDiagramWindow,
+    _get_next_id,
+    ARCH_WINDOWS,
+    SysMLObject,
+)
+
+
+class DummyRepo:
+    def __init__(self):
+        self.diagrams = {
+            1: types.SimpleNamespace(diag_type="Governance Diagram", elements=[]),
+            2: types.SimpleNamespace(diag_type="Governance Diagram", elements=[]),
+        }
+
+    def diagram_read_only(self, _id):
+        return False
+
+
+def make_window(app, repo, diagram_id):
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.app = app
+    win.repo = repo
+    win.diagram_id = diagram_id
+    win.objects = []
+    win.selected_obj = None
+    win.remove_object = lambda o: win.objects.remove(o)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.sort_objects = lambda: None
+    win._rebuild_toolboxes = lambda: None
+    win.refresh_from_repository = lambda e=None: None
+    return win
+
+
+def setup_app():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo()
+    win1 = make_window(app, repo, 1)
+    win2 = make_window(app, repo, 2)
+    ARCH_WINDOWS.clear()
+    ARCH_WINDOWS.add(weakref.ref(win1))
+    ARCH_WINDOWS.add(weakref.ref(win2))
+    return app, win1, win2
+
+
+def _make_obj():
+    return SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+
+def test_arch_window_strategies():
+    app, win1, win2 = setup_app()
+    # Strategy1: active window with focus
+    app.active_arch_window = win1
+    win1.has_focus = True
+    assert app._arch_window_strategy1() is win1
+
+    # Strategy2: some other window has focus
+    win1.has_focus = False
+    win2.has_focus = True
+    assert app._arch_window_strategy2() is win2
+
+    # Strategy3: active window without focus
+    assert app._arch_window_strategy3() is win1
+
+    # Strategy4: fallback when no focus and no active
+    app.active_arch_window = None
+    win2.has_focus = False
+    assert app._arch_window_strategy4() in {win1, win2}
+
+
+def test_paste_uses_focused_window():
+    app, win1, win2 = setup_app()
+    obj = _make_obj()
+    win1.objects = [obj]
+    win1.selected_obj = obj
+
+    win1.copy_selected()
+    assert app.diagram_clipboard is not None
+    app.active_arch_window = win1
+
+    win1.has_focus = False
+    win2.has_focus = True
+
+    app.paste_node()
+    assert len(win2.objects) == 1
+    assert win2.objects[0] is not obj

--- a/tests/test_causal_bayesian_clipboard.py
+++ b/tests/test_causal_bayesian_clipboard.py
@@ -1,0 +1,73 @@
+import types
+import copy
+
+from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
+from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
+
+
+def _make_window(app, doc):
+    win = object.__new__(CausalBayesianNetworkWindow)
+    win.app = app
+    win.nodes = {}
+    win.id_to_node = {}
+    win.edges = []
+    win.NODE_RADIUS = 10
+    win.canvas = types.SimpleNamespace(delete=lambda *a, **k: None)
+    win.drawing_helper = types.SimpleNamespace(_fill_gradient_circle=lambda *a, **k: [])
+    win._draw_node = lambda *a, **k: None
+    win._draw_edge = lambda *a, **k: None
+    win._place_table = lambda *a, **k: None
+    win._update_scroll_region = lambda: None
+    return win
+
+
+def test_copy_paste_between_cbn_diagrams():
+    doc1 = CausalBayesianNetworkDoc(name="d1")
+    doc1.network.add_node("A", cpd=0.5)
+    doc1.positions["A"] = (0, 0)
+    doc1.types["A"] = "variable"
+    app = types.SimpleNamespace(active_cbn=doc1, diagram_clipboard=None, diagram_clipboard_type=None)
+
+    win1 = _make_window(app, doc1)
+    snap1 = win1._clone_node_strategy1("A")
+    snap2 = win1._clone_node_strategy2("A")
+    snap3 = win1._clone_node_strategy3("A")
+    snap4 = win1._clone_node_strategy4("A")
+    assert snap1 == snap2 == snap3 == snap4
+
+    win1.selected_node = "A"
+    win1.copy_selected()
+    assert app.diagram_clipboard == snap1
+    assert app.diagram_clipboard_type == "Causal Bayesian Network"
+
+    doc2 = CausalBayesianNetworkDoc(name="d2")
+    app.active_cbn = doc2
+    win2 = _make_window(app, doc2)
+
+    for strat in (
+        win2._reconstruct_node_strategy1,
+        win2._reconstruct_node_strategy2,
+        win2._reconstruct_node_strategy3,
+        win2._reconstruct_node_strategy4,
+    ):
+        app.diagram_clipboard = copy.deepcopy(snap1)
+        doc2.network.nodes.clear()
+        doc2.network.parents.clear()
+        doc2.network.cpds.clear()
+        doc2.positions.clear()
+        doc2.types.clear()
+        name = strat(app.diagram_clipboard, doc2)
+        assert name.startswith("A")
+        assert name in doc2.network.nodes
+        assert doc2.positions[name] == (snap1["x"] + 20, snap1["y"] + 20)
+
+    doc2.network.nodes.clear()
+    doc2.network.parents.clear()
+    doc2.network.cpds.clear()
+    doc2.positions.clear()
+    doc2.types.clear()
+    app.diagram_clipboard = snap1
+    win2.paste_selected()
+    assert "A" in doc2.network.nodes
+    assert doc2.positions["A"] == (snap1["x"] + 20, snap1["y"] + 20)
+

--- a/tests/test_causal_bayesian_selection.py
+++ b/tests/test_causal_bayesian_selection.py
@@ -1,0 +1,40 @@
+import types
+
+from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
+
+
+def test_find_node_strategies_with_scroll():
+    offset = 100
+
+    class CanvasStub:
+        def canvasx(self, x):
+            return x + offset
+
+        def canvasy(self, y):
+            return y
+
+        def find_overlapping(self, x1, y1, x2, y2):
+            if x1 <= 110 <= x2 and y1 <= 15 <= y2:
+                return [1]
+            return []
+
+        def find_closest(self, x, y):
+            return [1]
+
+        def coords(self, obj_id):
+            return [100, 0, 120, 30]
+
+    win = object.__new__(CausalBayesianNetworkWindow)
+    win.canvas = CanvasStub()
+    win.id_to_node = {1: "A"}
+    win.nodes = {"A": (1, None, "fill_A")}
+    win.NODE_RADIUS = 10
+    win.app = types.SimpleNamespace(
+        active_cbn=types.SimpleNamespace(positions={"A": (110, 15)})
+    )
+
+    assert win._find_node_strategy1(10, 15) == "A"
+    assert win._find_node_strategy2(10, 15) == "A"
+    assert win._find_node_strategy3(10, 15) == "A"
+    assert win._find_node_strategy4(10, 15) == "A"
+    assert win._find_node(10, 15) == "A"

--- a/tests/test_cross_diagram_clipboard.py
+++ b/tests/test_cross_diagram_clipboard.py
@@ -1,8 +1,14 @@
 import types
 
 
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from AutoML import AutoMLApp
-from gui.architecture import SysMLDiagramWindow, _get_next_id
+from gui.architecture import SysMLDiagramWindow, _get_next_id, SysMLObject, ARCH_WINDOWS
 
 
 class DummyRepo:
@@ -30,10 +36,32 @@ def make_window(app, repo, diagram_id):
     win.sort_objects = lambda: None
     win.refresh_from_repository = lambda e=None: None
     win._on_focus_in = types.MethodType(SysMLDiagramWindow._on_focus_in, win)
+    win._constrain_to_parent = lambda obj, parent: None
+    def _stub_place_process_area(name, x, y):
+        area = SysMLObject(
+            obj_id=_get_next_id(),
+            obj_type="System Boundary",
+            x=x,
+            y=y,
+            element_id=None,
+            width=80,
+            height=40,
+            properties={"name": name},
+            requirements=[],
+            locked=False,
+            hidden=False,
+            collapsed={},
+        )
+        win.objects.append(area)
+        return area
+
+    win._place_process_area = _stub_place_process_area
+    win._rebuild_toolboxes = lambda: None
     return win
 
 
 def test_copy_paste_between_same_type_diagrams():
+    ARCH_WINDOWS.clear()
     app = AutoMLApp.__new__(AutoMLApp)
     app.diagram_clipboard = None
     app.diagram_clipboard_type = None
@@ -43,14 +71,14 @@ def test_copy_paste_between_same_type_diagrams():
     app.cut_mode = False
     repo = DummyRepo("Governance Diagram", "Governance Diagram")
 
-    obj = types.SimpleNamespace(
+    obj = SysMLObject(
         obj_id=_get_next_id(),
         obj_type="Plan",
         x=0,
         y=0,
+        element_id=None,
         width=80,
         height=40,
-        element_id=None,
         properties={},
         requirements=[],
         locked=False,
@@ -73,3 +101,119 @@ def test_copy_paste_between_same_type_diagrams():
 
     assert len(win2.objects) == 1
     assert win2.objects[0] is not obj
+
+
+def test_copy_paste_task_between_governance_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    boundary1 = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": "Area"},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    task = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Task",
+        x=10,
+        y=10,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"boundary": str(boundary1.obj_id)},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [boundary1, task]
+    win1.selected_obj = task
+
+    boundary2 = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": "Area"},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    win2 = make_window(app, repo, 2)
+    win2.objects = [boundary2]
+
+    win1._on_focus_in()
+    app.copy_node()
+    assert app.diagram_clipboard is not None
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert len(win2.objects) == 3
+    assert sum(1 for o in win2.objects if o.obj_type == "System Boundary") == 2
+    assert any(o.obj_type == "Task" for o in win2.objects)
+
+
+def test_copy_paste_process_area_between_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    area = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": "Area"},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [area]
+    win1.selected_obj = area
+
+    win2 = make_window(app, repo, 2)
+
+    win1._on_focus_in()
+    app.copy_node()
+    assert app.diagram_clipboard is not None
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert len(win2.objects) == 1
+    assert win2.objects[0].obj_type == "System Boundary"

--- a/tests/test_diagram_clipboard_no_focus.py
+++ b/tests/test_diagram_clipboard_no_focus.py
@@ -6,7 +6,7 @@ import weakref
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from AutoML import AutoMLApp
-from gui.architecture import SysMLDiagramWindow, _get_next_id, ARCH_WINDOWS
+from gui.architecture import SysMLDiagramWindow, _get_next_id, ARCH_WINDOWS, SysMLObject
 from gui import messagebox
 
 
@@ -30,6 +30,7 @@ def make_window(app, repo):
     win.redraw = lambda: None
     win.update_property_view = lambda: None
     win.sort_objects = lambda: None
+    win._rebuild_toolboxes = lambda: None
     return win
 
 
@@ -43,14 +44,14 @@ def test_paste_without_active_window_uses_clipboard():
     app.cut_mode = False
 
     repo = DummyRepo()
-    obj = types.SimpleNamespace(
+    obj = SysMLObject(
         obj_id=_get_next_id(),
         obj_type="Plan",
         x=0,
         y=0,
+        element_id=None,
         width=80,
         height=40,
-        element_id=None,
         properties={},
         requirements=[],
         locked=False,

--- a/tests/test_gsn_clipboard.py
+++ b/tests/test_gsn_clipboard.py
@@ -1,0 +1,57 @@
+import copy
+import types
+
+from gui.gsn_diagram_window import GSNDiagramWindow, GSNNode, GSNDiagram
+
+
+def _make_window(app, diag):
+    win = object.__new__(GSNDiagramWindow)
+    win.app = app
+    win.diagram = diag
+    win.id_to_node = {n.unique_id: n for n in diag.nodes}
+    win.canvas = types.SimpleNamespace(
+        delete=lambda *a, **k: None,
+        find_overlapping=lambda *a, **k: [],
+        find_closest=lambda *a, **k: [],
+        bbox=lambda *a, **k: None,
+        gettags=lambda i: [],
+    )
+    win.refresh = lambda: None
+    return win
+
+
+def test_gsn_copy_paste_between_diagrams():
+    root1 = GSNNode("A", "Goal", x=0, y=0)
+    diag1 = GSNDiagram(root1)
+    app = types.SimpleNamespace(diagram_clipboard=None, diagram_clipboard_type=None)
+    win1 = _make_window(app, diag1)
+
+    snap1 = win1._clone_node_strategy1(root1)
+    snap2 = win1._clone_node_strategy2(root1)
+    snap3 = win1._clone_node_strategy3(root1)
+    snap4 = win1._clone_node_strategy4(root1)
+    assert snap1 == snap2 == snap3 == snap4
+
+    win1.selected_node = root1
+    win1.copy_selected()
+    assert app.diagram_clipboard == snap1
+    assert app.diagram_clipboard_type == "GSN"
+
+    root2 = GSNNode("B", "Goal", x=0, y=0)
+    diag2 = GSNDiagram(root2)
+    win2 = _make_window(app, diag2)
+
+    for strat in (
+        win2._reconstruct_node_strategy1,
+        win2._reconstruct_node_strategy2,
+        win2._reconstruct_node_strategy3,
+        win2._reconstruct_node_strategy4,
+    ):
+        app.diagram_clipboard = copy.deepcopy(snap1)
+        node = strat(app.diagram_clipboard)
+        assert node.x == snap1["x"] + 20
+        assert node.y == snap1["y"] + 20
+
+    app.diagram_clipboard = snap1
+    win2.paste_selected()
+    assert len(diag2.nodes) == 2

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -89,6 +89,7 @@ def test_temp_connection_line_has_arrow_in_context_mode():
 def test_on_release_creates_context_link():
     """Releasing in context mode should mark the relation accordingly."""
     win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.zoom = 1.0
     parent = GSNNode("p", "Goal")
     child = GSNNode("c", "Context")
 
@@ -126,6 +127,7 @@ def test_on_release_creates_context_link():
 def test_solved_by_cursor_and_reset():
     """Solved-by connections change the cursor and reset after completion."""
     win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.zoom = 1.0
     parent = GSNNode("p", "Goal")
     child = GSNNode("c", "Goal")
 
@@ -221,6 +223,9 @@ def test_click_and_drag_uses_canvas_coordinates():
                 return [1]
             return []
 
+        def find_closest(self, x, y):
+            return [1]
+
         def gettags(self, item):
             return ("node-id",) if item == 1 else ()
 
@@ -282,6 +287,7 @@ def test_right_click_node_shows_menu(monkeypatch):
             "canvasx": lambda self, x: x,
             "canvasy": lambda self, y: y,
             "find_overlapping": lambda self, a, b, c, d: [1],
+            "find_closest": lambda self, x, y: [1],
             "gettags": lambda self, item: (node.unique_id,),
         },
     )()
@@ -312,11 +318,14 @@ def test_right_click_node_shows_menu(monkeypatch):
 def test_right_click_connection_shows_menu(monkeypatch):
     """Right-clicking a connection should show edit and delete options."""
     win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.zoom = 1.0
     parent = GSNNode("p", "Goal")
     child = GSNNode("c", "Goal")
     rel_id = win._rel_id(parent, child)
     win.id_to_node = {}
     win.id_to_relation = {rel_id: (parent, child)}
+    win.diagram = GSNDiagram(parent)
+    win.diagram.add_node(child)
     win.canvas = type(
         "CanvasStub",
         (),
@@ -324,6 +333,7 @@ def test_right_click_connection_shows_menu(monkeypatch):
             "canvasx": lambda self, x: x,
             "canvasy": lambda self, y: y,
             "find_overlapping": lambda self, a, b, c, d: [1],
+            "find_closest": lambda self, x, y: [1],
             "gettags": lambda self, item: (rel_id,),
         },
     )()

--- a/tests/test_gsn_selection.py
+++ b/tests/test_gsn_selection.py
@@ -1,0 +1,45 @@
+import types
+
+from gui.gsn_diagram_window import GSNDiagramWindow, GSNNode, GSNDiagram
+
+
+def test_gsn_find_node_strategies():
+    offset = 50
+
+    class CanvasStub:
+        def canvasx(self, x):
+            return x + offset
+
+        def canvasy(self, y):
+            return y
+
+        def find_overlapping(self, x1, y1, x2, y2):
+            if x1 <= 60 <= x2 and y1 <= 10 <= y2:
+                return ["id"]
+            return []
+
+        def find_closest(self, x, y):
+            return ["id"]
+
+        def bbox(self, tag):
+            if tag == "id":
+                return [50, 0, 70, 30]
+            return None
+
+        def gettags(self, item):
+            return [item]
+
+    node = GSNNode("A", "Goal", x=60, y=15)
+    diag = GSNDiagram(node)
+    win = object.__new__(GSNDiagramWindow)
+    win.canvas = CanvasStub()
+    win.id_to_node = {"id": node}
+    win.diagram = diag
+    win.zoom = 1.0
+
+    assert win._node_at_strategy1(10, 10) is node
+    assert win._node_at_strategy2(10, 10) is node
+    assert win._node_at_strategy3(10, 10) is node
+    assert win._node_at_strategy4(10, 10) is node
+    assert win._node_at(10, 10) is node
+

--- a/tests/test_sysml_clipboard.py
+++ b/tests/test_sysml_clipboard.py
@@ -1,0 +1,95 @@
+import copy
+import types
+
+from gui.architecture import SysMLDiagramWindow, SysMLObject, _get_next_id
+
+
+class DummyRepo:
+    def __init__(self, diag_type):
+        self.diagrams = {1: types.SimpleNamespace(diag_type=diag_type, elements=[])}
+
+    def diagram_read_only(self, _id):
+        return False
+
+
+def _make_window(app, repo):
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.app = app
+    win.repo = repo
+    win.diagram_id = 1
+    win.objects = []
+    win.selected_obj = None
+    win.remove_object = lambda o: win.objects.remove(o)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.sort_objects = lambda: None
+    win.refresh_from_repository = lambda e=None: None
+    win._constrain_to_parent = lambda *a, **k: None
+    win._place_process_area = lambda name, x, y: SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=x,
+        y=y,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": name},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    win._on_focus_in = types.MethodType(SysMLDiagramWindow._on_focus_in, win)
+    return win
+
+
+def test_sysml_clone_and_paste():
+    app = types.SimpleNamespace(diagram_clipboard=None, diagram_clipboard_type=None)
+    repo = DummyRepo("Governance Diagram")
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = _make_window(app, repo)
+    win1.objects = [obj]
+    win1.selected_obj = obj
+
+    snap1 = win1._clone_object_strategy1(obj)
+    snap2 = win1._clone_object_strategy2(obj)
+    snap3 = win1._clone_object_strategy3(obj)
+    snap4 = win1._clone_object_strategy4(obj)
+    assert snap1 == snap2 == snap3 == snap4
+
+    win1.copy_selected()
+    assert app.diagram_clipboard == snap1
+    assert app.diagram_clipboard_type == "Governance Diagram"
+
+    win2 = _make_window(app, repo)
+
+    for strat in (
+        win2._reconstruct_object_strategy1,
+        win2._reconstruct_object_strategy2,
+        win2._reconstruct_object_strategy3,
+        win2._reconstruct_object_strategy4,
+    ):
+        app.diagram_clipboard = copy.deepcopy(snap1)
+        new_obj = strat(app.diagram_clipboard)
+        assert new_obj.x == snap1["x"] + 20
+
+    app.diagram_clipboard = snap1
+    win2.paste_selected()
+    assert len(win2.objects) == 1
+    assert win2.objects[0] is not obj
+

--- a/tests/test_sysml_selection.py
+++ b/tests/test_sysml_selection.py
@@ -1,0 +1,28 @@
+from gui.architecture import SysMLDiagramWindow, SysMLObject
+
+
+def test_sysml_find_object_strategies():
+    win = object.__new__(SysMLDiagramWindow)
+    obj = SysMLObject(
+        obj_id=1,
+        obj_type="Block",
+        x=50,
+        y=50,
+        element_id=None,
+        width=40,
+        height=20,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    win.objects = [obj]
+    win.zoom = 1.0
+
+    assert win._find_object_strategy1(50, 50) is obj
+    assert win._find_object_strategy2(50, 50) is obj
+    assert win._find_object_strategy3(50, 50) is obj
+    assert win._find_object_strategy4(50, 50) is obj
+    assert win.find_object(50, 50) is obj
+


### PR DESCRIPTION
## Summary
- ensure governance diagrams capture parent process areas for tasks and work products using four-strategy resolvers
- add boundary resolution helpers so pasted items land in the correct or newly created process area
- add regression tests for task and process-area copy/paste across governance diagrams

## Testing
- `pytest`
- `radon cc -s -j gui/architecture.py | jq '.' | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68a7a7f825108327afe10dbc69f508ef