### PR TITLE
Handle away goal drawing for clones

### DIFF
--- a/tests/test_gsn_away_shapes.py
+++ b/tests/test_gsn_away_shapes.py
@@ -44,8 +44,8 @@ class RecordingHelper:
     def draw_away_justification_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
         self.calls.append(("justification", module_text))
     # Unused stubs
-    def draw_goal_shape(self, *a, **k):
-        pass
+    def draw_goal_shape(self, canvas, x, y, scale, text="", module_text="", font_obj=None, obj_id=""):
+        self.calls.append(("goal_primary", module_text))
     def draw_solution_shape(self, *a, **k):
         pass
     def draw_module_shape(self, *a, **k):
@@ -90,6 +90,16 @@ def test_away_shapes_without_module_identifier():
     canvas = StubCanvas()
     diag.draw(canvas)
     assert helper.calls[0] == ("goal", "")
+
+
+def test_goal_clone_with_original_but_primary_flag_draws_away_shape():
+    original = GSNNode("Orig", "Goal")
+    clone = GSNNode("Clone", "Goal", original=original)
+    helper = RecordingHelper()
+    diag = GSNDiagram(clone, drawing_helper=helper)
+    canvas = StubCanvas()
+    diag.draw(canvas)
+    assert helper.calls[0][0] == "goal"
 
 
 class DummyFont:


### PR DESCRIPTION
## Summary
- Treat nodes whose `original` differs from themselves as away nodes in GSN diagrams
- Add helper to select context drawing functions and cover clone scenario
- Verify cloned goals draw away shapes even when the primary flag is missing

## Testing
- `radon cc -j gsn/diagram.py | jq '."gsn/diagram.py"[] | select(.name=="_draw_node")'`
- `pytest -q` *(fails: tests/test_cbn_new_doc_unique.py::test_new_doc_rejects_duplicate_name, tests/test_gsn_clone_reject.py::test_paste_rejects_disallowed_clone, tests/test_gsn_copy_paste.py::GSNCopyPasteTests::test_context_relation_preserved_on_paste, tests/test_gsn_copy_paste.py::GSNCopyPasteTests::test_pasted_unsupported_node_rejected, tests/test_gsn_explorer.py::test_new_diagram_rejects_duplicate_name)*

------
https://chatgpt.com/codex/tasks/task_b_68a88028a5b883279df69367a4787c57