### PR TITLE
Clear relationships on GSN clone reset, fix connection creation, stabilize governance clipboard, enforce bi-directional text sync, and restore GSN cross-diagram clipboard

### DIFF
--- a/tests/test_copy_respects_active_arch_diagram.py
+++ b/tests/test_copy_respects_active_arch_diagram.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import types
+import weakref
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from gui.gsn_diagram_window import GSNNode, GSNDiagram, GSNDiagramWindow, GSN_WINDOWS
+from gui.architecture import SysMLDiagramWindow, _get_next_id, SysMLObject, ARCH_WINDOWS
+
+
+class DummyRepo:
+    def __init__(self):
+        self.diagrams = {1: types.SimpleNamespace(diag_type="Governance Diagram", elements=[])}
+
+    def diagram_read_only(self, _id):
+        return False
+
+
+def make_arch_window(app, repo):
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.app = app
+    win.repo = repo
+    win.diagram_id = 1
+    win.selected_obj = None
+    win.objects = []
+    win.remove_object = lambda o: win.objects.remove(o)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.sort_objects = lambda: None
+    win._rebuild_toolboxes = lambda: None
+    win._on_focus_in = types.MethodType(SysMLDiagramWindow._on_focus_in, win)
+    return win
+
+
+def test_copy_paste_respects_active_arch_diagram_when_gsn_exists():
+    ARCH_WINDOWS.clear()
+    GSN_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+
+    # Setup GSN window with a selected node
+    root = GSNNode("Root", "Goal")
+    child = GSNNode("Child", "Solution")
+    root.add_child(child)
+    diag = GSNDiagram(root)
+    win_gsn = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win_gsn.app = app
+    win_gsn.diagram = diag
+    win_gsn.id_to_node = {n.unique_id: n for n in diag.nodes}
+    win_gsn.selected_node = child
+    win_gsn.focus_get = lambda: None
+    win_gsn.winfo_toplevel = lambda: win_gsn
+    win_gsn.copy_selected = lambda: (setattr(app, "diagram_clipboard", child), setattr(app, "diagram_clipboard_type", "GSN"))
+    win_gsn.paste_selected = lambda: diag.nodes.append(GSNNode("Extra", "Goal"))
+    GSN_WINDOWS.add(weakref.ref(win_gsn))
+    app.active_gsn_window = win_gsn
+
+    # Setup architecture window with a selected object
+    repo = DummyRepo()
+    win_arch = make_arch_window(app, repo)
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    win_arch.objects = [obj]
+    win_arch.selected_obj = obj
+    win_arch.copy_selected = lambda: (
+        setattr(app, "diagram_clipboard", obj),
+        setattr(app, "diagram_clipboard_type", repo.diagrams[1].diag_type),
+    )
+    win_arch.paste_selected = lambda: win_arch.objects.append("pasted")
+    app.active_arch_window = win_arch
+
+    tab_gsn = types.SimpleNamespace(gsn_window=win_gsn, winfo_children=lambda: [])
+    tab_arch = types.SimpleNamespace(gsn_window=None, arch_window=win_arch, winfo_children=lambda: [])
+    app.doc_nb = types.SimpleNamespace(select=lambda: "arch", nametowidget=lambda tid: {"gsn": tab_gsn, "arch": tab_arch}[tid])
+
+    app.copy_node()
+    assert app.diagram_clipboard is obj
+
+    app.paste_node()
+    assert win_arch.objects[-1] == "pasted"
+    assert len(diag.nodes) == 1  # unchanged by paste

--- a/tests/test_cross_diagram_clipboard.py
+++ b/tests/test_cross_diagram_clipboard.py
@@ -9,6 +9,9 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from AutoML import AutoMLApp
 from gui.architecture import SysMLDiagramWindow, _get_next_id, SysMLObject, ARCH_WINDOWS
+from gui.gsn_diagram_window import GSNDiagramWindow, GSN_WINDOWS
+from gsn import GSNNode, GSNDiagram
+import weakref
 
 
 class DummyRepo:
@@ -58,6 +61,48 @@ def make_window(app, repo, diagram_id):
     win._place_process_area = _stub_place_process_area
     win._rebuild_toolboxes = lambda: None
     return win
