### PR TITLE
Add GSN diagram connection helper and context-aware cloning

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -51,6 +51,20 @@ class GSNDiagram:
             self.nodes.append(node)
 
     # ------------------------------------------------------------------
+    def connect(self, parent: GSNNode, child: GSNNode, relation: str = "solved") -> None:
+        """Create a relationship between ``parent`` and ``child``.
+
+        The nodes are automatically added to the diagram if they are not
+        already present.  ``relation`` may be ``"solved"`` for a solved-by
+        link or ``"context"`` for an in-context-of relationship.
+        """
+        if parent not in self.nodes:
+            self.add_node(parent)
+        if child not in self.nodes:
+            self.add_node(child)
+        parent.add_child(child, relation=relation)
+
+    # ------------------------------------------------------------------
     def to_dict(self) -> dict:
         """Return a JSON-serialisable representation of this diagram."""
         return {

--- a/tests/test_gsn_diagram_connect.py
+++ b/tests/test_gsn_diagram_connect.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gsn import GSNNode, GSNDiagram
+
+
+def test_connect_adds_relationship_and_nodes():
+    root = GSNNode("G1", "Goal")
+    ctx = GSNNode("C1", "Context")
+    diag = GSNDiagram(root)
+    # Context node not added to diagram yet; connect should add and link
+    diag.connect(root, ctx, relation="context")
+    assert ctx in diag.nodes
+    assert ctx in root.children
+    assert ctx in root.context_children
+
+
+def test_connect_solved_relationship():
+    root = GSNNode("G1", "Goal")
+    sol = GSNNode("S1", "Solution")
+    diag = GSNDiagram(root)
+    diag.connect(root, sol)
+    assert sol in diag.nodes
+    assert sol in root.children
+    assert sol not in root.context_children


### PR DESCRIPTION
## Summary
- add `GSNDiagram.connect` to easily create relationships between nodes
- ensure context/assumption/justification clones attach with in-context-of links
- cover new connection helper with unit tests

## Testing
- `pytest tests/test_gsn_diagram_connect.py tests/test_gsn_clone_context_relation.py -q`
- `radon cc -j gsn/diagram.py gsn/nodes.py`


------
https://chatgpt.com/codex/tasks/task_b_68a87119d3ac83278a0bbb4ec379bb97