### PR TITLE
Expose logger via gui package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.19
+version: 0.2.20
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.20 - Re-export logger through gui package to fix DIALOG_BG_COLOR import failure.
 - 0.2.19 - Provide compatibility wrapper for splash screen import.
 - 0.2.18 - Organized GUI modules into functional subpackages and reduced threat window refresh complexity.
 - 0.2.17 - Ensure AutoMLHelper fallback if AutoML module lacks helper export.

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 
 """Shared GUI helpers and widget customizations."""
 
+import sys
 import tkinter as tk
 from tkinter import ttk, simpledialog
+
+from .utils import logger
+
+# Re-export logger for ``from gui import logger`` compatibility
+sys.modules[f"{__name__}.logger"] = logger
 
 # Default background color for all dialog windows
 DIALOG_BG_COLOR = "#A9BCE2"
@@ -202,3 +208,4 @@ def _sortable_heading(self, column, option=None, **kw):
 
 
 ttk.Treeview.heading = _sortable_heading
+

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.19"
+VERSION = "0.2.20"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- expose `logger` at top-level of `gui` package to allow messagebox to import `DIALOG_BG_COLOR`
- bump version to 0.2.20 and document in README

## Testing
- `radon cc -j gui/controls/messagebox.py gui/__init__.py`
- `python -m pytest tests/test_messagebox_noninteractive.py -q` *(fails: ModuleNotFoundError: gui.drawing_helper)*


------
https://chatgpt.com/codex/tasks/task_b_68abc461e56c8327b7a1995621fa3f8a