### PR TITLE
feat: add away node shapes with module references

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -1457,18 +1457,418 @@ class GSNDrawingHelper(FTADrawingHelper):
             tags=(obj_id,),
         )
 
-    def draw_away_solution_shape(self, canvas, x, y, scale=40.0, **kwargs):
-        self.draw_solution_shape(canvas, x, y, scale=scale, **kwargs)
-        radius = scale / 2
-        self.draw_shared_marker(canvas, x + radius, y - radius, 1)
+    def _draw_module_reference_box(
+        self,
+        canvas,
+        x,
+        top,
+        w,
+        module_text,
+        outline_color,
+        line_width,
+        font_obj,
+        obj_id,
+    ):
+        """Draw the module identifier box used by away elements."""
+        padding = 2
+        m_width, m_height = self.get_text_size(module_text, font_obj)
+        box_w = max(w * 0.6, m_width + 2 * padding)
+        box_h = m_height + 2 * padding
+        left = x - box_w / 2
+        right = x + box_w / 2
+        bottom = top + box_h
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="white",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
+            x,
+            (top + bottom) / 2,
+            text=module_text,
+            font=font_obj,
+            anchor="center",
+            width=box_w - 2 * padding,
+            tags=(obj_id,),
+        )
+        return bottom
 
-    def draw_away_goal_shape(self, canvas, x, y, scale=60.0, **kwargs):
-        self.draw_goal_shape(canvas, x, y, scale=scale, **kwargs)
-        self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
+    def draw_away_goal_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Goal",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away goal shape with module reference."""
+        outline_color = self._resolve_outline(outline_color)
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        padding = 4
+        t_width, t_height = self.get_text_size(text, font_obj)
+        w = max(scale, t_width + 2 * padding)
+        h = max(scale * 0.6, t_height + 2 * padding)
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        self._fill_gradient_rect(canvas, left, top, right, bottom, fill)
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        line_y = top + h * 0.7
+        canvas.create_line(left, line_y, right, line_y, fill=outline_color, width=line_width)
+        module_scale = h * 0.25
+        self.draw_module_shape(
+            canvas,
+            x,
+            line_y + (bottom - line_y) / 2,
+            scale=module_scale,
+            text="",
+            fill="lightgray",
+            outline_color=outline_color,
+            line_width=line_width,
+            font_obj=self._scaled_font(module_scale),
+            obj_id=obj_id,
+        )
+        canvas.create_text(
+            x,
+            top + (line_y - top) / 2,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        box_font = self._scaled_font(scale * 0.4)
+        self._draw_module_reference_box(
+            canvas,
+            x,
+            bottom,
+            w,
+            module_text,
+            outline_color,
+            line_width,
+            box_font,
+            obj_id,
+        )
 
-    def draw_away_module_shape(self, canvas, x, y, scale=60.0, **kwargs):
+    def draw_away_solution_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Solution",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away solution as a rectangle with a semi-circle on top."""
+        outline_color = self._resolve_outline(outline_color)
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        padding = 4
+        t_width, t_height = self.get_text_size(text, font_obj)
+        w = max(scale, t_width + 2 * padding)
+        h = max(scale * 0.6, t_height + 2 * padding)
+        radius = w / 2
+        left = x - w / 2
+        rect_top = y - h / 2
+        right = x + w / 2
+        rect_bottom = y + h / 2
+        top = rect_top - radius
+        self._fill_gradient_rect(canvas, left, rect_top, right, rect_bottom, fill)
+        canvas.create_rectangle(
+            left,
+            rect_top,
+            right,
+            rect_bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_arc(
+            left,
+            top,
+            right,
+            top + 2 * radius,
+            start=0,
+            extent=180,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
+            x,
+            rect_top + (rect_bottom - rect_top) / 2,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        box_font = self._scaled_font(scale * 0.4)
+        self._draw_module_reference_box(
+            canvas,
+            x,
+            rect_bottom,
+            w,
+            module_text,
+            outline_color,
+            line_width,
+            box_font,
+            obj_id,
+        )
+
+    def draw_away_context_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Context",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away context: rectangle with rounded bottom."""
+        outline_color = self._resolve_outline(outline_color)
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        padding = 4
+        t_width, t_height = self.get_text_size(text, font_obj)
+        w = max(scale, t_width + 2 * padding)
+        h = max(scale * 0.6, t_height + 2 * padding)
+        radius = w / 2
+        left = x - w / 2
+        right = x + w / 2
+        rect_top = y - h / 2
+        rect_bottom = y + h / 2 - radius
+        self._fill_gradient_rect(canvas, left, rect_top, right, rect_bottom + radius, fill)
+        canvas.create_rectangle(
+            left,
+            rect_top,
+            right,
+            rect_bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_arc(
+            left,
+            rect_bottom,
+            right,
+            rect_bottom + 2 * radius,
+            start=180,
+            extent=180,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
+            x,
+            rect_top + (rect_bottom - rect_top) / 2,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        box_font = self._scaled_font(scale * 0.4)
+        self._draw_module_reference_box(
+            canvas,
+            x,
+            rect_bottom + 2 * radius,
+            w,
+            module_text,
+            outline_color,
+            line_width,
+            box_font,
+            obj_id,
+        )
+
+    def _draw_away_assumption_or_justification(
+        self,
+        canvas,
+        x,
+        y,
+        scale,
+        text,
+        label,
+        module_text,
+        fill,
+        outline_color,
+        line_width,
+        font_obj,
+        obj_id,
+    ):
+        outline_color = self._resolve_outline(outline_color)
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        padding = 4
+        t_width, t_height = self.get_text_size(text, font_obj)
+        w = max(scale, t_width + 2 * padding)
+        h = max(scale * 0.6, t_height + 2 * padding)
+        radius = w / 2
+        left = x - w / 2
+        right = x + w / 2
+        rect_bottom = y + h / 2
+        rect_top = y - h / 2 + radius
+        self._fill_gradient_rect(canvas, left, rect_top - radius, right, rect_bottom, fill)
+        canvas.create_rectangle(
+            left,
+            rect_top,
+            right,
+            rect_bottom,
+            fill="",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_arc(
+            left,
+            rect_top - 2 * radius,
+            right,
+            rect_top,
+            start=0,
+            extent=180,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
+            x,
+            rect_top + (rect_bottom - rect_top) / 2,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        label_font = tkFont.Font(font=font_obj)
+        label_font.configure(weight="bold")
+        offset = padding
+        canvas.create_text(
+            right - offset,
+            rect_top - radius + offset,
+            text=label,
+            font=label_font,
+            anchor="ne",
+            tags=(obj_id,),
+        )
+        box_font = self._scaled_font(scale * 0.4)
+        self._draw_module_reference_box(
+            canvas,
+            x,
+            rect_bottom,
+            w,
+            module_text,
+            outline_color,
+            line_width,
+            box_font,
+            obj_id,
+        )
+
+    def draw_away_assumption_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Assumption",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away assumption shape."""
+        self._draw_away_assumption_or_justification(
+            canvas,
+            x,
+            y,
+            scale,
+            text,
+            "A",
+            module_text,
+            fill,
+            outline_color,
+            line_width,
+            font_obj,
+            obj_id,
+        )
+
+    def draw_away_justification_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Justification",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away justification shape."""
+        self._draw_away_assumption_or_justification(
+            canvas,
+            x,
+            y,
+            scale,
+            text,
+            "J",
+            module_text,
+            fill,
+            outline_color,
+            line_width,
+            font_obj,
+            obj_id,
+        )
+
+    def draw_away_module_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        **kwargs,
+    ):
         self.draw_module_shape(canvas, x, y, scale=scale, **kwargs)
-        self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
 
 
 # Create a single GSNDrawingHelper object for convenience

--- a/tests/test_auto_paste_gsn_clone.py
+++ b/tests/test_auto_paste_gsn_clone.py
@@ -1,0 +1,30 @@
+import types
+
+from gsn import GSNNode, GSNDiagram
+from AutoML import AutoMLApp, AutoML_Helper
+from gui import messagebox
+
+
+def test_paste_node_creates_clone():
+    root = GSNNode("Root", "Goal")
+    child = GSNNode("Child", "Goal")
+    root.add_child(child)
+    diag = GSNDiagram(root)
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.root_node = root
+    app.top_events = []
+    app.clipboard_node = child
+    app.selected_node = root
+    app.analysis_tree = types.SimpleNamespace(selection=lambda: [], item=lambda *a, **k: {})
+    app.cut_mode = False
+    app.update_views = lambda: None
+    app._find_gsn_diagram = lambda n: diag
+    AutoML_Helper.calculate_assurance_recursive = lambda *a, **k: None
+    messagebox.showinfo = lambda *a, **k: None
+    app.paste_node()
+    assert len(root.children) == 2
+    clone = root.children[-1]
+    assert clone is not child
+    assert clone.original is child
+    assert not clone.is_primary_instance
+    assert clone in diag.nodes

--- a/tests/test_gsn_away_shapes.py
+++ b/tests/test_gsn_away_shapes.py
@@ -1,0 +1,89 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gsn.nodes import GSNNode
+from gsn.diagram import GSNDiagram
+
+class StubCanvas:
+    def __init__(self):
+        self.items = []
+    def create_rectangle(self, *args, **kwargs):
+        self.items.append((args, kwargs))
+    def create_arc(self, *args, **kwargs):
+        self.items.append((args, kwargs))
+    def create_text(self, *args, **kwargs):
+        self.items.append((args, kwargs))
+    def create_line(self, *args, **kwargs):
+        self.items.append((args, kwargs))
+    def bbox(self, tag):
+        return None
+    def tag_lower(self, *args, **kwargs):
+        pass
+    def tag_raise(self, *args, **kwargs):
+        pass
+
+class RecordingHelper:
+    def __init__(self):
+        self.calls = []
+    def get_text_size(self, text, font_obj):
+        return len(text) * 5, 10
+    def draw_away_goal_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("goal", module_text))
+    def draw_away_solution_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("solution", module_text))
+    def draw_away_context_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("context", module_text))
+    def draw_away_assumption_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("assumption", module_text))
+    def draw_away_justification_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("justification", module_text))
+    # Unused stubs
+    def draw_goal_shape(self, *a, **k):
+        pass
+    def draw_solution_shape(self, *a, **k):
+        pass
+    def draw_module_shape(self, *a, **k):
+        pass
+    def draw_assumption_shape(self, *a, **k):
+        pass
+    def draw_justification_shape(self, *a, **k):
+        pass
+    def draw_context_shape(self, *a, **k):
+        pass
+    def draw_solved_by_connection(self, *a, **k):
+        pass
+    def draw_in_context_connection(self, *a, **k):
+        pass
+    def point_on_shape(self, shape, target_pt):
+        return target_pt
+
+@pytest.mark.parametrize("node_type,expected", [
+    ("Goal", "goal"),
+    ("Solution", "solution"),
+    ("Context", "context"),
+    ("Assumption", "assumption"),
+    ("Justification", "justification"),
+])
+def test_away_shapes_receive_module_identifier(node_type, expected):
+    module = GSNNode("Mod", "Module")
+    original = GSNNode("Orig", node_type)
+    original.parents.append(module)
+    clone = GSNNode("Clone", node_type, is_primary_instance=False, original=original)
+    helper = RecordingHelper()
+    diag = GSNDiagram(clone, drawing_helper=helper)
+    canvas = StubCanvas()
+    diag.draw(canvas)
+    assert helper.calls[0] == (expected, "Mod")
+
+
+def test_away_shapes_without_module_identifier():
+    original = GSNNode("Orig", "Goal")
+    clone = GSNNode("Clone", "Goal", is_primary_instance=False, original=original)
+    helper = RecordingHelper()
+    diag = GSNDiagram(clone, drawing_helper=helper)
+    canvas = StubCanvas()
+    diag.draw(canvas)
+    assert helper.calls[0] == ("goal", "")

--- a/tests/test_gsn_clone_movement.py
+++ b/tests/test_gsn_clone_movement.py
@@ -31,3 +31,32 @@ def test_moving_gsn_clone_preserves_original_position():
 
     assert (root.x, root.y) == (0, 0)
     assert (clone.x, clone.y) == (150, 160)
+
+
+def test_moving_gsn_original_preserves_clone_position():
+    root = GSNNode("A", "Goal", x=0, y=0)
+    clone = root.clone()
+    clone.x = 50
+    clone.y = 60
+    diag = GSNDiagram(root)
+    diag.add_node(clone)
+    root.display_label = ""
+    clone.display_label = ""
+
+    def get_all_nodes(self, _):
+        return [root, clone]
+
+    def get_all_fmea(self):
+        return []
+
+    app = object.__new__(AutoMLApp)
+    app.root_node = root
+    app.get_all_nodes = types.MethodType(get_all_nodes, app)
+    app.get_all_fmea_entries = types.MethodType(get_all_fmea, app)
+
+    root.x += 100
+    root.y += 100
+    AutoMLApp.sync_nodes_by_id(app, root)
+
+    assert (clone.x, clone.y) == (50, 60)
+    assert (root.x, root.y) == (100, 100)

--- a/tests/test_gsn_copy_paste.py
+++ b/tests/test_gsn_copy_paste.py
@@ -61,10 +61,11 @@ class GSNCopyPasteTests(unittest.TestCase):
         self.app.copy_node()
         self.app.selected_node = self.other  # paste into a different goal
         self.app.paste_node()
-        self.assertEqual(len(self.diagram.nodes), 3)
+        self.assertEqual(len(self.diagram.nodes), 4)
         self.assertEqual(len(self.other.children), 1)
         cloned = self.other.children[0]
-        self.assertIs(cloned, self.child)
+        self.assertIsNot(cloned, self.child)
+        self.assertIs(cloned.original, self.child)
         self.assertIn(cloned, self.diagram.nodes)
 
 


### PR DESCRIPTION
## Summary
- enhance module lookup to consistently render away shapes for cloned GSN nodes
- prevent position synchronization across clones and originals while keeping attribute updates
- clone nodes on paste so away shapes appear and governance diagrams function correctly
- test independent movement, away-shape rendering, and paste cloning

## Testing
- `pytest tests/test_gsn_away_shapes.py tests/test_gsn_clone_movement.py tests/test_gsn_clone_paste.py tests/test_gsn_copy_paste.py tests/test_auto_paste_gsn_clone.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*
- `radon cc -j AutoML.py gsn/diagram.py gui/drawing_helper.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7d534ede48327887e22e14a236af0