### PR TITLE
Support parent context when cloning nodes

### DIFF
--- a/gui/causal_bayesian_network_window.py
+++ b/gui/causal_bayesian_network_window.py
@@ -211,7 +211,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
         name = simpledialog.askstring("New Analysis", "Name:", parent=self)
         if not name or self._doc_name_exists(name):
             if name:
-                messagebox.showerror("New Analysis", "Analysis name already exists")
+                messagebox.showwarning("New Analysis", "Analysis name already exists")
             return
         doc = CausalBayesianNetworkDoc(name)
         if not hasattr(self.app, "cbn_docs"):

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -196,7 +196,7 @@ class GSNExplorer(tk.Frame):
         name = simpledialog.askstring("New GSN Diagram", "Root goal name:", parent=self)
         if not name or self._diagram_name_exists(name):
             if name:
-                messagebox.showerror("New GSN Diagram", "Diagram name already exists")
+                messagebox.showwarning("New GSN Diagram", "Diagram name already exists")
             return
         undo = getattr(self.app, "push_undo_state", None)
         if undo:

--- a/tests/test_clone_gsn_node.py
+++ b/tests/test_clone_gsn_node.py
@@ -27,6 +27,14 @@ class CloneGSNNodeTests(unittest.TestCase):
         self.assertEqual(clone.y, original.y + 100)
         self.assertNotEqual(clone.unique_id, original.unique_id)
 
+    def test_clone_context_attaches_to_parent(self):
+        app = AutoMLApp.__new__(AutoMLApp)
+        parent = GSNNode("Parent", "Goal")
+        ctx = GSNNode("Ctx", "Context")
+        clone = app.clone_node_preserving_id(ctx, parent)
+        self.assertIn(clone, parent.context_children)
+        self.assertIn(parent, clone.parents)
+
 
 if __name__ == "__main__":  # pragma: no cover - manual test execution
     unittest.main()


### PR DESCRIPTION
## Summary
- allow `clone_node_preserving_id` to take an optional parent and link context nodes automatically
- propagate parent information through paste helpers
- use warnings for duplicate diagram or analysis names

## Testing
- `radon cc AutoML.py | rg "clone_node_preserving_id" -n -A2`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a88021df708327864f50c64e8186ce