### PR TITLE
Fix AutoMLHelper import and add launcher shim

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -17,7 +17,31 @@ from tools.crash_report_logger import install_best
 from tools.memory_manager import manager as memory_manager
 from tools.splash_launcher import SplashLauncher
 from mainappsrc.version import VERSION
-from mainappsrc.automl_core import AutoMLApp
+from mainappsrc.automl_core import (
+    AutoMLApp,
+    FaultTreeNode,
+    AutoML_Helper,
+    messagebox,
+    GATE_NODE_TYPES,
+)
+from mainappsrc.safety_analysis import SafetyAnalysis_FTA_FMEA
+from config.automl_constants import PMHF_TARGETS
+from analysis.models import HazopDoc
+from gui.dialogs.edit_node_dialog import EditNodeDialog
+from analysis.risk_assessment import AutoMLHelper
+
+__all__ = [
+    "AutoMLApp",
+    "FaultTreeNode",
+    "AutoML_Helper",
+    "messagebox",
+    "GATE_NODE_TYPES",
+    "PMHF_TARGETS",
+    "HazopDoc",
+    "EditNodeDialog",
+    "SafetyAnalysis_FTA_FMEA",
+    "AutoMLHelper",
+]
 
 # Hint PyInstaller to bundle AutoML and its dependencies (e.g. gui package)
 if False:  # pragma: no cover

--- a/__init__.py
+++ b/__init__.py
@@ -13,11 +13,13 @@ from .mainappsrc.safety_analysis import SafetyAnalysis_FTA_FMEA
 from config.automl_constants import PMHF_TARGETS
 from analysis.models import HazopDoc
 from gui.dialogs.edit_node_dialog import EditNodeDialog
