### PR TITLE
Maintain version alignment across documentation and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.22
+version: 0.2.24
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,40 @@
+"""Regression tests ensuring version consistency."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from mainappsrc.version import VERSION
+
+
+def _readme_version() -> str:
+    """Extract the version string from the README."""
+
+    first_line = ROOT.joinpath("README.md").read_text(encoding="utf-8").splitlines()[0]
+    prefix, version = first_line.split(":", maxsplit=1)
+    return version.strip()
+
+
+def test_readme_matches_version() -> None:
+    """README version must match the source version."""
+
+    assert _readme_version() == VERSION
+
+
+def test_cli_reports_same_version() -> None:
+    """The ``--version`` flag should report the package version."""
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "AutoML.py"), "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == VERSION
+
+


### PR DESCRIPTION
## Summary
- Update README to reflect release 0.2.24
- Add tests ensuring README, source, and `--version` flag stay in sync

## Testing
- `radon cc mainappsrc/version.py tests/test_version_sync.py AutoML.py -j`
- `pytest tests/test_version_sync.py -q`
- `python AutoML.py --version`
- `pytest` *(fails: ModuleNotFoundError: No module named 'gui.architecture')*

------
https://chatgpt.com/codex/tasks/task_b_68abd5a7159c8327aa962d27fbeb06b3