### PR TITLE
Refactor GSN logic into dedicated manager

### DIFF
--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -248,14 +248,17 @@ from gui.review_toolbox import (
 )
 from functools import partial
 from gui.safety_management_toolbox import SafetyManagementToolbox
-from gui.gsn_explorer import GSNExplorer
 from gui.safety_management_explorer import SafetyManagementExplorer
 from gui.safety_case_explorer import SafetyCaseExplorer
-from gui.gsn_diagram_window import GSNDiagramWindow, GSN_WINDOWS
+from gui.gsn_diagram_window import GSN_WINDOWS
 from gui.causal_bayesian_network_window import CBN_WINDOWS
 from gui.gsn_config_window import GSNElementConfig
 from gui.search_toolbox import SearchToolbox
 from gsn import GSNDiagram, GSNModule
+try:
+    from .gsn_manager import GSNManager
+except ImportError:  # pragma: no cover
+    from gsn_manager import GSNManager
 from gsn.nodes import GSNNode, ALLOWED_AWAY_TYPES
 from gui.closable_notebook import ClosableNotebook
 from gui.icon_factory import create_icon
@@ -882,6 +885,7 @@ class AutoMLApp:
         self.management_diagrams = []
         self.gsn_modules = []  # top-level GSN modules
         self.gsn_diagrams = []  # diagrams not assigned to a module
+        self.gsn_manager = GSNManager(self)
         # Track open diagram tabs to avoid duplicates
         self.diagram_tabs: dict[str, ttk.Frame] = {}
         self.top_events = []
@@ -1256,7 +1260,7 @@ class AutoMLApp:
         )
 
         gsn_menu = tk.Menu(menubar, tearoff=0)
-        gsn_menu.add_command(label="GSN Explorer", command=self.manage_gsn)
+        gsn_menu.add_command(label="GSN Explorer", command=self.gsn_manager.manage_gsn)
         self.work_product_menus.setdefault("GSN Argumentation", []).append(
             (gsn_menu, gsn_menu.index("end"))
         )
@@ -10414,6 +10418,8 @@ class AutoMLApp:
         self.update_views()
         # Regenerate requirement patterns for any model change
         regenerate_requirement_patterns()
+        # Refresh GSN views separately via the manager
+        self.gsn_manager.refresh()
         # Refresh any secondary windows that may be open
         for attr in dir(self):
             if attr.endswith("_window"):
@@ -17484,13 +17490,7 @@ class AutoMLApp:
         self.refresh_all()
 
     def manage_gsn(self):
-        if hasattr(self, "_gsn_tab") and self._gsn_tab.winfo_exists():
-            self.doc_nb.select(self._gsn_tab)
-        else:
-            self._gsn_tab = self._new_tab("GSN Explorer")
-            self._gsn_window = GSNExplorer(self._gsn_tab, self)
-            self._gsn_window.pack(fill=tk.BOTH, expand=True)
-        self.refresh_all()
+        self.gsn_manager.manage_gsn()
 
     def manage_safety_management(self):
         if not hasattr(self, "safety_mgmt_toolbox"):
@@ -17523,19 +17523,7 @@ class AutoMLApp:
         self.refresh_all()
 
     def open_gsn_diagram(self, diagram):
-        """Open a GSN diagram inside a new notebook tab."""
-        existing = self.diagram_tabs.get(diagram.diag_id)
-        if existing and str(existing) in self.doc_nb.tabs():
-            if existing.winfo_exists():
-                self.doc_nb.select(existing)
-                self.refresh_all()
-                return
-            self.diagram_tabs.pop(diagram.diag_id, None)
-        tab = self._new_tab(diagram.root.user_name)
-        self.diagram_tabs[diagram.diag_id] = tab
-        window = GSNDiagramWindow(tab, self, diagram)
-        setattr(tab, "gsn_window", window)
-        self.refresh_all()
+        self.gsn_manager.open_diagram(diagram)
 
     def open_arch_window(self, diag_id: str) -> None:
         """Open an existing architecture diagram from the repository."""

--- a/mainappsrc/gsn_manager.py
+++ b/mainappsrc/gsn_manager.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Utility class to handle GSN specific UI actions."""
+
+import tkinter as tk
+from typing import TYPE_CHECKING, Optional
+
+from gui.gsn_explorer import GSNExplorer
+from gui.gsn_diagram_window import GSNDiagramWindow, GSN_WINDOWS
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .AutoML import AutoMLApp
+
+
+class GSNManager:
+    """Manage GSN explorers and diagram windows.
+
+    The manager centralises creation and refreshing of GSN related views so the
+    main :class:`AutoMLApp` can delegate these responsibilities.
+    """
+
+    def __init__(self, app: "AutoMLApp") -> None:
+        self.app = app
+        self._gsn_tab: Optional[tk.Widget] = None
+        self._gsn_window: Optional[GSNExplorer] = None
+
+    # ------------------------------------------------------------------
+    def manage_gsn(self) -> None:  # pragma: no cover - requires tkinter
+        """Show the GSN explorer tab, creating it if necessary."""
+        if self._gsn_tab and self._gsn_tab.winfo_exists():
+            self.app.doc_nb.select(self._gsn_tab)
+        else:
+            self._gsn_tab = self.app._new_tab("GSN Explorer")
+            self._gsn_window = GSNExplorer(self._gsn_tab, self.app)
+            self._gsn_window.pack(fill=tk.BOTH, expand=True)
+        self.app.refresh_all()
+
+    # ------------------------------------------------------------------
+    def open_diagram(self, diagram) -> None:  # pragma: no cover - requires tkinter
+        """Open *diagram* inside a new notebook tab."""
+        existing = self.app.diagram_tabs.get(diagram.diag_id)
+        if existing and str(existing) in self.app.doc_nb.tabs():
+            if existing.winfo_exists():
+                self.app.doc_nb.select(existing)
+                self.app.refresh_all()
+                return
+            self.app.diagram_tabs.pop(diagram.diag_id, None)
+        tab = self.app._new_tab(diagram.root.user_name)
+        self.app.diagram_tabs[diagram.diag_id] = tab
+        window = GSNDiagramWindow(tab, self.app, diagram)
+        setattr(tab, "gsn_window", window)
+        self.app.refresh_all()
+
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:  # pragma: no cover - requires tkinter
+        """Refresh open GSN windows."""
+        if self._gsn_window and self._gsn_window.winfo_exists():
+            if hasattr(self._gsn_window, "refresh"):
+                self._gsn_window.refresh()
+        for ref in list(GSN_WINDOWS):
+            win = ref()
+            if win and hasattr(win, "winfo_exists") and win.winfo_exists():
+                if hasattr(win, "refresh_from_repository"):
+                    win.refresh_from_repository()
+                elif hasattr(win, "refresh"):
+                    win.refresh()


### PR DESCRIPTION
## Summary
- Extract GSN explorer and diagram window handling into new `GSNManager`
- Delegate GSN UI actions through `GSNManager` in `AutoMLApp`
- Refresh GSN views via manager when application state changes

## Testing
- `radon cc mainappsrc/gsn_manager.py -s -j`
- `radon cc mainappsrc/AutoML.py -s -a -j > /tmp/radon_auto.json`
- `PYTHONPATH=mainappsrc pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68ab2757d7bc8327a14e8001849d4e40