### PR TITLE
Allow annotations as context parents

### DIFF
--- a/gsn/nodes.py
+++ b/gsn/nodes.py
@@ -93,6 +93,9 @@ class GSNNode:
                 "Strategy": {"Context", "Assumption", "Justification"},
                 "Solution": {"Context", "Assumption", "Justification"},
                 "Module": {"Context", "Assumption", "Justification"},
+                "Context": {"Context", "Assumption", "Justification"},
+                "Assumption": {"Context", "Assumption", "Justification"},
+                "Justification": {"Context", "Assumption", "Justification"},
             }
             if self.node_type not in allowed or child.node_type not in allowed[self.node_type]:
                 raise ValueError(

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -3,6 +3,7 @@ import types
 import csv
 import tempfile
 from unittest import mock
+import pytest
 
 import gui.gsn_diagram_window as gdw
 from gui.gsn_diagram_window import GSNDiagramWindow
@@ -86,12 +87,13 @@ def test_temp_connection_line_has_arrow_in_context_mode():
     assert lines[0].get("arrow") == tk.LAST
 
 
-def test_on_release_creates_context_link():
+@pytest.mark.parametrize("typ", ["Context", "Assumption", "Justification"])
+def test_on_release_creates_context_link(typ):
     """Releasing in context mode should mark the relation accordingly."""
     win = GSNDiagramWindow.__new__(GSNDiagramWindow)
     win.zoom = 1.0
     parent = GSNNode("p", "Goal")
-    child = GSNNode("c", "Context")
+    child = GSNNode("c", typ)
 
     class CanvasStub:
         def __init__(self):
@@ -122,6 +124,43 @@ def test_on_release_creates_context_link():
     assert child in parent.children
     assert child in parent.context_children
     assert win.canvas.cursor == ""
+
+
+@pytest.mark.parametrize("ptype", ["Context", "Assumption", "Justification"])
+@pytest.mark.parametrize("ctype", ["Context", "Assumption", "Justification"])
+def test_on_release_context_link_from_annotation(ptype, ctype):
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.zoom = 1.0
+    parent = GSNNode("p", ptype)
+    child = GSNNode("c", ctype)
+
+    class CanvasStub:
+        def __init__(self):
+            self.cursor = None
+
+        def canvasx(self, x):
+            return x
+
+        def canvasy(self, y):
+            return y
+
+        def delete(self, *a, **k):
+            pass
+
+        def configure(self, **kwargs):
+            if "cursor" in kwargs:
+                self.cursor = kwargs["cursor"]
+
+    win.canvas = CanvasStub()
+    win._node_at = lambda x, y: child
+    win.refresh = lambda: None
+
+    GSNDiagramWindow.connect_in_context(win)
+    win._connect_parent = parent
+    event = type("Event", (), {"x": 0, "y": 0})
+    win._on_release(event)
+    assert child in parent.children
+    assert child in parent.context_children
 
 
 def test_solved_by_cursor_and_reset():

--- a/tests/test_gsn_relationship_validation.py
+++ b/tests/test_gsn_relationship_validation.py
@@ -21,3 +21,12 @@ def test_assumption_cannot_have_children():
     goal = GSNNode("g", "Goal")
     with pytest.raises(ValueError):
         assump.add_child(goal)
+
+
+@pytest.mark.parametrize("parent", ["Context", "Assumption", "Justification"])
+@pytest.mark.parametrize("child", ["Context", "Assumption", "Justification"])
+def test_annotation_context_links_allowed(parent, child):
+    p = GSNNode("p", parent)
+    c = GSNNode("c", child)
+    p.add_child(c, relation="context")
+    assert c in p.context_children

--- a/tests/test_statusbar_transparency.py
+++ b/tests/test_statusbar_transparency.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-PyQt6 = pytest.importorskip("PyQt6")
+pytest.importorskip("PyQt6.QtWidgets")
 from PyQt6.QtWidgets import QApplication
 from gui.faults_gui import FaultsWindow
 


### PR DESCRIPTION
## Summary
- permit Context/Assumption/Justification nodes to host `in context of` links
- cover annotation context connections in validation and GUI tests
- ensure PyQt6 tests are skipped when Qt widgets unavailable

## Testing
- `radon cc -s -j gsn/nodes.py`
- `PYTHONPATH=. pytest tests/test_gsn_relationship_validation.py`
- `PYTHONPATH=. pytest tests/test_gsn_diagram_window.py tests/test_statusbar_transparency.py`
- `pytest` *(fails: AttributeError: 'SimpleNamespace' object ...)*

------
https://chatgpt.com/codex/tasks/task_b_68a890539c708327bf6d0aaf57d06596