### PR TITLE
Refactor governance handling into manager

### DIFF
--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -247,6 +247,8 @@ from gui.review_toolbox import (
     VersionCompareDialog,
 )
 from functools import partial
+# Governance helper class
+from mainappsrc.governance_manager import GovernanceManager
 from gui.safety_management_toolbox import SafetyManagementToolbox
 from gui.gsn_explorer import GSNExplorer
 from gui.safety_management_explorer import SafetyManagementExplorer
@@ -888,8 +890,9 @@ class AutoMLApp:
         self.reviews = []
         self.review_data = None
         self.review_window = None
+        self.governance_manager = GovernanceManager(self)
         self.safety_mgmt_toolbox = SafetyManagementToolbox()
-        self.safety_mgmt_toolbox.on_change = self._on_toolbox_change
+        self.governance_manager.attach_toolbox(self.safety_mgmt_toolbox)
         self.current_user = ""
         self.comment_target = None
         self._undo_stack: list[dict] = []
@@ -3317,7 +3320,7 @@ class AutoMLApp:
             self.project_properties["severity_probabilities"],
         )
         if smt:
-            smt.set_all_diagrams_frozen(freeze)
+            self.governance_manager.freeze_governance_diagrams(freeze)
 
     def edit_project_properties(self):
         prop_win = tk.Toplevel(self.root)
@@ -3408,7 +3411,7 @@ class AutoMLApp:
                 self.project_properties["severity_probabilities"],
             )
             if smt:
-                smt.set_all_diagrams_frozen(var_freeze.get())
+                self.governance_manager.freeze_governance_diagrams(var_freeze.get())
             messagebox.showinfo(
                 "Project Properties", "Project properties updated."
             )
@@ -8555,91 +8558,25 @@ class AutoMLApp:
             action()
 
     def _on_toolbox_change(self) -> None:
-        self.refresh_tool_enablement()
-        self._refresh_phase_requirements_menu()
-        try:
-            self.update_views()
-        except Exception:
-            pass
+        self.governance_manager._on_toolbox_change()
 
     def apply_governance_rules(self) -> None:
         """Apply governance rules and refresh related UI elements."""
-        try:
-            self._on_toolbox_change()
-        except Exception:
-            pass
+        self.governance_manager.apply_governance_rules()
 
     def refresh_tool_enablement(self) -> None:
-        if not hasattr(self, "tool_listboxes"):
-            return
-        toolbox = getattr(self, "safety_mgmt_toolbox", None)
-        if toolbox:
-            declared = set(toolbox.enabled_products())
-            # Parent menu categories must also be considered declared when
-            # any of their children are enabled so the cascade can be
-            # activated.
-            for name in list(declared):
-                parent = self.WORK_PRODUCT_PARENTS.get(name)
-                while parent:
-                    declared.add(parent)
-                    parent = self.WORK_PRODUCT_PARENTS.get(parent)
+        self.governance_manager.refresh_tool_enablement()
 
