### PR TITLE
Add threaded initialization for launcher and user data

### DIFF
--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -226,6 +226,7 @@ import re
 import math
 import sys
 import json
+from concurrent.futures import ThreadPoolExecutor
 import tkinter as tk
 import os, sys
 base = os.path.dirname(__file__)
@@ -20432,7 +20433,15 @@ class AutoMLApp:
                     targets.append(slabel)
 
         return targets, target_map
-        
+
+def load_user_data() -> tuple[dict, tuple[str, str]]:
+    """Load cached users and last user config concurrently."""
+    with ThreadPoolExecutor() as executor:
+        users_future = executor.submit(load_all_users)
+        config_future = executor.submit(load_user_config)
+        return users_future.result(), config_future.result()
+
+
 def main():
     root = tk.Tk()
     # Prevent the main window from being resized so small that
@@ -20449,8 +20458,7 @@ def main():
         email=AUTHOR_EMAIL,
         linkedin=AUTHOR_LINKEDIN,
     ).wait_window()
-    users = load_all_users()
-    last_name, last_email = load_user_config()
+    users, (last_name, last_email) = load_user_data()
     if users:
         dlg = UserSelectDialog(root, users, last_name)
         if dlg.result:

--- a/tests/test_launcher_threading.py
+++ b/tests/test_launcher_threading.py
@@ -1,0 +1,28 @@
+import time
+import AutoML_Launcher as launcher
+
+
+def test_ensure_packages_runs_in_parallel(monkeypatch):
+    fake_required = ["pkg1", "pkg2"]
+    monkeypatch.setattr(launcher, "REQUIRED_PACKAGES", fake_required)
+
+    def fake_import_module(name):
+        raise ImportError
+
+    monkeypatch.setattr(launcher.importlib, "import_module", fake_import_module)
+
+    class FakeProc:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def wait(self):
+            time.sleep(0.2)
+
+    monkeypatch.setattr(launcher.subprocess, "Popen", lambda *a, **k: FakeProc())
+    monkeypatch.setattr(launcher.memory_manager, "register_process", lambda *a, **k: None)
+    monkeypatch.setattr(launcher.memory_manager, "cleanup", lambda: None)
+
+    start = time.time()
+    launcher.ensure_packages()
+    elapsed = time.time() - start
+    assert elapsed < 0.35

--- a/tests/test_user_data_threading.py
+++ b/tests/test_user_data_threading.py
@@ -1,0 +1,27 @@
+import time
+
+import importlib
+
+
+# Import AutoML module for testing
+automl = importlib.import_module("mainappsrc.AutoML")
+
+
+def test_load_user_data_parallel(monkeypatch):
+    def fake_load_all_users():
+        time.sleep(0.2)
+        return {"u": "e"}
+
+    def fake_load_user_config():
+        time.sleep(0.2)
+        return "name", "email"
+
+    monkeypatch.setattr(automl, "load_all_users", fake_load_all_users)
+    monkeypatch.setattr(automl, "load_user_config", fake_load_user_config)
+
+    start = time.time()
+    users, config = automl.load_user_data()
+    elapsed = time.time() - start
+    assert users == {"u": "e"}
+    assert config == ("name", "email")
+    assert elapsed < 0.35


### PR DESCRIPTION
## Summary
- Parallelize package installation and Ghostscript checks in `AutoML_Launcher`
- Load user list and config concurrently in `AutoML` startup
- Add unit tests covering new threading helpers

## Testing
- `radon` complexity check
- `PYTHONPATH=mainappsrc pytest` *(fails: AttributeError in AutoMLApp; 43 failed, 454 passed, 28 skipped)*
- `PYTHONPATH=.:mainappsrc pytest tests/test_launcher_threading.py tests/test_user_data_threading.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab54b4d0b483278118b533e654efa9