### PR TITLE
Expose dialog color via utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.19
+version: 0.2.21
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,8 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.21 - Expose DIALOG_BG_COLOR via gui.utils and re-export drawing helper for compatibility.
+- 0.2.20 - Re-export logger through gui package to fix DIALOG_BG_COLOR import failure.
 - 0.2.19 - Provide compatibility wrapper for splash screen import.
 - 0.2.18 - Organized GUI modules into functional subpackages and reduced threat window refresh complexity.
 - 0.2.17 - Ensure AutoMLHelper fallback if AutoML module lacks helper export.

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 
 """Shared GUI helpers and widget customizations."""
 
+import sys
 import tkinter as tk
 from tkinter import ttk, simpledialog
 
-# Default background color for all dialog windows
-DIALOG_BG_COLOR = "#A9BCE2"
+from .utils import DIALOG_BG_COLOR, logger, drawing_helper
+
+# Re-export selected utilities for backward-compatible import paths such as
+# ``from gui import logger`` or ``from gui import drawing_helper``.
+sys.modules[f"{__name__}.logger"] = logger
+sys.modules[f"{__name__}.drawing_helper"] = drawing_helper
 
 
 _orig_dialog_init = simpledialog.Dialog.__init__
@@ -202,3 +207,4 @@ def _sortable_heading(self, column, option=None, **kw):
 
 
 ttk.Treeview.heading = _sortable_heading
+

--- a/gui/utils/__init__.py
+++ b/gui/utils/__init__.py
@@ -1,0 +1,22 @@
+"""Utility helpers exposed for backward-compatible imports.
+
+This package re-exports commonly used utilities so that modules can simply
+``import gui.utils`` and access members such as :mod:`logger` or
+``DIALOG_BG_COLOR``.  Keeping these aliases here preserves compatibility with
+older code that expected these objects to live directly under
+``gui.utils``.
+"""
+
+# The logging helper is implemented in ``logger.py`` but we import it here so
+# ``from gui.utils import logger`` continues to work.
+from . import logger  # noqa: F401
+
+
+# Default background colour used by dialog windows across the application.
+# This constant is defined here to allow both ``from gui.utils import
+# DIALOG_BG_COLOR`` and ``from gui import DIALOG_BG_COLOR`` (which imports it
+# via ``gui.__init__``).
+DIALOG_BG_COLOR = "#A9BCE2"
+
+
+__all__ = ["logger", "DIALOG_BG_COLOR"]

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.19"
+VERSION = "0.2.21"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- expose dialog background colour and logger through `gui.utils` and re-export drawing helpers for backward compatibility
- bump version to 0.2.21 and update documentation

## Testing
- `radon cc -j gui/controls/messagebox.py`
- `radon cc -j gui/__init__.py`
- `radon cc -j gui/utils/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gui.architecture'; 356 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68abc461e56c8327b7a1995621fa3f8a