### PR TITLE
Clone diagram elements and enforce unique names

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -200,7 +200,10 @@ class CausalBayesianNetworkWindow(tk.Frame):
         name = simpledialog.askstring("New Analysis", "Name:", parent=self)
         if not name:
             return
-        name = unique_name_v4(name, collect_work_product_names(self.app))
+        existing = {d.name for d in getattr(self.app, "cbn_docs", [])}
+        if name in existing:
+            messagebox.showwarning("New Analysis", "An analysis with this name already exists.")
+            return
         doc = CausalBayesianNetworkDoc(name)
         if not hasattr(self.app, "cbn_docs"):
             self.app.cbn_docs = []
@@ -1103,54 +1106,28 @@ class CausalBayesianNetworkWindow(tk.Frame):
         doc = getattr(self.app, "active_cbn", None)
         if not doc or name not in doc.network.nodes:
             return None
-        x, y = doc.positions.get(name, (0.0, 0.0))
-        return {
-            "name": name,
-            "parents": list(doc.network.parents.get(name, [])),
-            "cpd": copy.deepcopy(doc.network.cpds.get(name)),
-            "x": x,
-            "y": y,
-            "kind": doc.types.get(name, "variable"),
-        }
+        return {"doc": doc, "name": name}
 
     def _clone_node_strategy2(self, name: str) -> dict | None:
-        snap = self._clone_node_strategy1(name)
-        if snap:
-            snap["cpd"] = json.loads(json.dumps(snap["cpd"]))
+        doc = getattr(self.app, "active_cbn", None)
+        if not doc or name not in doc.network.nodes:
+            return None
+        snap: dict = {}
+        snap["doc"] = doc
+        snap["name"] = name
         return snap
 
     def _clone_node_strategy3(self, name: str) -> dict | None:
         doc = getattr(self.app, "active_cbn", None)
         if not doc or name not in doc.network.nodes:
             return None
-        parents = tuple(doc.network.parents.get(name, []))
-        cpd = doc.network.cpds.get(name)
-        if isinstance(cpd, dict):
-            cpd = {tuple(k): v for k, v in cpd.items()}
-        x, y = doc.positions.get(name, (0.0, 0.0))
-        return {
-            "name": name,
-            "parents": list(parents),
-            "cpd": copy.deepcopy(cpd),
-            "x": x,
-            "y": y,
-            "kind": doc.types.get(name, "variable"),
-        }
+        return {"doc": doc, "name": str(name)}
 
     def _clone_node_strategy4(self, name: str) -> dict | None:
         doc = getattr(self.app, "active_cbn", None)
         if not doc or name not in doc.network.nodes:
             return None
