### PR TITLE
refactor: extract top event workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.22
+version: 0.2.25
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.25 - Extract top event workflows into dedicated module.
 - 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.
 - 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.
 - 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.

--- a/mainappsrc/core/top_event_workflows.py
+++ b/mainappsrc/core/top_event_workflows.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Helpers for fault tree top event workflows.
+
+The :class:`Top_Event_Workflows` class centralises operations related to
+creating and manipulating top events within a fault tree.  It is
+instantiated by :class:`AutoMLApp` and delegates to existing FTA
+utilities when required.
+"""
+
+from gui.controls import messagebox
+
+from ..models.fta.fault_tree_node import FaultTreeNode
+
+
+class Top_Event_Workflows:
+    """Provide helpers for top event manipulation."""
+
+    def __init__(self, app: "AutoMLApp") -> None:
+        self.app = app
+
+    # ------------------------------------------------------------------
+    # Helpers for malfunctions and failure modes
+    def create_top_event_for_malfunction(self, name: str) -> None:
+        """Create a new top level event linked to the given malfunction."""
+        app = self.app
+        app.push_undo_state()
+        new_event = FaultTreeNode("", "TOP EVENT")
+        new_event.x, new_event.y = 300, 200
+        new_event.is_top_event = True
+        new_event.malfunction = name
+        app.top_events.append(new_event)
+        app.root_node = new_event
+        if hasattr(app, "safety_mgmt_toolbox"):
+            analysis = (
+                "Prototype Assurance Analysis"
+                if getattr(app, "diagram_mode", "") == "PAA"
+                else "FTA"
+            )
+            app.safety_mgmt_toolbox.register_created_work_product(
+                analysis, new_event.name
+            )
+        app.update_views()
+
+    def add_gate_from_failure_mode(self) -> None:
+        app = self.app
+        app.push_undo_state()
+        modes = app.get_available_failure_modes_for_gates()
+        if not modes:
+            messagebox.showinfo("No Failure Modes", "No failure modes available.")
+            return
+        dialog = app.SelectFailureModeDialog(app.root, app, modes)
+        selected = dialog.selected
+        if not selected:
+            return
+        if app.selected_node:
+            parent_node = app.selected_node
+            if not parent_node.is_primary_instance:
+                messagebox.showwarning(
+                    "Invalid Operation",
+                    "Cannot add to a clone node. Select the original.",
+                )
+                return
+        else:
+            sel = app.analysis_tree.selection()
+            if not sel:
+                messagebox.showwarning(
+                    "No selection", "Select a parent node to paste into."
+                )
+                return
+            try:
+                node_id = int(app.analysis_tree.item(sel[0], "tags")[0])
+            except (IndexError, ValueError):
+                messagebox.showwarning(
+                    "No selection", "Select a parent node from the tree."
+                )
+                return
+            parent_node = app.find_node_by_id_all(node_id)
+        if parent_node.node_type.upper() in [
+            "CONFIDENCE LEVEL",
+            "ROBUSTNESS SCORE",
+            "BASIC EVENT",
+        ]:
+            messagebox.showwarning("Invalid", "Base events cannot have children.")
+            return
+        new_node = FaultTreeNode("", "GATE", parent=parent_node)
+        new_node.gate_type = "AND"
+        if hasattr(selected, "unique_id"):
+            new_node.failure_mode_ref = selected.unique_id
+            new_node.description = getattr(selected, "description", "")
+            new_node.user_name = getattr(selected, "user_name", "")
+        else:
+            new_node.description = app.get_entry_field(selected, "description", "")
+            new_node.user_name = app.get_entry_field(selected, "user_name", "")
+        new_node.x = parent_node.x + 100
+        new_node.y = parent_node.y + 100
+        parent_node.children.append(new_node)
+        new_node.parents.append(parent_node)
+        app.update_views()
+
+    def get_top_event(self, node):
+        return self.app.fta_app.get_top_event(self.app, node)
+
+    def generate_top_event_summary(self, top_event):
+        return self.app.fta_app.generate_top_event_summary(self.app, top_event)
+

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.24"
+VERSION = "0.2.25"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- refactor top event logic into dedicated `Top_Event_Workflows` helper
- delegate AutoML top event methods through `self.top_event_workflows`
- bump version to 0.2.25 and document in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gui.architecture')*
- `python tools/metrics_generator.py --path mainappsrc`


------
https://chatgpt.com/codex/tasks/task_b_68abd568d4048327817773a91d50e0cb