### PR TITLE
Fix missing import for top event workflows

### DIFF
--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -287,6 +287,7 @@ from gui.utils.drawing_helper import FTADrawingHelper, fta_drawing_helper
 from mainappsrc.core.event_dispatcher import EventDispatcher
 from mainappsrc.core.window_controllers import WindowControllers
 from mainappsrc.core.navigation_selection_input import Navigation_Selection_Input
+from mainappsrc.core.top_event_workflows import Top_Event_Workflows
 from mainappsrc.managers.review_manager import ReviewManager
 from .versioning_review import Versioning_Review
 from mainappsrc.core.diagram_renderer import DiagramRenderer


### PR DESCRIPTION
## Summary
- import `Top_Event_Workflows` in `AutoMLApp` implementation to define `top_event_workflows` property

## Testing
- `pytest` *(fails: 221 errors during collection)*
- `radon cc -j mainappsrc/core/automl_core.py`


------
https://chatgpt.com/codex/tasks/task_b_68abda24baf08327a662f11f189795fc