### PR TITLE
Fix GSN clone sync and away shape rendering

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -256,7 +256,7 @@ from gui.causal_bayesian_network_window import CBN_WINDOWS
 from gui.gsn_config_window import GSNElementConfig
 from gui.search_toolbox import SearchToolbox
 from gsn import GSNDiagram, GSNModule
-from gsn.nodes import GSNNode
+from gsn.nodes import GSNNode, ALLOWED_AWAY_TYPES
 from gui.closable_notebook import ClosableNotebook
 from gui.icon_factory import create_icon
 from gui.splash_screen import SplashScreen
@@ -10706,11 +10706,49 @@ class AutoMLApp:
         self.drag_offset_x = 0
         self.drag_offset_y = 0
 
-    def move_subtree(self, node, dx, dy):
-        for child in node.children:
+    def _move_subtree_strategy1(self, node, dx, dy):
+        for child in getattr(node, "children", []):
+            if not getattr(child, "is_primary_instance", True):
+                continue
             child.x += dx
             child.y += dy
-            self.move_subtree(child, dx, dy)
+            self._move_subtree_strategy1(child, dx, dy)
+
+    def _move_subtree_strategy2(self, node, dx, dy):
+        for child in [c for c in getattr(node, "children", []) if getattr(c, "is_primary_instance", True)]:
+            child.x += dx
+            child.y += dy
+            self._move_subtree_strategy2(child, dx, dy)
+
+    def _move_subtree_strategy3(self, node, dx, dy):
+        children = getattr(node, "children", [])
+        for child in children:
+            if not getattr(child, "is_primary_instance", True):
+                continue
+            child.x += dx
+            child.y += dy
+            self._move_subtree_strategy3(child, dx, dy)
+
+    def _move_subtree_strategy4(self, node, dx, dy):
+        for child in list(getattr(node, "children", [])):
+            if not getattr(child, "is_primary_instance", True):
+                continue
+            child.x += dx
+            child.y += dy
+            self._move_subtree_strategy4(child, dx, dy)
+
+    def move_subtree(self, node, dx, dy):
+        for strat in (
+            self._move_subtree_strategy1,
+            self._move_subtree_strategy2,
+            self._move_subtree_strategy3,
+            self._move_subtree_strategy4,
+        ):
+            try:
+                strat(node, dx, dy)
+                return
+            except Exception:
+                continue
 
     def zoom_in(self):
         self.zoom *= 1.2
@@ -18826,6 +18864,12 @@ class AutoMLApp:
             self.clipboard_node = node
             self.selected_node = node
             self.cut_mode = False
+            if node.parents:
+                parent = node.parents[0]
+                rel = "context" if node in parent.context_children else "solved"
+            else:
+                rel = "solved"
+            self.clipboard_relation = rel
             return
         win = self._focused_cbn_window()
         if win and getattr(win, "selected_node", None):
@@ -18863,6 +18907,12 @@ class AutoMLApp:
             self.clipboard_node = node
             self.selected_node = node
             self.cut_mode = True
+            if node.parents:
+                parent = node.parents[0]
+                rel = "context" if node in parent.context_children else "solved"
+            else:
+                rel = "solved"
+            self.clipboard_relation = rel
             return
         win = self._focused_cbn_window()
         if win and getattr(win, "selected_node", None):
@@ -18889,6 +18939,66 @@ class AutoMLApp:
             return
         messagebox.showwarning("Cut", "Select a non-root node to cut.")
 
+    # ------------------------------------------------------------------
+    def _reset_gsn_clone(self, node):
+        if isinstance(node, GSNNode):
+            node.unique_id = str(uuid.uuid4())
+            node.is_primary_instance = True
+            node.original = node
+            for child in getattr(node, "children", []):
+                self._reset_gsn_clone(child)
+
+    # ------------------------------------------------------------------
+    def _clone_for_paste_strategy1(self, node):
+        if hasattr(node, "clone"):
+            return node.clone()
+        import copy
+        clone = copy.deepcopy(node)
+        self._reset_gsn_clone(clone)
+        return clone
+
+    def _clone_for_paste_strategy2(self, node):
+        import copy
+        if isinstance(node, GSNNode):
+            return node.clone()
+        clone = copy.deepcopy(node)
+        self._reset_gsn_clone(clone)
+        return clone
+
+    def _clone_for_paste_strategy3(self, node):
+        try:
+            return node.clone()  # type: ignore[attr-defined]
+        except Exception:
+            import copy
+            clone = copy.deepcopy(node)
+            self._reset_gsn_clone(clone)
+            return clone
+
+    def _clone_for_paste_strategy4(self, node):
+        import copy
+        clone = copy.deepcopy(node)
+        self._reset_gsn_clone(clone)
+        return clone
+
+    def _clone_for_paste(self, node):
+        for strat in (
+            self._clone_for_paste_strategy1,
+            self._clone_for_paste_strategy2,
+            self._clone_for_paste_strategy3,
+            self._clone_for_paste_strategy4,
+        ):
+            try:
+                clone = strat(node)
+                if clone is not None:
+                    return clone
+            except ValueError:
+                messagebox.showwarning("Clone", "Cannot clone this node type.")
+                return None
+            except Exception:
+                continue
+        messagebox.showwarning("Clone", "Cannot clone this node type.")
+        return None
+
     def paste_node(self):
         if self.clipboard_node:
             target = None
