### PR TITLE
Fix governance diagram cut/paste and conditional GSN cloning

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -19151,20 +19151,18 @@ class AutoMLApp:
                 messagebox.showinfo("Paste", "Node moved successfully (cut & pasted).")
             else:
                 target_diag = self._find_gsn_diagram(target)
-                if isinstance(self.clipboard_node, GSNNode):
-                    cloned_node = self._clone_for_paste(self.clipboard_node)
-                    target.children.append(cloned_node)
-                    cloned_node.parents.append(target)
-                    if target_diag and cloned_node not in target_diag.nodes:
-                        target_diag.add_node(cloned_node)
-                    node_for_pos = cloned_node
+                if (
+                    isinstance(self.clipboard_node, GSNNode)
+                    and target in getattr(self.clipboard_node, "parents", [])
+                ):
+                    node_for_pos = self._clone_for_paste(self.clipboard_node)
                 else:
-                    target.children.append(self.clipboard_node)
-                    self.clipboard_node.parents.append(target)
-                    if isinstance(self.clipboard_node, GSNNode):
-                        if target_diag and self.clipboard_node not in target_diag.nodes:
-                            target_diag.add_node(self.clipboard_node)
                     node_for_pos = self.clipboard_node
+                target.children.append(node_for_pos)
+                node_for_pos.parents.append(target)
+                if isinstance(node_for_pos, GSNNode):
+                    if target_diag and node_for_pos not in target_diag.nodes:
+                        target_diag.add_node(node_for_pos)
                 node_for_pos.x = target.x + 100
                 node_for_pos.y = target.y + 100
                 if hasattr(node_for_pos, "display_label"):

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -281,6 +281,22 @@ class GSNDiagramWindow(tk.Frame):
         set_uniform_button_width(self.toolbox)
 
     # ------------------------------------------------------------------
+    def _sync_from_originals(self) -> None:
+        """Synchronise cloned nodes with their original counterparts."""
+        for node in getattr(self.diagram, "nodes", []):
+            original = getattr(node, "original", None)
+            if original and original is not node:
+                node.user_name = original.user_name
+                node.description = original.description
+                node.manager_notes = getattr(original, "manager_notes", "")
+
+    # ------------------------------------------------------------------
+    def refresh_from_repository(self) -> None:  # pragma: no cover - requires tkinter
+        """Refresh the diagram and sync cloned nodes on tab activation."""
+        self._sync_from_originals()
+        self.refresh()
+
+    # ------------------------------------------------------------------
     def refresh(self):  # pragma: no cover - requires tkinter
         # Ensure the diagram has access to the application for SPI lookups
         setattr(self.diagram, "app", getattr(self, "app", None))

--- a/tests/test_governance_cut_paste.py
+++ b/tests/test_governance_cut_paste.py
@@ -1,0 +1,79 @@
+import types
+
+from AutoML import AutoMLApp
+from gui.architecture import SysMLObject, ARCH_WINDOWS, _get_next_id
+from tests.test_cross_diagram_clipboard import DummyRepo, make_window
+
+
+def test_cut_paste_task_between_governance_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    boundary1 = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": "Area1"},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    task = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Task",
+        x=10,
+        y=10,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"boundary": str(boundary1.obj_id)},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [boundary1, task]
+    win1.selected_obj = task
+
+    boundary2 = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": "Area2"},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    win2 = make_window(app, repo, 2)
+    win2.objects = [boundary2]
+
+    win1._on_focus_in()
+    win1.copy_selected()
+    assert app.diagram_clipboard is not None
+    win1.objects.remove(task)
+    app.cut_mode = True
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert any(o.obj_type == "Task" for o in win2.objects)
+    assert sum(1 for o in win2.objects if o.obj_type == "System Boundary") == 2

--- a/tests/test_gsn_clone_cross_diagram_sync.py
+++ b/tests/test_gsn_clone_cross_diagram_sync.py
@@ -1,0 +1,48 @@
+
+from gui.gsn_diagram_window import GSNDiagramWindow
+from gui.gsn_config_window import GSNElementConfig
+from gsn import GSNDiagram, GSNNode
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+    def get(self):
+        return self.value
+
+
+class DummyText:
+    def __init__(self, text=""):
+        self.text = text
+    def get(self, *_args, **_kwargs):
+        return self.text
+
+
+def _configure(node, diagram, name="", desc="", notes=""):
+    cfg = GSNElementConfig.__new__(GSNElementConfig)
+    cfg.node = node
+    cfg.diagram = diagram
+    cfg.name_var = DummyVar(name or node.user_name)
+    cfg.desc_text = DummyText(desc or node.description)
+    cfg.notes_text = DummyText(notes or node.manager_notes)
+    cfg.destroy = lambda: None
+    cfg._on_ok()
+
+
+def test_clone_sync_on_tab_focus():
+    original = GSNNode("Orig", "Goal")
+    diag1 = GSNDiagram(original)
+    clone = original.clone()
+    diag2 = GSNDiagram(clone)
+    diag2.add_node(clone)
+
+    _configure(original, diag1, name="NewName", desc="NewDesc", notes="NewNote")
+    assert clone.user_name != "NewName"
+
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.diagram = diag2
+    win.refresh = lambda: None
+    GSNDiagramWindow.refresh_from_repository(win)
+
+    assert clone.user_name == "NewName"
+    assert clone.description == "NewDesc"
+    assert clone.manager_notes == "NewNote"


### PR DESCRIPTION
## Summary
- clone GSN nodes only when pasting back under an existing parent
- add regression test for cutting and pasting tasks between governance diagrams

## Testing
- `PYTHONPATH=. pytest tests/test_copy_paste_active_diagram.py tests/test_auto_paste_gsn_clone.py tests/test_cross_diagram_clipboard.py tests/test_governance_cut_paste.py -q`
- `python tools/metrics_generator.py --path gui --output metrics.json`
- `PYTHONPATH=. pytest -q` *(fails: missing AutoML_Helper configuration and other dependency stubs)*

------
https://chatgpt.com/codex/tasks/task_b_68a8bfb744c08327b03ac2b573c04150