### PR TITLE
Fix governance copy/paste and sync GSN clone module names

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -19152,19 +19152,20 @@ class AutoMLApp:
             else:
                 target_diag = self._find_gsn_diagram(target)
                 if isinstance(self.clipboard_node, GSNNode):
-                    cloned_node = self._clone_for_paste(self.clipboard_node)
-                    target.children.append(cloned_node)
-                    cloned_node.parents.append(target)
-                    if target_diag and cloned_node not in target_diag.nodes:
-                        target_diag.add_node(cloned_node)
-                    node_for_pos = cloned_node
+                    if target in getattr(self.clipboard_node, "parents", []):
+                        node_for_pos = self._clone_for_paste(self.clipboard_node)
+                    else:
+                        node_for_pos = self.clipboard_node
+                    target.children.append(node_for_pos)
+                    node_for_pos.parents.append(target)
+                    if target_diag and node_for_pos not in target_diag.nodes:
+                        target_diag.add_node(node_for_pos)
                 else:
-                    target.children.append(self.clipboard_node)
-                    self.clipboard_node.parents.append(target)
-                    if isinstance(self.clipboard_node, GSNNode):
-                        if target_diag and self.clipboard_node not in target_diag.nodes:
-                            target_diag.add_node(self.clipboard_node)
-                    node_for_pos = self.clipboard_node
+                    import copy
+                    node_for_pos = copy.deepcopy(self.clipboard_node)
+                    target.children.append(node_for_pos)
+                    if hasattr(node_for_pos, "parents"):
+                        node_for_pos.parents.append(target)
                 node_for_pos.x = target.x + 100
                 node_for_pos.y = target.y + 100
                 if hasattr(node_for_pos, "display_label"):

--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -219,51 +219,26 @@ class GSNDiagram:
         return None
 
     # ------------------------------------------------------------------
-    def _find_module_name_strategy1(self, node: GSNNode) -> str:
-        for parent in getattr(getattr(node, "original", node), "parents", []):
-            if getattr(parent, "node_type", "") == "Module":
-                return getattr(parent, "user_name", "")
-        return ""
-
-    def _find_module_name_strategy2(self, node: GSNNode) -> str:
-        for parent in getattr(node, "parents", []):
-            if getattr(parent, "node_type", "") == "Module":
-                return getattr(parent, "user_name", "")
-        return ""
-
-    def _find_module_name_strategy3(self, node: GSNNode) -> str:
-        parents = []
-        if getattr(node, "original", None):
-            parents.extend(getattr(node.original, "parents", []))
-        parents.extend(getattr(node, "parents", []))
-        for parent in parents:
-            if getattr(parent, "node_type", "") == "Module":
-                return getattr(parent, "user_name", "")
-        return ""
-
-    def _find_module_name_strategy4(self, node: GSNNode) -> str:
-        try:
-            return next(
-                p.user_name
-                for p in getattr(getattr(node, "original", node), "parents", [])
-                if getattr(p, "node_type", "") == "Module"
-            )
-        except StopIteration:
-            return ""
-
     def _find_module_name(self, node: GSNNode) -> str:
-        for strat in (
-            self._find_module_name_strategy1,
-            self._find_module_name_strategy2,
-            self._find_module_name_strategy3,
-            self._find_module_name_strategy4,
-        ):
-            try:
-                name = strat(node)
-                if name:
-                    return name
-            except Exception:
+        """Return the name of the module containing ``node``'s original.
+
+        The search walks up the ancestor chain to handle goals nested beneath
+        other goals or strategies.  The nearest module ancestor's name is
+        returned; if none is found an empty string is yielded allowing callers
+        to fall back to ``root``.
+        """
+        original = getattr(node, "original", node)
+        queue = list(getattr(original, "parents", []))
+        visited: set[int] = set()
+        while queue:
+            parent = queue.pop(0)
+            key = id(parent)
+            if key in visited:
                 continue
