### PR TITLE
Fix messagebox circular import via lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.14
+version: 0.2.15
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.15 - Lazily import messagebox module to resolve circular import.
 - 0.2.14 - Fade out splash screen symmetrically before launching application.
 - 0.2.13 - Delegate tab motion events to lifecycle UI to prevent missing handler error.
 - 0.2.12 - Fix property initialisation error in safety analysis facade.

--- a/gui/controls/__init__.py
+++ b/gui/controls/__init__.py
@@ -1,9 +1,31 @@
-"""Custom control widgets for the AutoML GUI."""
+"""Custom control widgets for the AutoML GUI.
 
-from . import button_utils, mac_button_style, messagebox
+The messagebox module is imported lazily to avoid circular import issues.  It
+depends on high level widgets defined in :mod:`gui.__init__`, so importing it
+at module import time would cause a partially initialised package when
+``gui`` itself loads controls.  ``__getattr__`` performs a deferred import when
+``messagebox`` is first requested.
+"""
 
-__all__ = [
-    "button_utils",
-    "mac_button_style",
-    "messagebox",
-]
+from __future__ import annotations
+
+from types import ModuleType
+import importlib
+
+from . import button_utils, mac_button_style
+
+__all__ = ["button_utils", "mac_button_style", "messagebox"]
+
+
+def __getattr__(name: str) -> ModuleType:
+    """Dynamically import submodules on first access.
+
+    Parameters
+    ----------
+    name:
+        Attribute name being accessed.
+    """
+
+    if name == "messagebox":
+        return importlib.import_module(f"{__name__}.messagebox")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- lazily import `messagebox` in `gui.controls` to avoid circular import during startup
- document change and bump version to 0.2.15

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'AutoML_Helper' ...)*
- `PYTHONPATH=. pytest tests/test_messagebox_noninteractive.py tests/test_messagebox_style.py -q`
- `python tools/metrics_generator.py --path gui/controls --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68abaea73f548327a6688e81f48bc89c