### PR TITLE
Separate CTA menus and governance

### DIFF
--- a/analysis/safety_management.py
+++ b/analysis/safety_management.py
@@ -46,6 +46,7 @@ ALLOWED_PROPAGATIONS: set[tuple[str, str]] = {
     ("FMEA", "Prototype Assurance Analysis"),
     ("FMEDA", "Prototype Assurance Analysis"),
     ("FTA", "Product Goal Specification"),
+    ("FTA", "CTA"),
     ("Prototype Assurance Analysis", "Product Goal Specification"),
 }
 
@@ -76,6 +77,7 @@ SAFETY_ANALYSIS_WORK_PRODUCTS: set[str] = {
     "FMEA",
     "FMEDA",
     "FTA",
+    "CTA",
     "Prototype Assurance Analysis",
     "Reliability Analysis",
     "Causal Bayesian Network Analysis",

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -164,6 +164,7 @@ WORK_PRODUCT_AREA_MAP = {
     "TC2FI": "Hazard & Threat Analysis",
     "Risk Assessment": "Risk Assessment",
     "FTA": "Safety Analysis",
+    "CTA": "Safety Analysis",
     "Prototype Assurance Analysis": "Safety Analysis",
     "FMEA": "Safety Analysis",
     "FMEDA": "Safety Analysis",

--- a/tests/test_analysis_tree_grouping.py
+++ b/tests/test_analysis_tree_grouping.py
@@ -1,0 +1,126 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main.AutoML import AutoMLApp
+
+
+class DummyTree:
+    def __init__(self):
+        self.children = {"": []}
+        self.items = {}
+        self._focus = ""
+
+    def delete(self, *nodes):
+        for n in nodes:
+            for parent, kids in self.children.items():
+                if n in kids:
+                    kids.remove(n)
+            self.children.pop(n, None)
+            self.items.pop(n, None)
+
+    def get_children(self, item=""):
+        return self.children.get(item, [])
+
+    def insert(self, parent, index, text, **kwargs):
+        node_id = f"id{len(self.items)}"
+        self.children.setdefault(parent, []).append(node_id)
+        self.children.setdefault(node_id, [])
+        self.items[node_id] = {"text": text, "tags": kwargs.get("tags", ())}
+        return node_id
+
+    def item(self, node, option):
+        return self.items[node][option]
+
+    def focus(self, item=None):
+        if item is not None:
+            self._focus = item
+        return self._focus
+
+
+def _setup_app_for_tree():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.analysis_tree = DummyTree()
+    app.top_events = []
+    app.cta_events = [type("N", (), {"name": "c1", "unique_id": 1})()]
+    app.paa_events = [type("N", (), {"name": "p1", "unique_id": 2})()]
+    app.fmeas = []
+    app.fmedas = []
+    app.hara_docs = []
+    app.gsn_diagrams = []
+    app.gsn_modules = []
+    app.management_diagrams = []
+    app.enabled_work_products = {"CTA", "Prototype Assurance Analysis"}
+    app.refresh_model = lambda: None
+    app.compute_occurrence_counts = lambda: {}
+
+    class TB:
+        work_products = [1]
+        modules = []
+        diagrams = {}
+
+        def enabled_products(self):
+            return app.enabled_work_products
+
+        def document_visible(self, a, b):
+            return True
+
+        def list_diagrams(self):
+            pass
+
+    app.safety_mgmt_toolbox = TB()
+    app.update_lifecycle_cb = lambda: None
+    app.refresh_tool_enablement = lambda: None
+    app.filter_var = type("FV", (), {"get": lambda self: ""})()
+    app.displayed_filters = set()
+    app.filter_lifecycle = None
+    return app
+
+
+def test_cta_and_paa_groups_separate():
+    app = _setup_app_for_tree()
+    app.update_views()
+    sa_root = next(n for n, d in app.analysis_tree.items.items() if d["text"] == "Safety Analysis")
+    child_texts = [app.analysis_tree.items[c]["text"] for c in app.analysis_tree.get_children(sa_root)]
+    assert "CTAs" in child_texts
+    assert "PAAs" in child_texts
+
+
+def test_paa_group_not_duplicated():
+    app = _setup_app_for_tree()
+    app.update_views()
+    sa_root = next(n for n, d in app.analysis_tree.items.items() if d["text"] == "Safety Analysis")
+    child_texts = [app.analysis_tree.items[c]["text"] for c in app.analysis_tree.get_children(sa_root)]
+    assert child_texts.count("PAAs") == 1
+
+
+def test_double_click_sets_mode_for_fta():
+    app = _setup_app_for_tree()
+    fta_node = type("N", (), {"name": "f1", "unique_id": 3})()
+    app.top_events = [fta_node]
+    app.update_views()
+    sa_root = next(n for n, d in app.analysis_tree.items.items() if d["text"] == "Safety Analysis")
+    fta_root = next(c for c in app.analysis_tree.get_children(sa_root) if app.analysis_tree.items[c]["text"] == "FTAs")
+    fta_item = app.analysis_tree.get_children(fta_root)[0]
+    app.analysis_tree.focus(fta_item)
+    app.ensure_fta_tab = lambda *args, **kwargs: None
+    app.doc_nb = type("NB", (), {"select": lambda self, tab: None})()
+    app.open_page_diagram = lambda te: None
+    app.canvas_tab = object()
+    app.diagram_mode = "CTA"
+    app.on_analysis_tree_double_click(None)
+    assert app.diagram_mode == "FTA"
+
+
+def test_get_node_fill_color_by_mode():
+    app = AutoMLApp.__new__(AutoMLApp)
+    class C:
+        pass
+    app.canvas = C()
+    app.canvas.diagram_mode = "CTA"
+    assert app.get_node_fill_color(None) == "#EE82EE"
+    app.canvas.diagram_mode = "PAA"
+    assert app.get_node_fill_color(None) == "#40E0D0"
+    app.canvas.diagram_mode = "FTA"
+    assert app.get_node_fill_color(None) == "#FAD7A0"

--- a/tests/test_fta_menu_quantitative.py
+++ b/tests/test_fta_menu_quantitative.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import tkinter as tk
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main.AutoML import AutoMLApp
+
+
+def test_fta_menu_within_quantitative():
+    try:
+        root = tk.Tk()
+        root.withdraw()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    app = AutoMLApp(root)
+    q_labels = [app.quantitative_menu.entrycget(i, "label") for i in range(app.quantitative_menu.index("end") + 1)]
+    assert "FTA" in q_labels
+    top_labels = [app.menubar.entrycget(i, "label") for i in range(app.menubar.index("end") + 1)]
+    assert "FTA" not in top_labels
+    fta_labels = [app.fta_menu.entrycget(i, "label") for i in range(app.fta_menu.index("end") + 1)]
+    assert "Add Confidence" not in fta_labels
+    assert "Add Robustness" not in fta_labels
+    root.destroy()

--- a/tests/test_governance_cta_work_product.py
+++ b/tests/test_governance_cta_work_product.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+from analysis import SafetyManagementToolbox
+from sysml.sysml_repository import SysMLRepository
+
+
+def test_governance_cta_work_product_enabled(monkeypatch):
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    diag = repo.create_diagram("Governance Diagram", name="Gov1")
+    diag.tags.append("safety-management")
+
+    from analysis import safety_management as _sm
+    prev_tb = _sm.ACTIVE_TOOLBOX
+    toolbox = SafetyManagementToolbox()
+
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+    win.repo = repo
+    win.diagram_id = diag.diag_id
+    win.objects = []
+    win.connections = []
+    win.zoom = 1.0
+    win.sort_objects = lambda: None
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+
+    enabled = []
+    captured = {}
+
+    class DummyApp:
+        safety_mgmt_toolbox = toolbox
+
+        def enable_work_product(self, name, *, refresh=True):
+            enabled.append(name)
+
+    win.app = DummyApp()
+
+    class DummyDialog:
+        def __init__(self, parent, title, options):
+            if title == "Add Process Area":
+                self.selection = "Safety Analysis"
+            else:
+                captured["wp_options"] = options
+                self.selection = "CTA"
+
+    monkeypatch.setattr(GovernanceDiagramWindow, "_SelectDialog", DummyDialog)
+    win.add_work_product()
+
+    assert "CTA" in captured.get("wp_options", [])
+    assert "CTA" in enabled
+    _sm.ACTIVE_TOOLBOX = prev_tb

--- a/tests/test_malfunction_sharing.py
+++ b/tests/test_malfunction_sharing.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main.AutoML import AutoMLApp
+
+def test_shared_malfunction_across_analyses():
+    app = AutoMLApp.__new__(AutoMLApp)
+    te1 = type("N", (), {"unique_id": 1, "user_name": "F", "description": "d", "malfunction": "m"})()
+    te2 = type("N", (), {"unique_id": 2, "user_name": "C", "description": "d2", "malfunction": "m"})()
+    app.top_events = [te1]
+    app.cta_events = [te2]
+    app.paa_events = []
+    app._update_shared_product_goals()
+    assert te1.name_readonly and te2.name_readonly
+    assert te1.description == te2.description
+    assert te1.product_goal is te2.product_goal

--- a/tests/test_paa_top_event_creation.py
+++ b/tests/test_paa_top_event_creation.py
@@ -9,13 +9,21 @@ from main.AutoML import AutoMLApp
 def test_paa_diagram_has_top_event(monkeypatch):
     app = AutoMLApp.__new__(AutoMLApp)
     class DummyCanvas:
-        mode = ""
-    def fake_create_tab():
+        diagram_mode = ""
+
+    def fake_create_tab(mode):
         app.canvas = DummyCanvas()
+        app.canvas.diagram_mode = mode
+        app.diagram_mode = mode
+
     app._create_fta_tab = fake_create_tab
     app.top_events = []
+    app.cta_events = []
+    app.paa_events = []
     app.update_views = lambda: None
+    app.open_page_diagram = lambda *a, **k: None
     app.create_paa_diagram()
-    assert app.canvas.mode == "PAA"
-    assert len(app.top_events) == 1
-    assert getattr(app.top_events[0], "is_top_event", False)
+    assert app.canvas.diagram_mode == "PAA"
+    assert app.diagram_mode == "PAA"
+    assert len(app.paa_events) == 1
+    assert getattr(app.paa_events[0], "is_top_event", False)

--- a/tests/test_product_goal_requirement_menu.py
+++ b/tests/test_product_goal_requirement_menu.py
@@ -1,0 +1,37 @@
+import tkinter as tk
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main.AutoML import AutoMLApp
+
+class DummyMenu:
+    def __init__(self):
+        self.states = {}
+    def entryconfig(self, idx, state=tk.DISABLED):
+        self.states[idx] = state
+
+class DummyToolbox:
+    work_products = [1]
+    active_module = None
+    def enabled_products(self):
+        return {"Product Goal Specification"}
+
+def test_product_goal_enables_requirement_menu():
+    menu = DummyMenu()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.tool_listboxes = {}
+    app.tool_categories = {}
+    app.tool_actions = {}
+    app.enable_process_area = lambda area: None
+    app.update_views = lambda: None
+    app.work_product_menus = {"Product Goal Specification": [(menu, 0)]}
+    app.enabled_work_products = set()
+    app.WORK_PRODUCT_INFO = AutoMLApp.WORK_PRODUCT_INFO
+    app.WORK_PRODUCT_PARENTS = AutoMLApp.WORK_PRODUCT_PARENTS
+    app.tool_to_work_product = {}
+    app.safety_mgmt_toolbox = DummyToolbox()
+    AutoMLApp.enable_work_product(app, "Product Goal Specification", refresh=False)
+    AutoMLApp.refresh_tool_enablement(app)
+    assert menu.states[0] == tk.NORMAL


### PR DESCRIPTION
## Summary
- prevent PAA group duplication in the Safety Analysis explorer and fix FTA tabs so they open in the correct mode
- allow CTA and PAA analyses to share malfunctions with FTAs, locking names/descriptions and syncing through a shared product goal
- reject duplicate malfunctions within the same analysis type

## Testing
- `radon cc -s -j main/AutoML.py | jq '."main/AutoML.py"[] | select(.name | test("on_analysis_tree_double_click|_update_shared_product_goals"))'`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'AutoML')*
- `pytest tests/test_analysis_tree_grouping.py tests/test_malfunction_sharing.py tests/test_paa_top_event_creation.py tests/test_governance_paa_work_product.py tests/test_governance_cta_work_product.py tests/test_product_goal_requirement_menu.py tests/test_fta_menu_quantitative.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a9d5b3f1008327b8c88e51b683d06b