### PR TITLE
Refactor navigation input handlers into dedicated class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.22
+version: 0.2.25
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.25 - Extract navigation and input handlers into dedicated class.
 - 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.
 - 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.
 - 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -254,7 +254,6 @@ from gui.explorers.safety_case_explorer import SafetyCaseExplorer
 from gui.windows.gsn_diagram_window import GSN_WINDOWS
 from gui.windows.causal_bayesian_network_window import CBN_WINDOWS
 from gui.windows.gsn_config_window import GSNElementConfig
-from gui.toolboxes.search_toolbox import SearchToolbox
 from mainappsrc.models.gsn import GSNDiagram, GSNModule
 from mainappsrc.managers.gsn_manager import GSNManager
 from mainappsrc.models.gsn.nodes import GSNNode, ALLOWED_AWAY_TYPES
@@ -295,6 +294,7 @@ except Exception:  # pragma: no cover
 from mainappsrc.core.event_dispatcher import EventDispatcher
 from mainappsrc.core.page_diagram import PageDiagram
 from mainappsrc.core.window_controllers import WindowControllers
+from mainappsrc.core.navigation_selection_input import Navigation_Selection_Input
 from mainappsrc.managers.review_manager import ReviewManager
 from mainappsrc.core.diagram_renderer import DiagramRenderer
 from analysis.user_config import (
@@ -658,6 +658,30 @@ class AutoMLApp:
         self.helper = AutoML_Helper
         # Dedicated renderer for all diagram-related operations.
         self.diagram_renderer = DiagramRenderer(self)
+        # Delegate navigation and selection input handling
+        self.nav_input = Navigation_Selection_Input(self)
+        for _name in (
+            "go_back",
+            "back_all_pages",
+            "focus_on_node",
+            "on_canvas_click",
+            "on_canvas_double_click",
+            "on_canvas_drag",
+            "on_canvas_release",
+            "on_analysis_tree_double_click",
+            "on_analysis_tree_right_click",
+            "on_analysis_tree_select",
+            "on_ctrl_mousewheel",
+            "on_ctrl_mousewheel_page",
+            "on_right_mouse_press",
+            "on_right_mouse_drag",
+            "on_right_mouse_release",
+            "on_tool_list_double_click",
+            "on_treeview_click",
+            "show_context_menu",
+            "open_search_toolbox",
+        ):
+            setattr(self, _name, getattr(self.nav_input, _name))
         # style-aware icons used across tree views
         style_mgr = StyleManager.get_instance()
 
@@ -1614,7 +1638,7 @@ class AutoMLApp:
         return self.fta_app.generate_recommendations_for_top_event(self, node)
 
     def back_all_pages(self):
-        return self.fta_app.back_all_pages(self)
+        return self.nav_input.back_all_pages()
 
     def move_top_event_up(self):
         return self.fta_app.move_top_event_up(self)
@@ -2399,47 +2423,23 @@ class AutoMLApp:
         self.diagram_export_app.save_diagram_png()
 
     def on_treeview_click(self, event):
-        self.tree_app.on_treeview_click(self, event)
+        return self.nav_input.on_treeview_click(event)
 
     def on_analysis_tree_double_click(self, event):
-        self.tree_app.on_analysis_tree_double_click(self, event)
+        return self.nav_input.on_analysis_tree_double_click(event)
 
     def on_analysis_tree_right_click(self, event):
-        self.tree_app.on_analysis_tree_right_click(self, event)
+        return self.nav_input.on_analysis_tree_right_click(event)
 
     def on_analysis_tree_select(self, _event):
-        """Update property view when a tree item is selected."""
-        self.tree_app.on_analysis_tree_select(self, _event)
+        return self.nav_input.on_analysis_tree_select(_event)
 
 
     def rename_selected_tree_item(self):
         self.tree_app.rename_selected_tree_item(self)
 
     def on_tool_list_double_click(self, event):
-        lb = event.widget
-        sel = lb.curselection()
-        if not sel:
-            # Tk may trigger a double-click event before updating the
-            # selection, so determine the item from the pointer location.
-            index = lb.nearest(getattr(event, "y", 0))
-            if index is None or index < 0:
-                return
-            lb.selection_clear(0, tk.END)
-            lb.selection_set(index)
-            sel = (index,)
-        name = lb.get(sel[0])
-        analysis_names = self.tool_to_work_product.get(name, set())
-        if isinstance(analysis_names, str):
-            analysis_names = {analysis_names}
-        if analysis_names:
-            enabled = set(getattr(self, "enabled_work_products", set()))
-            if self.safety_mgmt_toolbox:
-                enabled.update(self.safety_mgmt_toolbox.enabled_products())
-            if not any(n in enabled for n in analysis_names):
-                return
-        action = self.tool_actions.get(name)
-        if action:
-            action()
+        return self.nav_input.on_tool_list_double_click(event)
 
     def _on_toolbox_change(self) -> None:
         self.governance_manager._on_toolbox_change()
@@ -2714,10 +2714,7 @@ class AutoMLApp:
 
 
     def on_ctrl_mousewheel(self, event):
-        if event.delta > 0:
-            self.zoom_in()
-        else:
-            self.zoom_out()
+        return self.nav_input.on_ctrl_mousewheel(event)
 
     def new_model(self):
         self.project_manager.new_model()
@@ -2761,126 +2758,28 @@ class AutoMLApp:
         return "#FAD7A0"
 
     def on_right_mouse_press(self, event):
-        self.rc_dragged = False
-        self.canvas.scan_mark(event.x, event.y)
+        return self.nav_input.on_right_mouse_press(event)
 
     def on_right_mouse_drag(self, event):
-        self.rc_dragged = True
-        self.canvas.scan_dragto(event.x, event.y, gain=1)
+        return self.nav_input.on_right_mouse_drag(event)
 
     def on_right_mouse_release(self, event):
-        # Use getattr to avoid attribute errors if the press event was not
-        # processed (e.g. when the canvas loses focus).  Also reset the flag so
-        # a stale ``True`` value from a previous drag does not suppress future
-        # context menus.
-        if not getattr(self, "rc_dragged", False):
-            self.show_context_menu(event)
-        self.rc_dragged = False
+        return self.nav_input.on_right_mouse_release(event)
 
     def show_context_menu(self, event):
-        x = self.canvas.canvasx(event.x) / self.zoom
-        y = self.canvas.canvasy(event.y) / self.zoom
-        clicked_node = None
-        for n in self.get_all_nodes(self.root_node):
-            radius = 60 if n.node_type.upper() in GATE_NODE_TYPES else 45
-            if (x - n.x)**2 + (y - n.y)**2 < radius**2:
-                clicked_node = n
-                break
-        if not clicked_node:
-            return
-        self.selected_node = clicked_node
-        menu = tk.Menu(self.root, tearoff=0)
-        menu.add_command(label="Edit", command=lambda: self.edit_selected())
-        menu.add_command(label="Remove Connection", command=lambda: self.remove_connection(clicked_node))
-        menu.add_command(label="Delete Node", command=lambda: self.delete_node_and_subtree(clicked_node))
-        menu.add_command(label="Remove Node", command=lambda: self.remove_node())
-        menu.add_command(label="Copy", command=lambda: self.copy_node())
-        menu.add_command(label="Cut", command=lambda: self.cut_node())
-        menu.add_command(label="Paste", command=lambda: self.paste_node())
-        menu.add_separator()
-        menu.add_command(label="Edit User Name", command=lambda: self.user_manager.edit_user_name())
-        menu.add_command(label="Edit Description", command=lambda: self.edit_description())
-        menu.add_command(label="Edit Rationale", command=lambda: self.edit_rationale())
-        menu.add_command(label="Edit Value", command=lambda: self.edit_value())
-        menu.add_command(label="Edit Gate Type", command=lambda: self.edit_gate_type())
-        menu.add_command(label="Edit Severity", command=lambda: self.edit_severity())
-        menu.add_command(label="Edit Controllability", command=lambda: self.edit_controllability())
-        menu.add_command(label="Edit Page Flag", command=lambda: self.edit_page_flag())
-        menu.add_separator()
-        diag_mode = getattr(self.canvas, "diagram_mode", "FTA")
-        if diag_mode == "PAA":
-            menu.add_command(label="Add Confidence", command=lambda: self.add_node_of_type("Confidence Level"))
-            menu.add_command(label="Add Robustness", command=lambda: self.add_node_of_type("Robustness Score"))
-        elif diag_mode == "CTA":
-            menu.add_command(label="Add Triggering Condition", command=lambda: self.add_node_of_type("Triggering Condition"))
-            menu.add_command(label="Add Functional Insufficiency", command=lambda: self.add_node_of_type("Functional Insufficiency"))
-        else:
-            menu.add_command(label="Add Gate", command=lambda: self.add_node_of_type("GATE"))
-            menu.add_command(label="Add Basic Event", command=lambda: self.add_node_of_type("Basic Event"))
-            menu.add_command(label="Add Gate from Failure Mode", command=self.add_gate_from_failure_mode)
-            menu.add_command(label="Add Fault Event", command=self.add_fault_event)
-        menu.tk_popup(event.x_root, event.y_root)
+        return self.nav_input.show_context_menu(event)
 
     def on_canvas_click(self, event):
-        x = self.canvas.canvasx(event.x) / self.zoom
-        y = self.canvas.canvasy(event.y) / self.zoom
-        clicked_node = None
-        for n in self.get_all_nodes(self.root_node):
-            radius = 60 if n.node_type.upper() in GATE_NODE_TYPES else 45
-            if (x - n.x)**2 + (y - n.y)**2 < radius**2:
-                clicked_node = n
-                break
-        self.selected_node = clicked_node
-        if clicked_node:
-            self.push_undo_state()
-            self.dragging_node = clicked_node
-            self.drag_offset_x = x - clicked_node.x
-            self.drag_offset_y = y - clicked_node.y
-        else:
-            self.dragging_node = None
-        self.redraw_canvas()
+        return self.nav_input.on_canvas_click(event)
 
     def on_canvas_double_click(self, event):
-        x = self.canvas.canvasx(event.x) / self.zoom
-        y = self.canvas.canvasy(event.y) / self.zoom
-        clicked_node = None
-        for n in self.get_all_nodes(self.root_node):
-            radius = 60 if n.node_type.upper() in GATE_NODE_TYPES else 45
-            if (x - n.x)**2 + (y - n.y)**2 < radius**2:
-                clicked_node = n
-                break
-        if clicked_node:
-            if not clicked_node.is_primary_instance:
-                self.window_controllers.open_page_diagram(getattr(clicked_node, "original", clicked_node))
-            else:
-                if clicked_node.is_page:
-                    self.window_controllers.open_page_diagram(clicked_node)
-                else:
-                    EditNodeDialog(self.root, clicked_node, self)
-            self.update_views()
+        return self.nav_input.on_canvas_double_click(event)
 
     def on_canvas_drag(self, event):
-        if self.dragging_node:
-            x = self.canvas.canvasx(event.x) / self.zoom
-            y = self.canvas.canvasy(event.y) / self.zoom
-            new_x = x - self.drag_offset_x
-            new_y = y - self.drag_offset_y
-            dx = new_x - self.dragging_node.x
-            dy = new_y - self.dragging_node.y
-            self.dragging_node.x = new_x
-            self.dragging_node.y = new_y
-            if self.dragging_node.is_primary_instance:
-                self.move_subtree(self.dragging_node, dx, dy)
-            self.redraw_canvas()
+        return self.nav_input.on_canvas_drag(event)
 
     def on_canvas_release(self, event):
-        if self.dragging_node:
-            self.dragging_node.x = round(self.dragging_node.x/self.grid_size)*self.grid_size
-            self.dragging_node.y = round(self.dragging_node.y/self.grid_size)*self.grid_size
-            self.push_undo_state()
-        self.dragging_node = None
-        self.drag_offset_x = 0
-        self.drag_offset_y = 0
+        return self.nav_input.on_canvas_release(event)
 
     def _move_subtree_strategy1(self, node, dx, dy):
         for child in getattr(node, "children", []):
@@ -10087,13 +9986,7 @@ class AutoMLApp:
             pd.redraw_canvas()
 
     def open_search_toolbox(self):
-        """Open the search toolbox in a new working-area tab."""
-        if getattr(self, "search_tab", None) and self.search_tab.winfo_exists():
-            self.doc_nb.select(self.search_tab)
-            return
-        self.search_tab = SearchToolbox(self.doc_nb, self)
-        self.doc_nb.add(self.search_tab, text="Search")
-        self.doc_nb.select(self.search_tab)
+        return self.nav_input.open_search_toolbox()
 
     def open_style_editor(self):
         """Open the diagram style editor window."""
@@ -12343,13 +12236,7 @@ class AutoMLApp:
         return node
 
     def go_back(self):
-        if self.page_history:
-            # Pop one page off the history and open it without pushing the current page again.
-            previous_page = self.page_history.pop()
-            self.window_controllers.open_page_diagram(previous_page, push_history=False)
-        #else:
-            # If history is empty, remain on the current (root) page.
-            #messagebox.showinfo("Back", "You are already at the root page.")
+        return self.nav_input.go_back()
 
     def draw_page_subtree(self, page_root):
         self.page_canvas.delete("all")
@@ -12502,10 +12389,7 @@ class AutoMLApp:
                 )
 
     def on_ctrl_mousewheel_page(self, event):
