### PR TITLE
Introduce DiagramRenderer wrapper and update docs

### DIFF
--- a/AutoML_Launcher.py
+++ b/AutoML_Launcher.py
@@ -37,7 +37,9 @@ GS_PATH = Path(r"C:\\Program Files\\gs\\gs10.04.0\\bin\\gswin64c.exe")
 def parse_args() -> None:
     """Handle command line arguments for the launcher."""
 
-    parser = argparse.ArgumentParser(description="Launch the AutoML application")
+    parser = argparse.ArgumentParser(
+        description="Launch the AutoML application with DiagramRenderer support"
+    )
     parser.add_argument("--version", action="version", version=VERSION)
     parser.parse_args()
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-version: 0.2.5
+version: 0.2.6
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
 AutoML is an automotive modeling and analysis tool built around a SysML-based metamodel. It lets you describe items, operating scenarios, functions, structure and interfaces in a single environment.
 
 The metamodel blends concepts from key automotive standards—ISO 26262 (functional safety), ISO 21448 (SOTIF), ISO 21434 (cybersecurity) and ISO 8800 (safety and AI)—so one project can address safety, cybersecurity and assurance requirements side by side.
+
+Beginning with version 0.2.6, diagram drawing and capture routines are wrapped by a dedicated ``DiagramRenderer`` class to keep rendering logic modular and easier to test.
 
 ## Getting Started
 
@@ -1636,6 +1638,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.6 - Introduced DiagramRenderer to centralize diagram rendering logic.
 - 0.2.5 - Added PDF report generation placeholder and fixed missing menu action.
 - 0.2.4 - Centralized diff capture and review tools into ReviewManager.
 - 0.2.3 - Moved capsule button into dedicated controls module.

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -553,7 +553,7 @@ class ReviewToolbox(tk.Frame):
         self.start_participant_timer()
         try:
             if hasattr(self.app, "canvas") and self.app.canvas.winfo_exists():
-                self.app.redraw_canvas()
+                self.app.diagram_renderer.redraw_canvas()
         except tk.TclError:
             pass
 
@@ -1426,7 +1426,7 @@ class ReviewDocumentDialog(tk.Frame):
             c.bind("<ButtonPress-1>", lambda e, cv=c: cv.scan_mark(e.x, e.y))
             c.bind("<B1-Motion>", lambda e, cv=c: cv.scan_dragto(e.x, e.y, gain=1))
 