-        x, y = doc.positions.get(name, (0.0, 0.0))
-        cpd = doc.network.cpds.get(name)
-        return {
-            "name": str(name),
-            "parents": [p for p in doc.network.parents.get(name, [])],
-            "cpd": copy.deepcopy(cpd),
-            "x": float(x),
-            "y": float(y),
-            "kind": str(doc.types.get(name, "variable")),
-        }
+        return {"doc": doc, "name": name[:]}  # copy of the string
 
     def _clone_node(self, name: str) -> dict | None:
         for strat in (
@@ -1165,47 +1142,63 @@ class CausalBayesianNetworkWindow(tk.Frame):
         return None
 
     def _reconstruct_node_strategy1(self, snap: dict, doc, offset=(20, 20)) -> str:
+        orig_doc = snap["doc"]
         name = snap["name"]
-        new_name = name
-        while new_name in doc.network.nodes:
-            idx = sum(1 for n in doc.network.nodes if n.startswith(name + "_")) + 1
-            new_name = f"{name}_{idx}"
-        doc.network.add_node(new_name, parents=snap["parents"], cpd=copy.deepcopy(snap["cpd"]))
-        doc.positions[new_name] = (snap["x"] + offset[0], snap["y"] + offset[1])
-        doc.types[new_name] = snap["kind"]
-        return new_name
-
-    def _reconstruct_node_strategy2(self, snap: dict, doc, offset=(20, 20)) -> str:
-        name = snap["name"]
+        x, y = orig_doc.positions.get(name, (0.0, 0.0))
         new_name = name
         while new_name in doc.network.nodes:
             idx = sum(1 for n in doc.network.nodes if n.startswith(name + "_")) + 1
             new_name = f"{name}_{idx}"
         doc.network.nodes.append(new_name)
-        doc.network.parents[new_name] = list(snap["parents"])
-        doc.network.cpds[new_name] = copy.deepcopy(snap["cpd"])
-        doc.positions[new_name] = (snap["x"] + offset[0], snap["y"] + offset[1])
-        doc.types[new_name] = snap["kind"]
+        doc.network.parents[new_name] = orig_doc.network.parents.get(name, [])
+        doc.network.cpds[new_name] = orig_doc.network.cpds.get(name)
+        doc.positions[new_name] = (x + offset[0], y + offset[1])
+        doc.types[new_name] = orig_doc.types.get(name, "variable")
+        return new_name
+
+    def _reconstruct_node_strategy2(self, snap: dict, doc, offset=(20, 20)) -> str:
+        orig_doc = snap.get("doc")
+        name = snap.get("name")
+        x, y = orig_doc.positions.get(name, (0.0, 0.0))
+        idx = 1
+        new_name = name
+        while new_name in doc.network.nodes:
+            new_name = f"{name}_{idx}"
+            idx += 1
+        doc.network.add_node(new_name, parents=orig_doc.network.parents.get(name, []), cpd=orig_doc.network.cpds.get(name))
+        doc.positions[new_name] = (x + offset[0], y + offset[1])
+        doc.types[new_name] = orig_doc.types.get(name, "variable")
         return new_name
 
     def _reconstruct_node_strategy3(self, snap: dict, doc, offset=(20, 20)) -> str:
-        clone = copy.deepcopy(snap)
-        clone["cpd"] = json.loads(json.dumps(clone["cpd"]))
-        return self._reconstruct_node_strategy1(clone, doc, offset)
+        orig_doc, name = snap["doc"], snap["name"]
+        x, y = orig_doc.positions.get(name, (0.0, 0.0))
+        new_name = name
+        counter = 1
+        while new_name in doc.network.nodes:
+            new_name = f"{name}_{counter}"
+            counter += 1
+        doc.network.nodes.append(new_name)
+        doc.network.parents[new_name] = orig_doc.network.parents.get(name, [])
+        doc.network.cpds[new_name] = orig_doc.network.cpds.get(name)
+        doc.positions[new_name] = (float(x) + offset[0], float(y) + offset[1])
+        doc.types[new_name] = orig_doc.types.get(name, "variable")
+        return new_name
 
     def _reconstruct_node_strategy4(self, snap: dict, doc, offset=(20, 20)) -> str:
+        orig_doc = snap["doc"]
         name = snap["name"]
+        x, y = orig_doc.positions.get(name, (0.0, 0.0))
         new_name = name
+        suffix = 1
         while new_name in doc.network.nodes:
-            idx = sum(1 for n in doc.network.nodes if n.startswith(name + "_")) + 1
-            new_name = f"{name}_{idx}"
-        parents = [p for p in snap.get("parents", [])]
-        cpd = snap.get("cpd")
-        if isinstance(cpd, dict):
-            cpd = {tuple(k): v for k, v in cpd.items()}
-        doc.network.add_node(new_name, parents=parents, cpd=cpd)
-        doc.positions[new_name] = (snap.get("x", 0) + offset[0], snap.get("y", 0) + offset[1])
-        doc.types[new_name] = snap.get("kind", "variable")
+            new_name = f"{name}_{suffix}"
+            suffix += 1
+        doc.network.nodes.append(new_name)
+        doc.network.parents[new_name] = orig_doc.network.parents.get(name, [])
+        doc.network.cpds[new_name] = orig_doc.network.cpds.get(name)
+        doc.positions[new_name] = (x + offset[0], y + offset[1])
+        doc.types[new_name] = orig_doc.types.get(name, "variable")
         return new_name
 
     def _reconstruct_node(self, snap: dict, doc) -> str | None:
@@ -1244,7 +1237,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
         if clip_type and clip_type != "Causal Bayesian Network":
             messagebox.showwarning("Paste", "Clipboard contains incompatible diagram element.")
             return
-        snap = copy.deepcopy(self.app.diagram_clipboard)
+        snap = self.app.diagram_clipboard
         name = self._reconstruct_node(snap, doc)
         if not name:
             return

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -9,6 +9,7 @@ from gui import format_name_with_phase
 from gui.style_manager import StyleManager
 from gui.icon_factory import create_icon
 from .name_utils import collect_work_product_names, unique_name_v4
+from . import messagebox
 
 
 class GSNExplorer(tk.Frame):
@@ -195,7 +196,9 @@ class GSNExplorer(tk.Frame):
         name = simpledialog.askstring("New GSN Diagram", "Root goal name:", parent=self)
         if not name:
             return
-        name = self._unique_diagram_name(name)
+        if name in self._all_diagram_names():
+            messagebox.showwarning("New GSN Diagram", "A diagram with this name already exists.")
+            return
         undo = getattr(self.app, "push_undo_state", None)
         if undo:
             undo()

--- a/tests/test_causal_bayesian_clipboard.py
+++ b/tests/test_causal_bayesian_clipboard.py
@@ -1,5 +1,4 @@
 import types
-import copy
 
 from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
 from analysis.causal_bayesian_network import CausalBayesianNetworkDoc
@@ -50,7 +49,7 @@ def test_copy_paste_between_cbn_diagrams():
         win2._reconstruct_node_strategy3,
         win2._reconstruct_node_strategy4,
     ):
