### PR TITLE
Fix missing PrototypeAssuranceManager import

### DIFF
--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -256,6 +256,7 @@ from gui.review_toolbox import (
 from functools import partial
 # Governance helper class
 from mainappsrc.governance_manager import GovernanceManager
+from mainappsrc.paa_manager import PrototypeAssuranceManager
 from gui.safety_management_toolbox import SafetyManagementToolbox
 from gui.safety_management_explorer import SafetyManagementExplorer
 from gui.safety_case_explorer import SafetyCaseExplorer


### PR DESCRIPTION
## Summary
- import PrototypeAssuranceManager to satisfy type hint resolution

## Testing
- `pytest tests/test_paa_top_event_creation.py::test_paa_diagram_has_top_event -q`
- `pytest` *(fails: 97 errors during collection)*
- `radon cc -s -j mainappsrc/AutoML.py`


------
https://chatgpt.com/codex/tasks/task_b_68ab2bf1fb7c83278f3df54cb7470c59