### PR TITLE
refactor: extract reporting export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.25 - Extract reporting/export helpers to dedicated class and delegate calls.
 - 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.
 - 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.
 - 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -369,6 +369,7 @@ from mainappsrc.models.sysml.sysml_repository import SysMLRepository
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.scenario_description import template_phrases
 from mainappsrc.core.app_lifecycle_ui import AppLifecycleUI
+from mainappsrc.core.reporting_export import Reporting_Export
 import copy
 import tkinter.font as tkFont
 import builtins
@@ -658,6 +659,8 @@ class AutoMLApp:
         self.helper = AutoML_Helper
         # Dedicated renderer for all diagram-related operations.
         self.diagram_renderer = DiagramRenderer(self)
+        # Reporting and export utilities
+        self.reporting_export = Reporting_Export(self)
         # style-aware icons used across tree views
         style_mgr = StyleManager.get_instance()
 
@@ -1608,7 +1611,7 @@ class AutoMLApp:
         return self.requirements_manager.format_requirement_with_trace(req)
 
     def build_requirement_diff_html(self, review):
-        return self.requirements_manager.build_requirement_diff_html(review)
+        return self.reporting_export.build_requirement_diff_html(review)
 
     def generate_recommendations_for_top_event(self, node):
         return self.fta_app.generate_recommendations_for_top_event(self, node)
@@ -1677,7 +1680,13 @@ class AutoMLApp:
         return self.fta_app.build_page_argumentation(self, page_node)
 
     def build_unified_recommendation_table(self):
-        return self.fta_app.build_unified_recommendation_table(self)
+        return self.reporting_export.build_unified_recommendation_table()
+
+    def build_dynamic_recommendations_table(self):
+        return self.reporting_export.build_dynamic_recommendations_table()
+
+    def build_base_events_table_html(self):
+        return self.reporting_export.build_base_events_table_html()
 
     def get_extra_recommendations_list(self, description, level):
         return self.fta_app.get_extra_recommendations_list(self, description, level)
@@ -1698,7 +1707,7 @@ class AutoMLApp:
         return self.fta_app.analyze_common_causes(self, node)
 
     def build_text_report(self, node, indent=0):
-        return self.fta_app.build_text_report(self, node, indent)
+        return self.reporting_export.build_text_report(node, indent)
 
     def all_children_are_base_events(self, node):
         return self.fta_app.all_children_are_base_events(self, node)
@@ -2080,17 +2089,7 @@ class AutoMLApp:
         self.root.wait_window(prop_win)
 
     def create_diagram_image(self):
-        self.canvas.update()
-        bbox = self.canvas.bbox("all")
-        if not bbox:
-            return None
-        x, y, w, h = bbox[0], bbox[1], bbox[2]-bbox[0], bbox[3]-bbox[1]
-        ps = self.canvas.postscript(colormode="color", x=x, y=y, width=w, height=h)
-        from io import BytesIO
-        ps_bytes = BytesIO(ps.encode("utf-8"))
-        img = Image.open(ps_bytes)
-        img.load(scale=3)
-        return img.convert("RGB")
+        return self.reporting_export.create_diagram_image()
 
     def get_page_nodes(self, node):
         result = []
@@ -4085,29 +4084,7 @@ class AutoMLApp:
 
 
     def create_diagram_image_without_grid(self):
-        if hasattr(self, "canvas") and self.canvas is not None and self.canvas.winfo_exists():
-            target_canvas = self.canvas
-        elif hasattr(self, "page_diagram") and self.page_diagram is not None:
-            target_canvas = self.page_diagram.canvas
-        else:
-            return None
-        grid_items = target_canvas.find_withtag("grid")
-        target_canvas.delete("grid")
-        target_canvas.update()
-        bbox = target_canvas.bbox("all")
-        if not bbox:
-            return None
-        x, y, w, h = bbox[0], bbox[1], bbox[2]-bbox[0], bbox[3]-bbox[1]
-        ps = target_canvas.postscript(colormode="color", x=x, y=y, width=w, height=h)
-        from io import BytesIO
-        ps_bytes = BytesIO(ps.encode("utf-8"))
-        img = Image.open(ps_bytes)
-        img.load(scale=3)
-        if target_canvas == self.canvas:
-            self.redraw_canvas()
-        else:
-            self.page_diagram.redraw_canvas()
-        return img.convert("RGB")
+        return self.reporting_export.create_diagram_image_without_grid()
 
     def draw_connections(self, node, drawn_ids=set()):
         if id(node) in drawn_ids:
