### PR TITLE
Show splash screen during startup

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -143,8 +143,16 @@ def ensure_packages() -> None:
         executor.map(install, missing)
     memory_manager.cleanup()
 
-def main() -> None:
-    """Entry point used by both source and bundled executions."""
+
+def _bootstrap() -> object:
+    """Run startup checks while the splash screen is displayed.
+
+    Returns
+    -------
+    Module
+        The main application module which provides a ``main`` entry point.
+    """
+
     parse_args()
     install_best()
     with ThreadPoolExecutor() as executor:
@@ -162,7 +170,12 @@ def main() -> None:
     for path in (str(mainappsrc_path), str(base_path)):
         if path not in sys.path:
             sys.path.insert(0, path)
-    SplashLauncher().launch()
+    return importlib.import_module("mainappsrc.automl_core")
+
+
+def main() -> None:
+    """Entry point used by both source and bundled executions."""
+    SplashLauncher(loader=_bootstrap, post_delay=5000).launch()
     memory_manager.cleanup()
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.8
+version: 0.2.10
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1638,6 +1638,8 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.10 - Hold splash screen for five seconds after initialisation completes.
+- 0.2.9 - Display splash screen during dependency checks and startup.
 - 0.2.8 - Renamed core module to `automl_core.py` and launcher to `automl.py`.
 - 0.2.7 - Launcher now shows the splash screen during application load.
 - 0.2.6 - Introduced WindowControllers class for centralized window management.

--- a/tools/splash_launcher.py
+++ b/tools/splash_launcher.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-"""Utility for displaying the splash screen while loading the main app."""
+"""Utility for displaying a splash screen during application start-up."""
 
 import importlib
 import threading
 import tkinter as tk
-from typing import Optional
+from types import ModuleType
+from typing import Callable, Optional
 
 from config.automl_constants import AUTHOR, AUTHOR_EMAIL, AUTHOR_LINKEDIN
 from gui.splash_screen import SplashScreen
@@ -13,17 +14,41 @@ from mainappsrc.version import VERSION
 
 
 class SplashLauncher:
-    """Show the splash screen until the application is ready."""
+    """Show the splash screen until the application is ready.
 
-    def __init__(self, module_name: str = "AutoML") -> None:
+    Parameters
+    ----------
+    loader:
+        Optional callable responsible for initialising the application.  If
+        provided it should return the module object whose ``main`` function
+        will be invoked once the splash screen closes.  When omitted the
+        launcher simply imports :mod:`module_name`.
+    module_name:
+        Name of the module to import when ``loader`` is not supplied.
+    post_delay:
+        Milliseconds to keep the splash screen visible after initialisation
+        completes.
+    """
+
+    def __init__(
+        self,
+        loader: Optional[Callable[[], ModuleType]] = None,
+        module_name: str = "AutoML",
+        post_delay: int = 0,
+    ) -> None:
+        self.loader = loader
         self.module_name = module_name
-        self._module: Optional[object] = None
+        self.post_delay = post_delay
+        self._module: Optional[ModuleType] = None
 
     def _load_module(self) -> None:
-        """Import the target module in a background thread."""
-        self._module = importlib.import_module(self.module_name)
+        """Initialise the application in a background thread."""
+        if self.loader:
+            self._module = self.loader()
+        else:
+            self._module = importlib.import_module(self.module_name)
         # Once loading is complete, close the splash screen on the main thread
-        self._root.after(0, self._root.destroy)
+        self._root.after(self.post_delay, self._root.destroy)
 
     def launch(self) -> None:
         """Display the splash screen and run the application's main function."""
@@ -39,5 +64,5 @@ class SplashLauncher:
         )
         threading.Thread(target=self._load_module, daemon=True).start()
         self._root.mainloop()
-        if self._module:
+        if self._module and hasattr(self._module, "main"):
             self._module.main()


### PR DESCRIPTION
## Summary
- Keep splash screen up for the duration of startup plus an extra 5 seconds
- Add optional post-load delay to `SplashLauncher`
- Bump version to 0.2.10

## Testing
- `pytest` *(fails: 36 errors during collection)*
- `radon cc -j AutoML.py tools/splash_launcher.py`


------
https://chatgpt.com/codex/tasks/task_b_68aba0760f44832792df89366d2081f4