-        app.diagram_clipboard = copy.deepcopy(snap1)
+        app.diagram_clipboard = snap1
         doc2.network.nodes.clear()
         doc2.network.parents.clear()
         doc2.network.cpds.clear()
@@ -59,7 +58,9 @@ def test_copy_paste_between_cbn_diagrams():
         name = strat(app.diagram_clipboard, doc2)
         assert name.startswith("A")
         assert name in doc2.network.nodes
-        assert doc2.positions[name] == (snap1["x"] + 20, snap1["y"] + 20)
+        assert doc2.positions[name] == (doc1.positions["A"][0] + 20, doc1.positions["A"][1] + 20)
+        assert doc2.network.cpds[name] is doc1.network.cpds["A"]
+        assert doc2.network.parents[name] is doc1.network.parents["A"]
 
     doc2.network.nodes.clear()
     doc2.network.parents.clear()
@@ -69,5 +70,7 @@ def test_copy_paste_between_cbn_diagrams():
     app.diagram_clipboard = snap1
     win2.paste_selected()
     assert "A" in doc2.network.nodes
-    assert doc2.positions["A"] == (snap1["x"] + 20, snap1["y"] + 20)
+    assert doc2.positions["A"] == (doc1.positions["A"][0] + 20, doc1.positions["A"][1] + 20)
+    assert doc2.network.cpds["A"] is doc1.network.cpds["A"]
+    assert doc2.network.parents["A"] is doc1.network.parents["A"]
 