-            current = set(getattr(self, "enabled_work_products", set()))
-            for name in declared - current:
-                try:
-                    self.enable_work_product(name)
-                except Exception:
-                    self.enabled_work_products.add(name)
-            if getattr(toolbox, "work_products", None) or toolbox.active_module:
-                for name in current - declared:
-                    try:
-                        # Always hide work products that are not declared in
-                        # the active phase. ``force`` ensures the menu and
-                        # toolbox entries are disabled even when documents of
-                        # that type already exist.
-                        self.disable_work_product(name, force=True)
-                    except Exception:
-                        pass
-        global_enabled = getattr(self, "enabled_work_products", set())
-        if toolbox and (getattr(toolbox, "work_products", None) or toolbox.active_module):
-            phase_enabled = toolbox.enabled_products()
-            # Parent menu categories also need to remain active when any of
-            # their children are enabled.  ``phase_enabled`` only contains the
-            # direct work products declared in the governance diagram so we
-            # ascend the hierarchy here to ensure parent menus are treated as
-            # enabled as well.
-            for name in list(phase_enabled):
-                parent = self.WORK_PRODUCT_PARENTS.get(name)
-                while parent:
-                    phase_enabled.add(parent)
-                    parent = self.WORK_PRODUCT_PARENTS.get(parent)
-        else:
-            phase_enabled = global_enabled
-        enabled = global_enabled & phase_enabled
-        for lb in self.tool_listboxes.values():
-            for i, tool_name in enumerate(lb.get(0, tk.END)):
-                analysis_names = getattr(self, "tool_to_work_product", {}).get(tool_name, set())
-                if isinstance(analysis_names, str):
-                    analysis_names = {analysis_names}
-                if not analysis_names:
-                    in_enabled = tool_name in enabled
-                else:
-                    in_enabled = any(n in enabled for n in analysis_names)
-                if not in_enabled:
-                    lb.itemconfig(i, foreground="gray")
-                else:
-                    lb.itemconfig(i, foreground="black")
-        entry_state: dict[tuple[tk.Menu, int], bool] = {}
-        for wp, menus in getattr(self, "work_product_menus", {}).items():
-            is_enabled = wp in enabled
-            for menu, idx in menus:
-                key = (menu, idx)
-                entry_state[key] = entry_state.get(key, False) or is_enabled
-        for (menu, idx), is_enabled in entry_state.items():
-            try:
-                menu.entryconfig(idx, state=tk.NORMAL if is_enabled else tk.DISABLED)
-            except tk.TclError:
-                pass
+    def update_lifecycle_cb(self) -> None:
+        self.governance_manager.update_lifecycle_cb()
+
+    def _export_toolbox_dict(self) -> dict:
+        toolbox = getattr(self, "safety_mgmt_toolbox", None)
+        if toolbox is None:
+            toolbox = SafetyManagementToolbox()
+            self.governance_manager.attach_toolbox(toolbox)
+            self.safety_mgmt_toolbox = toolbox
+        return toolbox.to_dict()
 
     def on_lifecycle_selected(self, _event=None) -> None:
         phase = self.lifecycle_var.get()
@@ -8648,9 +8585,9 @@ class AutoMLApp:
                 text=f"Active phase: {phase or 'None'}"
             )
         if not phase:
-            self.safety_mgmt_toolbox.set_active_module(None)
+            self.governance_manager.set_active_module(None)
         else:
-            self.safety_mgmt_toolbox.set_active_module(phase)
+            self.governance_manager.set_active_module(phase)
         self.update_views()
         if hasattr(self, "refresh_tool_enablement"):
             try:
@@ -8677,23 +8614,6 @@ class AutoMLApp:
 
         for tab in getattr(self, "diagram_tabs", {}).values():
             _refresh_children(tab)
-
-
-    def update_lifecycle_cb(self) -> None:
-        if not hasattr(self, "lifecycle_cb"):
-            return
-        smt = getattr(self, "safety_mgmt_toolbox", None)
-        list_modules = getattr(smt, "list_modules", None)
-        names = (
-            list_modules()
-            if callable(list_modules)
-            else [m.name for m in getattr(smt, "modules", [])]
-        )
-        self.lifecycle_cb.configure(values=names)
-        if getattr(smt, "active_module", None) in names:
-            self.lifecycle_var.set(smt.active_module)
-        else:
-            self.lifecycle_var.set("")
 
     def _add_tool_category(self, cat: str, names: list[str]) -> None:
         frame = ttk.Frame(self.tools_nb)
@@ -9915,6 +9835,7 @@ class AutoMLApp:
                 self, "safety_mgmt_toolbox", SafetyManagementToolbox()
             )
             toolbox = self.safety_mgmt_toolbox
+            self.governance_manager.attach_toolbox(toolbox)
             toolbox.list_diagrams()
             self.update_lifecycle_cb()
             self.refresh_tool_enablement()
@@ -16807,6 +16728,7 @@ class AutoMLApp:
 
         if not hasattr(self, "safety_mgmt_toolbox"):
             self.safety_mgmt_toolbox = SafetyManagementToolbox()
