### PR TITLE
Fix GSN canvas selection on empty clicks

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -409,7 +409,7 @@ class GSNDiagramWindow(tk.Frame):
             self.selected_connection = None
         if not hasattr(self, "_selected_conn_id"):
             self._selected_conn_id = ""
-        node = self._node_at(cx, cy)
+        node = self._node_at(event.x, event.y)
         connection = self._connection_at(cx, cy)
         app = getattr(self, "app", None)
         if self._connect_mode:
@@ -752,6 +752,12 @@ class GSNDiagramWindow(tk.Frame):
         cx, cy = canvasx(x), canvasy(y)
         items = self.canvas.find_closest(cx, cy)
         for item in items:
+            bbox = getattr(self.canvas, "bbox", lambda *_: None)(item)
+            if bbox:
+                x1, y1, x2, y2 = bbox
+                margin = 5
+                if not (x1 - margin <= cx <= x2 + margin and y1 - margin <= cy <= y2 + margin):
+                    continue
             for tag in self.canvas.gettags(item):
                 node = self.id_to_node.get(tag)
                 if node:
@@ -775,7 +781,8 @@ class GSNDiagramWindow(tk.Frame):
         canvasx = getattr(self.canvas, "canvasx", lambda v: v)
         canvasy = getattr(self.canvas, "canvasy", lambda v: v)
         cx, cy = canvasx(x), canvasy(y)
-        for node in self.diagram._traverse():
+        traverse = getattr(getattr(self, "diagram", None), "_traverse", lambda: [])
+        for node in traverse():
             if (cx - node.x) ** 2 + (cy - node.y) ** 2 <= (20 * self.zoom) ** 2:
                 return node
         return None

--- a/tests/test_gsn_selection.py
+++ b/tests/test_gsn_selection.py
@@ -43,3 +43,42 @@ def test_gsn_find_node_strategies():
     assert win._node_at_strategy4(10, 10) is node
     assert win._node_at(10, 10) is node
 
+
+def test_gsn_find_node_strategies_far_click():
+    offset = 50
+
+    class CanvasStub:
+        def canvasx(self, x):
+            return x + offset
+
+        def canvasy(self, y):
+            return y
+
+        def find_overlapping(self, x1, y1, x2, y2):
+            return []
+
+        def find_closest(self, x, y):
+            return ["id"]
+
+        def bbox(self, tag):
+            if tag == "id":
+                return [50, 0, 70, 30]
+            return None
+
+        def gettags(self, item):
+            return [item]
+
+    node = GSNNode("A", "Goal", x=60, y=15)
+    diag = GSNDiagram(node)
+    win = object.__new__(GSNDiagramWindow)
+    win.canvas = CanvasStub()
+    win.id_to_node = {"id": node}
+    win.diagram = diag
+    win.zoom = 1.0
+
+    assert win._node_at_strategy1(1000, 1000) is None
+    assert win._node_at_strategy2(1000, 1000) is None
+    assert win._node_at_strategy3(1000, 1000) is None
+    assert win._node_at_strategy4(1000, 1000) is None
+    assert win._node_at(1000, 1000) is None
+


### PR DESCRIPTION
## Summary
- Guard GSN diagram node lookup against off-target clicks by verifying proximity to node bounds
- Pass raw event coordinates to node hit-testing and safely traverse diagram in fallback search
- Cover distant click behavior in GSN selection tests

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_selection.py`
- `pytest` *(fails: AttributeError: 'FaultTreeNode' object has no attribute 'context_children')*
- `python -m radon cc -s -j gui/gsn_diagram_window.py | jq '."gui/gsn_diagram_window.py"[] | select(.name|test("_node_at_strategy"))'`


------
https://chatgpt.com/codex/tasks/task_b_68a85f9677a0832795e3b9ad2c6a0a97