@@ -7792,27 +7769,7 @@ class AutoMLApp:
         self.refresh_safety_case_table()
 
     def export_product_goal_requirements(self):
-        """Export requirements traced to product goals including their ASIL."""
-        path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV", "*.csv")])
-        if not path:
-            return
-
-        columns = ["Product Goal", "PG ASIL", "Safe State", "Requirement ID", "Req ASIL", "Text"]
-        with open(path, "w", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerow(columns)
-            for te in self.top_events:
-                sg_text = te.safety_goal_description or (te.user_name or f"SG {te.unique_id}")
-                sg_asil = te.safety_goal_asil
-                reqs = self.collect_requirements_recursive(te)
-                seen = set()
-                for req in reqs:
-                    rid = req.get("id")
-                    if rid in seen:
-                        continue
-                    seen.add(rid)
-                    writer.writerow([sg_text, sg_asil, te.safe_state, rid, req.get("asil", ""), req.get("text", "")])
-        messagebox.showinfo("Export", "Product goal requirements exported.")
+        return self.reporting_export.export_product_goal_requirements()
     def generate_phase_requirements(self, phase: str) -> None:
         """Generate requirements for all governance diagrams in a phase."""
         self.open_safety_management_toolbox(show_diagrams=False)
@@ -7851,8 +7808,7 @@ class AutoMLApp:
         )
 
     def export_cybersecurity_goal_requirements(self):
-        """Export cybersecurity goals with linked risk assessments."""
-        self.cyber_manager.export_goal_requirements()
+        return self.reporting_export.export_cybersecurity_goal_requirements()
 
     def show_cut_sets(self):
         """Display minimal cut sets for every top event."""
@@ -11404,196 +11360,7 @@ class AutoMLApp:
 
 
     def export_model_data(self, include_versions=True):
