### PR TITLE
Fix FTA node copy to create clones

### DIFF
--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -17416,6 +17416,19 @@ class AutoMLApp:
         messagebox.showwarning("Clone", "Cannot clone this node type.")
         return None
 
+    def _prepare_node_for_paste(self, target):
+        """Return appropriate node instance when pasting."""
+        if (
+            isinstance(self.clipboard_node, GSNNode)
+            and target in getattr(self.clipboard_node, "parents", [])
+        ):
+            return self._clone_for_paste(self.clipboard_node)
+        from .models.fault_tree_node import FaultTreeNode
+
+        if isinstance(self.clipboard_node, FaultTreeNode):
+            return self._clone_for_paste(self.clipboard_node)
+        return self.clipboard_node
+
     def paste_node(self):
         if self.clipboard_node:
             # NOTE: Paste logic and target resolution chain (selection → focused diagram root → app root)
@@ -17501,13 +17514,7 @@ class AutoMLApp:
                 messagebox.showinfo("Paste", "Node moved successfully (cut & pasted).")
             else:
                 target_diag = self._find_gsn_diagram(target)
-                if (
-                    isinstance(self.clipboard_node, GSNNode)
-                    and target in getattr(self.clipboard_node, "parents", [])
-                ):
-                    node_for_pos = self._clone_for_paste(self.clipboard_node)
-                else:
-                    node_for_pos = self.clipboard_node
+                node_for_pos = self._prepare_node_for_paste(target)
                 target.children.append(node_for_pos)
                 node_for_pos.parents.append(target)
                 if isinstance(node_for_pos, GSNNode):

--- a/mainappsrc/models/fault_tree_node.py
+++ b/mainappsrc/models/fault_tree_node.py
@@ -276,3 +276,20 @@ class FaultTreeNode:
         else:
             node._original_id = None
         return node
+
+    # ------------------------------------------------------------------
+    def clone(self, parent=None):
+        """Return a copy of this node referencing the same original."""
+        import copy
+        from AutoML import AutoML_Helper
+
+        clone = copy.deepcopy(self)
+        clone.unique_id = AutoML_Helper.get_next_unique_id()
+        clone.children = []
+        clone.parents = []
+        clone.is_primary_instance = False
+        clone.original = self.original if getattr(self, "original", None) else self
+        if parent is not None:
+            clone.parents.append(parent)
+            parent.children.append(clone)
+        return clone

--- a/tests/test_fta_clone_paste.py
+++ b/tests/test_fta_clone_paste.py
@@ -1,0 +1,57 @@
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location(
+    "AutoML", repo_root / "__init__.py", submodule_search_locations=[str(repo_root)]
+)
+automl = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = automl
+spec.loader.exec_module(automl)
+AutoMLApp = automl.AutoMLApp
+FaultTreeNode = automl.FaultTreeNode
+messagebox = automl.messagebox
+
+
+def _make_app_with_nodes():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.top_events = []
+    app.root_node = None
+    app.selected_node = None
+    app.analysis_tree = types.SimpleNamespace(selection=lambda: ())
+    app.update_views = lambda: None
+    app._diagram_copy_strategy1 = app._diagram_copy_strategy2 = lambda: False
+    app._diagram_copy_strategy3 = app._diagram_copy_strategy4 = lambda: False
+    app._find_gsn_diagram = lambda node: None
+    app._focused_gsn_window = lambda: None
+    app._focused_cbn_window = lambda: None
+    app._find_cbn_diagram = lambda node: None
+    app._focused_arch_window = lambda t=None: None
+    messagebox.showinfo = lambda *a, **k: None
+    messagebox.showwarning = lambda *a, **k: None
+    return app
+
+
+def test_fta_copy_paste_creates_clone():
+    app = _make_app_with_nodes()
+    root = FaultTreeNode("Root", "TOP EVENT")
+    child = FaultTreeNode("Child", "GATE", parent=root)
+    root.children.append(child)
+    app.root_node = root
+    app.top_events.append(root)
+    app.selected_node = child
+
+    app.copy_node()
+    assert app.clipboard_node is child
+
+    app.selected_node = root
+    app.paste_node()
+
+    assert len(root.children) == 2
+    pasted = root.children[-1]
+    assert pasted is not child
+    assert pasted.original is child
+    assert not pasted.is_primary_instance


### PR DESCRIPTION
## Summary
- Add `clone` method to `FaultTreeNode` to generate proper cloned nodes
- Refactor `paste_node` logic and introduce `_prepare_node_for_paste` to clone FTA nodes when copying
- Cover FTA copy-paste cloning with unit test

## Testing
- `pytest tests/test_fta_clone_paste.py::test_fta_copy_paste_creates_clone -q`
- `PYTHONPATH=. pytest -q` *(fails: ImportError: cannot import name 'AutoML_Helper' from 'AutoML'; ImportError: libGL.so.1: cannot open shared object file)*
- `radon cc -j mainappsrc/AutoML.py mainappsrc/models/fault_tree_node.py`


------
https://chatgpt.com/codex/tasks/task_b_68ab3d9f18a88327b648cac217c48928