--- a/tests/test_diagram_name_enforcement.py
+++ b/tests/test_diagram_name_enforcement.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gui.gsn_explorer import GSNExplorer
+from gui.causal_bayesian_network_window import CausalBayesianNetworkWindow
+
+
+def test_gsn_new_diagram_duplicate_name():
+    app = SimpleNamespace(gsn_diagrams=[], gsn_modules=[])
+    explorer = GSNExplorer.__new__(GSNExplorer)
+    explorer.app = app
+    explorer.tree = SimpleNamespace(selection=lambda: [])
+    explorer.item_map = {}
+    explorer.populate = lambda: None
+    with patch("gui.gsn_explorer.simpledialog.askstring", return_value="D"):
+        with patch("gui.gsn_explorer.messagebox.showwarning", lambda *a, **k: None):
+            explorer.new_diagram()
+            assert len(app.gsn_diagrams) == 1
+            explorer.new_diagram()
+            assert len(app.gsn_diagrams) == 1
+
+
+def test_cbn_new_doc_duplicate_name():
+    app = SimpleNamespace(cbn_docs=[])
+    win = CausalBayesianNetworkWindow.__new__(CausalBayesianNetworkWindow)
+    win.app = app
+    win.refresh_docs = lambda: None
+    win.doc_var = SimpleNamespace(set=lambda v: None)
+    win.select_doc = lambda: None
+    with patch("gui.causal_bayesian_network_window.simpledialog.askstring", return_value="A"):
+        with patch("gui.causal_bayesian_network_window.messagebox.showwarning", lambda *a, **k: None):
+            win.new_doc()
+            assert len(app.cbn_docs) == 1
+            win.new_doc()
+            assert len(app.cbn_docs) == 1
+

--- a/tests/test_gsn_clipboard.py
+++ b/tests/test_gsn_clipboard.py
@@ -1,4 +1,3 @@
-import copy
 import types
 
 from gui.gsn_diagram_window import GSNDiagramWindow, GSNNode, GSNDiagram
@@ -30,13 +29,11 @@ def test_gsn_copy_paste_between_diagrams():
     snap2 = win1._clone_node_strategy2(root1)
     snap3 = win1._clone_node_strategy3(root1)
     snap4 = win1._clone_node_strategy4(root1)
-    assert snap1 == snap2 == snap3 == snap4
-    assert "unique_id" not in snap1
-    assert "original" not in snap1
+    assert snap1 is snap2 is snap3 is snap4 is root1
 
     win1.selected_node = root1
     win1.copy_selected()
-    assert app.diagram_clipboard == snap1
+    assert app.diagram_clipboard is snap1
     assert app.diagram_clipboard_type == "GSN"
 
     root2 = GSNNode("B", "Goal", x=0, y=0)
@@ -49,11 +46,14 @@ def test_gsn_copy_paste_between_diagrams():
         win2._reconstruct_node_strategy3,
         win2._reconstruct_node_strategy4,
     ):
-        app.diagram_clipboard = copy.deepcopy(snap1)
+        app.diagram_clipboard = snap1
         node = strat(app.diagram_clipboard)
-        assert node.x == snap1["x"] + 20
-        assert node.y == snap1["y"] + 20
+        assert node.x == root1.x + 20
+        assert node.y == root1.y + 20
+        assert node.original is root1
 
     app.diagram_clipboard = snap1
     win2.paste_selected()
     assert len(diag2.nodes) == 2
+    new_node = next(n for n in diag2.nodes if n is not root2)
+    assert new_node.original is root1


### PR DESCRIPTION
## Summary
- Clone GSN diagram nodes by reference and paste without deep copies so updates propagate across instances
- Clone Bayesian network nodes by reference and avoid duplicate analysis names
- Prevent duplicate GSN diagram names at creation and add tests

## Testing
- `radon cc -s -j gui/gsn_diagram_window.py gui/causal_bayesian_network_window.py gui/gsn_explorer.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_gsn_clipboard.py tests/test_causal_bayesian_clipboard.py tests/test_diagram_name_enforcement.py` *(fails: ModuleNotFoundError: No module named 'gui')*

------
https://chatgpt.com/codex/tasks/task_b_68a7b7d92648832781528e441ffa6b86