### PR TITLE
Clear relationships on GSN clone reset, fix connection creation, and stabilize governance clipboard

### DIFF
--- a/tests/test_copy_respects_active_arch_diagram.py
+++ b/tests/test_copy_respects_active_arch_diagram.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import types
+import weakref
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from gui.gsn_diagram_window import GSNNode, GSNDiagram, GSNDiagramWindow, GSN_WINDOWS
+from gui.architecture import SysMLDiagramWindow, _get_next_id, SysMLObject, ARCH_WINDOWS
+
+
+class DummyRepo:
+    def __init__(self):
+        self.diagrams = {1: types.SimpleNamespace(diag_type="Governance Diagram", elements=[])}
+
+    def diagram_read_only(self, _id):
+        return False
+
+
+def make_arch_window(app, repo):
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.app = app
+    win.repo = repo
+    win.diagram_id = 1
+    win.selected_obj = None
+    win.objects = []
+    win.remove_object = lambda o: win.objects.remove(o)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.sort_objects = lambda: None
+    win._rebuild_toolboxes = lambda: None
+    win._on_focus_in = types.MethodType(SysMLDiagramWindow._on_focus_in, win)
+    return win
+
+
+def test_copy_paste_respects_active_arch_diagram_when_gsn_exists():
+    ARCH_WINDOWS.clear()
+    GSN_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+
+    # Setup GSN window with a selected node
+    root = GSNNode("Root", "Goal")
+    child = GSNNode("Child", "Solution")
+    root.add_child(child)
+    diag = GSNDiagram(root)
+    win_gsn = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win_gsn.app = app
+    win_gsn.diagram = diag
+    win_gsn.id_to_node = {n.unique_id: n for n in diag.nodes}
+    win_gsn.selected_node = child
+    win_gsn.focus_get = lambda: None
+    win_gsn.winfo_toplevel = lambda: win_gsn
+    win_gsn.copy_selected = lambda: (setattr(app, "diagram_clipboard", child), setattr(app, "diagram_clipboard_type", "GSN"))
+    win_gsn.paste_selected = lambda: diag.nodes.append(GSNNode("Extra", "Goal"))
+    GSN_WINDOWS.add(weakref.ref(win_gsn))
+    app.active_gsn_window = win_gsn
+
+    # Setup architecture window with a selected object
+    repo = DummyRepo()
+    win_arch = make_arch_window(app, repo)
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    win_arch.objects = [obj]
+    win_arch.selected_obj = obj
+    win_arch.copy_selected = lambda: (
+        setattr(app, "diagram_clipboard", obj),
+        setattr(app, "diagram_clipboard_type", repo.diagrams[1].diag_type),
+    )
+    win_arch.paste_selected = lambda: win_arch.objects.append("pasted")
+    app.active_arch_window = win_arch
+
+    tab_gsn = types.SimpleNamespace(gsn_window=win_gsn, winfo_children=lambda: [])
+    tab_arch = types.SimpleNamespace(gsn_window=None, arch_window=win_arch, winfo_children=lambda: [])
+    app.doc_nb = types.SimpleNamespace(select=lambda: "arch", nametowidget=lambda tid: {"gsn": tab_gsn, "arch": tab_arch}[tid])
+
+    app.copy_node()
+    assert app.diagram_clipboard is obj
+
+    app.paste_node()
+    assert win_arch.objects[-1] == "pasted"
+    assert len(diag.nodes) == 1  # unchanged by paste

--- a/tests/test_cross_diagram_clipboard.py
+++ b/tests/test_cross_diagram_clipboard.py
@@ -176,6 +176,95 @@ def test_copy_paste_task_between_governance_diagrams():
     assert any(o.obj_type == "Task" for o in win2.objects)
 
 
+def test_copy_paste_governance_with_selected_node():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    # Simulate leftover selected node from another analysis
+    app.selected_node = types.SimpleNamespace(node_type="Event", parents=[])
+    app.root_node = object()
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [obj]
+    win1.selected_obj = obj
+
+    win2 = make_window(app, repo, 2)
+
+    win1._on_focus_in()
+    app.copy_node()
+    assert app.diagram_clipboard is not None
+    assert app.clipboard_node is None
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert len(win2.objects) == 1
+    assert win2.objects[0].obj_type == "Plan"
+
+
+def test_cut_paste_between_governance_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [obj]
+    win1.selected_obj = obj
+
+    win2 = make_window(app, repo, 2)
+
+    win1._on_focus_in()
+    app.cut_node()
+    assert app.diagram_clipboard is not None
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert len(win1.objects) == 0
+    assert len(win2.objects) == 1
+    assert win2.objects[0].obj_type == "Plan"
+
+
 def test_copy_paste_process_area_between_diagrams():
     ARCH_WINDOWS.clear()
     app = AutoMLApp.__new__(AutoMLApp)

