### PR TITLE
Prune unused helpers and clean up forward references

### DIFF
--- a/analysis/safety_case.py
+++ b/analysis/safety_case.py
@@ -78,8 +78,5 @@ class SafetyCaseLibrary:
         if case in self.cases:
             self.cases.remove(case)
 
-    def rename_case(self, case: SafetyCase, new_name: str) -> None:
-        case.name = new_name
-
     def list_cases(self) -> List[SafetyCase]:
         return list(self.cases)

--- a/gsn/module.py
+++ b/gsn/module.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, TYPE_CHECKING
 
 # forward import of GSNDiagram for type checking only
-if True:  # pragma: no cover - forward references
+if TYPE_CHECKING:  # pragma: no cover - forward references
     from .diagram import GSNDiagram
 
 


### PR DESCRIPTION
## Summary
- Remove unused helper methods from risk assessment utilities
- Drop dead rename_case method from safety case library
- Use TYPE_CHECKING for forward reference in GSN modules

## Testing
- `radon cc -j analysis/risk_assessment.py`
- `radon cc -j analysis/safety_case.py`
- `pytest -q` *(fails: ImportError: cannot import name 'AutoML_Helper'; missing libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_b_68ab383202fc83278b825950174e9468