@@ -18910,10 +19020,11 @@ class AutoMLApp:
             if target.unique_id == self.clipboard_node.unique_id:
                 messagebox.showwarning("Paste", "Cannot paste a node onto itself.")
                 return
-            for child in target.children:
-                if child.unique_id == self.clipboard_node.unique_id:
-                    messagebox.showwarning("Paste", "This node is already a child of the target.")
-                    return
+            if self.cut_mode:
+                for child in target.children:
+                    if child.unique_id == self.clipboard_node.unique_id:
+                        messagebox.showwarning("Paste", "This node is already a child of the target.")
+                        return
             if self.cut_mode:
                 if self.clipboard_node in self.top_events:
                     self.top_events.remove(self.clipboard_node)
@@ -18927,7 +19038,10 @@ class AutoMLApp:
                     self.clipboard_node.is_page = False
                     self.clipboard_node.input_subtype = "Failure"
                 self.clipboard_node.is_primary_instance = True
-                target.children.append(self.clipboard_node)
+                if getattr(self, "clipboard_relation", "solved") == "context":
+                    target.context_children.append(self.clipboard_node)
+                else:
+                    target.children.append(self.clipboard_node)
                 self.clipboard_node.parents.append(target)
                 if isinstance(self.clipboard_node, GSNNode):
                     old_diag = self._find_gsn_diagram(self.clipboard_node)
@@ -18943,13 +19057,20 @@ class AutoMLApp:
                 self.cut_mode = False
                 messagebox.showinfo("Paste", "Node moved successfully (cut & pasted).")
             else:
-                cloned_node = self.clipboard_node
-                target.children.append(cloned_node)
+                cloned_node = self._clone_for_paste(self.clipboard_node)
+                if cloned_node is None:
+                    return
+                if getattr(self, "clipboard_relation", "solved") == "context":
+                    target.context_children.append(cloned_node)
+                else:
+                    target.children.append(cloned_node)
                 cloned_node.parents.append(target)
                 if isinstance(cloned_node, GSNNode):
                     diag = self._find_gsn_diagram(target)
                     if diag and cloned_node not in diag.nodes:
                         diag.add_node(cloned_node)
+                cloned_node.x = target.x + 100
+                cloned_node.y = target.y + 100
                 messagebox.showinfo("Paste", "Node pasted successfully (copied).")
             AutoML_Helper.calculate_assurance_recursive(
                 self.root_node,
@@ -19122,6 +19243,10 @@ class AutoMLApp:
         """
 
         if isinstance(node, GSNNode):
+            if node.node_type not in ALLOWED_AWAY_TYPES:
+                raise ValueError(
+                    "Only Goal, Solution, Context, Assumption, and Justification nodes can be cloned."
+                )
             # GSN nodes provide their own clone method.  Offset the position of
             # the cloned node so that it does not overlap the original.
             new_node = node.clone()
@@ -19233,6 +19358,70 @@ class AutoMLApp:
             except Exception:
                 continue
 
+    def _sync_nodes_by_id_strategy1(self, updated_node, attrs):
+        clone = updated_node if (not updated_node.is_primary_instance and updated_node.original) else None
+        if clone:
+            updated_node = clone.original
+            self._copy_attrs_no_xy(updated_node, clone, attrs)
+            updated_node.display_label = clone.display_label.replace(" (clone)", "")
+        updated_primary_id = updated_node.unique_id
+        nodes_to_check = self.get_all_nodes(self.root_node)
+        nodes_to_check.extend(self.get_all_fmea_entries())
+        for node in nodes_to_check:
+            if node is updated_node or node is clone:
+                continue
+            if node.is_primary_instance and node.unique_id == updated_primary_id:
+                self._copy_attrs_no_xy(node, updated_node, attrs)
+                node.display_label = updated_node.display_label
+            elif (
+                not node.is_primary_instance
+                and node.original
+                and node.original.unique_id == updated_primary_id
+            ):
+                self._copy_attrs_no_xy(node, updated_node, attrs)
+                node.display_label = updated_node.display_label + " (clone)"
+
+    def _sync_nodes_by_id_strategy2(self, updated_node, attrs):
+        clone = None
+        if not updated_node.is_primary_instance and updated_node.original:
+            clone = updated_node
+            updated_node = clone.original
+            self._copy_attrs_no_xy(updated_node, clone, attrs)
+            updated_node.display_label = clone.display_label.replace(" (clone)", "")
+        updated_primary_id = updated_node.unique_id
+        nodes = self.get_all_nodes(self.root_node) + self.get_all_fmea_entries()
+        for node in [n for n in nodes if n not in (updated_node, clone)]:
+            if node.is_primary_instance and node.unique_id == updated_primary_id:
+                self._copy_attrs_no_xy(node, updated_node, attrs)
+                node.display_label = updated_node.display_label
+            elif not node.is_primary_instance and getattr(node, "original", None) and node.original.unique_id == updated_primary_id:
+                self._copy_attrs_no_xy(node, updated_node, attrs)
+                node.display_label = updated_node.display_label + " (clone)"
+
+    def _sync_nodes_by_id_strategy3(self, updated_node, attrs):
+        clone = updated_node if (hasattr(updated_node, "is_primary_instance") and not updated_node.is_primary_instance and getattr(updated_node, "original", None)) else None
+        primary = clone.original if clone else updated_node
+        if clone:
+            self._copy_attrs_no_xy(primary, clone, attrs)
+            primary.display_label = clone.display_label.replace(" (clone)", "")
+        updated_primary_id = primary.unique_id
+        try:
+            nodes = list(self.get_all_nodes(self.root_node)) + list(self.get_all_fmea_entries())
+        except Exception:
+            nodes = []
+        for node in nodes:
+            if node in (primary, clone):
+                continue
+            if node.is_primary_instance and node.unique_id == updated_primary_id:
+                self._copy_attrs_no_xy(node, primary, attrs)
+                node.display_label = primary.display_label
+            elif not node.is_primary_instance and getattr(node, "original", None) and node.original.unique_id == updated_primary_id:
+                self._copy_attrs_no_xy(node, primary, attrs)
+                node.display_label = primary.display_label + " (clone)"
+
+    def _sync_nodes_by_id_strategy4(self, updated_node, attrs):
+        self._sync_nodes_by_id_strategy1(updated_node, attrs)
+
     def sync_nodes_by_id(self, updated_node):
         """Synchronize all nodes (original and clones) sharing an ID.
 
@@ -19272,35 +19461,17 @@ class AutoMLApp:
             "fmeda_fault_fraction",
         ]
 