--- a/tests/test_gsn_clone_relationships.py
+++ b/tests/test_gsn_clone_relationships.py
@@ -1,0 +1,97 @@
+import unittest
+import types
+import os
+import sys
+import copy
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from gsn.nodes import GSNNode
+
+
+class GSNCloneRelationshipTests(unittest.TestCase):
+    def test_reset_clone_clears_relationships(self):
+        app = AutoMLApp.__new__(AutoMLApp)
+        parent = GSNNode("parent", "Goal")
+        child = GSNNode("child", "Goal")
+        parent.add_child(child)
+        clone = copy.deepcopy(parent)
+        old_child = clone.children[0]
+        app._reset_gsn_clone(clone)
+        self.assertEqual(clone.children, [])
+        self.assertEqual(clone.parents, [])
+        self.assertEqual(clone.context_children, [])
+        self.assertEqual(old_child.children, [])
+        self.assertEqual(old_child.parents, [])
+        self.assertEqual(old_child.context_children, [])
+
+    def test_reset_clone_preserves_away_properties(self):
+        app = AutoMLApp.__new__(AutoMLApp)
+        orig = GSNNode("orig", "Goal")
+        clone = orig.clone()
+        deep_clone = copy.deepcopy(clone)
+        app._reset_gsn_clone(deep_clone)
+        self.assertIsNot(deep_clone.original, deep_clone)
+        self.assertFalse(deep_clone.is_primary_instance)
+
+    def test_paste_node_clones_gsn_nodes(self):
+        import types
+        import AutoML as automl_module
+
+        automl_module.messagebox = types.SimpleNamespace(
+            showwarning=lambda *a, **k: None,
+            showinfo=lambda *a, **k: None,
+        )
+        automl_module.AutoML_Helper = types.SimpleNamespace(
+            calculate_assurance_recursive=lambda *a, **k: None
+        )
+
+        app = AutoMLApp.__new__(AutoMLApp)
+        app.analysis_tree = types.SimpleNamespace(selection=lambda: [])
+        parent1 = GSNNode("p1", "Goal")
+        parent2 = GSNNode("p2", "Goal")
+        child = GSNNode("c", "Goal")
+        parent1.add_child(child)
+        app.clipboard_node = child
+        app.clipboard_relation = "solved"
+        app.selected_node = parent2
+        app.root_node = parent1
+        app.top_events = []
+        app.update_views = lambda: None
+        app.cut_mode = False
+
+        class Diagram:
+            def __init__(self, nodes):
+                self.nodes = nodes
+
+            def add_node(self, n):
+                if n not in self.nodes:
+                    self.nodes.append(n)
+
+        diagram_a = Diagram([child])
+        diagram_b = Diagram([])
+
+        def fake_find(node):
+            return diagram_a if node is app.clipboard_node else diagram_b
+
+        app._find_gsn_diagram = fake_find
+
+        app.paste_node()
+
+        self.assertEqual(len(parent2.children), 1)
+        pasted = parent2.children[0]
+        self.assertIsNot(pasted, child)
+        self.assertFalse(pasted.is_primary_instance)
+        self.assertIs(pasted.original, child.original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gsn_sync_notes.py
+++ b/tests/test_gsn_sync_notes.py
@@ -1,0 +1,49 @@
+import types
+import os
+import sys
+import unittest
+
+# Provide dummy PIL modules to allow AutoML import without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AutoML import AutoMLApp
+from gsn import GSNNode
+
+
+class GSNCloneSyncNotesTests(unittest.TestCase):
+    def setUp(self):
+        self.app = AutoMLApp.__new__(AutoMLApp)
+        self.app.fmea_entries = []
+        self.app.fmeas = []
+        self.app.fmedas = []
+        self.original = GSNNode("Orig", "Goal")
+        self.clone = self.original.clone()
+
+        def all_nodes(_self, node=None):
+            return [self.original, self.clone]
+
+        self.app.get_all_nodes = types.MethodType(all_nodes, self.app)
+        self.app.get_all_fmea_entries = types.MethodType(lambda _self: [], self.app)
+        self.app.root_node = self.original
+
+    def test_sync_notes_and_description(self):
+        self.clone.user_name = "Updated"
+        self.clone.description = "Desc"
+        self.clone.manager_notes = "Note"
+        self.app.sync_nodes_by_id(self.clone)
+        self.assertEqual(self.original.user_name, "Updated")
+        self.assertEqual(self.original.description, "Desc")
+        self.assertEqual(self.original.manager_notes, "Note")
+
+        self.original.manager_notes = "NewNote"
+        self.app.sync_nodes_by_id(self.original)
+        self.assertEqual(self.clone.manager_notes, "NewNote")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Clear parent, child and context relationships when resetting a GSN node clone while preserving original links
- Always clone GSN nodes on paste so moving a clone no longer moves the original
- Sync manager notes between GSN clones and their originals via `sync_nodes_by_id`
- Guard copy/cut operations with diagram-focused strategies so governance diagrams paste correctly even when other nodes remain selected
- Ensure architecture clipboard operations honor the selected tab so copy, cut, and paste work again in governance diagrams
- Add regression tests covering away node metadata, cross-diagram pasting, raw coordinate relationship creation, clipboard focus, governance copy/paste with stale selections, and governance cut/paste across diagrams

## Testing
- `venv/bin/python -m pytest tests/test_cross_diagram_clipboard.py::test_cut_paste_between_governance_diagrams -q` *(fails: AttributeError: module 'tkinter' has no attribute 'Frame')*
- `venv/bin/radon cc AutoML.py -j > /tmp/radon.json` *(output filtered for targeted functions)*
- `venv/bin/python - <<'PY' \nimport json, re, sys\nwith open('/tmp/radon.json') as f:\n    data=json.load(f)\nfor item in data.get('AutoML.py', []):\n    if re.search(r'_arch_window_strategy[1-4]|_window_in_selected_tab', item['name']):\n        print(item)\nPY`


------
https://chatgpt.com/codex/tasks/task_b_68a8804c71ac832799844e7a309e4c87