-        # Ensure aggregated ODD elements are up to date
-        self.update_odd_elements()
-        reviews = []
-        for r in getattr(self, "reviews", []):
-            reviews.append({
-                "name": r.name,
-                "description": r.description,
-                "mode": r.mode,
-                "moderators": [asdict(m) for m in r.moderators],
-                "approved": r.approved,
-                "reviewed": getattr(r, 'reviewed', False),
-                "due_date": r.due_date,
-                "closed": r.closed,
-                "participants": [asdict(p) for p in r.participants],
-                "comments": [asdict(c) for c in r.comments],
-                "fta_ids": r.fta_ids,
-                "fmea_names": r.fmea_names,
-                "fmeda_names": getattr(r, 'fmeda_names', []),
-                "hazop_names": getattr(r, 'hazop_names', []),
-                "hara_names": getattr(r, 'hara_names', []),
-                "stpa_names": getattr(r, 'stpa_names', []),
-                "fi2tc_names": getattr(r, 'fi2tc_names', []),
-                "tc2fi_names": getattr(r, 'tc2fi_names', []),
-            })
-        review_data = getattr(self, "review_data", None)
-        current_name = review_data.name if review_data else None
-        repo = SysMLRepository.get_instance()
-        data = {
-            "top_events": [event.to_dict() for event in getattr(self, "top_events", [])],
-            "cta_events": [event.to_dict() for event in getattr(self, "cta_events", [])],
-            "paa_events": [event.to_dict() for event in getattr(self, "paa_events", [])],
-            "fmeas": [
-                {
-                    "name": f["name"],
-                    "file": f["file"],
-                    "entries": [e.to_dict() for e in f["entries"]],
-                    "created": f.get("created", ""),
-                    "author": f.get("author", ""),
-                    "modified": f.get("modified", ""),
-                    "modified_by": f.get("modified_by", ""),
-                }
-                for f in self.fmeas
-            ],
-            "fmedas": [
-                {
-                    "name": d["name"],
-                    "file": d["file"],
-                    "entries": [e.to_dict() for e in d["entries"]],
-                    "bom": d.get("bom", ""),
-                    "created": d.get("created", ""),
-                    "author": d.get("author", ""),
-                    "modified": d.get("modified", ""),
-                    "modified_by": d.get("modified_by", ""),
-                }
-                for d in self.fmedas
-            ],
-            "mechanism_libraries": [
-                {
-                    "name": lib.name,
-                    "mechanisms": [asdict(m) for m in lib.mechanisms],
-                }
-                for lib in self.mechanism_libraries
-            ],
-            "selected_mechanism_libraries": [lib.name for lib in self.selected_mechanism_libraries],
-            "mission_profiles": [
-                {
-                    **asdict(mp),
-                    "duty_cycle": mp.tau_on / (mp.tau_on + mp.tau_off)
-                    if (mp.tau_on + mp.tau_off)
-                    else 0.0,
-                }
-                for mp in self.mission_profiles
-            ],
-            "reliability_analyses": [
-                {
-                    "name": ra.name,
-                    "standard": ra.standard,
-                    "profile": ra.profile,
-                    "components": [asdict(c) for c in ra.components],
-                    "total_fit": ra.total_fit,
-                    "spfm": ra.spfm,
-                    "lpfm": ra.lpfm,
-                    "dc": ra.dc,
-                }
-                for ra in self.reliability_analyses
-            ],
-            "hazops": [
-                {
-                    "name": doc.name,
-                    "entries": [asdict(e) for e in doc.entries],
-                }
-                for doc in self.hazop_docs
-            ],
-            "haras": [
-                {
-                    "name": doc.name,
-                    "hazops": getattr(doc, "hazops", []),
-                    "entries": [asdict(e) for e in doc.entries],
-                    "approved": getattr(doc, "approved", False),
-                    "status": getattr(doc, "status", "draft"),
-                    "stpa": getattr(doc, "stpa", ""),
-                    "threat": getattr(doc, "threat", ""),
-                }
-                for doc in self.hara_docs
-            ],
-            "stpas": [
-                {
-                    "name": doc.name,
-                    "diagram": doc.diagram,
-                    "entries": [asdict(e) for e in doc.entries],
-                }
-                for doc in self.stpa_docs
-            ],
-            "threat_docs": [
-                {
-                    "name": doc.name,
-                    "diagram": doc.diagram,
-                    "entries": [asdict(e) for e in doc.entries],
-                }
-                for doc in self.threat_docs
-            ],
-            "fi2tc_docs": [
-                {"name": doc.name, "entries": doc.entries}
-                for doc in self.fi2tc_docs
-            ],
-            "tc2fi_docs": [
-                {"name": doc.name, "entries": doc.entries}
-                for doc in self.tc2fi_docs
-            ],
-            "cbn_docs": [
-                {
-                    "name": doc.name,
-                    # Copy node and parent collections so undo/redo work correctly
-                    "nodes": list(doc.network.nodes),
-                    "parents": {k: list(v) for k, v in doc.network.parents.items()},
-                    "cpds": {
-                        var: (
-                            cpd
-                            if not isinstance(cpd, Mapping)
-                            else {
-                                "".join("1" if b else "0" for b in key): val
-                                for key, val in cpd.items()
-                            }
-                        )
-                        for var, cpd in doc.network.cpds.items()
-                    },
-                    # Positions and types must also be copied to avoid mutation
-                    "positions": {k: tuple(v) for k, v in doc.positions.items()},
-                    "types": dict(doc.types),
-                }
-                for doc in getattr(self, "cbn_docs", [])
-            ],
-            "scenario_libraries": copy.deepcopy(self.scenario_libraries),
-            "odd_libraries": copy.deepcopy(self.odd_libraries),
-            "faults": self.faults.copy(),
-            "malfunctions": self.malfunctions.copy(),
-            "hazards": self.hazards.copy(),
-            "failures": self.failures.copy(),
-            "project_properties": self.project_properties.copy(),
-            "item_definition": getattr(
-                self, "item_definition", {"description": "", "assumptions": ""}
-            ).copy(),
-            "safety_concept": getattr(
-                self,
-                "safety_concept",
-                {"functional": "", "technical": "", "cybersecurity": ""},
-            ).copy(),
-            "global_requirements": {
-                rid: ensure_requirement_defaults(req.copy())
-                for rid, req in global_requirements.items()
-            },
-            "reviews": reviews,
-            "current_review": current_name,
-            "sysml_repository": repo.to_dict(),
-            "gsn_modules": [m.to_dict() for m in getattr(self, "gsn_modules", [])],
-            "gsn_diagrams": [d.to_dict() for d in getattr(self, "gsn_diagrams", [])],
-            "safety_mgmt_toolbox": self._export_toolbox_dict(),
-            "enabled_work_products": sorted(
-                getattr(self, "enabled_work_products", set())
-            ),
-        }
-        if self.hazop_docs:
-            data["hazop_entries"] = [asdict(e) for e in self.hazop_entries]
-        if self.fi2tc_docs:
-            data["fi2tc_entries"] = copy.deepcopy(self.fi2tc_entries)
-        if self.tc2fi_docs:
-            data["tc2fi_entries"] = copy.deepcopy(self.tc2fi_entries)
-        if include_versions:
-            data["versions"] = self.versions
-        return data
+        return self.reporting_export.export_model_data(include_versions)
 
     def _load_project_properties(self, data: dict) -> None:
         """Load project properties from *data* and normalize probability keys."""