+            self.governance_manager.attach_toolbox(self.safety_mgmt_toolbox)
 
         self.safety_mgmt_window = SafetyManagementWindow(
             self._safety_mgmt_tab, self, self.safety_mgmt_toolbox, show_diagrams=show_diagrams
@@ -17240,9 +17162,7 @@ class AutoMLApp:
                         )
                         module = toolbox.module_for_diagram(name)
                         if module != getattr(toolbox, "active_module", None):
-                            toolbox.set_active_module(module)
-                            if hasattr(self, "lifecycle_var") and hasattr(self.lifecycle_var, "set"):
-                                self.lifecycle_var.set(module or "")
+                            self.governance_manager.set_active_module(module)
                     break
 
     def _init_nav_button_style(self) -> None:
@@ -18974,9 +18894,7 @@ class AutoMLApp:
             "sysml_repository": repo.to_dict(),
             "gsn_modules": [m.to_dict() for m in getattr(self, "gsn_modules", [])],
             "gsn_diagrams": [d.to_dict() for d in getattr(self, "gsn_diagrams", [])],
-            "safety_mgmt_toolbox": getattr(
-                self, "safety_mgmt_toolbox", SafetyManagementToolbox()
-            ).to_dict(),
+            "safety_mgmt_toolbox": self._export_toolbox_dict(),
             "enabled_work_products": sorted(
                 getattr(self, "enabled_work_products", set())
             ),
@@ -19072,12 +18990,12 @@ class AutoMLApp:
             data.get("safety_mgmt_toolbox", {})
         )
         toolbox = self.safety_mgmt_toolbox
-        toolbox.on_change = self._on_toolbox_change
+        self.governance_manager.attach_toolbox(toolbox)
         # Refresh menus to expose phases from the loaded toolbox
         self._refresh_phase_requirements_menu()
         # Ensure the SysML repository knows about the active phase from the
         # loaded toolbox so diagrams and work products filter correctly.
-        toolbox.set_active_module(toolbox.active_module)
+        self.governance_manager.set_active_module(toolbox.active_module)
         for te in self.top_events:
             toolbox.register_loaded_work_product("FTA", te.user_name)
         for te in getattr(self, "cta_events", []):

