### PR TITLE
Ensure analysis tabs use their own colors

### DIFF
--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -9857,7 +9857,7 @@ class AutoMLApp:
             eff_y = int((node.y - min_y) * scale_factor)
             radius = int(45 * scale_factor)
             bbox = [eff_x - radius, eff_y - radius, eff_x + radius, eff_y + radius]
-            node_color = self.get_node_fill_color(node)
+            node_color = self.get_node_fill_color(node, getattr(self.canvas, "diagram_mode", None))
             draw.ellipse(bbox, outline="dimgray", fill=node_color)
             text = node.name
             text_size = draw.textsize(text, font=font)
@@ -23457,8 +23457,8 @@ class PageDiagram:
         outline_color = "red" if node == self.selected_node else "dimgray"
         line_width = 2 if node == self.selected_node else 1
 
-        # Determine the fill color (this function already uses the original's display_label)
-        fill_color = self.app.get_node_fill_color(node)
+        # Determine the fill color using this diagram's mode to avoid cross-tab color mixing
+        fill_color = self.app.get_node_fill_color(node, self.diagram_mode)
         font_obj = self.diagram_font
 
         # For shape selection, use the source’s node type and gate type.

--- a/tests/test_page_diagram_color_mode.py
+++ b/tests/test_page_diagram_color_mode.py
@@ -1,0 +1,62 @@
+from mainappsrc.AutoML import PageDiagram
+
+class DummyApp:
+    def __init__(self):
+        self.modes = []
+        self.project_properties = {}
+        self.occurrence_counts = {}
+
+    def get_node_fill_color(self, node, mode=None):
+        self.modes.append(mode)
+        return "#000000"
+
+
+class DummyCanvas:
+    diagram_mode = "CTA"
+
+    def bind(self, *args, **kwargs):
+        pass
+
+
+class DummyNode:
+    is_primary_instance = True
+    original = None
+    display_label = ""
+    input_subtype = None
+    description = ""
+    rationale = ""
+    equation = ""
+    detailed_equation = ""
+    name = "n"
+    x = 0
+    y = 0
+    unique_id = 1
+    node_type = "Basic Event"
+    children = []
+    parents = []
+    is_page = False
+    gate_type = "AND"
+
+
+class StubDrawingHelper:
+    def draw_circle_event_shape(self, *args, **kwargs):
+        pass
+
+
+class DummyFont:
+    def config(self, *args, **kwargs):
+        pass
+
+
+def test_page_diagram_uses_own_mode(monkeypatch):
+    from mainappsrc import AutoML as auto_module
+
+    monkeypatch.setattr(auto_module.tkFont, "Font", lambda *a, **k: DummyFont())
+    monkeypatch.setattr(auto_module, "fta_drawing_helper", StubDrawingHelper())
+
+    app = DummyApp()
+    canvas = DummyCanvas()
+    pd = PageDiagram(app, DummyNode(), canvas)
+    pd.draw_node(DummyNode())
+
+    assert app.modes == ["CTA"]


### PR DESCRIPTION
## Summary
- preserve node colors by passing each tab's diagram mode to color selection
- add regression test verifying page diagrams respect their diagram mode

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'AutoML')*
- `PYTHONPATH=. pytest tests/test_page_diagram_color_mode.py -q`
- `python tools/metrics_generator.py --path mainappsrc`


------
https://chatgpt.com/codex/tasks/task_b_68aa68636bc8832784e81932972e9483