### PR TITLE
Fix default style path to restore governance diagram colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.
 - 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.
 - 0.2.21 - Expose DIALOG_BG_COLOR via gui.utils and re-export drawing helper for compatibility.
 - 0.2.20 - Re-export logger through gui package to fix DIALOG_BG_COLOR import failure.

--- a/gui/styles/style_manager.py
+++ b/gui/styles/style_manager.py
@@ -3,7 +3,16 @@ import sys
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
-_DEFAULT_STYLE = Path(__file__).resolve().parent.parent / 'styles' / 'pastel.xml'
+# The default style XML lives in the repository's top level ``styles``
+# directory.  ``style_manager.py`` sits two levels deeper under
+# ``gui/styles`` so ``parents[2]`` resolves to the project root.  The
+# previous implementation only climbed one level which pointed to
+# ``gui/styles/pastel.xml`` – a non-existent path – leaving the
+# ``StyleManager`` with an empty palette.  As a result diagram elements and
+# icons fell back to black or transparent fills.  Correct the path so the
+# pastel style loads and governance diagrams render with their intended
+# colours.
+_DEFAULT_STYLE = Path(__file__).resolve().parents[2] / 'styles' / 'pastel.xml'
 if getattr(sys, 'frozen', False):
     # When packaged by PyInstaller resources live under sys._MEIPASS
     _DEFAULT_STYLE = Path(sys._MEIPASS) / 'styles' / 'pastel.xml'

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.22"
+VERSION = "0.2.23"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- load pastel color scheme from project root so diagram elements and icons regain their intended fills
- bump version to 0.2.23 and document change in README

## Testing
- `python tools/metrics_generator.py --path gui/styles --output metrics.json`
- `pytest` *(fails: ModuleNotFoundError: No module named 'gui.architecture')*

------
https://chatgpt.com/codex/tasks/task_b_68abd0da39608327abd8491f3b6e5d97