### PR TITLE
fix: remove faulty safety analysis properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.11
+version: 0.2.12
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.12 - Fix property initialisation error in safety analysis facade.
 - 0.2.11 - Keep splash screen visible through startup and five-second post-load delay.
 - 0.2.10 - Hold splash screen for five seconds after initialisation completes.
 - 0.2.9 - Display splash screen during dependency checks and startup.

--- a/mainappsrc/safety_analysis.py
+++ b/mainappsrc/safety_analysis.py
@@ -111,20 +111,10 @@ class SafetyAnalysis_FTA_FMEA(FTASubApp, FMEAService, FMEDAManager):
     def update_base_event_requirement_asil(self):
         return self.app.risk_app.update_base_event_requirement_asil(self.app)
 
-    # Convenience properties to expose underlying data structures
-    @property
-    def fmeas(self):
-        return self.fmea_service.fmeas if isinstance(self, FMEAService) else self.fmeas
-
-    @fmeas.setter
-    def fmeas(self, value):
-        self.fmea_service.fmeas = value
-
-    @property
-    def fmedas(self):
-        return self.fmeda_manager.fmedas if isinstance(self, FMEDAManager) else self.fmedas
-
-    @fmedas.setter
-    def fmedas(self, value):
-        self.fmeda_manager.fmedas = value
+    # The mixins :class:`FMEAService` and :class:`FMEDAManager` already expose
+    # ``fmeas`` and ``fmedas`` attributes respectively.  Previous versions of
+    # this facade attempted to proxy those attributes through properties, but
+    # that indirection caused the ``AttributeError`` seen when the mixins were
+    # initialised.  By relying directly on the inherited attributes we avoid the
+    # recursive property lookups while keeping the public interface unchanged.
 


### PR DESCRIPTION
## Summary
- avoid AttributeError when initialising safety analysis facade by relying on inherited FMEA and FMEDA attributes
- bump documentation version to 0.2.12

## Testing
- `pytest` *(fails: ImportError: cannot import name 'AutoML_Helper', ModuleNotFoundError: No module named 'automl', libGL.so.1 missing)*
- `python tools/metrics_generator.py --path mainappsrc --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68abaa61d22c83279e1af30c876bcc6f