### PR TITLE
refactor: centralize label editing and styling helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.22
+version: 0.2.25
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.25 - Extract editing and styling helpers into dedicated class and delegate from core.
 - 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.
 - 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.
 - 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -369,6 +369,7 @@ from mainappsrc.models.sysml.sysml_repository import SysMLRepository
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.scenario_description import template_phrases
 from mainappsrc.core.app_lifecycle_ui import AppLifecycleUI
+from mainappsrc.core.editing_labels_styling import Editing_Labels_Styling
 import copy
 import tkinter.font as tkFont
 import builtins
@@ -548,6 +549,7 @@ class AutoMLApp:
     #: titles are truncated with an ellipsis to avoid giant tabs that overflow
     #: the working area.
     MAX_TAB_TEXT_LENGTH = 20
+    GATE_NODE_TYPES = GATE_NODE_TYPES
 
     @property
     def fmedas(self):
@@ -620,6 +622,7 @@ class AutoMLApp:
         AutoMLApp._instance = self
         self.root = root
         self.lifecycle_ui = AppLifecycleUI(self, root)
+        self.labels_styling = Editing_Labels_Styling(self)
         self.top_events = []
         self.cta_events = []
         self.paa_events = []
@@ -1581,6 +1584,72 @@ class AutoMLApp:
     def _new_tab(self, *args, **kwargs):
         return self.lifecycle_ui._new_tab(*args, **kwargs)
 
+    # ------------------------------------------------------------------
+    # Label editing and styling helper wrappers
+    # ------------------------------------------------------------------
+    def edit_controllability(self, *args, **kwargs):
+        return self.labels_styling.edit_controllability(*args, **kwargs)
+
+    def edit_description(self, *args, **kwargs):
+        return self.labels_styling.edit_description(*args, **kwargs)
+
+    def edit_gate_type(self, *args, **kwargs):
+        return self.labels_styling.edit_gate_type(*args, **kwargs)
+
+    def edit_page_flag(self, *args, **kwargs):
+        return self.labels_styling.edit_page_flag(*args, **kwargs)
+
+    def edit_rationale(self, *args, **kwargs):
+        return self.labels_styling.edit_rationale(*args, **kwargs)
+
+    def edit_selected(self, *args, **kwargs):
+        return self.labels_styling.edit_selected(*args, **kwargs)
+
+    def edit_user_name(self, *args, **kwargs):
+        return self.labels_styling.edit_user_name(*args, **kwargs)
+
+    def edit_value(self, *args, **kwargs):
+        return self.labels_styling.edit_value(*args, **kwargs)
+
+    def rename_failure(self, *args, **kwargs):
+        return self.labels_styling.rename_failure(*args, **kwargs)
+
+    def rename_fault(self, *args, **kwargs):
+        return self.labels_styling.rename_fault(*args, **kwargs)
+
+    def rename_functional_insufficiency(self, *args, **kwargs):
+        return self.labels_styling.rename_functional_insufficiency(*args, **kwargs)
+
+    def rename_hazard(self, *args, **kwargs):
+        return self.labels_styling.rename_hazard(*args, **kwargs)
+
+    def rename_malfunction(self, *args, **kwargs):
+        return self.labels_styling.rename_malfunction(*args, **kwargs)
+
+    def rename_selected_tree_item(self, *args, **kwargs):
+        return self.labels_styling.rename_selected_tree_item(*args, **kwargs)
+
+    def rename_triggering_condition(self, *args, **kwargs):
+        return self.labels_styling.rename_triggering_condition(*args, **kwargs)
+
+    def apply_style(self, *args, **kwargs):
+        return self.labels_styling.apply_style(*args, **kwargs)
+
+    def format_failure_mode_label(self, *args, **kwargs):
+        return self.labels_styling.format_failure_mode_label(*args, **kwargs)
+
+    def _resize_prop_columns(self, *args, **kwargs):
+        return self.labels_styling._resize_prop_columns(*args, **kwargs)
+
+    def _spi_label(self, *args, **kwargs):
+        return self.labels_styling._spi_label(*args, **kwargs)
+
+    def _product_goal_name(self, *args, **kwargs):
+        return self.labels_styling._product_goal_name(*args, **kwargs)
+
+    def _create_icon(self, *args, **kwargs):
+        return self.labels_styling._create_icon(*args, **kwargs)
+
     @property
     def fmeas(self):
         service = getattr(self, "fmea_service", None) or self.safety_analysis
