### PR TITLE
Fix FTA node copy to create clones

### DIFF
--- a/gui/drawing_helper.py
+++ b/gui/drawing_helper.py
@@ -183,7 +183,7 @@ class FTADrawingHelper:
         font_obj=None,
         obj_id: str = "",
     ):
-        """Draw a page connector for a cloned node using GSN's shared-marker notation."""
+        """Draw a page connector for a cloned node using a bottom line marker."""
         outline_color = self._resolve_outline(outline_color)
         # Draw the base triangle.
         self.draw_triangle_shape(
@@ -199,10 +199,17 @@ class FTADrawingHelper:
             font_obj=font_obj,
             obj_id=obj_id,
         )
-        # Add a small shared marker in the upper-right corner to indicate a clone.
-        marker_x = x + scale / 2
-        marker_y = y - scale * 0.3
-        self.draw_shared_marker(canvas, marker_x, marker_y, 1)
+        # Add a small horizontal line below the shape to indicate a clone.
+        line_y = y + scale * 0.5
+        canvas.create_line(
+            x - scale * 0.4,
+            line_y,
+            x + scale * 0.4,
+            line_y,
+            fill=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
 
     def draw_shared_marker(self, canvas, x, y, zoom):
         """Draw a small shared marker at the given canvas coordinates."""
@@ -584,10 +591,17 @@ class FTADrawingHelper:
             font_obj=font_obj,
             obj_id=obj_id,
         )