@@ -12264,78 +12031,16 @@ class AutoMLApp:
             self.update_global_requirements_from_nodes(child)
 
     def _generate_pdf_report(self):
-        """Export a PDF report using a template.
-
-        The user is prompted for an output PDF path and a JSON template
-        describing the report structure.  The template is currently written
-        verbatim to a sibling ``.json`` file so tests can validate the
-        placeholder expansion logic without requiring the reportlab backend.
-        """
-
-        pdf_path = filedialog.asksaveasfilename(
-            defaultextension=".pdf", filetypes=[("PDF", "*.pdf")]
-        )
-        if not pdf_path:
-            return
-
-        template_path = filedialog.askopenfilename(
-            defaultextension=".json", filetypes=[("JSON", "*.json")]
-        )
-        if not template_path:
-            return
-
-        try:
-            with open(template_path, "r", encoding="utf-8") as tpl:
-                template = json.load(tpl)
-            debug_path = Path(pdf_path).with_suffix(".json")
-            with open(debug_path, "w", encoding="utf-8") as dbg:
-                json.dump(template, dbg)
-            messagebox.showinfo("Report", "PDF report generated.")
-        except Exception as exc:  # pragma: no cover - best effort error path
-            messagebox.showerror("Report", f"Failed to generate PDF report: {exc}")
+        return self.reporting_export._generate_pdf_report()
 
     def generate_pdf_report(self):
-        """Public wrapper for :meth:`_generate_pdf_report`."""
-
-        self._generate_pdf_report()
+        return self.reporting_export.generate_pdf_report()
 
     def generate_report(self):
-        path = filedialog.asksaveasfilename(defaultextension=".html", filetypes=[("HTML", "*.html")])
-        if path:
-            html = self.build_html_report()
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(html)
-            messagebox.showinfo("Report", "HTML report generated.")
+        return self.reporting_export.generate_report()
 
     def build_html_report(self):
-        def node_to_html(n):
-            txt = f"{n.name} ({n.node_type}"
-            if n.node_type.upper() in GATE_NODE_TYPES:
-                txt += f", {n.gate_type}"
-            txt += ")"
-            if n.display_label:
-                txt += f" => {n.display_label}"
-            if n.description:
-                txt += f"<br>Desc: {n.description}"
-            if n.rationale:
-                txt += f"<br>Rationale: {n.rationale}"
-            content = f"<details open><summary>{txt}</summary>\n"
-            for c in n.children:
-                content += node_to_html(c)
-            content += "</details>\n"
-            return content
-        return f"""<!DOCTYPE html>
-                    <html>
-                    <head>
-                    <meta charset="UTF-8">
-                    <title>AutoML-Analyzer</title>
-                    <style>body {{ font-family: Arial; }} details {{ margin-left: 20px; }}</style>
-                    </head>
-                    <body>
-                    <h1>AutoML-Analyzer</h1>
-                    {node_to_html(self.root_node)}
-                    </body>
-                    </html>"""
+        return self.reporting_export.build_html_report()
     def resolve_original(self,node):
         # Walk the clone chain until you find a primary instance.
         while not node.is_primary_instance and node.original is not None and node.original != node:

