### PR TITLE
feat: introduce diagram renderer facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-version: 0.2.6
+version: 0.2.7
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
 AutoML is an automotive modeling and analysis tool built around a SysML-based metamodel. It lets you describe items, operating scenarios, functions, structure and interfaces in a single environment.
 
 The metamodel blends concepts from key automotive standards—ISO 26262 (functional safety), ISO 21448 (SOTIF), ISO 21434 (cybersecurity) and ISO 8800 (safety and AI)—so one project can address safety, cybersecurity and assurance requirements side by side.
+
+Diagram drawing is centralised in a dedicated :class:`DiagramRenderer`, providing a clear interface for generating and exporting diagrams.
 
 ## Getting Started
 
@@ -1636,6 +1638,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.7 - Introduced `DiagramRenderer` for unified diagram rendering.
 - 0.2.6 - Introduced WindowControllers class for centralized window management.
 - 0.2.5 - Added PDF report generation placeholder and fixed missing menu action.
 - 0.2.4 - Centralized diff capture and review tools into ReviewManager.

--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -301,6 +301,7 @@ from mainappsrc.window_controllers import WindowControllers
 from mainappsrc.fmeda_manager import FMEDAManager
 from mainappsrc.fmea_service import FMEAService
 from mainappsrc.review_manager import ReviewManager
