### PR TITLE
feat: consolidate safety analysis helpers into facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.10
+version: 0.2.11
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -308,6 +308,10 @@ Open the **Requirements Matrix** from the Requirements menu to see every require
 ## AutoML Diagrams and Safety Analyses
 
 Use case, activity, block and internal block diagrams can be created from the **Architecture** menu. Diagrams are stored inside a built-in SysML repository and appear in the *Analyses* explorer under *System Design (Item Definition)* so they can be reopened alongside safety documents. Each object keeps its saved size and properties so layouts remain stable when returning to the project.
+
+The new :class:`SafetyAnalysis_FTA_FMEA` facade combines previously separate
+fault-tree, FMEA and FMEDA helpers into a single interface, simplifying how the
+application orchestrates safety analyses.
 
 Activity diagrams list individual **actions** that describe the expected behavior for a block. These actions can be referenced directly in HAZOP tables as potential malfunctions. When a block is linked to a reliability analysis, any actions in its internal block diagram are inherited as additional failure modes for that analysis. The inherited actions automatically show up in new FMEDA tables along with the failure modes already defined for the analysis components.
 
@@ -1638,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.11 - Introduced SafetyAnalysis_FTA_FMEA facade for FTA, FMEA and FMEDA.
 - 0.2.10 - Extracted lifecycle UI helpers into dedicated AppLifecycleUI class.
 - 0.2.9 - Display splash screen during dependency checks and startup.
 - 0.2.8 - Renamed core module to `automl_core.py` and launcher to `automl.py`.

--- a/__init__.py
+++ b/__init__.py
@@ -9,6 +9,7 @@ from .mainappsrc.automl_core import (
     messagebox,
     GATE_NODE_TYPES,
 )
+from .mainappsrc.safety_analysis import SafetyAnalysis_FTA_FMEA
 from config.automl_constants import PMHF_TARGETS
 from analysis.models import HazopDoc
 from gui.dialogs.edit_node_dialog import EditNodeDialog
@@ -27,4 +28,5 @@ __all__ = [
     "PMHF_TARGETS",
     "HazopDoc",
     "EditNodeDialog",
+    "SafetyAnalysis_FTA_FMEA",
 ]

--- a/mainappsrc/safety_analysis.py
+++ b/mainappsrc/safety_analysis.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+"""Combined FTA/FMEA helper class.
+
+This module introduces :class:`SafetyAnalysis_FTA_FMEA` which consolidates
+functions for fault-tree analysis (FTA), failure mode and effects analysis
+(FMEA) and FMEDA handling.  The class provides a single facade so the main
+application can interact with these related analyses via one object instead of
+three separate helpers.
+"""
+
+import tkinter as tk
+from tkinter import filedialog, ttk
+import csv
+
+from .fta_subapp import FTASubApp
+from .fmea_service import FMEAService
+from .fmeda_manager import FMEDAManager
+
+
+class SafetyAnalysis_FTA_FMEA(FTASubApp, FMEAService, FMEDAManager):
+    """Facade combining FTA, FMEA and FMEDA behaviours."""
+
+    def __init__(self, app: tk.Misc) -> None:
+        # Initialise parent helper classes that require the application instance.
+        FMEAService.__init__(self, app)
+        FMEDAManager.__init__(self, app)
+        self.app = app
+
+    # ------------------------------------------------------------------
+    # FTA convenience wrappers
+    # ------------------------------------------------------------------
+    def create_fta_diagram(self) -> None:
+        """Initialize a new FTA diagram with a single top level event."""
+        self.app._create_fta_tab("FTA")
+        self.app.add_top_level_event()
+        if getattr(self.app, "fta_root_node", None):
+            self.app.window_controllers.open_page_diagram(self.app.fta_root_node)
+
+    @staticmethod
+    def auto_generate_fta_diagram(fta_model, output_path):
+        return FTASubApp.auto_generate_fta_diagram(fta_model, output_path)
+
+    def enable_fta_actions(self, enabled: bool) -> None:
+        """Enable or disable FTA-related menu actions on the main app."""
+        if hasattr(self.app, "fta_menu"):
+            state = tk.NORMAL if enabled else tk.DISABLED
+            for key in (
+                "add_gate",
+                "add_basic_event",
+                "add_gate_from_failure_mode",
+                "add_fault_event",
+            ):
+                self.app.fta_menu.entryconfig(self.app._fta_menu_indices[key], state=state)
+
+    def show_cut_sets(self) -> None:
+        """Display minimal cut sets for all top level events."""
+        top_events = getattr(self.app, "top_events", [])
+        if not top_events:
+            return
+        win = tk.Toplevel(self.app.root)
+        win.title("FTA Cut Sets")
+        columns = ("Top Event", "Cut Set #", "Basic Events")
+        tree = ttk.Treeview(win, columns=columns, show="headings")
+        for c in columns:
+            tree.heading(c, text=c)
+        tree.pack(fill=tk.BOTH, expand=True)
+
+        for te in top_events:
+            nodes_by_id = {}
+
+            def map_nodes(n):
+                nodes_by_id[n.unique_id] = n
+                for child in n.children:
+                    map_nodes(child)
+
+            map_nodes(te)
+            cut_sets = self.calculate_cut_sets(self.app, te)
+            te_label = te.user_name or f"Top Event {te.unique_id}"
+            for idx, cs in enumerate(cut_sets, start=1):
+                names = ", ".join(
+                    f"{nodes_by_id[uid].user_name or nodes_by_id[uid].node_type} [{uid}]"
+                    for uid in sorted(cs)
+                )
+                tree.insert("", "end", values=(te_label, idx, names))
+                te_label = ""
+
+        def export_csv():
+            path = filedialog.asksaveasfilename(
+                defaultextension=".csv", filetypes=[("CSV", "*.csv")]
+            )
+            if not path:
+                return
+            with open(path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(["Top Event", "Cut Set #", "Basic Events"])
+                for iid in tree.get_children():
+                    writer.writerow(tree.item(iid, "values"))
+
+        ttk.Button(win, text="Export CSV", command=export_csv).pack(pady=5)
+
+    # ------------------------------------------------------------------
+    # Delegated helpers used by existing code paths
+    # ------------------------------------------------------------------
+    def update_fta_statuses(self):
+        return self.app.risk_app.update_fta_statuses(self.app)
+
+    def update_basic_event_probabilities(self):
+        return self.app.risk_app.update_basic_event_probabilities(self.app)
+
+    def update_base_event_requirement_asil(self):
+        return self.app.risk_app.update_base_event_requirement_asil(self.app)
+
+    # Convenience properties to expose underlying data structures
+    @property
+    def fmeas(self):
+        return self.fmea_service.fmeas if isinstance(self, FMEAService) else self.fmeas
+
+    @fmeas.setter
+    def fmeas(self, value):
+        self.fmea_service.fmeas = value
+
+    @property
+    def fmedas(self):
+        return self.fmeda_manager.fmedas if isinstance(self, FMEDAManager) else self.fmedas
+
+    @fmedas.setter
+    def fmedas(self, value):
+        self.fmeda_manager.fmedas = value
+


### PR DESCRIPTION
## Summary
- introduce SafetyAnalysis_FTA_FMEA facade combining fault-tree, FMEA and FMEDA helpers
- wire AutoML to use the unified safety analysis helper
- document new facade and bump version to 0.2.11

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file)*
- `python tools/metrics_generator.py --path mainappsrc`

------
https://chatgpt.com/codex/tasks/task_b_68aba6c4bf708327b67f74df3ec0430c