-        # Add shared marker at the upper-right corner of the gate.
-        marker_x = x + scale / 2
-        marker_y = y - scale * 0.3
-        self.draw_shared_marker(canvas, marker_x, marker_y, 1)
+        # Draw a horizontal line below the gate to indicate no children.
+        line_y = y + scale * 0.8
+        canvas.create_line(
+            x - scale * 0.4,
+            line_y,
+            x + scale * 0.4,
+            line_y,
+            fill=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
 
     def draw_rotated_or_gate_clone_shape(
         self,
@@ -618,10 +632,17 @@ class FTADrawingHelper:
             font_obj=font_obj,
             obj_id=obj_id,
         )
-        # Add shared marker at the upper-right corner of the gate.
-        marker_x = x + scale / 2
-        marker_y = y - scale * 0.3
-        self.draw_shared_marker(canvas, marker_x, marker_y, 1)
+        # Draw a horizontal line below the gate to indicate no children.
+        line_y = y + scale * 0.8
+        canvas.create_line(
+            x - scale * 0.4,
+            line_y,
+            x + scale * 0.4,
+            line_y,
+            fill=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
 
     def draw_triangle_shape(
         self,
@@ -805,6 +826,45 @@ class FTADrawingHelper:
                            font=font_obj, anchor="center",
                            width=bottom_box_width,
                            tags=(obj_id,))
+
+    def draw_circle_event_clone_shape(
+        self,
+        canvas,
+        x,
+        y,
+        radius,
+        top_text="",
+        bottom_text="",
+        fill="lightyellow",
+        outline_color=None,
+        line_width=1,
+        font_obj=None,
+        obj_id: str = "",
+    ):
+        """Draw a circular event clone with a bottom line marker."""
+        self.draw_circle_event_shape(
+            canvas,
+            x,
+            y,
+            radius,
+            top_text=top_text,
+            bottom_text=bottom_text,
+            fill=fill,
+            outline_color=outline_color,
+            line_width=line_width,
+            font_obj=font_obj,
+            obj_id=obj_id,
+        )
+        outline_color = self._resolve_outline(outline_color)
+        canvas.create_line(
+            x - radius / 2,
+            y + radius,
+            x + radius / 2,
+            y + radius,
+            fill=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
                            
     def draw_triangle_clone_shape(
         self,
@@ -838,10 +898,17 @@ class FTADrawingHelper:
             font_obj=font_obj,
             obj_id=obj_id,
         )
-        # Add a shared marker to indicate the node is a clone.
-        marker_x = x + scale / 2
-        marker_y = y - scale * 0.3
-        self.draw_shared_marker(canvas, marker_x, marker_y, 1)
+        # Draw a horizontal line below the triangle to indicate a clone.
+        line_y = y + scale * 0.5
+        canvas.create_line(
+            x - scale * 0.4,
+            line_y,
+            x + scale * 0.4,
+            line_y,
+            fill=outline_color,
+            width=line_width,
+            tags=(obj_id,),
+        )
                            
 # Create a single FTADrawingHelper object that can be used by other classes
 fta_drawing_helper = FTADrawingHelper()

--- a/mainappsrc/models/fault_tree_node.py
+++ b/mainappsrc/models/fault_tree_node.py
@@ -276,3 +276,20 @@ class FaultTreeNode:
         else:
             node._original_id = None
         return node
+
+    # ------------------------------------------------------------------
+    def clone(self, parent=None):
+        """Return a copy of this node referencing the same original."""
+        import copy
+        from AutoML import AutoML_Helper
+
+        clone = copy.deepcopy(self)
+        clone.unique_id = AutoML_Helper.get_next_unique_id()
+        clone.children = []
+        clone.parents = []
+        clone.is_primary_instance = False
+        clone.original = self.original if getattr(self, "original", None) else self
+        if parent is not None:
+            clone.parents.append(parent)
+            parent.children.append(clone)
+        return clone

--- a/tests/test_fta_clone_paste.py
+++ b/tests/test_fta_clone_paste.py
@@ -1,0 +1,156 @@
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location(
+    "AutoML", repo_root / "__init__.py", submodule_search_locations=[str(repo_root)]
+)
+automl = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = automl
+spec.loader.exec_module(automl)
+AutoMLApp = automl.AutoMLApp
+FaultTreeNode = automl.FaultTreeNode
+messagebox = automl.messagebox
+
+page_spec = importlib.util.spec_from_file_location(
+    "page_diagram", repo_root / "mainappsrc/page_diagram.py"
+)
+page_module = importlib.util.module_from_spec(page_spec)
+page_spec.loader.exec_module(page_module)
+PageDiagram = page_module.PageDiagram
+fta_drawing_helper = page_module.fta_drawing_helper
+
+
+def _make_app_with_nodes():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.top_events = []
+    app.root_node = None
+    app.selected_node = None
+    app.analysis_tree = types.SimpleNamespace(selection=lambda: ())
+    app.update_views = lambda: None
+    app._diagram_copy_strategy1 = app._diagram_copy_strategy2 = lambda: False
+    app._diagram_copy_strategy3 = app._diagram_copy_strategy4 = lambda: False
+    app._find_gsn_diagram = lambda node: None
+    app._focused_gsn_window = lambda: None
+    app._focused_cbn_window = lambda: None
+    app._find_cbn_diagram = lambda node: None
+    app._focused_arch_window = lambda t=None: None
+    messagebox.showinfo = lambda *a, **k: None
+    messagebox.showwarning = lambda *a, **k: None
+    return app
+
+
+def test_fta_copy_paste_creates_clone():
+    app = _make_app_with_nodes()
+    root = FaultTreeNode("Root", "TOP EVENT")
+    child = FaultTreeNode("Child", "GATE", parent=root)
+    root.children.append(child)
+    app.root_node = root
+    app.top_events.append(root)
+    app.selected_node = child
+
+    app.copy_node()
+    assert app.clipboard_node is child
+
+    app.selected_node = root
+    app.paste_node()
+
+    assert len(root.children) == 2
+    pasted = root.children[-1]
+    assert pasted is not child
+    assert pasted.original is child
+    assert not pasted.is_primary_instance
+
+
+def test_fta_copy_paste_clone_across_module():
+    app = _make_app_with_nodes()
+
+    alt_spec = importlib.util.spec_from_file_location(
+        "alt_fault_tree_node", repo_root / "mainappsrc/models/fault_tree_node.py"
+    )
+    alt_module = importlib.util.module_from_spec(alt_spec)
+    alt_spec.loader.exec_module(alt_module)
+    AltFaultTreeNode = alt_module.FaultTreeNode
+
+    root = AltFaultTreeNode("Root", "TOP EVENT")
+    child = AltFaultTreeNode("Child", "GATE", parent=root)
+    root.children.append(child)
+    app.root_node = root
+    app.top_events.append(root)
+    app.selected_node = child
+
+    app.copy_node()
+    app.selected_node = root
+    app.paste_node()
+
+    assert len(root.children) == 2
+    first, second = root.children
+    assert first is child
+    assert second is not child
+    assert second.original is child
+
+
+class DummyFont:
+    def measure(self, text):
+        return len(text) * 7
+
+    def metrics(self, key):
+        return 10
+
+
+class DummyCanvas:
+    def create_line(self, *a, **k):
+        pass
+
+    def create_rectangle(self, *a, **k):
+        pass
+
+    def create_polygon(self, *a, **k):
+        pass
+
+    def create_text(self, *a, **k):
+        pass
+
+    def create_oval(self, *a, **k):
+        pass
+
+
+def test_fta_clone_draws_original_shape(monkeypatch):
+    root = FaultTreeNode("Root", "TOP EVENT")
+    child = FaultTreeNode("Child", "GATE", parent=root)
+    child.gate_type = "OR"
+    root.children.append(child)
+    clone = child.clone(parent=root)
+
+    app = types.SimpleNamespace(
+        project_properties={},
+        get_node_fill_color=lambda n, m: "lightgray",
+        occurrence_counts={},
+    )
+
+    pd = PageDiagram.__new__(PageDiagram)
+    pd.app = app
+    pd.root_node = root
+    pd.canvas = DummyCanvas()
+    pd.diagram_mode = "FTA"
+    pd.zoom = 1.0
+    pd.diagram_font = DummyFont()
+    pd.selected_node = None
+
+    called = {}
+
+    def fake_or_clone(*args, **kwargs):
+        called["or"] = True
+
+    monkeypatch.setattr(fta_drawing_helper, "draw_rotated_or_gate_clone_shape", fake_or_clone)
+    monkeypatch.setattr(fta_drawing_helper, "draw_circle_event_clone_shape", lambda *a, **k: called.setdefault("circle", True))
+    monkeypatch.setattr(fta_drawing_helper, "draw_triangle_clone_shape", lambda *a, **k: called.setdefault("triangle", True))
+    monkeypatch.setattr(fta_drawing_helper, "draw_rotated_and_gate_clone_shape", lambda *a, **k: called.setdefault("and", True))
+
+    pd.draw_node(clone)
+
+    assert called.get("or")
+    assert "circle" not in called


### PR DESCRIPTION
## Summary
- Render pasted FTA nodes using the original gate or event shape with a bottom marker
- Update clone-drawing helpers to add a horizontal line for detached clones
- Cover clone rendering with a regression test

## Testing
- `pytest tests/test_fta_clone_paste.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ImportError: cannot import name 'AutoML_Helper'; ImportError: libGL.so.1: cannot open shared object file)*
- `radon cc -j mainappsrc/page_diagram.py | jq '."mainappsrc/page_diagram.py"[] | select(.name=="draw_node")'`
- `radon cc -j gui/drawing_helper.py | jq '."gui/drawing_helper.py"[] | select(.name=="draw_circle_event_clone_shape")'`


------
https://chatgpt.com/codex/tasks/task_b_68ab3d9f18a88327b648cac217c48928