@@ -1798,8 +1867,6 @@ class AutoMLApp:
     def delete_triggering_condition(self, name: str) -> None:
         return self.risk_app.delete_triggering_condition(self, name)
 
-    def rename_triggering_condition(self, old: str, new: str) -> None:
-        return self.risk_app.rename_triggering_condition(self, old, new)
 
     def add_functional_insufficiency(self, name: str) -> None:
         return self.risk_app.add_functional_insufficiency(self, name)
@@ -1807,11 +1874,6 @@ class AutoMLApp:
     def delete_functional_insufficiency(self, name: str) -> None:
         return self.risk_app.delete_functional_insufficiency(self, name)
 
-    def rename_functional_insufficiency(self, old: str, new: str) -> None:
-        return self.risk_app.rename_functional_insufficiency(self, old, new)
-
-    def rename_malfunction(self, old: str, new: str) -> None:
-        return self.risk_app.rename_malfunction(self, old, new)
 
     def _update_shared_product_goals(self):
         groups = {}
@@ -1836,17 +1898,10 @@ class AutoMLApp:
                 ev.name_readonly = False
                 ev.product_goal = None
 
-    def rename_hazard(self, old: str, new: str) -> None:
-        return self.risk_app.rename_hazard(self, old, new)
 
     def update_hazard_severity(self, hazard: str, severity: int | str) -> None:
         return self.risk_app.update_hazard_severity(self, hazard, severity)
 
-    def rename_fault(self, old: str, new: str) -> None:
-        return self.risk_app.rename_fault(self, old, new)
-
-    def rename_failure(self, old: str, new: str) -> None:
-        return self.risk_app.rename_failure(self, old, new)
 
     def calculate_fmeda_metrics(self, events):
         """Delegate FMEDA metric calculation to the dedicated helper."""
@@ -1864,27 +1919,6 @@ class AutoMLApp:
         """Synchronise cyber risk results with cybersecurity goals."""
         return self.risk_app.sync_cyber_risk_to_goals(self)
 
-    def edit_selected(self):
-        sel = self.analysis_tree.selection()
-        target = None
-        if sel:
-            try:
-                node_id = int(self.analysis_tree.item(sel[0], "tags")[0])
-            except (IndexError, ValueError):
-                return
-            target = self.find_node_by_id_all(node_id)
-        elif self.selected_node:
-            target = self.selected_node
-        if not target:
-            messagebox.showwarning("No selection", "Select a node to edit.")
-            return
-
-        # If the node is a clone, resolve it to its original.
-        if not target.is_primary_instance and hasattr(target, "original") and target.original:
-            target = target.original
-
-        EditNodeDialog(self.root, target, self)
-        self.update_views()
 
     def add_top_level_event(self):
         new_event = FaultTreeNode("", "TOP EVENT")
@@ -2412,8 +2446,6 @@ class AutoMLApp:
         self.tree_app.on_analysis_tree_select(self, _event)
 
 
-    def rename_selected_tree_item(self):
-        self.tree_app.rename_selected_tree_item(self)
 
     def on_tool_list_double_click(self, event):
         lb = event.widget
@@ -2691,26 +2723,6 @@ class AutoMLApp:
     # NEVER DELETE OR TOUCH THIS: helper keeps the value column synced with
     # the Properties tab width. Removing this breaks property display.
     # ----------------------------------------------------------------------
