### PR TITLE
Fix missing tab motion handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.12
+version: 0.2.13
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.13 - Delegate tab motion events to lifecycle UI to prevent missing handler error.
 - 0.2.12 - Fix property initialisation error in safety analysis facade.
 - 0.2.11 - Keep splash screen visible through startup and five-second post-load delay.
 - 0.2.10 - Hold splash screen for five seconds after initialisation completes.

--- a/mainappsrc/event_dispatcher.py
+++ b/mainappsrc/event_dispatcher.py
@@ -94,10 +94,10 @@ class EventDispatcher:
         app.prop_view.bind("<Map>", app._resize_prop_columns)
         app.prop_frame.bind("<Configure>", app._resize_prop_columns)
 
-        app.tools_nb.bind("<Motion>", app._on_tool_tab_motion)
+        app.tools_nb.bind("<Motion>", app.lifecycle_ui._on_tool_tab_motion)
         app.tools_nb.bind("<Leave>", lambda _e: app._tools_tip.hide())
 
-        app.doc_nb.bind("<<NotebookTabClosed>>", app._on_tab_close)
-        app.doc_nb.bind("<<NotebookTabChanged>>", app._on_tab_change)
-        app.doc_nb.bind("<Motion>", app._on_doc_tab_motion)
+        app.doc_nb.bind("<<NotebookTabClosed>>", app.lifecycle_ui._on_tab_close)
+        app.doc_nb.bind("<<NotebookTabChanged>>", app.lifecycle_ui._on_tab_change)
+        app.doc_nb.bind("<Motion>", app.lifecycle_ui._on_doc_tab_motion)
         app.doc_nb.bind("<Leave>", lambda _e: app._doc_tip.hide())


### PR DESCRIPTION
## Summary
- delegate tool and document notebook tab events to `AppLifecycleUI`
- bump version to 0.2.13 in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'automl')*
- `python tools/metrics_generator.py --path mainappsrc --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68ababa96e888327b20050e4396d624b