### PR TITLE
Show splash screen during startup

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -143,8 +143,16 @@ def ensure_packages() -> None:
         executor.map(install, missing)
     memory_manager.cleanup()
 
-def main() -> None:
-    """Entry point used by both source and bundled executions."""
+
+def _bootstrap() -> object:
+    """Run startup checks while the splash screen is displayed.
+
+    Returns
+    -------
+    Module
+        The main application module which provides a ``main`` entry point.
+    """
+
     parse_args()
     install_best()
     with ThreadPoolExecutor() as executor:
@@ -162,7 +170,12 @@ def main() -> None:
     for path in (str(mainappsrc_path), str(base_path)):
         if path not in sys.path:
             sys.path.insert(0, path)
-    SplashLauncher().launch()
+    return importlib.import_module("mainappsrc.automl_core")
+
+
+def main() -> None:
+    """Entry point used by both source and bundled executions."""
+    SplashLauncher(loader=_bootstrap).launch()
     memory_manager.cleanup()
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.8
+version: 0.2.9
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1638,6 +1638,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.9 - Display splash screen during dependency checks and startup.
 - 0.2.8 - Renamed core module to `automl_core.py` and launcher to `automl.py`.
 - 0.2.7 - Launcher now shows the splash screen during application load.
 - 0.2.6 - Introduced WindowControllers class for centralized window management.


### PR DESCRIPTION
## Summary
- Keep the splash screen visible while dependency checks and environment setup run
- Add optional loader hook to `SplashLauncher` for custom initialization
- Bump version to 0.2.9

## Testing
- `pytest` *(fails: ImportError and ModuleNotFoundError – 36 errors)*
- `radon cc -j AutoML.py tools/splash_launcher.py`


------
https://chatgpt.com/codex/tasks/task_b_68aba0760f44832792df89366d2081f4