### PR TITLE
Fix GSN clone sync on tab activation

### DIFF
--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -281,6 +281,22 @@ class GSNDiagramWindow(tk.Frame):
         set_uniform_button_width(self.toolbox)
 
     # ------------------------------------------------------------------
+    def _sync_from_originals(self) -> None:
+        """Synchronise cloned nodes with their original counterparts."""
+        for node in getattr(self.diagram, "nodes", []):
+            original = getattr(node, "original", None)
+            if original and original is not node:
+                node.user_name = original.user_name
+                node.description = original.description
+                node.manager_notes = getattr(original, "manager_notes", "")
+
+    # ------------------------------------------------------------------
+    def refresh_from_repository(self) -> None:  # pragma: no cover - requires tkinter
+        """Refresh the diagram and sync cloned nodes on tab activation."""
+        self._sync_from_originals()
+        self.refresh()
+
+    # ------------------------------------------------------------------
     def refresh(self):  # pragma: no cover - requires tkinter
         # Ensure the diagram has access to the application for SPI lookups
         setattr(self.diagram, "app", getattr(self, "app", None))

--- a/tests/test_gsn_clone_cross_diagram_sync.py
+++ b/tests/test_gsn_clone_cross_diagram_sync.py
@@ -1,0 +1,48 @@
+
+from gui.gsn_diagram_window import GSNDiagramWindow
+from gui.gsn_config_window import GSNElementConfig
+from gsn import GSNDiagram, GSNNode
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+    def get(self):
+        return self.value
+
+
+class DummyText:
+    def __init__(self, text=""):
+        self.text = text
+    def get(self, *_args, **_kwargs):
+        return self.text
+
+
+def _configure(node, diagram, name="", desc="", notes=""):
+    cfg = GSNElementConfig.__new__(GSNElementConfig)
+    cfg.node = node
+    cfg.diagram = diagram
+    cfg.name_var = DummyVar(name or node.user_name)
+    cfg.desc_text = DummyText(desc or node.description)
+    cfg.notes_text = DummyText(notes or node.manager_notes)
+    cfg.destroy = lambda: None
+    cfg._on_ok()
+
+
+def test_clone_sync_on_tab_focus():
+    original = GSNNode("Orig", "Goal")
+    diag1 = GSNDiagram(original)
+    clone = original.clone()
+    diag2 = GSNDiagram(clone)
+    diag2.add_node(clone)
+
+    _configure(original, diag1, name="NewName", desc="NewDesc", notes="NewNote")
+    assert clone.user_name != "NewName"
+
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.diagram = diag2
+    win.refresh = lambda: None
+    GSNDiagramWindow.refresh_from_repository(win)
+
+    assert clone.user_name == "NewName"
+    assert clone.description == "NewDesc"
+    assert clone.manager_notes == "NewNote"


### PR DESCRIPTION
## Summary
- ensure cloned GSN nodes refresh from originals when tab is activated
- cover cross-diagram clone synchronisation with unit test

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_clone_data_sync.py tests/test_gsn_clone_cross_diagram_sync.py -q`
- `python tools/metrics_generator.py --path gui --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68a8bfb744c08327b03ac2b573c04150