### PR TITLE
Fix treeview helper import and add GUI wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.21
+version: 0.2.22
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.
 - 0.2.21 - Expose DIALOG_BG_COLOR via gui.utils and re-export drawing helper for compatibility.
 - 0.2.20 - Re-export logger through gui package to fix DIALOG_BG_COLOR import failure.
 - 0.2.19 - Provide compatibility wrapper for splash screen import.

--- a/gui/architecture.py
+++ b/gui/architecture.py
@@ -1,0 +1,4 @@
+"""Compatibility wrapper for the main architecture window module."""
+
+from .windows.architecture import *  # noqa: F401,F403
+

--- a/gui/dialog_utils.py
+++ b/gui/dialog_utils.py
@@ -1,0 +1,4 @@
+"""Compatibility wrapper for dialog utilities relocated under gui.dialogs."""
+
+from .dialogs.dialog_utils import *  # noqa: F401,F403
+

--- a/gui/gsn_diagram_window.py
+++ b/gui/gsn_diagram_window.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper for the relocated GSN diagram window module."""
+
+from .windows.gsn_diagram_window import GSNDiagramWindow, GSN_WINDOWS
+
+__all__ = ["GSNDiagramWindow", "GSN_WINDOWS"]

--- a/gui/gsn_explorer.py
+++ b/gui/gsn_explorer.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper for the relocated GSN explorer module."""
+
+from .explorers.gsn_explorer import GSNExplorer
+
+__all__ = ["GSNExplorer"]

--- a/gui/review_toolbox.py
+++ b/gui/review_toolbox.py
@@ -1,0 +1,4 @@
+"""Compatibility wrapper for the relocated review toolbox module."""
+
+from .toolboxes.review_toolbox import *  # noqa: F401,F403
+

--- a/gui/stpa_window.py
+++ b/gui/stpa_window.py
@@ -1,0 +1,4 @@
+"""Compatibility wrapper for the relocated STPA window module."""
+
+from .windows.stpa_window import *  # noqa: F401,F403
+

--- a/gui/style_manager.py
+++ b/gui/style_manager.py
@@ -1,0 +1,4 @@
+"""Compatibility wrapper for the relocated style manager module."""
+
+from .styles.style_manager import *  # noqa: F401,F403
+

--- a/gui/threat_window.py
+++ b/gui/threat_window.py
@@ -1,0 +1,4 @@
+"""Compatibility wrapper for the relocated threat window module."""
+
+from .windows.threat_window import *  # noqa: F401,F403
+

--- a/gui/utils/__init__.py
+++ b/gui/utils/__init__.py
@@ -11,6 +11,19 @@ older code that expected these objects to live directly under
 # ``from gui.utils import logger`` continues to work.
 from . import logger  # noqa: F401
 
+# Treeview convenience helpers live in the top level ``gui`` package. Importing
+# them here preserves backward compatibility for modules that relied on
+# ``from gui.utils import add_treeview_scrollbars``.
+# ``add_treeview_scrollbars`` is defined in the top-level ``gui`` package. To
+# avoid circular import issues during package initialisation we lazily resolve
+# the real implementation on first use and forward the call.
+def add_treeview_scrollbars(*args, **kwargs):
+    """Forward to :func:`gui.add_treeview_scrollbars` for legacy imports."""
+
+    from .. import add_treeview_scrollbars as _impl
+
+    return _impl(*args, **kwargs)
+
 
 # Default background colour used by dialog windows across the application.
 # This constant is defined here to allow both ``from gui.utils import
@@ -19,4 +32,4 @@ from . import logger  # noqa: F401
 DIALOG_BG_COLOR = "#A9BCE2"
 
 
-__all__ = ["logger", "DIALOG_BG_COLOR"]
+__all__ = ["logger", "DIALOG_BG_COLOR", "add_treeview_scrollbars"]

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.21"
+VERSION = "0.2.22"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- expose add_treeview_scrollbars through `gui.utils` with lazy proxy
- add compatibility wrappers for relocated GUI modules
- bump version to 0.2.22 and update documentation

## Testing
- `python tools/metrics_generator.py --path gui/utils --output metrics.json`
- `pytest` *(fails: 174 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68abca4fd4b0832798f075a5fab14b9a