-        # If a clone was edited, copy its changes to the original before
-        # propagating.
-        if not updated_node.is_primary_instance and updated_node.original:
-            clone = updated_node
-            updated_node = clone.original
-            self._copy_attrs_no_xy(updated_node, clone, attrs)
-            # Remove the clone marker before storing the label on the original.
-            updated_node.display_label = clone.display_label.replace(" (clone)", "")
-
-        updated_primary_id = updated_node.unique_id
-
-        nodes_to_check = self.get_all_nodes(self.root_node)
-        nodes_to_check.extend(self.get_all_fmea_entries())
-
-        for node in nodes_to_check:
-            # Skip the updated node itself.
-            if node is updated_node:
+        for strat in (
+            self._sync_nodes_by_id_strategy1,
+            self._sync_nodes_by_id_strategy2,
+            self._sync_nodes_by_id_strategy3,
+            self._sync_nodes_by_id_strategy4,
+        ):
+            try:
+                strat(updated_node, attrs)
+                break
+            except Exception:
                 continue
-
-            if node.is_primary_instance:
-                if node.unique_id == updated_primary_id:
-                    self._copy_attrs_no_xy(node, updated_node, attrs)
-                    node.display_label = updated_node.display_label
-            else:
-                # Use the original pointer to compare.
-                if node.original and node.original.unique_id == updated_primary_id:
-                    self._copy_attrs_no_xy(node, updated_node, attrs)
-                    # Append a marker to the display label to indicate this is a clone.
-                    node.display_label = updated_node.display_label + " (clone)"
 
     def edit_user_name(self):
         if self.selected_node:

--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -219,6 +219,54 @@ class GSNDiagram:
         return None
 
     # ------------------------------------------------------------------
+    def _find_module_name_strategy1(self, node: GSNNode) -> str:
+        for parent in getattr(getattr(node, "original", node), "parents", []):
+            if getattr(parent, "node_type", "") == "Module":
+                return getattr(parent, "user_name", "")
+        return ""
+
+    def _find_module_name_strategy2(self, node: GSNNode) -> str:
+        for parent in getattr(node, "parents", []):
+            if getattr(parent, "node_type", "") == "Module":
+                return getattr(parent, "user_name", "")
+        return ""
+
+    def _find_module_name_strategy3(self, node: GSNNode) -> str:
+        parents = []
+        if getattr(node, "original", None):
+            parents.extend(getattr(node.original, "parents", []))
+        parents.extend(getattr(node, "parents", []))
+        for parent in parents:
+            if getattr(parent, "node_type", "") == "Module":
+                return getattr(parent, "user_name", "")
+        return ""
+
+    def _find_module_name_strategy4(self, node: GSNNode) -> str:
+        try:
+            return next(
+                p.user_name
+                for p in getattr(getattr(node, "original", node), "parents", [])
+                if getattr(p, "node_type", "") == "Module"
+            )
+        except StopIteration:
+            return ""
+
+    def _find_module_name(self, node: GSNNode) -> str:
+        for strat in (
+            self._find_module_name_strategy1,
+            self._find_module_name_strategy2,
+            self._find_module_name_strategy3,
+            self._find_module_name_strategy4,
+        ):
+            try:
+                name = strat(node)
+                if name:
+                    return name
+            except Exception:
+                continue
+        return ""
+
+    # ------------------------------------------------------------------
     def _draw_node(self, canvas, node: GSNNode, zoom: float) -> None:  # pragma: no cover - requires tkinter
         x, y = node.x * zoom, node.y * zoom
         typ = node.node_type.lower()
@@ -233,6 +281,10 @@ class GSNDiagram:
         padding = 10 * zoom
         base_scale = 60 * zoom
 