+from analysis.risk_assessment import AutoMLHelper
 
 __all__ = [
     "AutoMLApp",
     "FaultTreeNode",
     "AutoML_Helper",
+    "AutoMLHelper",
     "messagebox",
     "tk",
     "ttk",

--- a/automl.py
+++ b/automl.py
@@ -1,0 +1,5 @@
+from AutoML import *  # noqa: F401,F403
+
+if __name__ == "__main__":
+    from AutoML import main
+    main()

--- a/mainappsrc/automl_core.py
+++ b/mainappsrc/automl_core.py
@@ -371,7 +371,10 @@ from gui.architecture import (
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.scenario_description import template_phrases
-from .app_lifecycle_ui import AppLifecycleUI
+try:  # pragma: no cover - support direct module import
+    from .app_lifecycle_ui import AppLifecycleUI
+except Exception:  # pragma: no cover
+    from mainappsrc.app_lifecycle_ui import AppLifecycleUI
 import copy
 import tkinter.font as tkFont
 import builtins
@@ -470,20 +473,20 @@ try:  # pragma: no cover - support direct module import
     from .reliability_subapp import ReliabilitySubApp
     from .version import VERSION
 except Exception:  # pragma: no cover
-    from style_subapp import StyleSubApp
-    from tree_subapp import TreeSubApp
-    from diagram_export_subapp import DiagramExportSubApp
-    from requirements_manager import RequirementsManagerSubApp
-    from use_case_diagram_subapp import UseCaseDiagramSubApp
-    from activity_diagram_subapp import ActivityDiagramSubApp
-    from block_diagram_subapp import BlockDiagramSubApp
-    from internal_block_diagram_subapp import InternalBlockDiagramSubApp
-    from control_flow_diagram_subapp import ControlFlowDiagramSubApp
-    from safety_analysis import SafetyAnalysis_FTA_FMEA
-    from project_editor_subapp import ProjectEditorSubApp
-    from risk_assessment_subapp import RiskAssessmentSubApp
-    from reliability_subapp import ReliabilitySubApp
-    from version import VERSION
+    from mainappsrc.style_subapp import StyleSubApp
+    from mainappsrc.tree_subapp import TreeSubApp
+    from mainappsrc.diagram_export_subapp import DiagramExportSubApp
+    from mainappsrc.requirements_manager import RequirementsManagerSubApp
+    from mainappsrc.use_case_diagram_subapp import UseCaseDiagramSubApp
+    from mainappsrc.activity_diagram_subapp import ActivityDiagramSubApp
+    from mainappsrc.block_diagram_subapp import BlockDiagramSubApp
+    from mainappsrc.internal_block_diagram_subapp import InternalBlockDiagramSubApp
+    from mainappsrc.control_flow_diagram_subapp import ControlFlowDiagramSubApp
+    from mainappsrc.safety_analysis import SafetyAnalysis_FTA_FMEA
+    from mainappsrc.project_editor_subapp import ProjectEditorSubApp
+    from mainappsrc.risk_assessment_subapp import RiskAssessmentSubApp
+    from mainappsrc.reliability_subapp import ReliabilitySubApp
+    from mainappsrc.version import VERSION
 try:  # pragma: no cover
     from .models.fta.fault_tree_node import FaultTreeNode
 except Exception:  # pragma: no cover

--- a/mainappsrc/project_manager.py
+++ b/mainappsrc/project_manager.py
@@ -10,7 +10,6 @@ from analysis.utils import (
     update_probability_tables,
 )
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
-from analysis.risk_assessment import AutoMLHelper
 
 
 class ProjectManager:
@@ -43,11 +42,10 @@ class ProjectManager:
                 except Exception:
                     pass
         app._reset_fta_state()
-        import importlib
+        import AutoML as automl_mod
         global AutoML_Helper, unique_node_id_counter
-        automl_mod = importlib.import_module("AutoML")
-        AutoML_Helper = automl_mod.AutoMLHelper()
-        unique_node_id_counter = 1
+        AutoML_Helper = automl_mod.AutoML_Helper = automl_mod.AutoMLHelper()
+        unique_node_id_counter = automl_mod.unique_node_id_counter = 1
         SysMLRepository.reset_instance()
         app.zoom = 1.0
         app.diagram_font.config(size=int(8 * app.zoom))
@@ -105,11 +103,10 @@ class ProjectManager:
         app.activity_windows = []
         app.block_windows = []
         app.ibd_windows = []
-        import importlib
-        automl_mod = importlib.import_module("AutoML")
+        import AutoML as automl_mod
         global AutoML_Helper, unique_node_id_counter
-        AutoML_Helper = automl_mod.AutoMLHelper()
-        unique_node_id_counter = 1
+        AutoML_Helper = automl_mod.AutoML_Helper = automl_mod.AutoMLHelper()
+        unique_node_id_counter = automl_mod.unique_node_id_counter = 1
         SysMLRepository.reset_instance()
         app.top_events = []
         app.cta_events = []

--- a/mainappsrc/safety_analysis.py
+++ b/mainappsrc/safety_analysis.py
@@ -13,9 +13,14 @@ import tkinter as tk
 from tkinter import filedialog, ttk
 import csv
 
-from .fta_subapp import FTASubApp
-from .fmea_service import FMEAService
-from .fmeda_manager import FMEDAManager
+try:  # pragma: no cover - support direct module import
+    from .fta_subapp import FTASubApp
+    from .fmea_service import FMEAService
+    from .fmeda_manager import FMEDAManager
+except Exception:  # pragma: no cover
+    from mainappsrc.fta_subapp import FTASubApp
+    from mainappsrc.fmea_service import FMEAService
+    from mainappsrc.fmeda_manager import FMEDAManager
 
 
 class SafetyAnalysis_FTA_FMEA(FTASubApp, FMEAService, FMEDAManager):


### PR DESCRIPTION
## Summary
- expose `AutoMLHelper` at package root so project manager can instantiate it
- reset global helper and unique-node counter when starting or loading projects
- export app classes from `AutoML.py` and provide lowercase `automl` shim

## Testing
- `pytest`
- `python tools/metrics_generator.py --path mainappsrc`


------
https://chatgpt.com/codex/tasks/task_b_68abb4758b6883279af05b835f667996