-        if event.delta > 0:
-            self.page_diagram.zoom_in()
-        else:
-            self.page_diagram.zoom_out()
+        return self.nav_input.on_ctrl_mousewheel_page(event)
 
     def close_page_diagram(self):
         if self.page_history:
@@ -12712,16 +12596,7 @@ class AutoMLApp:
         return self.user_manager.get_current_user_role()
 
     def focus_on_node(self, node):
-        self.selected_node = node
-        try:
-            if hasattr(self, "canvas") and self.canvas is not None and self.canvas.winfo_exists():
-                self.redraw_canvas()
-                bbox = self.canvas.bbox("all")
-                if bbox:
-                    self.canvas.xview_moveto(max(0, (node.x * self.zoom - self.canvas.winfo_width()/2) / bbox[2]))
-                    self.canvas.yview_moveto(max(0, (node.y * self.zoom - self.canvas.winfo_height()/2) / bbox[3]))
-        except tk.TclError:
-            pass
+        return self.nav_input.focus_on_node(node)
 
     def get_review_targets(self):
         return self.review_manager.get_review_targets()

--- a/mainappsrc/core/navigation_selection_input.py
+++ b/mainappsrc/core/navigation_selection_input.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import tkinter as tk
+from typing import TYPE_CHECKING
+
+from analysis.fmeda_utils import GATE_NODE_TYPES
+from gui.dialogs.edit_node_dialog import EditNodeDialog
+from gui.toolboxes.search_toolbox import SearchToolbox
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .automl_core import AutoMLApp
+
+
+class Navigation_Selection_Input:
+    """Handle navigation, selection and input events for :class:`AutoMLApp`."""
+
+    def __init__(self, app: "AutoMLApp") -> None:
+        self.app = app
+
+    # ------------------------------------------------------------------
+    # Basic navigation helpers
+    # ------------------------------------------------------------------
+    def go_back(self) -> None:
+        app = self.app
+        if app.page_history:
+            previous_page = app.page_history.pop()
+            app.window_controllers.open_page_diagram(previous_page, push_history=False)
+
+    def back_all_pages(self):
+        return self.app.fta_app.back_all_pages(self.app)
+
+    def focus_on_node(self, node) -> None:
+        app = self.app
+        app.selected_node = node
+        try:
+            if hasattr(app, "canvas") and app.canvas is not None and app.canvas.winfo_exists():
+                app.redraw_canvas()
+                bbox = app.canvas.bbox("all")
+                if bbox:
+                    app.canvas.xview_moveto(max(0, (node.x * app.zoom - app.canvas.winfo_width() / 2) / bbox[2]))
+                    app.canvas.yview_moveto(max(0, (node.y * app.zoom - app.canvas.winfo_height() / 2) / bbox[3]))
+        except tk.TclError:  # pragma: no cover - GUI dependent
+            pass
+
+    # ------------------------------------------------------------------
+    # Canvas interaction
+    # ------------------------------------------------------------------
+    def on_canvas_click(self, event):
+        app = self.app
+        x = app.canvas.canvasx(event.x) / app.zoom
+        y = app.canvas.canvasy(event.y) / app.zoom
+        clicked_node = None
+        for n in app.get_all_nodes(app.root_node):
+            radius = 60 if n.node_type.upper() in GATE_NODE_TYPES else 45
+            if (x - n.x) ** 2 + (y - n.y) ** 2 < radius ** 2:
+                clicked_node = n
+                break
+        app.selected_node = clicked_node
+        if clicked_node:
+            app.push_undo_state()
+            app.dragging_node = clicked_node
+            app.drag_offset_x = x - clicked_node.x
+            app.drag_offset_y = y - clicked_node.y
+        else:
+            app.dragging_node = None
+        app.redraw_canvas()
+
+    def on_canvas_double_click(self, event):
+        app = self.app
+        x = app.canvas.canvasx(event.x) / app.zoom
+        y = app.canvas.canvasy(event.y) / app.zoom
+        clicked_node = None
+        for n in app.get_all_nodes(app.root_node):
+            radius = 60 if n.node_type.upper() in GATE_NODE_TYPES else 45
+            if (x - n.x) ** 2 + (y - n.y) ** 2 < radius ** 2:
+                clicked_node = n
+                break
+        if clicked_node:
+            if not clicked_node.is_primary_instance:
+                app.window_controllers.open_page_diagram(getattr(clicked_node, "original", clicked_node))
+            else:
+                if clicked_node.is_page:
+                    app.window_controllers.open_page_diagram(clicked_node)
+                else:
+                    EditNodeDialog(app.root, clicked_node, app)
+            app.update_views()
+
+    def on_canvas_drag(self, event):
+        app = self.app
+        if app.dragging_node:
+            x = app.canvas.canvasx(event.x) / app.zoom
+            y = app.canvas.canvasy(event.y) / app.zoom
+            new_x = x - app.drag_offset_x
+            new_y = y - app.drag_offset_y
+            dx = new_x - app.dragging_node.x
+            dy = new_y - app.dragging_node.y
+            app.dragging_node.x = new_x
+            app.dragging_node.y = new_y
+            if app.dragging_node.is_primary_instance:
+                app.move_subtree(app.dragging_node, dx, dy)
+            app.redraw_canvas()
+
+    def on_canvas_release(self, event):
+        app = self.app
+        if app.dragging_node:
+            app.dragging_node.x = round(app.dragging_node.x / app.grid_size) * app.grid_size
+            app.dragging_node.y = round(app.dragging_node.y / app.grid_size) * app.grid_size
+            app.push_undo_state()
+        app.dragging_node = None
+        app.drag_offset_x = 0
+        app.drag_offset_y = 0
+
+    # ------------------------------------------------------------------
+    # Tree view interactions
+    # ------------------------------------------------------------------
+    def on_treeview_click(self, event):
+        return self.app.tree_app.on_treeview_click(self.app, event)
+
+    def on_analysis_tree_double_click(self, event):
+        return self.app.tree_app.on_analysis_tree_double_click(self.app, event)
+
+    def on_analysis_tree_right_click(self, event):
+        return self.app.tree_app.on_analysis_tree_right_click(self.app, event)
+
+    def on_analysis_tree_select(self, _event):
+        return self.app.tree_app.on_analysis_tree_select(self.app, _event)
+
+    def on_tool_list_double_click(self, event):
+        app = self.app
+        lb = event.widget
+        sel = lb.curselection()
+        if not sel:
+            index = lb.nearest(getattr(event, "y", 0))
+            if index is None or index < 0:
+                return
+            lb.selection_clear(0, tk.END)
+            lb.selection_set(index)
+            sel = (index,)
+        name = lb.get(sel[0])
+        analysis_names = app.tool_to_work_product.get(name, set())
+        if isinstance(analysis_names, str):
+            analysis_names = {analysis_names}
+        if analysis_names:
+            enabled = set(getattr(app, "enabled_work_products", set()))
+            if app.safety_mgmt_toolbox:
+                enabled.update(app.safety_mgmt_toolbox.enabled_products())
+            if not any(n in enabled for n in analysis_names):
+                return
+        action = app.tool_actions.get(name)
+        if action:
+            action()
+
+    # ------------------------------------------------------------------
+    # Mouse wheel and right-click behaviour
+    # ------------------------------------------------------------------
+    def on_ctrl_mousewheel(self, event):
+        app = self.app
+        if event.delta > 0:
+            app.zoom_in()
+        else:
+            app.zoom_out()
+
+    def on_ctrl_mousewheel_page(self, event):
+        app = self.app
+        if event.delta > 0:
+            app.page_diagram.zoom_in()
+        else:
+            app.page_diagram.zoom_out()
+
+    def on_right_mouse_press(self, event):
+        app = self.app
+        app.rc_dragged = False
+        app.canvas.scan_mark(event.x, event.y)
+
+    def on_right_mouse_drag(self, event):
+        app = self.app
+        app.rc_dragged = True
+        app.canvas.scan_dragto(event.x, event.y, gain=1)
+
+    def on_right_mouse_release(self, event):
+        app = self.app
+        if not getattr(app, "rc_dragged", False):
+            self.show_context_menu(event)
+        app.rc_dragged = False
+
+    def show_context_menu(self, event):
+        app = self.app
+        x = app.canvas.canvasx(event.x) / app.zoom
+        y = app.canvas.canvasy(event.y) / app.zoom
+        clicked_node = None
+        for n in app.get_all_nodes(app.root_node):
+            radius = 60 if n.node_type.upper() in GATE_NODE_TYPES else 45
+            if (x - n.x) ** 2 + (y - n.y) ** 2 < radius ** 2:
+                clicked_node = n
+                break
+        if not clicked_node:
+            return
+        app.selected_node = clicked_node
+        menu = tk.Menu(app.root, tearoff=0)
+        menu.add_command(label="Edit", command=lambda: app.edit_selected())
+        menu.add_command(label="Remove Connection", command=lambda: app.remove_connection(clicked_node))
+        menu.add_command(label="Delete Node", command=lambda: app.delete_node_and_subtree(clicked_node))
+        menu.add_command(label="Remove Node", command=lambda: app.remove_node())
+        menu.add_command(label="Copy", command=lambda: app.copy_node())
+        menu.add_command(label="Cut", command=lambda: app.cut_node())
+        menu.add_command(label="Paste", command=lambda: app.paste_node())
+        menu.add_separator()
+        menu.add_command(label="Edit User Name", command=lambda: app.user_manager.edit_user_name())
+        menu.add_command(label="Edit Description", command=lambda: app.edit_description())
+        menu.add_command(label="Edit Rationale", command=lambda: app.edit_rationale())
+        menu.add_command(label="Edit Value", command=lambda: app.edit_value())
+        menu.add_command(label="Edit Gate Type", command=lambda: app.edit_gate_type())
+        menu.add_command(label="Edit Severity", command=lambda: app.edit_severity())
+        menu.add_command(label="Edit Controllability", command=lambda: app.edit_controllability())
+        menu.add_command(label="Edit Page Flag", command=lambda: app.edit_page_flag())
+        menu.add_separator()
+        diag_mode = getattr(app.canvas, "diagram_mode", "FTA")
+        if diag_mode == "PAA":
+            menu.add_command(label="Add Confidence", command=lambda: app.add_node_of_type("Confidence Level"))
+            menu.add_command(label="Add Robustness", command=lambda: app.add_node_of_type("Robustness Score"))
+        elif diag_mode == "CTA":
+            menu.add_command(label="Add Triggering Condition", command=lambda: app.add_node_of_type("Triggering Condition"))
+            menu.add_command(label="Add Functional Insufficiency", command=lambda: app.add_node_of_type("Functional Insufficiency"))
+        else:
+            menu.add_command(label="Add Gate", command=lambda: app.add_node_of_type("GATE"))
+            menu.add_command(label="Add Basic Event", command=lambda: app.add_node_of_type("Basic Event"))
+            menu.add_command(label="Add Gate from Failure Mode", command=app.add_gate_from_failure_mode)
+            menu.add_command(label="Add Fault Event", command=app.add_fault_event)
+        menu.tk_popup(event.x_root, event.y_root)
+
+    # ------------------------------------------------------------------
+    # Toolbox interactions
+    # ------------------------------------------------------------------
+    def open_search_toolbox(self):
+        app = self.app
+        if getattr(app, "search_tab", None) and app.search_tab.winfo_exists():
+            app.doc_nb.select(app.search_tab)
+            return
+        app.search_tab = SearchToolbox(app.doc_nb, app)
+        app.doc_nb.add(app.search_tab, text="Search")
+        app.doc_nb.select(app.search_tab)

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.24"
+VERSION = "0.2.25"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- add `Navigation_Selection_Input` for canvas and tree interaction logic
- delegate navigation and selection handlers from `AutoMLApp` to the new class
- bump version to 0.2.25 and document the change

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gui.architecture')*
- `python tools/metrics_generator.py --path mainappsrc --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68abd5500d988327bd2fb0f19f084eae