--- a/mainappsrc/governance_manager.py
+++ b/mainappsrc/governance_manager.py
@@ -1,0 +1,150 @@
+"""Governance management helpers for :class:`AutoMLApp`.
+
+This module centralises interactions with the Safety Management Toolbox so the
+main application can delegate governance specific operations.  The manager
+controls lifecycle module activation, toolbox change propagation and diagram
+freezing utilities.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Iterable
+import tkinter as tk
+
+
+class GovernanceManager:
+    """Coordinate governance related features for the application.
+
+    Parameters
+    ----------
+    app:
+        The :class:`AutoMLApp` instance using this manager.  The manager calls
+        back into the application to enable/disable tools and to refresh views.
+    """
+
+    def __init__(self, app: "AutoMLApp") -> None:  # pragma: no cover - simple init
+        self.app = app
+        self.toolbox = None
+
+    # ------------------------------------------------------------------
+    def attach_toolbox(self, toolbox) -> None:
+        """Register the toolbox and hook change notifications."""
+        self.toolbox = toolbox
+        if self.toolbox is not None:
+            self.toolbox.on_change = self._on_toolbox_change
+
+    # ------------------------------------------------------------------
+    def freeze_governance_diagrams(self, freeze: bool) -> None:
+        """Freeze or unfreeze all registered governance diagrams."""
+        if self.toolbox is not None:
+            self.toolbox.set_all_diagrams_frozen(freeze)
+
+    # ------------------------------------------------------------------
+    def set_active_module(self, module: Optional[str]) -> None:
+        """Activate the requested lifecycle module in the toolbox."""
+        if self.toolbox is not None:
+            self.toolbox.set_active_module(module)
+        var = getattr(self.app, "lifecycle_var", None)
+        if var is not None and hasattr(var, "set"):
+            var.set(module or "")
+
+    # ------------------------------------------------------------------
+    def update_lifecycle_cb(self) -> None:
+        """Refresh the lifecycle combobox with available modules."""
+        cb = getattr(self.app, "lifecycle_cb", None)
+        if cb is None:
+            return
+        smt = self.toolbox
+        list_modules = getattr(smt, "list_modules", None)
+        names: Iterable[str]
+        if callable(list_modules):
+            names = list_modules()
+        else:
+            names = [m.name for m in getattr(smt, "modules", [])]
+        cb.configure(values=names)
+        active = getattr(smt, "active_module", None)
+        var = getattr(self.app, "lifecycle_var", None)
+        if var is not None and hasattr(var, "set"):
+            if active in names:
+                var.set(active)
+            else:
+                var.set("")
+
+    # ------------------------------------------------------------------
+    def apply_governance_rules(self) -> None:
+        """Public entry point used by the application to refresh tools."""
+        try:
+            self._on_toolbox_change()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def _on_toolbox_change(self) -> None:
+        """Handle toolbox modifications."""
+        self.refresh_tool_enablement()
+        refresh_menu = getattr(self.app, "_refresh_phase_requirements_menu", None)
+        if refresh_menu:
+            refresh_menu()
+        try:
+            if hasattr(self.app, "update_views"):
+                self.app.update_views()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def refresh_tool_enablement(self) -> None:
+        """Enable or disable tools based on toolbox configuration."""
+        if not hasattr(self.app, "tool_listboxes"):
+            return
+        toolbox = self.toolbox
+        if toolbox:
+            declared = set(toolbox.enabled_products())
+            for name in list(declared):
+                parent = self.app.WORK_PRODUCT_PARENTS.get(name)
+                while parent:
+                    declared.add(parent)
+                    parent = self.app.WORK_PRODUCT_PARENTS.get(parent)
+            current = set(getattr(self.app, "enabled_work_products", set()))
+            for name in declared - current:
+                try:
+                    self.app.enable_work_product(name)
+                except Exception:
+                    self.app.enabled_work_products.add(name)
+            if getattr(toolbox, "work_products", None) or toolbox.active_module:
+                for name in current - declared:
+                    try:
+                        self.app.disable_work_product(name, force=True)
+                    except Exception:
+                        pass
+        global_enabled = getattr(self.app, "enabled_work_products", set())
+        if toolbox and (getattr(toolbox, "work_products", None) or toolbox.active_module):
+            phase_enabled = toolbox.enabled_products()
+            for name in list(phase_enabled):
+                parent = self.app.WORK_PRODUCT_PARENTS.get(name)
+                while parent:
+                    phase_enabled.add(parent)
+                    parent = self.app.WORK_PRODUCT_PARENTS.get(parent)
+        else:
+            phase_enabled = global_enabled
+        enabled = global_enabled & phase_enabled
+        for lb in self.app.tool_listboxes.values():
+            for i, tool_name in enumerate(lb.get(0, tk.END)):
+                analysis_names = getattr(self.app, "tool_to_work_product", {}).get(tool_name, set())
+                if isinstance(analysis_names, str):
+                    analysis_names = {analysis_names}
+                if not analysis_names:
+                    in_enabled = tool_name in enabled
+                else:
+                    in_enabled = any(n in enabled for n in analysis_names)
+                lb.itemconfig(i, foreground="gray" if not in_enabled else "black")
+        entry_state: dict[tuple[tk.Menu, int], bool] = {}
+        for wp, menus in getattr(self.app, "work_product_menus", {}).items():
+            is_enabled = wp in enabled
+            for menu, idx in menus:
+                key = (menu, idx)
+                entry_state[key] = entry_state.get(key, False) or is_enabled
+        for (menu, idx), is_enabled in entry_state.items():
+            try:
+                menu.entryconfig(idx, state=tk.NORMAL if is_enabled else tk.DISABLED)
+            except tk.TclError:
+                pass


### PR DESCRIPTION
## Summary
- introduce `GovernanceManager` to centralize toolbox change handling, module activation, and diagram freezing
- delegate governance operations in `AutoMLApp` to `GovernanceManager`
- support exporting toolbox state through `_export_toolbox_dict`

## Testing
- `radon cc -s -j mainappsrc/governance_manager.py mainappsrc/AutoML.py`
- `pytest` *(fails: 101 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68ab275ec2ec8327a073480a13d95768