+        module_name = ""
+        if not node.is_primary_instance:
+            module_name = self._find_module_name(node)
+
         def _call(method, *args, **kwargs):
             try:
                 method(*args, **kwargs)
@@ -241,6 +293,7 @@ class GSNDiagram:
                 kwargs.pop("top_text", None)
                 kwargs.pop("bottom_text", None)
                 kwargs.pop("font_obj", None)
+                kwargs.pop("module_text", None)
                 method(*args, **kwargs)
 
         if typ == "solution":
@@ -262,16 +315,14 @@ class GSNDiagram:
                 if node.is_primary_instance
                 else self.drawing_helper.draw_away_solution_shape
             )
-            _call(
-                draw_func,
-                canvas,
-                x,
-                y,
-                scale,
-                text=text,
-                font_obj=font_obj,
-                obj_id=node.unique_id,
-            )
+            kwargs = {
+                "text": text,
+                "font_obj": font_obj,
+                "obj_id": node.unique_id,
+            }
+            if not node.is_primary_instance:
+                kwargs["module_text"] = module_name
+            _call(draw_func, canvas, x, y, scale, **kwargs)
         elif typ == "goal":
             ratio = 0.6
             scale = max(base_scale, width + padding, (height + padding) / ratio)
@@ -280,26 +331,19 @@ class GSNDiagram:
                 if node.is_primary_instance
                 else self.drawing_helper.draw_away_goal_shape
             )
-            _call(
-                draw_func,
-                canvas,
-                x,
-                y,
-                scale,
-                text=text,
-                font_obj=font_obj,
-                obj_id=node.unique_id,
-            )
+            kwargs = {
+                "text": text,
+                "font_obj": font_obj,
+                "obj_id": node.unique_id,
+            }
+            if not node.is_primary_instance:
+                kwargs["module_text"] = module_name
+            _call(draw_func, canvas, x, y, scale, **kwargs)
         elif typ == "module":
             ratio = 0.6
             scale = max(base_scale, width + padding, (height + padding) / ratio)
-            draw_func = (
-                self.drawing_helper.draw_module_shape
-                if node.is_primary_instance
-                else self.drawing_helper.draw_away_module_shape
-            )
             _call(
-                draw_func,
+                self.drawing_helper.draw_module_shape,
                 canvas,
                 x,
                 y,
@@ -329,16 +373,22 @@ class GSNDiagram:
                 "justification": self.drawing_helper.draw_justification_shape,
                 "context": self.drawing_helper.draw_context_shape,
             }
-            _call(
-                draw_map[typ],
-                canvas,
-                x,
-                y,
-                scale,
-                text=text,
-                font_obj=font_obj,
-                obj_id=node.unique_id,
-            )
+            if node.is_primary_instance:
+                draw_func = draw_map[typ]
+            else:
+                draw_func = {
+                    "assumption": self.drawing_helper.draw_away_assumption_shape,
+                    "justification": self.drawing_helper.draw_away_justification_shape,
+                    "context": self.drawing_helper.draw_away_context_shape,
+                }[typ]
+            kwargs = {
+                "text": text,
+                "font_obj": font_obj,
+                "obj_id": node.unique_id,
+            }
+            if not node.is_primary_instance:
+                kwargs["module_text"] = module_name
+            _call(draw_func, canvas, x, y, scale, **kwargs)
 
     def _format_text(self, node: GSNNode) -> str:
         """Return node label including description if present."""

--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 import uuid
 import logging
 
