### PR TITLE
Extract review/version helpers into Versioning_Review class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.25 - Move review and versioning helpers to dedicated class and delegate calls.
 - 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.
 - 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.
 - 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -296,6 +296,7 @@ from mainappsrc.core.event_dispatcher import EventDispatcher
 from mainappsrc.core.page_diagram import PageDiagram
 from mainappsrc.core.window_controllers import WindowControllers
 from mainappsrc.managers.review_manager import ReviewManager
+from .versioning_review import Versioning_Review
 from mainappsrc.core.diagram_renderer import DiagramRenderer
 from analysis.user_config import (
     load_user_config,
@@ -784,6 +785,7 @@ class AutoMLApp:
         self.cta_manager = ControlTreeManager(self)
         self.requirements_manager = RequirementsManagerSubApp(self)
         self.review_manager = ReviewManager(self)
+        self.versioning_review = Versioning_Review(self)
 
         self.mechanism_libraries = []
         self.selected_mechanism_libraries = []
@@ -12555,19 +12557,25 @@ class AutoMLApp:
 
     # --- Review Toolbox Methods ---
     def start_peer_review(self):
-        return self.review_manager.start_peer_review()
+        return self.versioning_review.start_peer_review()
 
     def start_joint_review(self):
-        return self.review_manager.start_joint_review()
+        return self.versioning_review.start_joint_review()
 
     def open_review_document(self, review):
-        return self.review_manager.open_review_document(review)
+        return self.versioning_review.open_review_document(review)
 
     def open_review_toolbox(self):
-        return self.review_manager.open_review_toolbox()
+        return self.versioning_review.open_review_toolbox()
 
     def send_review_email(self, review):
-        return self.review_manager.send_review_email(review)
+        return self.versioning_review.send_review_email(review)
+
+    def review_is_closed(self):
+        return self.versioning_review.review_is_closed()
+
+    def review_is_closed_for(self, review):
+        return self.versioning_review.review_is_closed_for(review)
 
     def capture_diff_diagram(self, top_event):
         return self.review_manager.capture_diff_diagram(top_event)
@@ -12657,40 +12665,21 @@ class AutoMLApp:
         self.update_all_validation_criteria()
 
     def invalidate_reviews_for_hara(self, name):
-        """Reopen reviews associated with the given risk assessment."""
-        for r in self.reviews:
-            if name in getattr(r, "hara_names", []):
-                r.closed = False
-                r.approved = False
-                r.reviewed = False
-                for p in r.participants:
-                    p.done = False
-                    p.approved = False
-        self.update_hara_statuses()
-        self.update_fta_statuses()
+        return self.versioning_review.invalidate_reviews_for_hara(name)
 
     def invalidate_reviews_for_requirement(self, req_id):
-        """Reopen reviews that include the given requirement."""
-        for r in self.reviews:
-            if req_id in self.get_requirements_for_review(r):
-                r.closed = False
-                r.approved = False
-                r.reviewed = False
-                for p in r.participants:
-                    p.done = False
-                    p.approved = False
-        self.update_requirement_statuses()
+        return self.versioning_review.invalidate_reviews_for_requirement(req_id)
 
     def add_version(self):
-        return self.review_manager.add_version()
+        return self.versioning_review.add_version()
 
 
     def compare_versions(self):
-        return self.review_manager.compare_versions()
+        return self.versioning_review.compare_versions()
 
 
     def merge_review_comments(self):
-        return self.review_manager.merge_review_comments()
+        return self.versioning_review.merge_review_comments()
 
 
     def calculate_diff_nodes(self, old_data):
@@ -12724,7 +12713,7 @@ class AutoMLApp:
             pass
 
     def get_review_targets(self):
-        return self.review_manager.get_review_targets()
+        return self.versioning_review.get_review_targets()
 
 
 def load_user_data() -> tuple[dict, tuple[str, str]]:

--- a/mainappsrc/core/versioning_review.py
+++ b/mainappsrc/core/versioning_review.py
@@ -1,0 +1,55 @@
+"""Review and versioning helpers separated from the main application."""
+from __future__ import annotations
+
+from typing import Any
+
+
+class Versioning_Review:
+    """Facade for review and version-related operations.
+
+    This helper wraps :class:`ReviewManager` to keep
+    :class:`AutoMLApp` lean and focused on orchestration.
+    """
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    # Delegated review/version operations ---------------------------------
+    def add_version(self):
+        return self.app.review_manager.add_version()
+
+    def compare_versions(self):
+        return self.app.review_manager.compare_versions()
+
+    def open_review_document(self, review):
+        return self.app.review_manager.open_review_document(review)
+
+    def open_review_toolbox(self):
+        return self.app.review_manager.open_review_toolbox()
+
+    def start_joint_review(self):
+        return self.app.review_manager.start_joint_review()
+
+    def start_peer_review(self):
+        return self.app.review_manager.start_peer_review()
+
+    def merge_review_comments(self):
+        return self.app.review_manager.merge_review_comments()
+
+    def send_review_email(self, review):
+        return self.app.review_manager.send_review_email(review)
+
+    def review_is_closed(self):
+        return self.app.review_manager.review_is_closed()
+
+    def review_is_closed_for(self, review):
+        return self.app.review_manager.review_is_closed_for(review)
+
+    def invalidate_reviews_for_hara(self, name):
+        return self.app.review_manager.invalidate_reviews_for_hara(name)
+
+    def invalidate_reviews_for_requirement(self, req_id):
+        return self.app.review_manager.invalidate_reviews_for_requirement(req_id)
+
+    def get_review_targets(self):
+        return self.app.review_manager.get_review_targets()

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.24"
+VERSION = "0.2.25"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- centralize review/version operations in new `Versioning_Review` helper
- delegate review-related methods in `AutoMLApp` to `Versioning_Review`
- bump version to 0.2.25 and document in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gui.architecture')*
- `python tools/metrics_generator.py --path mainappsrc`


------
https://chatgpt.com/codex/tasks/task_b_68abd5529c9c83278f512a4bf143d0e9