-            img = self.app.capture_diff_diagram(node)
+            img = self.app.diagram_renderer.capture_diff_diagram(node)
             if img and Image and ImageTk:
                 img = img.resize((img.width // 2, img.height // 2), Image.LANCZOS)
                 photo = ImageTk.PhotoImage(img)
@@ -2887,7 +2887,7 @@ class VersionCompareDialog(tk.Frame):
         self.app.diff_nodes = []
         try:
             if hasattr(self.app, "canvas") and self.app.canvas.winfo_exists():
-                self.app.redraw_canvas()
+                self.app.diagram_renderer.redraw_canvas()
         except tk.TclError:
             pass
         self.destroy()

--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -300,6 +300,7 @@ from mainappsrc.page_diagram import PageDiagram
 from mainappsrc.fmeda_manager import FMEDAManager
 from mainappsrc.fmea_service import FMEAService
 from mainappsrc.review_manager import ReviewManager
+from mainappsrc.diagram_renderer import DiagramRenderer
 from analysis.user_config import (
     load_user_config,
     save_user_config,
@@ -768,6 +769,7 @@ class AutoMLApp:
         self.cta_manager = ControlTreeManager(self)
         self.requirements_manager = RequirementsManagerSubApp(self)
         self.review_manager = ReviewManager(self)
+        self.diagram_renderer = DiagramRenderer(self)
 
         self.mechanism_libraries = []
         self.selected_mechanism_libraries = []

--- a/mainappsrc/diagram_renderer.py
+++ b/mainappsrc/diagram_renderer.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+class DiagramRenderer:
+    """Thin wrapper around diagram-related methods.
+
+    This helper delegates to the original :mod:`AutoML` implementation so that
+    rendering logic can be accessed through a dedicated object.  Future refactors
+    can progressively move functionality here without touching call sites.
+    """
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    def draw_node(self, node: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_node(node)
+
+    def draw_subtree_with_filter(self, canvas: Any, root_event: Any,
+                                 visible_nodes: Iterable[Any]) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_subtree_with_filter(canvas, root_event, visible_nodes)
+
+    def draw_subtree(self, canvas: Any, root_event: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_subtree(canvas, root_event)
+
+    def draw_connections(self, node: Any, drawn_ids: set | None = None) -> Any:  # pragma: no cover - UI routine
+        if drawn_ids is None:
+            drawn_ids = set()
+        return self.app.draw_connections(node, drawn_ids)
+
+    def draw_connections_subtree(self, canvas: Any, node: Any, drawn_ids: set) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_connections_subtree(canvas, node, drawn_ids)
+
+    def draw_node_on_canvas_pdf(self, canvas: Any, node: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_node_on_canvas_pdf(canvas, node)
+
+    def draw_node_on_page_canvas(self, canvas: Any, node: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_node_on_page_canvas(canvas, node)
+
+    def draw_page_grid(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_page_grid()
+
+    def draw_page_nodes_subtree(self, node: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_page_nodes_subtree(node)
+
+    def draw_page_connections_subtree(self, node: Any, visited_ids: set) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_page_connections_subtree(node, visited_ids)
+
+    def draw_page_subtree(self, page_root: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.draw_page_subtree(page_root)
+
+    def render_cause_effect_diagram(self, row: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.render_cause_effect_diagram(row)
+
+    def redraw_canvas(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.redraw_canvas()
+
+    def zoom_in(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.zoom_in()
+
+    def zoom_out(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.zoom_out()
+
+    def create_diagram_image(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.create_diagram_image()
+
+    def create_diagram_image_without_grid(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.create_diagram_image_without_grid()
+
+    def save_diagram_png(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.save_diagram_png()
+
+    def close_page_diagram(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.close_page_diagram()
+
+    def capture_event_diagram(self, event: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.capture_event_diagram(event)
+
+    def capture_page_diagram(self, page_node: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.capture_page_diagram(page_node)
+
+    def capture_diff_diagram(self, top_event: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.capture_diff_diagram(top_event)
+
+    def capture_sysml_diagram(self, diagram: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.capture_sysml_diagram(diagram)
+
+    def capture_cbn_diagram(self, doc: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.capture_cbn_diagram(doc)
+
+    def capture_gsn_diagram(self, diagram: Any) -> Any:  # pragma: no cover - UI routine
+        return self.app.capture_gsn_diagram(diagram)
+
+    def show_cause_effect_chain(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.show_cause_effect_chain()
+
+    def show_common_cause_view(self) -> Any:  # pragma: no cover - UI routine
+        return self.app.show_common_cause_view()

--- a/mainappsrc/review_manager.py
+++ b/mainappsrc/review_manager.py
@@ -713,7 +713,7 @@ class ReviewManager:
     def capture_diff_diagram(self, top_event):
         """Return an image of the FTA with diff colouring versus last version."""
         if not self.app.versions:
-            return self.app.capture_page_diagram(top_event)
+            return self.app.diagram_renderer.capture_page_diagram(top_event)
         from io import BytesIO
         from PIL import Image
         import difflib


### PR DESCRIPTION
## Summary
- add `DiagramRenderer` helper for centralized diagram rendering calls
- wire up AutoML launcher description and review tools to use the renderer instance
- document DiagramRenderer and bump version to 0.2.6

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `radon cc -j mainappsrc/diagram_renderer.py`


------
https://chatgpt.com/codex/tasks/task_b_68ab9463075c8327a14038a45e4bc335