+ALLOWED_AWAY_TYPES = {"Goal", "Solution", "Context", "Assumption", "Justification"}
+
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +117,10 @@ class GSNNode:
         instance, enabling multiple diagram occurrences similar to away
         solutions in GSN 2.0.
         """
+        if self.node_type not in ALLOWED_AWAY_TYPES:
+            raise ValueError(
+                f"Cloning not supported for node type '{self.node_type}'."
+            )
         clone = GSNNode(
             self.user_name,
             self.node_type,

--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -1457,18 +1457,420 @@ class GSNDrawingHelper(FTADrawingHelper):
             tags=(obj_id,),
         )
 
-    def draw_away_solution_shape(self, canvas, x, y, scale=40.0, **kwargs):
-        self.draw_solution_shape(canvas, x, y, scale=scale, **kwargs)
-        radius = scale / 2
-        self.draw_shared_marker(canvas, x + radius, y - radius, 1)
+    def _draw_module_reference_box(
+        self,
+        canvas,
+        x,
+        top,
+        w,
+        module_text,
+        outline_color,
+        line_width,
+        font_obj,
+        obj_id,
+    ):
+        """Draw the module identifier box used by away elements."""
+        if not module_text:
+            return top
+        padding = 2
+        m_width, m_height = self.get_text_size(module_text, font_obj)
+        box_w = max(w * 0.6, m_width + 2 * padding)
+        box_h = m_height + 2 * padding
+        left = x - box_w / 2
+        right = x + box_w / 2
+        top -= line_width
+        bottom = top + box_h
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill="white",
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
+            x,
+            (top + bottom) / 2,
+            text=module_text,
+            font=font_obj,
+            anchor="center",
+            width=box_w - 2 * padding,
+            tags=(obj_id,),
+        )
+        return bottom
 
-    def draw_away_goal_shape(self, canvas, x, y, scale=60.0, **kwargs):
-        self.draw_goal_shape(canvas, x, y, scale=scale, **kwargs)
-        self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
+    def draw_away_goal_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Goal",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away goal shape with module reference."""
+        outline_color = self._resolve_outline(outline_color)
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        padding = 4
+        t_width, t_height = self.get_text_size(text, font_obj)
+        w = max(scale, t_width + 2 * padding)
+        h = max(scale * 0.6, t_height + 2 * padding)
+        left = x - w / 2
+        top = y - h / 2
+        right = x + w / 2
+        bottom = y + h / 2
+        canvas.create_rectangle(
+            left,
+            top,
+            right,
+            bottom,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        line_y = top + h * 0.6
+        canvas.create_line(left, line_y, right, line_y, fill=outline_color, width=line_width)
+        module_scale = (bottom - line_y) * 0.5
+        self.draw_module_shape(
+            canvas,
+            x,
+            line_y + (bottom - line_y) / 2,
+            scale=module_scale,
+            text="",
+            fill="lightgray",
+            outline_color=outline_color,
+            line_width=line_width,
+            font_obj=self._scaled_font(module_scale),
+            obj_id=obj_id,
+        )
+        canvas.create_text(
+            x,
+            top + (line_y - top) / 2,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        box_font = self._scaled_font(scale * 0.4)
+        self._draw_module_reference_box(
+            canvas,
+            x,
+            bottom,
+            w,
+            module_text,
+            outline_color,
+            line_width,
+            box_font,
+            obj_id,
+        )
 
-    def draw_away_module_shape(self, canvas, x, y, scale=60.0, **kwargs):
+    def draw_away_solution_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Solution",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away solution as a rectangle with a semi-circle on top."""
+        outline_color = self._resolve_outline(outline_color)
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        padding = 4
+        t_width, t_height = self.get_text_size(text, font_obj)
+        w = max(scale, t_width + 2 * padding)
+        h = max(scale * 0.6, t_height + 2 * padding)
+        radius = w / 2
+        left = x - w / 2
+        rect_top = y - h / 2
+        right = x + w / 2
+        rect_bottom = y + h / 2
+        top = rect_top - radius
+        canvas.create_rectangle(
+            left,
+            rect_top,
+            right,
+            rect_bottom,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_arc(
+            left,
+            top,
+            right,
+            top + 2 * radius,
+            start=0,
+            extent=180,
+            style=tk.CHORD,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
+            x,
+            rect_top + (rect_bottom - rect_top) / 2,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        box_font = self._scaled_font(scale * 0.4)
+        self._draw_module_reference_box(
+            canvas,
+            x,
+            rect_bottom,
+            w,
+            module_text,
+            outline_color,
+            line_width,
+            box_font,
+            obj_id,
+        )
+
+    def draw_away_context_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Context",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away context: rectangle with rounded bottom."""
+        outline_color = self._resolve_outline(outline_color)
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        padding = 4
+        t_width, t_height = self.get_text_size(text, font_obj)
+        w = max(scale, t_width + 2 * padding)
+        h = max(scale * 0.6, t_height + 2 * padding)
+        radius = w / 2
+        left = x - w / 2
+        right = x + w / 2
+        rect_top = y - h / 2
+        rect_bottom = y + h / 2 - radius
+        canvas.create_rectangle(
+            left,
+            rect_top,
+            right,
+            rect_bottom,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_arc(
+            left,
+            rect_bottom,
+            right,
+            rect_bottom + 2 * radius,
+            start=180,
+            extent=180,
+            style=tk.CHORD,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
+            x,
+            rect_top + (rect_bottom - rect_top) / 2,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        box_font = self._scaled_font(scale * 0.4)
+        self._draw_module_reference_box(
+            canvas,
+            x,
+            rect_bottom + 2 * radius,
+            w,
+            module_text,
+            outline_color,
+            line_width,
+            box_font,
+            obj_id,
+        )
+
+    def _draw_away_assumption_or_justification(
+        self,
+        canvas,
+        x,
+        y,
+        scale,
+        text,
+        label,
+        module_text,
+        fill,
+        outline_color,
+        line_width,
+        font_obj,
+        obj_id,
+    ):
+        outline_color = self._resolve_outline(outline_color)
+        if font_obj is None:
+            font_obj = self._scaled_font(scale)
+        padding = 4
+        t_width, t_height = self.get_text_size(text, font_obj)
+        w = max(scale, t_width + 2 * padding)
+        h = max(scale * 0.6, t_height + 2 * padding)
+        radius = w / 2
+        left = x - w / 2
+        right = x + w / 2
+        rect_bottom = y + h / 2
+        rect_top = y - h / 2 + radius
+        canvas.create_rectangle(
+            left,
+            rect_top,
+            right,
+            rect_bottom,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_arc(
+            left,
+            rect_top - 2 * radius,
+            right,
+            rect_top,
+            start=0,
+            extent=180,
+            style=tk.CHORD,
+            fill=fill,
+            outline=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
+        canvas.create_text(
+            x,
+            rect_top + (rect_bottom - rect_top) / 2,
+            text=text,
+            font=font_obj,
+            anchor="center",
+            width=w - 2 * padding,
+            tags=(obj_id,),
+        )
+        label_font = tkFont.Font(font=font_obj)
+        label_font.configure(weight="bold")
+        offset = padding
+        canvas.create_text(
+            right - offset,
+            rect_top - radius + offset,
+            text=label,
+            font=label_font,
+            anchor="ne",
+            tags=(obj_id,),
+        )
+        box_font = self._scaled_font(scale * 0.4)
+        self._draw_module_reference_box(
+            canvas,
+            x,
+            rect_bottom,
+            w,
+            module_text,
+            outline_color,
+            line_width,
+            box_font,
+            obj_id,
+        )
+
+    def draw_away_assumption_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Assumption",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away assumption shape."""
+        self._draw_away_assumption_or_justification(
+            canvas,
+            x,
+            y,
+            scale,
+            text,
+            "A",
+            module_text,
+            fill,
+            outline_color,
+            line_width,
+            font_obj,
+            obj_id,
+        )
+
+    def draw_away_justification_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        text="Justification",
+        module_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw an away justification shape."""
+        self._draw_away_assumption_or_justification(
+            canvas,
+            x,
+            y,
+            scale,
+            text,
+            "J",
+            module_text,
+            fill,
+            outline_color,
+            line_width,
+            font_obj,
+            obj_id,
+        )
+
+    def draw_away_module_shape(
+        self,
+        canvas,
+        x,
+        y,
+        scale=60.0,
+        **kwargs,
+    ):
         self.draw_module_shape(canvas, x, y, scale=scale, **kwargs)
-        self.draw_shared_marker(canvas, x + scale / 2, y - scale * 0.3, 1)
 
 
 # Create a single GSNDrawingHelper object for convenience

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -888,6 +888,16 @@ class GSNDiagramWindow(tk.Frame):
         if snap is not None:
             self.app.diagram_clipboard = snap
             self.app.diagram_clipboard_type = "GSN"
+            if self.selected_node.parents:
+                parent = self.selected_node.parents[0]
+                rel = (
+                    "context"
+                    if self.selected_node in parent.context_children
+                    else "solved"
+                )
+            else:
+                rel = "solved"
+            self.app.clipboard_relation = rel
 
     def cut_selected(self, _event=None) -> None:
         if not self.app or not self.selected_node:

--- a/tests/test_auto_paste_gsn_clone.py
+++ b/tests/test_auto_paste_gsn_clone.py
@@ -1,0 +1,30 @@
+import types
+
+from gsn import GSNNode, GSNDiagram
+from AutoML import AutoMLApp, AutoML_Helper
+from gui import messagebox
+
+
+def test_paste_node_creates_clone():
+    root = GSNNode("Root", "Goal")
+    child = GSNNode("Child", "Goal")
+    root.add_child(child)
+    diag = GSNDiagram(root)
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.root_node = root
+    app.top_events = []
+    app.clipboard_node = child
+    app.selected_node = root
+    app.analysis_tree = types.SimpleNamespace(selection=lambda: [], item=lambda *a, **k: {})
+    app.cut_mode = False
+    app.update_views = lambda: None
+    app._find_gsn_diagram = lambda n: diag
+    AutoML_Helper.calculate_assurance_recursive = lambda *a, **k: None
+    messagebox.showinfo = lambda *a, **k: None
+    app.paste_node()
+    assert len(root.children) == 2
+    clone = root.children[-1]
+    assert clone is not child
+    assert clone.original is child
+    assert not clone.is_primary_instance
+    assert clone in diag.nodes

--- a/tests/test_gsn_away_shapes.py
+++ b/tests/test_gsn_away_shapes.py
@@ -1,0 +1,121 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gsn.nodes import GSNNode
+from gsn.diagram import GSNDiagram
+from gui.drawing_helper import GSNDrawingHelper
+
+class StubCanvas:
+    def __init__(self):
+        self.items = []
+    def create_rectangle(self, *args, **kwargs):
+        self.items.append(("rect", args, kwargs))
+    def create_arc(self, *args, **kwargs):
+        self.items.append(("arc", args, kwargs))
+    def create_text(self, *args, **kwargs):
+        self.items.append(("text", args, kwargs))
+    def create_line(self, *args, **kwargs):
+        self.items.append(("line", args, kwargs))
+    def bbox(self, tag):
+        return None
+    def tag_lower(self, *args, **kwargs):
+        pass
+    def tag_raise(self, *args, **kwargs):
+        pass
+
+class RecordingHelper:
+    def __init__(self):
+        self.calls = []
+    def get_text_size(self, text, font_obj):
+        return len(text) * 5, 10
+    def draw_away_goal_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("goal", module_text))
+    def draw_away_solution_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("solution", module_text))
+    def draw_away_context_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("context", module_text))
+    def draw_away_assumption_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("assumption", module_text))
+    def draw_away_justification_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("justification", module_text))
+    # Unused stubs
+    def draw_goal_shape(self, *a, **k):
+        pass
+    def draw_solution_shape(self, *a, **k):
+        pass
+    def draw_module_shape(self, *a, **k):
+        pass
+    def draw_assumption_shape(self, *a, **k):
+        pass
+    def draw_justification_shape(self, *a, **k):
+        pass
+    def draw_context_shape(self, *a, **k):
+        pass
+    def draw_solved_by_connection(self, *a, **k):
+        pass
+    def draw_in_context_connection(self, *a, **k):
+        pass
+    def point_on_shape(self, shape, target_pt):
+        return target_pt
+
+@pytest.mark.parametrize("node_type,expected", [
+    ("Goal", "goal"),
+    ("Solution", "solution"),
+    ("Context", "context"),
+    ("Assumption", "assumption"),
+    ("Justification", "justification"),
+])
+def test_away_shapes_receive_module_identifier(node_type, expected):
+    module = GSNNode("Mod", "Module")
+    original = GSNNode("Orig", node_type)
+    original.parents.append(module)
+    clone = GSNNode("Clone", node_type, is_primary_instance=False, original=original)
+    helper = RecordingHelper()
+    diag = GSNDiagram(clone, drawing_helper=helper)
+    canvas = StubCanvas()
+    diag.draw(canvas)
+    assert helper.calls[0] == (expected, "Mod")
+
+
+def test_away_shapes_without_module_identifier():
+    original = GSNNode("Orig", "Goal")
+    clone = GSNNode("Clone", "Goal", is_primary_instance=False, original=original)
+    helper = RecordingHelper()
+    diag = GSNDiagram(clone, drawing_helper=helper)
+    canvas = StubCanvas()
+    diag.draw(canvas)
+    assert helper.calls[0] == ("goal", "")
+
+
+class DummyFont:
+    def measure(self, text):
+        return len(text) * 5
+
+    def metrics(self, _):
+        return 10
+
+
+def test_away_solution_module_box_adjacent():
+    helper = GSNDrawingHelper()
+    helper.get_text_size = lambda text, font: (len(text) * 5, 10)
+    helper._scaled_font = lambda scale: DummyFont()
+    canvas = StubCanvas()
+    helper.draw_away_solution_shape(
+        canvas,
+        0,
+        0,
+        scale=60,
+        text="S",
+        module_text="M",
+        font_obj=DummyFont(),
+    )
+    rects = [item for item in canvas.items if item[0] == "rect"]
+    assert len(rects) == 2
+    outer = rects[0][1]
+    box = rects[1][1]
+    outer_bottom = outer[3]
+    box_top = box[1]
+    assert abs(box_top - outer_bottom) <= 1

--- a/tests/test_gsn_clone_data_sync.py
+++ b/tests/test_gsn_clone_data_sync.py
@@ -1,0 +1,48 @@
+from gsn import GSNNode, GSNDiagram
+from gui.gsn_config_window import GSNElementConfig
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+    def get(self):
+        return self.value
+
+
+class DummyText:
+    def __init__(self, text=""):
+        self.text = text
+    def get(self, *_args, **_kwargs):
+        return self.text
+
+
+def _configure(node, diagram, name="", desc="", notes=""):
+    cfg = GSNElementConfig.__new__(GSNElementConfig)
+    cfg.node = node
+    cfg.diagram = diagram
+    cfg.name_var = DummyVar(name or node.user_name)
+    cfg.desc_text = DummyText(desc or node.description)
+    cfg.notes_text = DummyText(notes or node.manager_notes)
+    cfg.destroy = lambda: None
+    cfg._on_ok()
+
+
+def test_goal_clone_and_original_sync():
+    original = GSNNode("Orig", "Goal")
+    diag = GSNDiagram(original)
+    clone = original.clone()
+    diag.add_node(clone)
+
+    _configure(clone, diag, name="Updated", desc="Desc", notes="Note")
+    assert original.user_name == "Updated"
+    assert original.description == "Desc"
+    assert clone.user_name == "Updated"
+    assert clone.description == "Desc"
+    assert clone.manager_notes == "Note"
+    assert original.is_primary_instance
+    assert not clone.is_primary_instance
+
+    _configure(original, diag, name="New", desc="NewDesc", notes="NewNote")
+    assert clone.user_name == "New"
+    assert clone.description == "NewDesc"
+    assert clone.manager_notes == "NewNote"

--- a/tests/test_gsn_clone_movement.py
+++ b/tests/test_gsn_clone_movement.py
@@ -31,3 +31,63 @@ def test_moving_gsn_clone_preserves_original_position():
 
     assert (root.x, root.y) == (0, 0)
     assert (clone.x, clone.y) == (150, 160)
+
+
+def test_moving_gsn_original_preserves_clone_position():
+    root = GSNNode("A", "Goal", x=0, y=0)
+    clone = root.clone()
+    clone.x = 50
+    clone.y = 60
+    diag = GSNDiagram(root)
+    diag.add_node(clone)
+    root.display_label = ""
+    clone.display_label = ""
+
+    def get_all_nodes(self, _):
+        return [root, clone]
+
+    def get_all_fmea(self):
+        return []
+
+    app = object.__new__(AutoMLApp)
+    app.root_node = root
+    app.get_all_nodes = types.MethodType(get_all_nodes, app)
+    app.get_all_fmea_entries = types.MethodType(get_all_fmea, app)
+
+    root.x += 100
+    root.y += 100
+    AutoMLApp.move_subtree(app, root, 100, 100)
+    AutoMLApp.sync_nodes_by_id(app, root)
+
+    assert (clone.x, clone.y) == (50, 60)
+    assert (root.x, root.y) == (100, 100)
+
+
+def test_moving_parent_with_clone_child_keeps_clone_static():
+    root = GSNNode("A", "Goal", x=0, y=0)
+    clone = root.clone(root)
+    clone.x = 50
+    clone.y = 60
+    diag = GSNDiagram(root)
+    diag.add_node(clone)
+    root.display_label = ""
+    clone.display_label = ""
+
+    def get_all_nodes(self, _):
+        return [root, clone]
+
+    def get_all_fmea(self):
+        return []
+
+    app = object.__new__(AutoMLApp)
+    app.root_node = root
+    app.get_all_nodes = types.MethodType(get_all_nodes, app)
+    app.get_all_fmea_entries = types.MethodType(get_all_fmea, app)
+
+    root.x += 10
+    root.y += 20
+    AutoMLApp.move_subtree(app, root, 10, 20)
+    AutoMLApp.sync_nodes_by_id(app, root)
+
+    assert (root.x, root.y) == (10, 20)
+    assert (clone.x, clone.y) == (50, 60)

--- a/tests/test_gsn_clone_reject.py
+++ b/tests/test_gsn_clone_reject.py
@@ -1,0 +1,41 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gsn.nodes import GSNNode
+from gsn.diagram import GSNDiagram
+from AutoML import AutoMLApp, AutoML_Helper
+from gui import messagebox
+
+
+def test_clone_rejects_unsupported_types():
+    strategy = GSNNode("S", "Strategy")
+    with pytest.raises(ValueError):
+        strategy.clone()
+    module = GSNNode("M", "Module")
+    with pytest.raises(ValueError):
+        module.clone()
+
+
+def test_paste_rejects_disallowed_clone():
+    root = GSNNode("Root", "Goal")
+    strat = GSNNode("Strat", "Strategy")
+    root.add_child(strat)
+    diag = GSNDiagram(root)
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.root_node = root
+    app.top_events = []
+    app.clipboard_node = strat
+    app.selected_node = root
+    app.analysis_tree = type("T", (), {"selection": lambda self: [], "item": lambda *a, **k: {}})()
+    app.cut_mode = False
+    app.update_views = lambda: None
+    app._find_gsn_diagram = lambda n: diag
+    AutoML_Helper.calculate_assurance_recursive = lambda *a, **k: None
+    called = {}
+    messagebox.showwarning = lambda *a, **k: called.setdefault("msg", a[1] if len(a) > 1 else "")
+    app.paste_node()
+    assert len(root.children) == 1
+    assert called

--- a/tests/test_gsn_copy_paste.py
+++ b/tests/test_gsn_copy_paste.py
@@ -57,15 +57,41 @@ class GSNCopyPasteTests(unittest.TestCase):
         messagebox.showinfo = self._orig_info
         messagebox.showwarning = self._orig_warn
 
-    def test_pasted_node_added_to_diagram(self):
+    def test_pasted_unsupported_node_rejected(self):
         self.app.copy_node()
         self.app.selected_node = self.other  # paste into a different goal
         self.app.paste_node()
         self.assertEqual(len(self.diagram.nodes), 3)
-        self.assertEqual(len(self.other.children), 1)
-        cloned = self.other.children[0]
-        self.assertIs(cloned, self.child)
-        self.assertIn(cloned, self.diagram.nodes)
+        self.assertEqual(len(self.other.children), 0)
+
+    def test_context_relation_preserved_on_paste(self):
+        root = GSNNode("Root", "Goal")
+        ctx = GSNNode("Ctx", "Context")
+        root.context_children.append(ctx)
+        ctx.parents.append(root)
+        diag = GSNDiagram(root)
+        diag.add_node(ctx)
+        app = AutoMLApp.__new__(AutoMLApp)
+        app.root_node = root
+        app.analysis_tree = DummyTree()
+        app.top_events = []
+        app.update_views = lambda: None
+        app.selected_node = ctx
+        orig_info = messagebox.showinfo
+        orig_warn = messagebox.showwarning
+        messagebox.showinfo = lambda *a, **k: None
+        messagebox.showwarning = lambda *a, **k: None
+        try:
+            app.copy_node()
+            app.selected_node = root
+            app.paste_node()
+        finally:
+            messagebox.showinfo = orig_info
+            messagebox.showwarning = orig_warn
+        assert len(root.context_children) == 2
+        pasted = root.context_children[-1]
+        assert pasted is not ctx
+        assert pasted.original is ctx
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- tighten clone rejection to warn and abort when attempting to copy unsupported GSN node types
- align away element module reference boxes without gaps or stray squares and add geometry regression tests
- update copy/paste and clone rejection tests for new behavior

## Testing
- `pytest tests/test_gsn_away_shapes.py tests/test_gsn_clone_movement.py tests/test_auto_paste_gsn_clone.py tests/test_gsn_clone_data_sync.py tests/test_gsn_copy_paste.py tests/test_gsn_clone_reject.py tests/test_gsn_clone_paste.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `radon cc -j AutoML.py gsn/diagram.py gui/drawing_helper.py gui/gsn_diagram_window.py | cut -c1-200`


------
https://chatgpt.com/codex/tasks/task_b_68a7d534ede48327887e22e14a236af0