+
+
+def make_gsn_window(app, diagram):
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.app = app
+    win.diagram = diagram
+    win.id_to_node = {n.unique_id: n for n in diagram.nodes}
+    win.selected_node = None
+    win.canvas = types.SimpleNamespace(
+        delete=lambda *a, **k: None,
+        find_overlapping=lambda *a, **k: [],
+        find_closest=lambda *a, **k: [],
+        bbox=lambda *a, **k: None,
+        gettags=lambda i: [],
+    )
+    win.refresh = lambda: None
+    win.focus_get = lambda: win if getattr(win, "_focus", False) else None
+    win.winfo_toplevel = lambda: win
+    win._on_focus_in = types.MethodType(GSNDiagramWindow._on_focus_in, win)
+    GSN_WINDOWS.add(weakref.ref(win))
+    return win
+
+
+class DummyNotebook:
+    def __init__(self):
+        self.tabs = {}
+        self._selected = None
+
+    def add(self, name, win):
+        tab = types.SimpleNamespace(gsn_window=win)
+        self.tabs[name] = tab
+        if self._selected is None:
+            self._selected = name
+        return tab
+
+    def select(self, name=None):
+        if name is None:
+            return self._selected
+        self._selected = name
+
+    def nametowidget(self, name):
+        return self.tabs.get(name)
 
 
 def test_copy_paste_between_same_type_diagrams():
@@ -176,6 +221,95 @@ def test_copy_paste_task_between_governance_diagrams():
     assert any(o.obj_type == "Task" for o in win2.objects)
 
 
+def test_copy_paste_governance_with_selected_node():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    # Simulate leftover selected node from another analysis
+    app.selected_node = types.SimpleNamespace(node_type="Event", parents=[])
+    app.root_node = object()
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [obj]
+    win1.selected_obj = obj
+
+    win2 = make_window(app, repo, 2)
+
+    win1._on_focus_in()
+    app.copy_node()
+    assert app.diagram_clipboard is not None
+    assert app.clipboard_node is None
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert len(win2.objects) == 1
+    assert win2.objects[0].obj_type == "Plan"
+
+
+def test_cut_paste_between_governance_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [obj]
+    win1.selected_obj = obj
+
+    win2 = make_window(app, repo, 2)
+
+    win1._on_focus_in()
+    app.cut_node()
+    assert app.diagram_clipboard is not None
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert len(win1.objects) == 0
+    assert len(win2.objects) == 1
+    assert win2.objects[0].obj_type == "Plan"
+
+
 def test_copy_paste_process_area_between_diagrams():
     ARCH_WINDOWS.clear()
     app = AutoMLApp.__new__(AutoMLApp)
@@ -217,3 +351,69 @@ def test_copy_paste_process_area_between_diagrams():
 
     assert len(win2.objects) == 1
     assert win2.objects[0].obj_type == "System Boundary"
+
+
+def test_copy_paste_between_gsn_diagrams():
+    GSN_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    root1 = GSNNode("R1", "Goal")
+    child = GSNNode("C1", "Goal")
+    root1.add_child(child)
+    diag1 = GSNDiagram(root1)
+    diag1.add_node(child)
+    root2 = GSNNode("R2", "Goal")
+    diag2 = GSNDiagram(root2)
+    app.gsn_diagrams = [diag1, diag2]
+    app.gsn_modules = []
+    win1 = make_gsn_window(app, diag1)
+    win2 = make_gsn_window(app, diag2)
+    nb = DummyNotebook()
+    nb.add("t1", win1)
+    nb.add("t2", win2)
+    app.doc_nb = nb
+    win1.selected_node = child
+    win1._focus = True
+    nb.select("t1")
+    app.copy_node()
+    nb.select("t2")
+    app.paste_node()
+    assert len(diag2.nodes) == 2
+    assert diag2.nodes[-1].original is child.original
+
+
+def test_cut_paste_between_gsn_diagrams():
+    GSN_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    root1 = GSNNode("R1", "Goal")
+    child = GSNNode("C1", "Goal")
+    root1.add_child(child)
+    diag1 = GSNDiagram(root1)
+    diag1.add_node(child)
+    root2 = GSNNode("R2", "Goal")
+    diag2 = GSNDiagram(root2)
+    app.gsn_diagrams = [diag1, diag2]
+    app.gsn_modules = []
+    win1 = make_gsn_window(app, diag1)
+    win2 = make_gsn_window(app, diag2)
+    nb = DummyNotebook()
+    nb.add("t1", win1)
+    nb.add("t2", win2)
+    app.doc_nb = nb
+    win1.selected_node = child
+    win1._focus = True
+    nb.select("t1")
+    app.cut_node()
+    nb.select("t2")
+    app.paste_node()
+    assert child not in diag1.nodes
+    assert any(n.original is child.original for n in diag2.nodes)

