### PR TITLE
Ensure pasted diagram elements remain linked to originals

### DIFF
--- a/tests/test_gsn_clipboard.py
+++ b/tests/test_gsn_clipboard.py
@@ -1,4 +1,3 @@
-import copy
 import types
 
 from gui.gsn_diagram_window import GSNDiagramWindow, GSNNode, GSNDiagram
@@ -26,34 +25,16 @@ def test_gsn_copy_paste_between_diagrams():
     app = types.SimpleNamespace(diagram_clipboard=None, diagram_clipboard_type=None)
     win1 = _make_window(app, diag1)
 
-    snap1 = win1._clone_node_strategy1(root1)
-    snap2 = win1._clone_node_strategy2(root1)
-    snap3 = win1._clone_node_strategy3(root1)
-    snap4 = win1._clone_node_strategy4(root1)
-    assert snap1 == snap2 == snap3 == snap4
-    assert "unique_id" not in snap1
-    assert "original" not in snap1
-
     win1.selected_node = root1
     win1.copy_selected()
-    assert app.diagram_clipboard == snap1
+    assert app.diagram_clipboard is root1
     assert app.diagram_clipboard_type == "GSN"
 
     root2 = GSNNode("B", "Goal", x=0, y=0)
     diag2 = GSNDiagram(root2)
     win2 = _make_window(app, diag2)
 
-    for strat in (
-        win2._reconstruct_node_strategy1,
-        win2._reconstruct_node_strategy2,
-        win2._reconstruct_node_strategy3,
-        win2._reconstruct_node_strategy4,
-    ):
-        app.diagram_clipboard = copy.deepcopy(snap1)
-        node = strat(app.diagram_clipboard)
-        assert node.x == snap1["x"] + 20
-        assert node.y == snap1["y"] + 20
-
-    app.diagram_clipboard = snap1
     win2.paste_selected()
     assert len(diag2.nodes) == 2
+    clone = diag2.nodes[1]
+    assert clone.original is root1


### PR DESCRIPTION
## Summary
- Reworked GSN diagram copy/paste to clone nodes while tracking originals, so multiple views stay synchronized
- Updated Bayesian network copy/paste to reuse parent and CPD references, letting pasted nodes share updates
- Adjusted clipboard unit tests for GSN and Bayesian diagrams to cover clone semantics

## Testing
- `pytest`
- `radon cc gui/gsn_diagram_window.py -j`
- `radon cc gui/causal_bayesian_network_window.py -j`


------
https://chatgpt.com/codex/tasks/task_b_68a7b8abcf54832796298846b43f0ed3