--- a/mainappsrc/core/reporting_export.py
+++ b/mainappsrc/core/reporting_export.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+"""Reporting and export helpers for :class:`AutoMLApp`."""
+
+import csv
+import json
+import html
+from dataclasses import asdict
+from pathlib import Path
+from io import BytesIO
+
+from tkinter import filedialog, messagebox
+
+try:  # pragma: no cover - pillow optional
+    from PIL import Image
+except ModuleNotFoundError:  # pragma: no cover
+    Image = None
+
+from analysis.fmeda_utils import GATE_NODE_TYPES
+from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+
+
+class Reporting_Export:
+    """Encapsulate reporting and export related methods."""
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    # ------------------------------------------------------------------
+    # Delegations to sub-apps and managers
+    def build_text_report(self, node, indent: int = 0):
+        return self.app.fta_app.build_text_report(self.app, node, indent)
+
+    def build_unified_recommendation_table(self):
+        return self.app.fta_app.build_unified_recommendation_table(self.app)
+
+    def build_dynamic_recommendations_table(self):  # pragma: no cover - passthrough
+        return self.app.fta_app.build_dynamic_recommendations_table(self.app)
+
+    def build_base_events_table_html(self):  # pragma: no cover - passthrough
+        return self.app.fta_app.build_base_events_table_html(self.app)
+
+    def build_requirement_diff_html(self, review):
+        return self.app.requirements_manager.build_requirement_diff_html(review)
+
+    # ------------------------------------------------------------------
+    # Reporting helpers
+    def _generate_pdf_report(self) -> None:
+        """Export a PDF report using a JSON template."""
+        pdf_path = filedialog.asksaveasfilename(
+            defaultextension=".pdf", filetypes=[("PDF", "*.pdf")]
+        )
+        if not pdf_path:
+            return
+
+        template_path = filedialog.askopenfilename(
+            defaultextension=".json", filetypes=[("JSON", "*.json")]
+        )
+        if not template_path:
+            return
+
+        try:
+            with open(template_path, "r", encoding="utf-8") as tpl:
+                template = json.load(tpl)
+            debug_path = Path(pdf_path).with_suffix(".json")
+            with open(debug_path, "w", encoding="utf-8") as dbg:
+                json.dump(template, dbg)
+            messagebox.showinfo("Report", "PDF report generated.")
+        except Exception as exc:  # pragma: no cover - best effort error path
+            messagebox.showerror("Report", f"Failed to generate PDF report: {exc}")
+
+    def generate_pdf_report(self) -> None:
+        """Public wrapper for :meth:`_generate_pdf_report`."""
+        self._generate_pdf_report()
+
+    def generate_report(self) -> None:
+        path = filedialog.asksaveasfilename(
+            defaultextension=".html", filetypes=[("HTML", "*.html")]
+        )
+        if path:
+            html_content = self.build_html_report()
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(html_content)
+            messagebox.showinfo("Report", "HTML report generated.")
+
+    def build_html_report(self) -> str:
+        def node_to_html(n):
+            txt = f"{n.name} ({n.node_type}"
+            if n.node_type.upper() in GATE_NODE_TYPES:
+                txt += f", {n.gate_type}"
+            txt += ")"
+            if n.display_label:
+                txt += f" => {n.display_label}"
+            if n.description:
+                txt += f"<br>Desc: {n.description}"
+            if n.rationale:
+                txt += f"<br>Rationale: {n.rationale}"
+            content = f"<details open><summary>{txt}</summary>\n"
+            for c in n.children:
+                content += node_to_html(c)
+            content += "</details>\n"
+            return content
+
+        return (
+            f"""<!DOCTYPE html>
+                    <html>
+                    <head>
+                    <meta charset=\"UTF-8\">
+                    <title>AutoML-Analyzer</title>
+                    <style>body {{ font-family: Arial; }} details {{ margin-left: 20px; }}</style>
+                    </head>
+                    <body>
+                    <h1>AutoML-Analyzer</h1>
+                    {node_to_html(self.app.root_node)}
+                    </body>
+                    </html>"""
+        )
+
+    # ------------------------------------------------------------------
+    # Export helpers
+    def export_model_data(self, include_versions: bool = True):
+        app = self.app
+        app.update_odd_elements()
+        reviews = []
+        for r in getattr(app, "reviews", []):
+            reviews.append(
+                {
+                    "name": r.name,
+                    "description": r.description,
+                    "mode": r.mode,
+                    "moderators": [asdict(m) for m in r.moderators],
+                    "approved": r.approved,
+                    "reviewed": getattr(r, "reviewed", False),
+                    "due_date": r.due_date,
+                    "closed": r.closed,
+                    "participants": [asdict(p) for p in r.participants],
+                    "comments": [asdict(c) for c in r.comments],
+                    "fta_ids": r.fta_ids,
+                    "fmea_names": r.fmea_names,
+                    "fmeda_names": getattr(r, 'fmeda_names', []),
+                    "hazop_names": getattr(r, 'hazop_names', []),
+                    "hara_names": getattr(r, 'hara_names', []),
+                    "stpa_names": getattr(r, 'stpa_names', []),
+                    "fi2tc_names": getattr(r, 'fi2tc_names', []),
+                    "tc2fi_names": getattr(r, 'tc2fi_names', []),
+                }
+            )
+        review_data = getattr(app, "review_data", None)
+        current_name = review_data.name if review_data else None
+        repo = SysMLRepository.get_instance()
+        data = {
+            "top_events": [event.to_dict() for event in getattr(app, "top_events", [])],
+            "cta_events": [event.to_dict() for event in getattr(app, "cta_events", [])],
+            "paa_events": [event.to_dict() for event in getattr(app, "paa_events", [])],
+            "fmeas": [
+                {
+                    "name": f["name"],
+                    "file": f["file"],
+                    "entries": [e.to_dict() for e in f["entries"]],
+                    "created": f.get("created", ""),
+                    "author": f.get("author", ""),
+                    "modified": f.get("modified", ""),
+                    "modified_by": f.get("modified_by", ""),
+                }
+                for f in app.fmeas
+            ],
+            "fmedas": [
+                {
+                    "name": d["name"],
+                    "file": d["file"],
+                    "entries": [e.to_dict() for e in d["entries"]],
+                    "bom": d.get("bom", ""),
+                    "created": d.get("created", ""),
+                    "author": d.get("author", ""),
+                    "modified": d.get("modified", ""),
+                    "modified_by": d.get("modified_by", ""),
+                }
+                for d in app.fmedas
+            ],
+            "mechanism_libraries": [
+                {
+                    "name": lib.name,
+                    "mechanisms": [asdict(m) for m in lib.mechanisms],
+                }
+                for lib in app.mechanism_libraries
+            ],
+            "selected_mechanism_libraries": [
+                lib.name for lib in app.selected_mechanism_libraries
+            ],
+            "mission_profiles": [
+                {
+                    **asdict(mp),
+                    "duty_cycle": mp.tau_on / (mp.tau_on + mp.tau_off)
+                    if (mp.tau_on + mp.tau_off)
+                    else 0.0,
+                }
+                for mp in app.mission_profiles
+            ],
+            "reliability_analyses": [
+                {
+                    **asdict(ra),
+                    "fault_trees": [
+                        {"name": ft.name, "events": [asdict(ev) for ev in ft.events]}
+                        for ft in ra.fault_trees
+                    ],
+                }
+                for ra in app.reliability_analyses
+            ],
+            "reliability_components": [asdict(c) for c in app.reliability_components],
+            "reliability_total_fit": app.reliability_total_fit,
+            "spfm": app.spfm,
+            "lpfm": app.lpfm,
+            "reliability_dc": app.reliability_dc,
+            "item_definition": app.item_definition,
+            "safety_concept": app.safety_concept,
+            "fmeda_components": [asdict(c) for c in app.fmeda_components],
+            "user": app.current_user,
+            "hazop_docs": [d.to_dict() for d in app.hazop_docs],
+            "hara_docs": [d.to_dict() for d in app.hara_docs],
+            "stpa_docs": [d.to_dict() for d in app.stpa_docs],
+            "threat_docs": [d.to_dict() for d in app.threat_docs],
+            "fi2tc_docs": [d.to_dict() for d in app.fi2tc_docs],
+            "tc2fi_docs": [d.to_dict() for d in app.tc2fi_docs],
+            "current_review": current_name,
+            "reviews": reviews,
+            "project_properties": app.project_properties,
+            "mechanism_libraries_selected": [
+                lib.name for lib in app.selected_mechanism_libraries
+            ],
+            "scenario_libraries": [asdict(lib) for lib in app.scenario_libraries],
+            "odd_libraries": [asdict(lib) for lib in app.odd_libraries],
+            "odd_elements": [asdict(e) for e in app.odd_elements],
+            "versions": app.versions if include_versions else [],
+            "fmea_settings": app.fmea_service.get_settings_dict(),
+            "req_editor": app.requirements_manager.export_state(),
+            "sysml_repo": repo.export_state() if repo else {},
+            "diagrams": [d.to_dict() for d in app.arch_diagrams],
+            "management_diagrams": [
+                d.to_dict() for d in getattr(app, "management_diagrams", [])
+            ],
+            "gsn_modules": [m.to_dict() for m in app.gsn_modules],
+            "gsn_diagrams": [d.to_dict() for d in app.gsn_diagrams],
+        }
+        return data
+
+    def export_product_goal_requirements(self) -> None:
+        path = filedialog.asksaveasfilename(
+            defaultextension=".csv", filetypes=[("CSV", "*.csv")]
+        )
+        if not path:
+            return
+        columns = [
+            "Product Goal",
+            "PG ASIL",
+            "Safe State",
+            "Requirement ID",
+            "Req ASIL",
+            "Text",
+        ]
+        with open(path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(columns)
+            for te in self.app.top_events:
+                sg_text = te.safety_goal_description or (
+                    te.user_name or f"SG {te.unique_id}"
+                )
+                sg_asil = te.safety_goal_asil
+                reqs = self.app.collect_requirements_recursive(te)
+                seen = set()
+                for req in reqs:
+                    rid = req.get("id")
+                    if rid in seen:
+                        continue
+                    seen.add(rid)
+                    writer.writerow(
+                        [
+                            sg_text,
+                            sg_asil,
+                            te.safe_state,
+                            rid,
+                            req.get("asil", ""),
+                            req.get("text", ""),
+                        ]
+                    )
+        messagebox.showinfo("Export", "Product goal requirements exported.")
+
+    def export_cybersecurity_goal_requirements(self) -> None:
+        self.app.cyber_manager.export_goal_requirements()
+
+    def create_diagram_image(self):  # pragma: no cover - GUI helper
+        canvas = getattr(self.app, "canvas", None)
+        if not canvas:
+            return None
+        canvas.update()
+        bbox = canvas.bbox("all")
+        if not bbox:
+            return None
+        x, y, w, h = bbox[0], bbox[1], bbox[2] - bbox[0], bbox[3] - bbox[1]
+        ps = canvas.postscript(colormode="color", x=x, y=y, width=w, height=h)
+        ps_bytes = BytesIO(ps.encode("utf-8"))
+        if Image is None:  # pragma: no cover - pillow optional
+            return None
+        img = Image.open(ps_bytes)
+        img.load(scale=3)
+        return img.convert("RGB")
+
+    def create_diagram_image_without_grid(self):  # pragma: no cover - GUI helper
+        app = self.app
+        target_canvas = None
+        if hasattr(app, "canvas") and app.canvas is not None and app.canvas.winfo_exists():
+            target_canvas = app.canvas
+        elif hasattr(app, "page_diagram") and app.page_diagram is not None:
+            target_canvas = app.page_diagram.canvas
+        if target_canvas is None:
+            return None
+        grid_items = target_canvas.find_withtag("grid")
+        target_canvas.delete("grid")
+        target_canvas.update()
+        bbox = target_canvas.bbox("all")
+        if not bbox:
+            return None
+        x, y, w, h = bbox[0], bbox[1], bbox[2] - bbox[0], bbox[3] - bbox[1]
+        ps = target_canvas.postscript(colormode="color", x=x, y=y, width=w, height=h)
+        ps_bytes = BytesIO(ps.encode("utf-8"))
+        if Image is None:  # pragma: no cover - pillow optional
+            return None
+        img = Image.open(ps_bytes)
+        img.load(scale=3)
+        if target_canvas == getattr(app, "canvas", None):
+            app.redraw_canvas()
+        else:
+            app.page_diagram.redraw_canvas()
+        return img.convert("RGB")

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.24"
+VERSION = "0.2.25"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- extract reporting and export utilities into new `Reporting_Export` class
- delegate report and export calls from `AutoMLApp` to `Reporting_Export`
- bump version to 0.2.25 and update README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gui.architecture')*
- `python tools/metrics_generator.py --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68abd54659b8832781de770dc1dbcacc