-    def _resize_prop_columns(self, event: tk.Event | None = None) -> None:
-        """Resize property view columns so the value column fills the tab."""
-        if not hasattr(self, "prop_view"):
-            return
-
-        # Determine the width of the containing frame rather than the treeview
-        # itself, as the tree may not yet have expanded to the full tab width.
-        container = self.prop_view.master
-        container.update_idletasks()
-        tree_width = container.winfo_width()
-        field_width = self.prop_view.column("field")["width"]
-
-        # If the container hasn't been fully laid out yet (width too small),
-        # try again on the next loop iteration so the value column starts at
-        # the full tab width. DO NOT REMOVE.
-        if tree_width <= field_width + 1:
-            self.prop_view.after(50, self._resize_prop_columns)
-            return
-        new_width = max(tree_width - field_width, 20)
-        self.prop_view.column("value", width=new_width, stretch=True)
 
 
     def on_ctrl_mousewheel(self, event):
@@ -3443,10 +3455,6 @@ class AutoMLApp:
                 return parent.user_name
         return getattr(src, "fmea_component", "")
 
-    def format_failure_mode_label(self, node):
-        comp = self.get_component_name_for_node(node)
-        label = node.description if node.description else (node.user_name or f"Node {node.unique_id}")
-        return f"{comp}: {label}" if comp else label
 
     def get_failure_modes_for_malfunction(self, malfunction: str) -> list[str]:
         """Return labels of basic events linked to the given malfunction."""
@@ -7425,18 +7433,7 @@ class AutoMLApp:
 
         refresh_tree()
 
-    def _spi_label(self, sg):
-        """Return a human-readable label for a product goal's SPI."""
-        return (
-            getattr(sg, "validation_desc", "")
-            or getattr(sg, "safety_goal_description", "")
-            or getattr(sg, "user_name", "")
-            or f"SG {getattr(sg, 'unique_id', '')}"
-        )
 
-    def _product_goal_name(self, sg) -> str:
-        """Return the display name for a product goal."""
-        return getattr(sg, "user_name", "") or f"SG {getattr(sg, 'unique_id', '')}"
 
     def _parse_spi_target(self, target: str) -> tuple[str, str]:
         """Split ``target`` into product goal name and SPI type."""
@@ -10100,10 +10097,6 @@ class AutoMLApp:
         StyleEditor(self.root)
 
 
-    def apply_style(self, filename: str) -> None:
-        path = Path(__file__).resolve().parent / 'styles' / filename
-        StyleManager.get_instance().load_style(path)
-        self.root.event_generate('<<StyleChanged>>', when='tail')
 
     def refresh_styles(self, event=None):
         """Redraw all open diagram windows using current styles."""
@@ -10274,9 +10267,6 @@ class AutoMLApp:
             return f"\N{LEFT-POINTING DOUBLE ANGLE QUOTATION MARK}{diag.diag_type}\N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK} {diag.name}"
         return f"\N{LEFT-POINTING DOUBLE ANGLE QUOTATION MARK}{diag.diag_type}\N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK}"
 
-    def _create_icon(self, shape: str, color: str) -> tk.PhotoImage:
-        """Delegate icon creation to the shared icon factory."""
-        return create_icon(shape, color)
 
     def open_use_case_diagram(self):
         self.window_controllers.open_use_case_diagram()
@@ -11012,64 +11002,10 @@ class AutoMLApp:
             except Exception:
                 continue
 
-    def edit_user_name(self):
-        self.user_manager.edit_user_name()
        
-    def edit_description(self):
-        if self.selected_node:
-            new_desc = askstring_fixed(
-                simpledialog,
-                "Edit Description",
-                "Enter new description:",
-                initialvalue=self.selected_node.description,
-            )
-            if new_desc is not None:
-                self.selected_node.description = new_desc
-                # Propagate the updated description across clones/original.
-                self.sync_nodes_by_id(self.selected_node)
-                self.update_views()
-        else:
-            messagebox.showwarning("Edit Description", "Select a node first.")
 
-    def edit_rationale(self):
-        if self.selected_node:
-            new_rat = simpledialog.askstring("Edit Rationale", "Enter new rationale:", initialvalue=self.selected_node.rationale)
-            if new_rat is not None:
-                self.selected_node.rationale = new_rat
-                # Synchronize rationale changes with related clones.
-                self.sync_nodes_by_id(self.selected_node)
-                self.update_views()
-        else:
-            messagebox.showwarning("Edit Rationale", "Select a node first.")
 
