### PR TITLE
Fix connection creation when releasing on nodes

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -510,15 +510,16 @@ class GSNDiagramWindow(tk.Frame):
         self.refresh()
 
     def _on_release(self, event):  # pragma: no cover - requires tkinter
-        cx = self.canvas.canvasx(event.x)
-        cy = self.canvas.canvasy(event.y)
+        raw_x, raw_y = event.x, event.y
+        cx = self.canvas.canvasx(raw_x)
+        cy = self.canvas.canvasy(raw_y)
         if self._connect_mode and self._connect_parent:
             self.canvas.delete("_temp_conn")
             anim = getattr(self, "_temp_conn_anim", None)
             if anim:
                 self.canvas.after_cancel(anim)
                 self._temp_conn_anim = None
-            node = self._node_at(cx, cy)
+            node = self._node_at(raw_x, raw_y)
             if node and node is not self._connect_parent:
                 # Use the current connect mode to decide whether this is a
                 # solved-by or in-context-of relationship.
@@ -655,9 +656,10 @@ class GSNDiagramWindow(tk.Frame):
     # ------------------------------------------------------------------
     def _on_right_click(self, event):  # pragma: no cover - requires tkinter
         """Show a context menu for the element under the cursor."""
-        cx = self.canvas.canvasx(event.x)
-        cy = self.canvas.canvasy(event.y)
-        node = self._node_at(cx, cy)
+        raw_x, raw_y = event.x, event.y
+        cx = self.canvas.canvasx(raw_x)
+        cy = self.canvas.canvasy(raw_y)
+        node = self._node_at(raw_x, raw_y)
         conn = self._connection_at(cx, cy)
         if not node and not conn:
             return

--- a/tests/test_gsn_diagram_window.py
+++ b/tests/test_gsn_diagram_window.py
@@ -256,6 +256,58 @@ def test_click_and_drag_uses_canvas_coordinates():
     assert node.x == 160 and node.y == 260
 
 
+def test_on_release_uses_raw_coordinates():
+    """Releasing a connection should resolve nodes using raw event coordinates."""
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.zoom = 1.0
+    parent = GSNNode("p", "Goal")
+    child = GSNNode("c", "Goal")
+    win._connect_mode = "solved"
+    win._connect_parent = parent
+    win.refresh = lambda: None
+
+    class CanvasStub:
+        def __init__(self):
+            self.off_x = 100
+            self.off_y = 200
+            self.cursor = None
+
+        def canvasx(self, x):
+            return x + self.off_x
+
+        def canvasy(self, y):
+            return y + self.off_y
+
+        def delete(self, *a, **k):
+            pass
+
+        def after_cancel(self, *a, **k):
+            pass
+
+        def find_overlapping(self, x1, y1, x2, y2):
+            if x1 <= 110 <= x2 and y1 <= 210 <= y2:
+                return [1]
+            return []
+
+        def find_closest(self, x, y):
+            return []
+
+        def gettags(self, item):
+            return (child.unique_id,)
+
+        def configure(self, **kwargs):
+            if "cursor" in kwargs:
+                self.cursor = kwargs["cursor"]
+
+    win.canvas = CanvasStub()
+    win.id_to_node = {child.unique_id: child}
+
+    event = type("Evt", (), {"x": 10, "y": 10})
+    win._on_release(event)
+
+    assert child in parent.children
+
+
 def test_add_module_uses_existing_modules(monkeypatch):
     app = types.SimpleNamespace(gsn_modules=[GSNModule("Pkg1"), GSNModule("Pkg2")])
     diagram = GSNDiagram(GSNNode("r", "Goal"))


### PR DESCRIPTION
## Summary
- resolve nodes using raw event coordinates on mouse release to establish connections reliably
- ensure right-click context menus also use raw coordinates
- add regression test verifying connection creation uses raw coordinates

## Testing
- `pytest -q` *(fails: 34 failed, 1056 passed, 50 skipped)*
- `PYTHONPATH=. pytest tests/test_gsn_diagram_window.py::test_on_release_uses_raw_coordinates -q`


------
https://chatgpt.com/codex/tasks/task_b_68a892e769d48327b9cda4cae1d09a58