### PR TITLE
Clear relationships on GSN clone reset

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -18947,7 +18947,11 @@ class AutoMLApp:
             node.unique_id = str(uuid.uuid4())
             node.is_primary_instance = True
             node.original = node
-            for child in getattr(node, "children", []):
+            old_children = list(getattr(node, "children", []))
+            node.children = []
+            node.parents = []
+            node.context_children = []
+            for child in old_children:
                 self._reset_gsn_clone(child)
 
     # ------------------------------------------------------------------

--- a/tests/test_gsn_clone_relationships.py
+++ b/tests/test_gsn_clone_relationships.py
@@ -1,0 +1,38 @@
+import unittest
+import types
+import os
+import sys
+import copy
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from gsn.nodes import GSNNode
+
+
+class GSNCloneRelationshipTests(unittest.TestCase):
+    def test_reset_clone_clears_relationships(self):
+        app = AutoMLApp.__new__(AutoMLApp)
+        parent = GSNNode("parent", "Goal")
+        child = GSNNode("child", "Goal")
+        parent.add_child(child)
+        clone = copy.deepcopy(parent)
+        old_child = clone.children[0]
+        app._reset_gsn_clone(clone)
+        self.assertEqual(clone.children, [])
+        self.assertEqual(clone.parents, [])
+        self.assertEqual(clone.context_children, [])
+        self.assertEqual(old_child.children, [])
+        self.assertEqual(old_child.parents, [])
+        self.assertEqual(old_child.context_children, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Clear parent, child and context relationships when resetting a GSN node clone
- Recursively reset former children and add regression test ensuring clones start empty

## Testing
- `pytest tests/test_gsn_clone_relationships.py::GSNCloneRelationshipTests::test_reset_clone_clears_relationships -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*
- `radon cc AutoML.py -j | jq '."AutoML.py"[] | select(.name == "_reset_gsn_clone")'`


------
https://chatgpt.com/codex/tasks/task_b_68a8804c71ac832799844e7a309e4c87