### PR TITLE
Fix GSN canvas selection and improve paste handling

### DIFF
--- a/tests/test_gsn_node_at.py
+++ b/tests/test_gsn_node_at.py
@@ -1,0 +1,107 @@
+"""Tests for GSNDiagramWindow node selection helpers.
+
+These tests exercise the four different ``_node_at`` strategies used by
+``GSNDiagramWindow`` to locate a node under a given cursor position.  The
+regression ensures that clicking on empty canvas space does not randomly
+select a node which previously happened due to ``Canvas.find_closest`` always
+returning an item.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gsn import GSNNode
+from gui.gsn_diagram_window import GSNDiagramWindow
+
+
+class _FakeCanvas:
+    """Minimal stand-in for :class:`tkinter.Canvas` used for testing."""
+
+    def __init__(self) -> None:
+        self._item_tags: dict[int, tuple[str, ...]] = {}
+        self._tag_bbox: dict[str, tuple[int, int, int, int]] = {}
+
+    def register(self, item_id: int, tag: str, bbox: tuple[int, int, int, int]) -> None:
+        self._item_tags[item_id] = (tag,)
+        self._tag_bbox[tag] = bbox
+
+    def canvasx(self, value: float) -> float:  # pragma: no cover - trivial
+        return value
+
+    def canvasy(self, value: float) -> float:  # pragma: no cover - trivial
+        return value
+
+    def find_overlapping(self, x1, y1, x2, y2):
+        result = []
+        for item, tags in self._item_tags.items():
+            x1b, y1b, x2b, y2b = self._tag_bbox[tags[0]]
+            if not (x2 < x1b or x1 > x2b or y2 < y1b or y1 > y2b):
+                result.append(item)
+        return result
+
+    def find_closest(self, _x, _y):  # pragma: no cover - deterministic
+        return list(self._item_tags.keys())
+
+    def gettags(self, item):  # pragma: no cover - trivial
+        return self._item_tags.get(item, ())
+
+    def bbox(self, item_or_tag):  # pragma: no cover - trivial
+        if isinstance(item_or_tag, str):
+            return self._tag_bbox.get(item_or_tag)
+        for tag in self._item_tags.get(item_or_tag, ()):  # pragma: no cover
+            return self._tag_bbox.get(tag)
+        return None
+
+
+class _FakeDiagram:
+    def __init__(self, nodes):  # pragma: no cover - simple container
+        self._nodes = nodes
+
+    def _traverse(self):  # pragma: no cover - simple iterator
+        return list(self._nodes)
+
+
+@pytest.fixture
+def window() -> GSNDiagramWindow:
+    node = GSNNode("Goal", "Goal", x=0, y=0)
+    canvas = _FakeCanvas()
+    canvas.register(1, "n1", (0, 0, 10, 10))
+    diagram = _FakeDiagram([node])
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.canvas = canvas
+    win.id_to_node = {"n1": node}
+    win.diagram = diagram
+    win.zoom = 1.0
+    return win
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "_node_at_strategy1",
+        "_node_at_strategy2",
+        "_node_at_strategy3",
+        "_node_at_strategy4",
+        "_node_at",
+    ],
+)
+def test_click_outside_returns_none(window: GSNDiagramWindow, method: str) -> None:
+    strat = getattr(window, method)
+    assert strat(100, 100) is None
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "_node_at_strategy1",
+        "_node_at_strategy2",
+        "_node_at_strategy3",
+        "_node_at_strategy4",
+        "_node_at",
+    ],
+)
+def test_click_inside_returns_node(window: GSNDiagramWindow, method: str) -> None:
+    strat = getattr(window, method)
+    assert strat(5, 5) is window.id_to_node["n1"]
+


### PR DESCRIPTION
## Summary
- prevent random node selection on GSN canvas by verifying click bounds
- handle missing context relations during copy/cut operations
- allow pasting GSN nodes across diagrams without unwanted clones
- add regression tests for `_node_at` strategies

## Testing
- `pytest -q`
- `radon cc -j gui/gsn_diagram_window.py | jq '."gui/gsn_diagram_window.py"[] | select(.name | test("_node_at|_node_from_canvas_item"))'`


------
https://chatgpt.com/codex/tasks/task_b_68a85f9677a0832795e3b9ad2c6a0a97