+            visited.add(key)
+            if getattr(parent, "node_type", "") == "Module":
+                return getattr(parent, "user_name", "")
+            queue.extend(getattr(parent, "parents", []))
         return ""
 
     # ------------------------------------------------------------------

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -281,6 +281,22 @@ class GSNDiagramWindow(tk.Frame):
         set_uniform_button_width(self.toolbox)
 
     # ------------------------------------------------------------------
+    def _sync_from_originals(self) -> None:
+        """Synchronise cloned nodes with their original counterparts."""
+        for node in getattr(self.diagram, "nodes", []):
+            original = getattr(node, "original", None)
+            if original and original is not node:
+                node.user_name = original.user_name
+                node.description = original.description
+                node.manager_notes = getattr(original, "manager_notes", "")
+
+    # ------------------------------------------------------------------
+    def refresh_from_repository(self) -> None:  # pragma: no cover - requires tkinter
+        """Refresh the diagram and sync cloned nodes on tab activation."""
+        self._sync_from_originals()
+        self.refresh()
+
+    # ------------------------------------------------------------------
     def refresh(self):  # pragma: no cover - requires tkinter
         # Ensure the diagram has access to the application for SPI lookups
         setattr(self.diagram, "app", getattr(self, "app", None))

--- a/tests/test_governance_copy_paste.py
+++ b/tests/test_governance_copy_paste.py
@@ -1,0 +1,78 @@
+import types
+
+from AutoML import AutoMLApp
+from gui.architecture import SysMLObject, ARCH_WINDOWS, _get_next_id
+from tests.test_cross_diagram_clipboard import DummyRepo, make_window
+
+
+def test_copy_paste_task_via_window_between_governance_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    boundary1 = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": "Area1"},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    task = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Task",
+        x=10,
+        y=10,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"boundary": str(boundary1.obj_id)},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [boundary1, task]
+    win1.selected_obj = task
+
+    boundary2 = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": "Area2"},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    win2 = make_window(app, repo, 2)
+    win2.objects = [boundary2]
+
+    win1._on_focus_in()
+    win1.copy_selected()
+    assert app.diagram_clipboard is not None
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert any(o.obj_type == "Task" for o in win2.objects)
+    assert any(o is task for o in win1.objects)
+    assert sum(1 for o in win2.objects if o.obj_type == "System Boundary") == 2

--- a/tests/test_governance_cut_paste.py
+++ b/tests/test_governance_cut_paste.py
@@ -1,0 +1,79 @@
+import types
+
+from AutoML import AutoMLApp
+from gui.architecture import SysMLObject, ARCH_WINDOWS, _get_next_id
+from tests.test_cross_diagram_clipboard import DummyRepo, make_window
+
+
+def test_cut_paste_task_between_governance_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = None
+    app.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.clipboard_node = None
+    app.cut_mode = False
+    repo = DummyRepo("Governance Diagram", "Governance Diagram")
+
+    boundary1 = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": "Area1"},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    task = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Task",
+        x=10,
+        y=10,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"boundary": str(boundary1.obj_id)},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.objects = [boundary1, task]
+    win1.selected_obj = task
+
+    boundary2 = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": "Area2"},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+    win2 = make_window(app, repo, 2)
+    win2.objects = [boundary2]
+
+    win1._on_focus_in()
+    win1.copy_selected()
+    assert app.diagram_clipboard is not None
+    win1.objects.remove(task)
+    app.cut_mode = True
+
+    win2._on_focus_in()
+    app.paste_node()
+
+    assert any(o.obj_type == "Task" for o in win2.objects)
+    assert sum(1 for o in win2.objects if o.obj_type == "System Boundary") == 2

