### PR TITLE
Refactor SOTIF management into dedicated component

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,30 @@
+"""Expose AutoML application classes at the package root."""
+import tkinter as tk
+from tkinter import ttk, simpledialog, filedialog, scrolledtext
+
+from .mainappsrc.AutoML import (
+    AutoMLApp,
+    PMHF_TARGETS,
+    FaultTreeNode,
+    AutoML_Helper,
+    messagebox,
+    GATE_NODE_TYPES,
+)
+from analysis.models import HazopDoc
+from gui.dialogs.edit_node_dialog import EditNodeDialog
+
+__all__ = [
+    "AutoMLApp",
+    "PMHF_TARGETS",
+    "FaultTreeNode",
+    "AutoML_Helper",
+    "messagebox",
+    "tk",
+    "ttk",
+    "simpledialog",
+    "filedialog",
+    "scrolledtext",
+    "GATE_NODE_TYPES",
+    "HazopDoc",
+    "EditNodeDialog",
+]

--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -227,6 +227,13 @@ import math
 import sys
 import json
 import tkinter as tk
+import os, sys
+base = os.path.dirname(__file__)
+if base not in sys.path:
+    sys.path.append(base)
+parent = os.path.dirname(base)
+if parent not in sys.path:
+    sys.path.append(parent)
 from typing import Any, Optional
 from tkinter import ttk, filedialog, simpledialog, scrolledtext
 from gui.dialog_utils import askstring_fixed
@@ -284,7 +291,14 @@ try:
 except Exception:  # openpyxl may not be installed
     load_workbook = None
 from gui.drawing_helper import FTADrawingHelper, fta_drawing_helper