+from mainappsrc.diagram_renderer import DiagramRenderer
 from analysis.user_config import (
     load_user_config,
     save_user_config,
@@ -647,6 +648,8 @@ class AutoMLApp:
         self.fmeda = self.risk_app
         self.reliability_app = ReliabilitySubApp()
         self.helper = AutoML_Helper
+        # Dedicated renderer for all diagram-related operations.
+        self.diagram_renderer = DiagramRenderer(self)
         # style-aware icons used across tree views
         style_mgr = StyleManager.get_instance()
 

--- a/mainappsrc/__init__.py
+++ b/mainappsrc/__init__.py
@@ -3,5 +3,6 @@
 from .AutoML import AutoMLApp
 from .page_diagram import PageDiagram
 from .fmeda_manager import FMEDAManager
+from .diagram_renderer import DiagramRenderer
 
-__all__ = ["AutoMLApp", "PageDiagram", "FMEDAManager"]
+__all__ = ["AutoMLApp", "PageDiagram", "FMEDAManager", "DiagramRenderer"]

--- a/mainappsrc/diagram_renderer.py
+++ b/mainappsrc/diagram_renderer.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Centralised renderer for AutoML diagrams.
+
+This class acts as a façade over the existing rendering helpers
+from :mod:`mainappsrc.AutoML`.  It allows the GUI and tests to
+invoke diagram operations through a dedicated object rather than
+calling functions directly on the application.
+"""
+
+from typing import Any
+
+
+class DiagramRenderer:
+    """Delegate drawing and capture operations for AutoML diagrams."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    # Basic node and subtree drawing -------------------------------------------------
+    def draw_node(self, *args, **kwargs):
+        return self.app.draw_node(*args, **kwargs)
+
+    def draw_subtree(self, *args, **kwargs):
+        return self.app.draw_subtree(*args, **kwargs)
+
+    def draw_subtree_with_filter(self, *args, **kwargs):
+        return self.app.draw_subtree_with_filter(*args, **kwargs)
+
+    def draw_connections(self, *args, **kwargs):
+        return self.app.draw_connections(*args, **kwargs)
+
+    def draw_connections_subtree(self, *args, **kwargs):
+        return self.app.draw_connections_subtree(*args, **kwargs)
+
+    def draw_node_on_canvas_pdf(self, *args, **kwargs):
+        return self.app.draw_node_on_canvas_pdf(*args, **kwargs)
+
+    def draw_node_on_page_canvas(self, *args, **kwargs):
+        return self.app.draw_node_on_page_canvas(*args, **kwargs)
+
+    def draw_page_grid(self, *args, **kwargs):
+        return self.app.draw_page_grid(*args, **kwargs)
+
+    def draw_page_nodes_subtree(self, *args, **kwargs):
+        return self.app.draw_page_nodes_subtree(*args, **kwargs)
+
+    def draw_page_connections_subtree(self, *args, **kwargs):
+        return self.app.draw_page_connections_subtree(*args, **kwargs)
+
+    def draw_page_subtree(self, *args, **kwargs):
+        return self.app.draw_page_subtree(*args, **kwargs)
+
+    # Rendering and canvas management ------------------------------------------------
+    def render_cause_effect_diagram(self, *args, **kwargs):
+        return self.app.render_cause_effect_diagram(*args, **kwargs)
+
+    def redraw_canvas(self, *args, **kwargs):
+        return self.app.redraw_canvas(*args, **kwargs)
+
+    def zoom_in(self, *args, **kwargs):
+        return self.app.zoom_in(*args, **kwargs)
+
+    def zoom_out(self, *args, **kwargs):
+        return self.app.zoom_out(*args, **kwargs)
+
+    def create_diagram_image(self, *args, **kwargs):
+        return self.app.create_diagram_image(*args, **kwargs)
+
+    def create_diagram_image_without_grid(self, *args, **kwargs):
+        return self.app.create_diagram_image_without_grid(*args, **kwargs)
+
+    def save_diagram_png(self, *args, **kwargs):
+        return self.app.save_diagram_png(*args, **kwargs)
+
+    def close_page_diagram(self, *args, **kwargs):
+        return self.app.close_page_diagram(*args, **kwargs)
+
+    # Capture helpers ---------------------------------------------------------------
+    def capture_event_diagram(self, *args, **kwargs):
+        return self.app.capture_event_diagram(*args, **kwargs)
+
+    def capture_page_diagram(self, *args, **kwargs):
+        return self.app.capture_page_diagram(*args, **kwargs)
+
+    def capture_diff_diagram(self, *args, **kwargs):
+        return self.app.capture_diff_diagram(*args, **kwargs)
+
+    def capture_sysml_diagram(self, *args, **kwargs):
+        return self.app.capture_sysml_diagram(*args, **kwargs)
+
+    def capture_cbn_diagram(self, *args, **kwargs):
+        return self.app.capture_cbn_diagram(*args, **kwargs)
+
+    def capture_gsn_diagram(self, *args, **kwargs):
+        return self.app.capture_gsn_diagram(*args, **kwargs)
+
+    # High-level views --------------------------------------------------------------
+    def show_cause_effect_chain(self, *args, **kwargs):
+        return self.app.show_cause_effect_chain(*args, **kwargs)
+
+    def show_common_cause_view(self, *args, **kwargs):
+        return self.app.show_common_cause_view(*args, **kwargs)

--- a/tests/test_render_cause_effect_diagram.py
+++ b/tests/test_render_cause_effect_diagram.py
@@ -16,6 +16,9 @@ from AutoML import AutoMLApp
 class CauseEffectPDFTests(unittest.TestCase):
     def setUp(self):
         self.app = AutoMLApp.__new__(AutoMLApp)
+        # Attach a renderer instance; __init__ is bypassed in tests.
+        from mainappsrc.diagram_renderer import DiagramRenderer
+        self.app.diagram_renderer = DiagramRenderer(self.app)
 
     def test_render_cause_effect_diagram_size(self):
         row = {
@@ -28,7 +31,7 @@ class CauseEffectPDFTests(unittest.TestCase):
             "attack_paths": set(),
             "threats": {},
         }
-        img = self.app.render_cause_effect_diagram(row)
+        img = self.app.diagram_renderer.render_cause_effect_diagram(row)
         self.assertIsNotNone(img)
         w, h = img.size
         self.assertGreaterEqual(w, 120)


### PR DESCRIPTION
## Summary
- add a `DiagramRenderer` facade to route all diagram rendering and capture operations
- expose renderer through `AutoMLApp` and module exports
- document new renderer and bump version to 0.2.7

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `python tools/metrics_generator.py --path mainappsrc --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68ab9a2f905083279b4c0f1ca6df59be