-    def edit_value(self):
-        if self.selected_node and self.selected_node.node_type.upper() in ["CONFIDENCE LEVEL", "ROBUSTNESS SCORE"]:
-            try:
-                new_val = simpledialog.askfloat("Edit Value", "Enter new value (1-5):", initialvalue=self.selected_node.quant_value)
-                if new_val is not None and 1 <= new_val <= 5:
-                    self.selected_node.quant_value = new_val
-                    # Keep all nodes sharing this ID up to date.
-                    self.sync_nodes_by_id(self.selected_node)
-                    self.update_views()
-                else:
-                    messagebox.showerror("Error", "Value must be between 1 and 5.")
-            except Exception:
-                messagebox.showerror("Error", "Invalid input.")
-        else:
-            messagebox.showwarning("Edit Value", "Select a Confidence or Robustness node.")
 
-    def edit_gate_type(self):
-        if self.selected_node and self.selected_node.node_type.upper() in GATE_NODE_TYPES:
-            new_gt = simpledialog.askstring("Edit Gate Type", "Enter new gate type (AND/OR):", initialvalue=self.selected_node.gate_type)
-            if new_gt is not None and new_gt.upper() in ["AND", "OR"]:
-                self.selected_node.gate_type = new_gt.upper()
-                # Reflect gate type changes everywhere.
-                self.sync_nodes_by_id(self.selected_node)
-                self.update_views()
-            else:
-                messagebox.showerror("Error", "Gate type must be AND or OR.")
-        else:
-            messagebox.showwarning("Edit Gate Type", "Select a gate-type node.")
 
     def edit_severity(self):
         messagebox.showinfo(
@@ -11077,30 +11013,7 @@ class AutoMLApp:
             "Severity is determined from the risk assessment and cannot be edited here.",
         )
 
-    def edit_controllability(self):
-        messagebox.showinfo(
-            "Controllability",
-            "Controllability is determined from the risk assessment and cannot be edited here.",
-        )
 
-    def edit_page_flag(self):
-        if not self.selected_node:
-            messagebox.showwarning("Edit Page Flag", "Select a node first.")
-            return
-        # If this is a clone, update its original.
-        target = self.selected_node if self.selected_node.is_primary_instance else self.selected_node.original
-
-        if target.node_type.upper() in ["TOP EVENT", "BASIC EVENT"]:
-            messagebox.showwarning("Edit Page Flag", "This node type cannot be a page.")
-            return
-
-        # Ask for the new page flag value.
-        response = messagebox.askyesno("Edit Page Flag", f"Should node '{target.name}' be a page gate?")
-        target.is_page = response
-
-        # Sync the changes to all clones.
-        self.sync_nodes_by_id(target)
-        self.update_views()
 
     def set_last_saved_state(self):
         """Record the current model state for change detection."""