--- a/tests/test_gsn_clone_cross_diagram_sync.py
+++ b/tests/test_gsn_clone_cross_diagram_sync.py
@@ -1,0 +1,48 @@
+
+from gui.gsn_diagram_window import GSNDiagramWindow
+from gui.gsn_config_window import GSNElementConfig
+from gsn import GSNDiagram, GSNNode
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+    def get(self):
+        return self.value
+
+
+class DummyText:
+    def __init__(self, text=""):
+        self.text = text
+    def get(self, *_args, **_kwargs):
+        return self.text
+
+
+def _configure(node, diagram, name="", desc="", notes=""):
+    cfg = GSNElementConfig.__new__(GSNElementConfig)
+    cfg.node = node
+    cfg.diagram = diagram
+    cfg.name_var = DummyVar(name or node.user_name)
+    cfg.desc_text = DummyText(desc or node.description)
+    cfg.notes_text = DummyText(notes or node.manager_notes)
+    cfg.destroy = lambda: None
+    cfg._on_ok()
+
+
+def test_clone_sync_on_tab_focus():
+    original = GSNNode("Orig", "Goal")
+    diag1 = GSNDiagram(original)
+    clone = original.clone()
+    diag2 = GSNDiagram(clone)
+    diag2.add_node(clone)
+
+    _configure(original, diag1, name="NewName", desc="NewDesc", notes="NewNote")
+    assert clone.user_name != "NewName"
+
+    win = GSNDiagramWindow.__new__(GSNDiagramWindow)
+    win.diagram = diag2
+    win.refresh = lambda: None
+    GSNDiagramWindow.refresh_from_repository(win)
+
+    assert clone.user_name == "NewName"
+    assert clone.description == "NewDesc"
+    assert clone.manager_notes == "NewNote"

--- a/tests/test_gsn_clone_module_name_sync.py
+++ b/tests/test_gsn_clone_module_name_sync.py
@@ -1,0 +1,45 @@
+from gsn import GSNNode, GSNDiagram
+
+
+def test_clone_displays_original_parent_module_name():
+    parent_a = GSNNode("ModuleA", "Module")
+    original = GSNNode("Goal", "Goal")
+    parent_a.add_child(original)
+
+    clone = original.clone()
+    parent_b = GSNNode("ModuleB", "Module")
+    parent_b.add_child(clone)
+
+    diag = GSNDiagram(parent_a)
+    diag.add_node(clone)
+    diag.add_node(parent_b)
+
+    assert diag._find_module_name(clone) == "ModuleA"
+
+    parent_a.user_name = "Renamed"
+    assert diag._find_module_name(clone) == "Renamed"
+
+
+def test_clone_traverses_ancestors_for_module_name():
+    root = GSNNode("ROOT", "Module")
+    module = GSNNode("ModuleA", "Module")
+    root.add_child(module)
+
+    parent_goal = GSNNode("Parent", "Goal")
+    module.add_child(parent_goal)
+
+    original = GSNNode("Child", "Goal")
+    parent_goal.add_child(original)
+
+    clone = original.clone()
+    other_module = GSNNode("Other", "Module")
+    root.add_child(other_module)
+    other_module.add_child(clone)
+
+    diag = GSNDiagram(root)
+    for n in [root, module, parent_goal, original, other_module, clone]:
+        diag.add_node(n)
+
+    assert diag._find_module_name(clone) == "ModuleA"
+    module.user_name = "Renamed"
+    assert diag._find_module_name(clone) == "Renamed"


### PR DESCRIPTION
## Summary
- clone GSN nodes only when pasting back under an existing parent and deep-copy other diagram elements so governance diagrams remain functional
- add regression tests ensuring copying and cutting tasks between governance diagrams works
- ensure away goals show the module name of their original and track module name updates
- traverse ancestor modules so away shapes nested under other goals display the correct module name

## Testing
- `PYTHONPATH=. pytest tests/test_gsn_clone_module_name_sync.py tests/test_gsn_clone_data_sync.py tests/test_gsn_clone_cross_diagram_sync.py tests/test_governance_copy_paste.py tests/test_governance_cut_paste.py tests/test_cross_diagram_clipboard.py tests/test_copy_paste_active_diagram.py tests/test_auto_paste_gsn_clone.py -q`
- `python tools/metrics_generator.py --path gui --output metrics.json`
- `PYTHONPATH=. pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68a8bfb744c08327b03ac2b573c04150