### PR TITLE
Lazily load toolbox buttons to reduce memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.24 - Lazily load toolbox buttons to reduce memory usage.
 - 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.
 - 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.
 - 0.2.21 - Expose DIALOG_BG_COLOR via gui.utils and re-export drawing helper for compatibility.

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.23"
+VERSION = "0.2.24"
 
 __all__ = ["VERSION"]

--- a/tests/test_governance_core_actions.py
+++ b/tests/test_governance_core_actions.py
@@ -61,8 +61,8 @@ def test_governance_core_has_add_buttons(monkeypatch):
     win.toolbox_selector = types.SimpleNamespace(configure=lambda **k: None)
     win.toolbox_var = types.SimpleNamespace(get=lambda: "Governance Core", set=lambda v: None)
     win._toolbox_frames = {}
-
     win._rebuild_toolboxes()
+    win._switch_toolbox()
     assert "Governance Core" in win._toolbox_frames
     core_frames = win._toolbox_frames["Governance Core"]
     assert win.rel_frame not in core_frames

--- a/tools/memory_manager.py
+++ b/tools/memory_manager.py
@@ -54,6 +54,12 @@ class MemoryManager:
         for key in inactive:
             obj = self._cache.pop(key, None)
             if obj is not None:
+                destroy = getattr(obj, "destroy", None)
+                if callable(destroy):
+                    try:
+                        destroy()
+                    except Exception:  # pragma: no cover - best effort cleanup
+                        pass
                 del obj
         if inactive:
             gc.collect()
@@ -84,6 +90,11 @@ def lazy_import(name: str) -> Any:
             return getattr(module, item)
 
     return _LazyModule()
+
+
+def lazy_widget(key: str, loader: Callable[[], Any]) -> Any:
+    """Lazily create a GUI widget using the shared memory manager."""
+    return manager.lazy_load(key, loader)
 
 
 manager = MemoryManager()


### PR DESCRIPTION
## Summary
- free unused GUI resources in `MemoryManager` and add `lazy_widget` helper
- lazily create governance toolbox button frames on first use
- document version 0.2.24

## Testing
- `pytest tests/test_governance_core_actions.py` (fails: ModuleNotFoundError: No module named 'gui.architecture')
- `python tools/metrics_generator.py --path gui --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68abd21c36148327a6401af0de19be7c