--- a/mainappsrc/core/editing_labels_styling.py
+++ b/mainappsrc/core/editing_labels_styling.py
@@ -1,0 +1,240 @@
+"""Editing and styling helpers extracted from AutoML core.
+
+This module defines :class:`Editing_Labels_Styling` which groups together
+label editing and styling utilities that previously lived directly on
+``AutoMLApp``.  The helper delegates attribute access back to the parent
+application instance so existing code can continue to call these methods
+without modification.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tkinter as tk
+from tkinter import simpledialog
+
+from gui.controls import messagebox
+from gui.dialogs.dialog_utils import askstring_fixed
+from gui.styles.style_manager import StyleManager
+from gui.utils.icon_factory import create_icon
+from gui.dialogs.edit_node_dialog import EditNodeDialog
+
+
+class Editing_Labels_Styling:
+    """Collection of label editing and styling helpers."""
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    def __getattr__(self, name):  # pragma: no cover - simple delegation
+        return getattr(self.app, name)
+
+    # ------------------------------------------------------------------
+    # Methods migrated from ``AutoMLApp``
+    # ------------------------------------------------------------------
+    def edit_controllability(self):
+        messagebox.showinfo(
+            "Controllability",
+            "Controllability is determined from the risk assessment and cannot be edited here.",
+        )
+
+    def edit_description(self):
+        if self.selected_node:
+            new_desc = askstring_fixed(
+                simpledialog,
+                "Edit Description",
+                "Enter new description:",
+                initialvalue=self.selected_node.description,
+            )
+            if new_desc is not None:
+                self.selected_node.description = new_desc
+                # Propagate the updated description across clones/original.
+                self.sync_nodes_by_id(self.selected_node)
+                self.update_views()
+        else:
+            messagebox.showwarning("Edit Description", "Select a node first.")
+
+    def edit_gate_type(self):
+        if self.selected_node and self.selected_node.node_type.upper() in self.GATE_NODE_TYPES:
+            new_gt = simpledialog.askstring(
+                "Edit Gate Type",
+                "Enter new gate type (AND/OR):",
+                initialvalue=self.selected_node.gate_type,
+            )
+            if new_gt is not None and new_gt.upper() in ["AND", "OR"]:
+                self.selected_node.gate_type = new_gt.upper()
+                # Reflect gate type changes everywhere.
+                self.sync_nodes_by_id(self.selected_node)
+                self.update_views()
+            else:
+                messagebox.showerror("Error", "Gate type must be AND or OR.")
+        else:
+            messagebox.showwarning("Edit Gate Type", "Select a gate-type node.")
+
+    def edit_page_flag(self):
+        if not self.selected_node:
+            messagebox.showwarning("Edit Page Flag", "Select a node first.")
+            return
+        # If this is a clone, update its original.
+        target = (
+            self.selected_node
+            if self.selected_node.is_primary_instance
+            else self.selected_node.original
+        )
+
+        if target.node_type.upper() in ["TOP EVENT", "BASIC EVENT"]:
+            messagebox.showwarning("Edit Page Flag", "This node type cannot be a page.")
+            return
+
+        # Ask for the new page flag value.
+        response = messagebox.askyesno(
+            "Edit Page Flag", f"Should node '{target.name}' be a page gate?"
+        )
+        target.is_page = response
+
+        # Sync the changes to all clones.
+        self.sync_nodes_by_id(target)
+        self.update_views()
+
+    def edit_rationale(self):
+        if self.selected_node:
+            new_rat = simpledialog.askstring(
+                "Edit Rationale",
+                "Enter new rationale:",
+                initialvalue=self.selected_node.rationale,
+            )
+            if new_rat is not None:
+                self.selected_node.rationale = new_rat
+                # Synchronize rationale changes with related clones.
+                self.sync_nodes_by_id(self.selected_node)
+                self.update_views()
+        else:
+            messagebox.showwarning("Edit Rationale", "Select a node first.")
+
+    def edit_selected(self):
+        sel = self.analysis_tree.selection()
+        target = None
+        if sel:
+            try:
+                node_id = int(self.analysis_tree.item(sel[0], "tags")[0])
+            except (IndexError, ValueError):
+                return
+            target = self.find_node_by_id_all(node_id)
+        elif self.selected_node:
+            target = self.selected_node
+        if not target:
+            messagebox.showwarning("No selection", "Select a node to edit.")
+            return
+
+        # If the node is a clone, resolve it to its original.
+        if (
+            not target.is_primary_instance
+            and hasattr(target, "original")
+            and target.original
+        ):
+            target = target.original
+
+        EditNodeDialog(self.root, target, self)
+        self.update_views()
+
+    def edit_user_name(self):
+        self.user_manager.edit_user_name()
+
+    def edit_value(self):
+        if self.selected_node and self.selected_node.node_type.upper() in [
+            "CONFIDENCE LEVEL",
+            "ROBUSTNESS SCORE",
+        ]:
+            try:
+                new_val = simpledialog.askfloat(
+                    "Edit Value",
+                    "Enter new value (1-5):",
+                    initialvalue=self.selected_node.quant_value,
+                )
+                if new_val is not None and 1 <= new_val <= 5:
+                    self.selected_node.quant_value = new_val
+                    # Keep all nodes sharing this ID up to date.
+                    self.sync_nodes_by_id(self.selected_node)
+                    self.update_views()
+                else:
+                    messagebox.showerror("Error", "Value must be between 1 and 5.")
+            except Exception:
+                messagebox.showerror("Error", "Invalid input.")
+        else:
+            messagebox.showwarning(
+                "Edit Value", "Select a Confidence or Robustness node."
+            )
+
+    def rename_failure(self, old: str, new: str) -> None:
+        return self.risk_app.rename_failure(self, old, new)
+
+    def rename_fault(self, old: str, new: str) -> None:
+        return self.risk_app.rename_fault(self, old, new)
+
+    def rename_functional_insufficiency(self, old: str, new: str) -> None:
+        return self.risk_app.rename_functional_insufficiency(self, old, new)
+
+    def rename_hazard(self, old: str, new: str) -> None:
+        return self.risk_app.rename_hazard(self, old, new)
+
+    def rename_malfunction(self, old: str, new: str) -> None:
+        return self.risk_app.rename_malfunction(self, old, new)
+
+    def rename_selected_tree_item(self):
+        self.tree_app.rename_selected_tree_item(self)
+
+    def rename_triggering_condition(self, old: str, new: str) -> None:
+        return self.risk_app.rename_triggering_condition(self, old, new)
+
+    def apply_style(self, filename: str) -> None:
+        path = Path(__file__).resolve().parent / "styles" / filename
+        StyleManager.get_instance().load_style(path)
+        self.root.event_generate("<<StyleChanged>>", when="tail")
+
+    def format_failure_mode_label(self, node):
+        comp = self.get_component_name_for_node(node)
+        label = (
+            node.description
+            if node.description
+            else (node.user_name or f"Node {node.unique_id}")
+        )
+        return f"{comp}: {label}" if comp else label
+
+    def _resize_prop_columns(self, event: tk.Event | None = None) -> None:
+        """Resize property view columns so the value column fills the tab."""
+        if not hasattr(self, "prop_view"):
+            return
+
+        # Determine the width of the containing frame rather than the treeview
+        # itself, as the tree may not yet have expanded to the full tab width.
+        container = self.prop_view.master
+        container.update_idletasks()
+        tree_width = container.winfo_width()
+        field_width = self.prop_view.column("field")["width"]
+
+        # If the container hasn't been fully laid out yet (width too small),
+        # try again on the next loop iteration so the value column starts at
+        # the full tab width. DO NOT REMOVE.
+        if tree_width <= field_width + 1:
+            self.prop_view.after(50, self._resize_prop_columns)
+            return
+        new_width = max(tree_width - field_width, 20)
+        self.prop_view.column("value", width=new_width, stretch=True)
+
+    def _spi_label(self, sg):
+        """Return a human-readable label for a product goal's SPI."""
+        return (
+            getattr(sg, "validation_desc", "")
+            or getattr(sg, "safety_goal_description", "")
+            or getattr(sg, "user_name", "")
+            or f"SG {getattr(sg, 'unique_id', '')}"
+        )
+
+    def _product_goal_name(self, sg) -> str:
+        """Return the display name for a product goal."""
+        return getattr(sg, "user_name", "") or f"SG {getattr(sg, 'unique_id', '')}"
+
+    def _create_icon(self, shape: str, color: str) -> tk.PhotoImage:
+        """Delegate icon creation to the shared icon factory."""
+        return create_icon(shape, color)
+

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.24"
+VERSION = "0.2.25"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- move editing and styling routines into new `Editing_Labels_Styling` helper
- delegate AutoML core methods to the helper for cleaner architecture
- bump version to 0.2.25 and document change

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gui.architecture')*
- `python tools/metrics_generator.py --path mainappsrc --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68abd55adda4832797cbf5087f013ef5