-from mainappsrc.page_diagram import PageDiagram
+try:  # pragma: no cover
+    from .page_diagram import PageDiagram
+except Exception:  # pragma: no cover
+    import os, sys
+    base = os.path.dirname(__file__)
+    sys.path.append(base)
+    sys.path.append(os.path.dirname(base))
+    from page_diagram import PageDiagram
 from analysis.user_config import (
     load_user_config,
     save_user_config,
@@ -360,9 +374,20 @@ from analysis.scenario_description import template_phrases
 import copy
 import tkinter.font as tkFont
 import builtins
-from user_manager import UserManager
-from project_manager import ProjectManager
-from diagram_controller import DiagramController
+try:  # pragma: no cover - support direct module import
+    from .user_manager import UserManager
+    from .project_manager import ProjectManager
+    from .diagram_controller import DiagramController
+    from .sotif_manager import SOTIFManager
+except Exception:  # pragma: no cover
+    import os, sys
+    base = os.path.dirname(__file__)
+    sys.path.append(base)
+    sys.path.append(os.path.dirname(base))
+    from user_manager import UserManager
+    from project_manager import ProjectManager
+    from diagram_controller import DiagramController
+    from sotif_manager import SOTIFManager
 from config.automl_constants import (
     dynamic_recommendations,
     WORK_PRODUCT_INFO as BASE_WORK_PRODUCT_INFO,
@@ -417,10 +442,6 @@ else:  # pragma: no cover - fallback for minimal stubs
 from analysis.constants import CHECK_MARK, CROSS_MARK
 from analysis.utils import (
     append_unique_insensitive,
-    derive_validation_target,
-    exposure_to_probability,
-    controllability_to_probability,
-    severity_to_probability,
     update_probability_tables,
     EXPOSURE_PROBABILITIES,
     CONTROLLABILITY_PROBABILITIES,
@@ -429,7 +450,14 @@ from analysis.utils import (
 )
 from analysis.safety_management import SafetyManagementToolbox, ACTIVE_TOOLBOX
 from analysis.causal_bayesian_network import CausalBayesianNetwork, CausalBayesianNetworkDoc
-from models.fault_tree_node import FaultTreeNode
+try:  # pragma: no cover
+    from .models.fault_tree_node import FaultTreeNode
+except Exception:  # pragma: no cover
+    import os, sys
+    base = os.path.dirname(__file__)
+    sys.path.append(base)
+    sys.path.append(os.path.dirname(base))
+    from models.fault_tree_node import FaultTreeNode
 
 from gui.toolboxes import (
     ReliabilityWindow,
@@ -916,6 +944,7 @@ class AutoMLApp:
         self.user_manager = UserManager(self)
         self.project_manager = ProjectManager(self)
         self.diagram_controller = DiagramController(self)
+        self.sotif_manager = SOTIFManager(self)
 
         self.mechanism_libraries = []
         self.selected_mechanism_libraries = []
@@ -14016,76 +14045,7 @@ class AutoMLApp:
                 self.desc_text.grid(row=5, column=1, padx=5, pady=5)
 
                 # --- SOTIF fields ---
-                ttk.Label(sotif_tab, text="Acceptance Rate (1/h):").grid(row=0, column=0, sticky="e")
-                self.accept_rate_var = tk.StringVar(value=str(getattr(self.initial, "acceptance_rate", 0.0)))
-                tk.Entry(
-                    sotif_tab,
-                    textvariable=self.accept_rate_var,
-                    validate="key",
-                    validatecommand=(master.register(self.app.validate_float), "%P"),
-                ).grid(row=0, column=1, padx=5, pady=5)
-
-                ttk.Label(sotif_tab, text="On Hours:").grid(row=1, column=0, sticky="e")
-                self.op_hours_var = tk.StringVar(value=str(getattr(self.initial, "operational_hours_on", 0.0)))
-                tk.Entry(
-                    sotif_tab,
-                    textvariable=self.op_hours_var,
-                    validate="key",
-                    validatecommand=(master.register(self.app.validate_float), "%P"),
-                ).grid(row=1, column=1, padx=5, pady=5)
-
-                ttk.Label(sotif_tab, text="Acceptance Criteria Description:").grid(row=2, column=0, sticky="ne")
-                self.acc_text = tk.Text(sotif_tab, width=30, height=3, wrap="word")
-                self.acc_text.insert("1.0", getattr(self.initial, "acceptance_criteria", ""))
-                self.acc_text.grid(row=2, column=1, padx=5, pady=5)
-
-                exp = exposure_to_probability(getattr(self.initial, "exposure", 1))
-                ctrl = controllability_to_probability(getattr(self.initial, "controllability", 1))
-                sev = severity_to_probability(getattr(self.initial, "severity", 1))
-
-                ttk.Label(sotif_tab, text="P(E|HB):").grid(row=3, column=0, sticky="e")
-                self.pehb_var = tk.StringVar(value=str(exp))
-                tk.Entry(sotif_tab, textvariable=self.pehb_var, state="readonly").grid(row=3, column=1, padx=5, pady=5)
-
-                ttk.Label(sotif_tab, text="P(C|E):").grid(row=4, column=0, sticky="e")
-                self.pce_var = tk.StringVar(value=str(ctrl))
-                tk.Entry(sotif_tab, textvariable=self.pce_var, state="readonly").grid(row=4, column=1, padx=5, pady=5)
-
-                ttk.Label(sotif_tab, text="P(S|C):").grid(row=5, column=0, sticky="e")
-                self.psc_var = tk.StringVar(value=str(sev))
-                tk.Entry(sotif_tab, textvariable=self.psc_var, state="readonly").grid(row=5, column=1, padx=5, pady=5)
-
-                ttk.Label(sotif_tab, text="Validation Target (1/h):").grid(row=6, column=0, sticky="e")
-                try:
-                    val = derive_validation_target(float(self.accept_rate_var.get() or 0.0), exp, ctrl, sev)
-                except Exception:
-                    val = 1.0
-                self.val_var = tk.StringVar(value=str(val))
-                tk.Entry(sotif_tab, textvariable=self.val_var, state="readonly").grid(row=6, column=1, padx=5, pady=5)
-
-                def _update_val(*_):
-                    try:
-                        acc = float(self.accept_rate_var.get())
-                        v = derive_validation_target(acc, float(self.pehb_var.get()), float(self.pce_var.get()), float(self.psc_var.get()))
-                    except Exception:
-                        v = 1.0
-                    self.val_var.set(str(v))
-
-                self.accept_rate_var.trace_add("write", _update_val)
-
-                ttk.Label(sotif_tab, text="Mission Profile:").grid(row=7, column=0, sticky="e")
-                self.profile_var = tk.StringVar(value=getattr(self.initial, "mission_profile", ""))
-                ttk.Combobox(
-                    sotif_tab,
-                    textvariable=self.profile_var,
-                    values=[mp.name for mp in self.app.mission_profiles],
-                    state="readonly",
-                ).grid(row=7, column=1, padx=5, pady=5)
-
-                ttk.Label(sotif_tab, text="Val Target Description:").grid(row=8, column=0, sticky="ne")
-                self.val_desc_text = tk.Text(sotif_tab, width=30, height=3, wrap="word")
-                self.val_desc_text.insert("1.0", getattr(self.initial, "validation_desc", ""))
-                self.val_desc_text.grid(row=8, column=1, padx=5, pady=5)
+                self.app.sotif_manager.build_goal_dialog(self, sotif_tab, self.initial)
 
                 # --- Cybersecurity fields ---
                 ttk.Label(cyber_tab, text="CAL:").grid(row=0, column=0, sticky="e")
@@ -14102,17 +14062,9 @@ class AutoMLApp:
                     "asil": asil,
                     "state": self.state_var.get().strip(),
                     "ftti": self.ftti_var.get().strip(),
-                    "accept_rate": self.accept_rate_var.get().strip(),
-                    "op_hours": self.op_hours_var.get().strip(),
-                    "pehb": self.pehb_var.get().strip(),
-                    "pce": self.pce_var.get().strip(),
-                    "psc": self.psc_var.get().strip(),
-                    "val": self.val_var.get().strip(),
-                    "profile": self.profile_var.get().strip(),
-                    "val_desc": self.val_desc_text.get("1.0", "end-1c"),
-                    "accept": self.acc_text.get("1.0", "end-1c"),
                     "desc": desc,
                 }
+                self.result.update(self.app.sotif_manager.collect_goal_data(self))
 
         def add_sg():
             dlg = SGDialog(win, self, "Add Product Goal")
@@ -14200,8 +14152,7 @@ class AutoMLApp:
         targets: set[str] = set()
         for sg in getattr(self, "top_events", []):
             pg_name = self._product_goal_name(sg)
-            if getattr(sg, "validation_target", "") not in ("", None):
-                targets.add(f"{pg_name} (SOTIF)")
+            targets.update(self.sotif_manager.get_spi_targets_for_goal(sg, pg_name))
             asil = getattr(sg, "safety_goal_asil", "")
             if asil in PMHF_TARGETS:
                 targets.add(f"{pg_name} (FUSA)")
@@ -14273,37 +14224,15 @@ class AutoMLApp:
             tree.delete(iid)
         self._spi_lookup = {}
 
-        for sg in getattr(self, "top_events", []):
-            # SOTIF SPI row
-            sotif_prob = getattr(sg, "spi_probability", "")
-            p_str = f"{sotif_prob:.2e}" if sotif_prob not in ("", None) else ""
-            v_target = getattr(sg, "validation_target", "")
-            if v_target not in ("", None):
-                v_str = f"{v_target:.2e}"
-                spi_val = ""
-                try:
-                    if sotif_prob not in ("", None):
-                        v_val = float(v_target)
-                        p_val = float(sotif_prob)
-                        if v_val > 0 and p_val > 0:
-                            spi_val = f"{math.log10(v_val / p_val):.2f}"
-                except Exception:
-                    spi_val = ""
-                iid = tree.insert(
-                    "",
-                    "end",
-                    values=[
-                        sg.user_name or f"SG {sg.unique_id}",
-                        v_str,
-                        p_str,
-                        spi_val,
-                        self._spi_label(sg),
-                        getattr(sg, "acceptance_criteria", ""),
-                    ],
-                )
-                self._spi_lookup[iid] = (sg, "SOTIF")
+        manager = getattr(self, "sotif_manager", None)
+        if manager is None:
+            manager = SOTIFManager(self)
+            self.sotif_manager = manager
+        for sg, values in manager.iter_spi_rows():
+            iid = tree.insert("", "end", values=values)
+            self._spi_lookup[iid] = (sg, "SOTIF")
 
-            # FUSA SPI row
+        for sg in getattr(self, "top_events", []):
             asil = getattr(sg, "safety_goal_asil", "")
             if asil in PMHF_TARGETS:
                 target = PMHF_TARGETS[asil]

--- a/mainappsrc/sotif_manager.py
+++ b/mainappsrc/sotif_manager.py
@@ -1,0 +1,165 @@
+"""SOTIF management utilities for AutoMLApp."""
+from __future__ import annotations
+
+import math
+import tkinter as tk
+from tkinter import ttk
+
+from analysis.utils import (
+    derive_validation_target,
+    exposure_to_probability,
+    controllability_to_probability,
+    severity_to_probability,
+)
+
+
+class SOTIFManager:
+    """Handle SOTIF specific helpers for :class:`AutoMLApp`.
+
+    The manager provides small utility methods used by the main application
+    to build dialogs, collect user input and derive values for Safety
+    Performance Indicators (SPIs).
+    """
+
+    def __init__(self, app: "AutoMLApp") -> None:
+        self.app = app
+
+    # ------------------------------------------------------------------
+    # Dialog helpers
+    # ------------------------------------------------------------------
+    def build_goal_dialog(self, dlg, tab: ttk.Frame, initial) -> None:
+        """Populate *tab* of the product goal dialog with SOTIF fields.
+
+        The created Tk variables are attached to *dlg* so they can be queried
+        later from :meth:`collect_goal_data`.
+        """
+
+        ttk.Label(tab, text="Acceptance Rate (1/h):").grid(row=0, column=0, sticky="e")
+        dlg.accept_rate_var = tk.StringVar(value=str(getattr(initial, "acceptance_rate", 0.0)))
+        tk.Entry(
+            tab,
+            textvariable=dlg.accept_rate_var,
+            validate="key",
+            validatecommand=(tab.register(dlg.app.validate_float), "%P"),
+        ).grid(row=0, column=1, padx=5, pady=5)
+
+        ttk.Label(tab, text="On Hours:").grid(row=1, column=0, sticky="e")
+        dlg.op_hours_var = tk.StringVar(value=str(getattr(initial, "operational_hours_on", 0.0)))
+        tk.Entry(
+            tab,
+            textvariable=dlg.op_hours_var,
+            validate="key",
+            validatecommand=(tab.register(dlg.app.validate_float), "%P"),
+        ).grid(row=1, column=1, padx=5, pady=5)
+
+        ttk.Label(tab, text="Acceptance Criteria Description:").grid(row=2, column=0, sticky="ne")
+        dlg.acc_text = tk.Text(tab, width=30, height=3, wrap="word")
+        dlg.acc_text.insert("1.0", getattr(initial, "acceptance_criteria", ""))
+        dlg.acc_text.grid(row=2, column=1, padx=5, pady=5)
+
+        exp, ctrl, sev = self.probabilities_for(initial)
+
+        ttk.Label(tab, text="P(E|HB):").grid(row=3, column=0, sticky="e")
+        dlg.pehb_var = tk.StringVar(value=str(exp))
+        tk.Entry(tab, textvariable=dlg.pehb_var, state="readonly").grid(row=3, column=1, padx=5, pady=5)
+
+        ttk.Label(tab, text="P(C|E):").grid(row=4, column=0, sticky="e")
+        dlg.pce_var = tk.StringVar(value=str(ctrl))
+        tk.Entry(tab, textvariable=dlg.pce_var, state="readonly").grid(row=4, column=1, padx=5, pady=5)
+
+        ttk.Label(tab, text="P(S|C):").grid(row=5, column=0, sticky="e")
+        dlg.psc_var = tk.StringVar(value=str(sev))
+        tk.Entry(tab, textvariable=dlg.psc_var, state="readonly").grid(row=5, column=1, padx=5, pady=5)
+
+        ttk.Label(tab, text="Validation Target (1/h):").grid(row=6, column=0, sticky="e")
+        try:
+            val = derive_validation_target(float(dlg.accept_rate_var.get() or 0.0), exp, ctrl, sev)
+        except Exception:
+            val = 1.0
+        dlg.val_var = tk.StringVar(value=str(val))
+        tk.Entry(tab, textvariable=dlg.val_var, state="readonly").grid(row=6, column=1, padx=5, pady=5)
+
+        def _update_val(*_):
+            try:
+                acc = float(dlg.accept_rate_var.get())
+                v = derive_validation_target(acc, float(dlg.pehb_var.get()), float(dlg.pce_var.get()), float(dlg.psc_var.get()))
+            except Exception:
+                v = 1.0
+            dlg.val_var.set(str(v))
+
+        dlg.accept_rate_var.trace_add("write", _update_val)
+
+        ttk.Label(tab, text="Mission Profile:").grid(row=7, column=0, sticky="e")
+        dlg.profile_var = tk.StringVar(value=getattr(initial, "mission_profile", ""))
+        ttk.Combobox(
+            tab,
+            textvariable=dlg.profile_var,
+            values=[mp.name for mp in self.app.mission_profiles],
+            state="readonly",
+        ).grid(row=7, column=1, padx=5, pady=5)
+
+        ttk.Label(tab, text="Val Target Description:").grid(row=8, column=0, sticky="ne")
+        dlg.val_desc_text = tk.Text(tab, width=30, height=3, wrap="word")
+        dlg.val_desc_text.insert("1.0", getattr(initial, "validation_desc", ""))
+        dlg.val_desc_text.grid(row=8, column=1, padx=5, pady=5)
+
+    # ------------------------------------------------------------------
+    def collect_goal_data(self, dlg) -> dict[str, str]:
+        """Return user input from the SOTIF section of the dialog."""
+        return {
+            "accept_rate": dlg.accept_rate_var.get().strip(),
+            "op_hours": dlg.op_hours_var.get().strip(),
+            "pehb": dlg.pehb_var.get().strip(),
+            "pce": dlg.pce_var.get().strip(),
+            "psc": dlg.psc_var.get().strip(),
+            "val": dlg.val_var.get().strip(),
+            "profile": dlg.profile_var.get().strip(),
+            "val_desc": dlg.val_desc_text.get("1.0", "end-1c"),
+            "accept": dlg.acc_text.get("1.0", "end-1c"),
+        }
+
+    # ------------------------------------------------------------------
+    # SPI helpers
+    # ------------------------------------------------------------------
+    def get_spi_targets_for_goal(self, sg, pg_name: str) -> list[str]:
+        """Return SPI target labels for *sg* if SOTIF data is present."""
+        if getattr(sg, "validation_target", "") not in ("", None):
+            return [f"{pg_name} (SOTIF)"]
+        return []
+
+    def iter_spi_rows(self):
+        """Yield (sg, values) pairs for populating the SPI table."""
+        for sg in getattr(self.app, "top_events", []):
+            v_target = getattr(sg, "validation_target", "")
+            if v_target in ("", None):
+                continue
+            v_str = f"{v_target:.2e}"
+            sotif_prob = getattr(sg, "spi_probability", "")
+            p_str = f"{sotif_prob:.2e}" if sotif_prob not in ("", None) else ""
+            spi_val = ""
+            try:
+                if sotif_prob not in ("", None):
+                    v_val = float(v_target)
+                    p_val = float(sotif_prob)
+                    if v_val > 0 and p_val > 0:
+                        spi_val = f"{math.log10(v_val / p_val):.2f}"
+            except Exception:
+                spi_val = ""
+            values = [
+                getattr(sg, "user_name", "") or f"SG {getattr(sg, 'unique_id', '')}",
+                v_str,
+                p_str,
+                spi_val,
+                self.app._spi_label(sg),
+                getattr(sg, "acceptance_criteria", ""),
+            ]
+            yield sg, values
+
+    # ------------------------------------------------------------------
+    def probabilities_for(self, sg) -> tuple[float, float, float]:
+        """Return exposure, controllability and severity probabilities for ``sg``."""
+        return (
+            exposure_to_probability(getattr(sg, "exposure", 1)),
+            controllability_to_probability(getattr(sg, "controllability", 1)),
+            severity_to_probability(getattr(sg, "severity", 1)),
+        )


### PR DESCRIPTION
## Summary
- add `SOTIFManager` to encapsulate SOTIF dialog and SPI logic
- delegate SPI target handling and dialog creation from `AutoMLApp`
- expose core application objects at package root for compatibility

## Testing
- `radon cc -s -j mainappsrc/sotif_manager.py`
- `PYTHONPATH=/workspace pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68ab27714ca08327925153b03a119ec6