--- a/tests/test_gsn_clone_relationships.py
+++ b/tests/test_gsn_clone_relationships.py
@@ -1,0 +1,97 @@
+import unittest
+import types
+import os
+import sys
+import copy
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from gsn.nodes import GSNNode
+
+
+class GSNCloneRelationshipTests(unittest.TestCase):
+    def test_reset_clone_clears_relationships(self):
+        app = AutoMLApp.__new__(AutoMLApp)
+        parent = GSNNode("parent", "Goal")
+        child = GSNNode("child", "Goal")
+        parent.add_child(child)
+        clone = copy.deepcopy(parent)
+        old_child = clone.children[0]
+        app._reset_gsn_clone(clone)
+        self.assertEqual(clone.children, [])
+        self.assertEqual(clone.parents, [])
+        self.assertEqual(clone.context_children, [])
+        self.assertEqual(old_child.children, [])
+        self.assertEqual(old_child.parents, [])
+        self.assertEqual(old_child.context_children, [])
+
+    def test_reset_clone_preserves_away_properties(self):
+        app = AutoMLApp.__new__(AutoMLApp)
+        orig = GSNNode("orig", "Goal")
+        clone = orig.clone()
+        deep_clone = copy.deepcopy(clone)
+        app._reset_gsn_clone(deep_clone)
+        self.assertIsNot(deep_clone.original, deep_clone)
+        self.assertFalse(deep_clone.is_primary_instance)
+
+    def test_paste_node_clones_gsn_nodes(self):
+        import types
+        import AutoML as automl_module
+
+        automl_module.messagebox = types.SimpleNamespace(
+            showwarning=lambda *a, **k: None,
+            showinfo=lambda *a, **k: None,
+        )
+        automl_module.AutoML_Helper = types.SimpleNamespace(
+            calculate_assurance_recursive=lambda *a, **k: None
+        )
+
+        app = AutoMLApp.__new__(AutoMLApp)
+        app.analysis_tree = types.SimpleNamespace(selection=lambda: [])
+        parent1 = GSNNode("p1", "Goal")
+        parent2 = GSNNode("p2", "Goal")
+        child = GSNNode("c", "Goal")
+        parent1.add_child(child)
+        app.clipboard_node = child
+        app.clipboard_relation = "solved"
+        app.selected_node = parent2
+        app.root_node = parent1
+        app.top_events = []
+        app.update_views = lambda: None
+        app.cut_mode = False
+
+        class Diagram:
+            def __init__(self, nodes):
+                self.nodes = nodes
+
+            def add_node(self, n):
+                if n not in self.nodes:
+                    self.nodes.append(n)
+
+        diagram_a = Diagram([child])
+        diagram_b = Diagram([])
+
+        def fake_find(node):
+            return diagram_a if node is app.clipboard_node else diagram_b
+
+        app._find_gsn_diagram = fake_find
+
+        app.paste_node()
+
+        self.assertEqual(len(parent2.children), 1)
+        pasted = parent2.children[0]
+        self.assertIsNot(pasted, child)
+        self.assertFalse(pasted.is_primary_instance)
+        self.assertIs(pasted.original, child.original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gsn_sync_notes.py
+++ b/tests/test_gsn_sync_notes.py
@@ -1,0 +1,72 @@
+import types
+import os
+import sys
+import unittest
+
+# Provide dummy PIL modules to allow AutoML import without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from AutoML import AutoMLApp
+from gsn import GSNNode
+
+
+class GSNCloneSyncNotesTests(unittest.TestCase):
+    def setUp(self):
+        self.app = AutoMLApp.__new__(AutoMLApp)
+        self.app.fmea_entries = []
+        self.app.fmeas = []
+        self.app.fmedas = []
+        self.original = GSNNode("Orig", "Goal")
+        self.clone = self.original.clone()
+
+        # Simulate a traversal that misses detached clones (real-world bug)
+        def all_nodes(_self, node=None):
+            return [self.original]
+
+        # Model-wide query still sees both nodes
+        def all_nodes_in_model(_self):
+            return [self.original, self.clone]
+
+        self.app.get_all_nodes = types.MethodType(all_nodes, self.app)
+        self.app.get_all_nodes_in_model = types.MethodType(all_nodes_in_model, self.app)
+        self.app.get_all_fmea_entries = types.MethodType(lambda _self: [], self.app)
+        self.app.root_node = self.original
+
+    def test_sync_notes_and_description(self):
+        self.clone.user_name = "Updated"
+        self.clone.description = "Desc"
+        self.clone.manager_notes = "Note"
+        self.app.sync_nodes_by_id(self.clone)
+        self.assertEqual(self.original.user_name, "Updated")
+        self.assertEqual(self.original.description, "Desc")
+        self.assertEqual(self.original.manager_notes, "Note")
+
+        self.original.user_name = "OrigUpdated"
+        self.original.description = "OrigDesc"
+        self.original.manager_notes = "NewNote"
+        self.app.sync_nodes_by_id(self.original)
+        self.assertEqual(self.clone.user_name, "OrigUpdated")
+        self.assertEqual(self.clone.description, "OrigDesc")
+        self.assertEqual(self.clone.manager_notes, "NewNote")
+
+    def test_original_syncs_clone_when_model_missing(self):
+        self.app.get_all_nodes_in_model = types.MethodType(lambda _self: [self.original], self.app)
+        diag = types.SimpleNamespace(nodes=[self.original, self.clone])
+        self.app.gsn_diagrams = [diag]
+        self.app.all_gsn_diagrams = [diag]
+        self.original.description = "OrigDesc"
+        self.original.user_name = "OrigName"
+        self.original.manager_notes = "OrigNote"
+        self.app.sync_nodes_by_id(self.original)
+        self.assertEqual(self.clone.description, "OrigDesc")
+        self.assertEqual(self.clone.user_name, "OrigName")
+        self.assertEqual(self.clone.manager_notes, "OrigNote")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Ensure GSN clones reset as away elements and remove parent/child/context links when deep-copied
- Restrict synchronization to name, description, and notes so clone positions stay independent and text edits propagate both directions
- Track GSN nodes across all diagrams so originals push name/description/notes updates to detached clones
- Prioritize the selected GSN tab when resolving clipboard targets so copy, cut, and paste work across diagrams

## Testing
- `PYTHONPATH=$PWD pytest tests/test_cross_diagram_clipboard.py::test_copy_paste_between_gsn_diagrams tests/test_cross_diagram_clipboard.py::test_cut_paste_between_gsn_diagrams -q`
- `PYTHONPATH=$PWD pytest tests/test_cross_diagram_clipboard.py::test_copy_paste_task_between_governance_diagrams tests/test_cross_diagram_clipboard.py::test_copy_paste_governance_with_selected_node tests/test_cross_diagram_clipboard.py::test_copy_paste_between_same_type_diagrams -q`
- `pytest tests/test_copy_respects_active_arch_diagram.py -q`
- `PYTHONPATH=$PWD pytest tests/test_gsn_window_focus.py::test_gsn_paste_uses_focused_window -q`
- `PYTHONPATH=$PWD pytest tests/test_gsn_clipboard.py -q`
- `radon cc AutoML.py -j | jq '."AutoML.py"[] | select(.name | test("_gsn_window_strategy[1-4]|_focused_gsn_window"))'`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a8804c71ac832799844e7a309e4c87