### PR TITLE
Launcher shows splash during app load

### DIFF
--- a/AutoML_Launcher.py
+++ b/AutoML_Launcher.py
@@ -15,6 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tools.crash_report_logger import install_best
 from tools.memory_manager import manager as memory_manager
+from tools.splash_launcher import SplashLauncher
 from mainappsrc.version import VERSION
 
 # Hint PyInstaller to bundle AutoML and its dependencies (e.g. gui package)
@@ -161,8 +162,7 @@ def main() -> None:
     for path in (str(mainappsrc_path), str(base_path)):
         if path not in sys.path:
             sys.path.insert(0, path)
-    automl = importlib.import_module("AutoML")
-    automl.main()
+    SplashLauncher().launch()
     memory_manager.cleanup()
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.6
+version: 0.2.7
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1636,6 +1636,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.7 - Launcher now shows the splash screen during application load.
 - 0.2.6 - Introduced WindowControllers class for centralized window management.
 - 0.2.5 - Added PDF report generation placeholder and fixed missing menu action.
 - 0.2.4 - Centralized diff capture and review tools into ReviewManager.

--- a/mainappsrc/AutoML.py
+++ b/mainappsrc/AutoML.py
@@ -262,7 +262,6 @@ except ImportError:  # pragma: no cover
 from mainappsrc.models.gsn.nodes import GSNNode, ALLOWED_AWAY_TYPES
 from gui.closable_notebook import ClosableNotebook
 from gui.icon_factory import create_icon
-from gui.splash_screen import SplashScreen
 from gui.mac_button_style import (
     apply_translucid_button_style,
     apply_purplish_button_style,
@@ -396,9 +395,6 @@ from config.automl_constants import (
     WORK_PRODUCT_INFO as BASE_WORK_PRODUCT_INFO,
     WORK_PRODUCT_PARENTS as BASE_WORK_PRODUCT_PARENTS,
     PMHF_TARGETS,
-    AUTHOR,
-    AUTHOR_EMAIL,
-    AUTHOR_LINKEDIN,
 )
 
 builtins.REQUIREMENT_WORK_PRODUCTS = REQUIREMENT_WORK_PRODUCTS
@@ -13223,14 +13219,6 @@ def main():
     enable_listbox_hover_highlight(root)
     # Hide the main window while prompting for user info
     root.withdraw()
-    # Show initialization splash screen
-    SplashScreen(
-        root,
-        version=VERSION,
-        author=AUTHOR,
-        email=AUTHOR_EMAIL,
-        linkedin=AUTHOR_LINKEDIN,
-    ).wait_window()
     users, (last_name, last_email) = load_user_data()
     if users:
         dlg = UserSelectDialog(root, users, last_name)

--- a/tests/dummy_module.py
+++ b/tests/dummy_module.py
@@ -1,0 +1,4 @@
+called = {"main": False}
+
+def main():
+    called["main"] = True

--- a/tests/test_splash_launcher.py
+++ b/tests/test_splash_launcher.py
@@ -1,0 +1,13 @@
+import importlib
+
+from tools.splash_launcher import SplashLauncher
+
+
+def test_launcher_invokes_main(monkeypatch):
+    dummy = importlib.import_module("tests.dummy_module")
+    dummy.called["main"] = False
+
+    launcher = SplashLauncher(module_name="tests.dummy_module")
+    launcher.launch()
+
+    assert dummy.called["main"] is True

--- a/tools/splash_launcher.py
+++ b/tools/splash_launcher.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Utility for displaying the splash screen while loading the main app."""
+
+import importlib
+import threading
+import tkinter as tk
+from typing import Optional
+
+from config.automl_constants import AUTHOR, AUTHOR_EMAIL, AUTHOR_LINKEDIN
+from gui.splash_screen import SplashScreen
+from mainappsrc.version import VERSION
+
+
+class SplashLauncher:
+    """Show the splash screen until the application is ready."""
+
+    def __init__(self, module_name: str = "AutoML") -> None:
+        self.module_name = module_name
+        self._module: Optional[object] = None
+
+    def _load_module(self) -> None:
+        """Import the target module in a background thread."""
+        self._module = importlib.import_module(self.module_name)
+        # Once loading is complete, close the splash screen on the main thread
+        self._root.after(0, self._root.destroy)
+
+    def launch(self) -> None:
+        """Display the splash screen and run the application's main function."""
+        self._root = tk.Tk()
+        self._root.withdraw()
+        SplashScreen(
+            self._root,
+            version=VERSION,
+            author=AUTHOR,
+            email=AUTHOR_EMAIL,
+            linkedin=AUTHOR_LINKEDIN,
+            duration=0,
+        )
+        threading.Thread(target=self._load_module, daemon=True).start()
+        self._root.mainloop()
+        if self._module:
+            self._module.main()


### PR DESCRIPTION
## Summary
- add SplashLauncher utility to display splash screen while importing the main app
- invoke SplashLauncher from AutoML_Launcher and remove splash call from main AutoML module
- bump version to 0.2.7 and document launcher splash change

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*
- `python tools/metrics_generator.py --output metrics.json`
- `python AutoML_Launcher.py --version`


------
https://chatgpt.com/codex/tasks/task_b_68ab9aa02b1083279cf715d9a5554664