### PR TITLE
fix: restore splash screen import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.18
+version: 0.2.19
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.19 - Provide compatibility wrapper for splash screen import.
 - 0.2.18 - Organized GUI modules into functional subpackages and reduced threat window refresh complexity.
 - 0.2.17 - Ensure AutoMLHelper fallback if AutoML module lacks helper export.
 - 0.2.16 - Import PurpleButton lazily in custom messagebox to avoid early circular imports.

--- a/gui/splash_screen.py
+++ b/gui/splash_screen.py
@@ -1,0 +1,8 @@
+"""Compatibility wrapper for splash screen module.
+
+This shim preserves the legacy import path ``gui.splash_screen``
+while the real implementation lives in ``gui.windows.splash_screen``.
+"""
+from .windows.splash_screen import SplashScreen
+
+__all__ = ["SplashScreen"]

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,0 +1,5 @@
+"""Project version information."""
+
+VERSION = "0.2.19"
+
+__all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- add `gui.splash_screen` shim to forward to `gui.windows.splash_screen`
- define project `VERSION` constant
- document version 0.2.19

## Testing
- `radon cc -j gui/windows/splash_screen.py | jq '."gui/windows/splash_screen.py"[0:2]'`
- `radon cc -j gui/splash_screen.py`
- `PYTHONPATH=. pytest tests/test_splash_screen.py tests/test_splash_launcher.py -q` *(fails: ModuleNotFoundError: No module named 'gui.drawing_helper')*
- `pytest -q --maxfail=1` *(fails: ModuleNotFoundError: No module named 'gui')*

------
https://chatgpt.com/codex/tasks/task_b_68abc0a994508327baa22d937633225b