### PR TITLE
Clone FTA nodes on paste to preserve original linkage

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -1,4 +1,29 @@
 """Compatibility module exposing AutoML application classes."""
-from mainappsrc.AutoML import AutoMLApp
+from mainappsrc.AutoML import (
+    AutoMLApp,
+    PMHF_TARGETS,
+    FaultTreeNode,
+    AutoML_Helper,
+    messagebox,
+    GATE_NODE_TYPES,
+)
+import tkinter as tk
+from tkinter import ttk, simpledialog, filedialog, scrolledtext
+from analysis.models import HazopDoc
+from gui.dialogs.edit_node_dialog import EditNodeDialog
 
-__all__ = ["AutoMLApp"]
+__all__ = [
+    "AutoMLApp",
+    "PMHF_TARGETS",
+    "FaultTreeNode",
+    "AutoML_Helper",
+    "messagebox",
+    "GATE_NODE_TYPES",
+    "tk",
+    "ttk",
+    "simpledialog",
+    "filedialog",
+    "scrolledtext",
+    "HazopDoc",
+    "EditNodeDialog",
+]

--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -17501,10 +17501,12 @@ class AutoMLApp:
                 messagebox.showinfo("Paste", "Node moved successfully (cut & pasted).")
             else:
                 target_diag = self._find_gsn_diagram(target)
-                if (
-                    isinstance(self.clipboard_node, GSNNode)
-                    and target in getattr(self.clipboard_node, "parents", [])
-                ):
+                if isinstance(self.clipboard_node, GSNNode):
+                    if target in getattr(self.clipboard_node, "parents", []):
+                        node_for_pos = self._clone_for_paste(self.clipboard_node, target)
+                    else:
+                        node_for_pos = self._clone_for_paste(self.clipboard_node)
+                elif isinstance(self.clipboard_node, FaultTreeNode):
                     node_for_pos = self._clone_for_paste(self.clipboard_node)
                 else:
                     node_for_pos = self.clipboard_node

--- a/mainappsrc/models/fault_tree_node.py
+++ b/mainappsrc/models/fault_tree_node.py
@@ -195,6 +195,20 @@ class FaultTreeNode:
             d["original_id"] = self.original.unique_id
         return d
 
+    def clone(self):
+        """Return a clone of this node sharing the same original reference."""
+        import copy
+        from AutoML import AutoML_Helper
+
+        new_node = copy.deepcopy(self)
+        new_node.unique_id = AutoML_Helper.get_next_unique_id()
+        new_node.parents = []
+        new_node.children = []
+        new_node.is_primary_instance = False
+        new_node.original = self if self.is_primary_instance else self.original
+        new_node._original_id = new_node.original.unique_id
+        return new_node
+
     @staticmethod
     def from_dict(data, parent=None):
         node = FaultTreeNode.__new__(FaultTreeNode)

--- a/tests/test_fta_clone_paste.py
+++ b/tests/test_fta_clone_paste.py
@@ -1,0 +1,61 @@
+import types
+import os
+import sys
+import unittest
+
+# Provide dummy PIL modules so AutoML can be imported without Pillow
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("PIL.Image"))
+sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
+sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
+sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
+
+# Ensure repository root is on the path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from AutoML import AutoMLApp, FaultTreeNode
+from gui import messagebox
+
+
+class DummyTree:
+    def selection(self):
+        return ()
+
+    def item(self, iid, attr):
+        return None
+
+
+class FTACopyPasteTests(unittest.TestCase):
+    def setUp(self):
+        self.app = AutoMLApp.__new__(AutoMLApp)
+        self.app.root_node = FaultTreeNode("root", "TOP EVENT")
+        self.app.analysis_tree = DummyTree()
+        self.app.top_events = []
+        self.app.update_views = lambda: None
+
+        self.child = FaultTreeNode("child", "Basic Event", parent=self.app.root_node)
+        self.app.root_node.children.append(self.child)
+        self.app.selected_node = self.child
+
+        self._orig_info = messagebox.showinfo
+        self._orig_warn = messagebox.showwarning
+        messagebox.showinfo = lambda *a, **k: None
+        messagebox.showwarning = lambda *a, **k: None
+
+    def tearDown(self):
+        messagebox.showinfo = self._orig_info
+        messagebox.showwarning = self._orig_warn
+
+    def test_copy_paste_creates_clone(self):
+        self.app.copy_node()
+        self.app.selected_node = self.app.root_node
+        self.app.paste_node()
+        self.assertEqual(len(self.app.root_node.children), 2)
+        clone = self.app.root_node.children[-1]
+        self.assertIsNot(clone, self.child)
+        self.assertIs(clone.original, self.child)
+        self.assertFalse(clone.is_primary_instance)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure pasting an FTA node creates a clone referencing the original
- expose AutoML helpers and tkinter utilities via compatibility module
- add regression test for FTA copy/paste cloning

## Testing
- `pytest tests/test_fta_clone_paste.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*
- `python tools/metrics_generator.py --path mainappsrc/models`

------
https://chatgpt.com/codex/tasks/task_b_68ab3d9f18a88327b648cac217c48928