### PR TITLE
Fix module name for GSN away elements

### DIFF
--- a/gsn/diagram.py
+++ b/gsn/diagram.py
@@ -222,9 +222,13 @@ class GSNDiagram:
     def _find_module_name(self, node: GSNNode) -> str:
         """Return the name of the module containing ``node``'s original."""
         original = getattr(node, "original", node)
-        for parent in getattr(original, "parents", []):
-            if getattr(parent, "node_type", "") == "Module":
-                return getattr(parent, "user_name", "")
+        parents = [
+            p for p in getattr(original, "parents", []) if getattr(p, "node_type", "") == "Module"
+        ]
+        for parent in parents:
+            name = getattr(parent, "user_name", "")
+            if parent is not self.root and name.lower() != "root":
+                return name
         return ""
 
     # ------------------------------------------------------------------

--- a/tests/test_gsn_away_shapes.py
+++ b/tests/test_gsn_away_shapes.py
@@ -82,6 +82,19 @@ def test_away_shapes_receive_module_identifier(node_type, expected):
     assert helper.calls[0] == (expected, "Mod")
 
 
+def test_away_shapes_prefer_non_root_module():
+    root_mod = GSNNode("Root", "Module")
+    sub_mod = GSNNode("Sub", "Module")
+    original = GSNNode("Orig", "Goal")
+    original.parents.extend([root_mod, sub_mod])
+    clone = GSNNode("Clone", "Goal", is_primary_instance=False, original=original)
+    helper = RecordingHelper()
+    diag = GSNDiagram(clone, drawing_helper=helper)
+    canvas = StubCanvas()
+    diag.draw(canvas)
+    assert helper.calls[0] == ("goal", "Sub")
+
+
 def test_away_shapes_without_module_identifier():
     original = GSNNode("Orig", "Goal")
     clone = GSNNode("Clone", "Goal", is_primary_instance=False, original=original)


### PR DESCRIPTION
## Summary
- ensure away shapes display their parent module instead of `root`
- verify non-root modules take precedence in away shape rendering

## Testing
- `pytest tests/test_gsn_away_shapes.py -q`
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'get_next_unique_id')*
- `python - <<'PY'
from radon.complexity import cc_visit
import json
code=open('gsn/diagram.py').read()
result=[{'name':n.name,'complexity':n.complexity} for n in cc_visit(code)]
print(json.dumps(result[:10], indent=2))
PY`
- `python - <<'PY'
from radon.complexity import cc_visit
import json
code=open('tests/test_gsn_away_shapes.py').read()
result=[{'name':n.name,'complexity':n.complexity} for n in cc_visit(code)]
print(json.dumps(result[:10], indent=2))
PY`


------
https://chatgpt.com/codex/tasks/task_b_68a8cc6c55848327be9be4b9d22d8bbd