### PR TITLE
Ensure Syncing_And_IDs imported in fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.25
+version: 0.2.26
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.26 - Import Syncing_And_IDs in fallback path to avoid initialization error.
 - 0.2.25 - Extract page and PAA helpers into dedicated module and delegate from core.
 - 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.
 - 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -465,6 +465,7 @@ except Exception:  # pragma: no cover
         from mainappsrc.subapps.project_editor_subapp import ProjectEditorSubApp
         from mainappsrc.subapps.risk_assessment_subapp import RiskAssessmentSubApp
         from mainappsrc.subapps.reliability_subapp import ReliabilitySubApp
+        from mainappsrc.core.syncing_and_ids import Syncing_And_IDs
         from mainappsrc.version import VERSION
 try:  # pragma: no cover
     from .models.fta.fault_tree_node import FaultTreeNode

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.25"
+VERSION = "0.2.26"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- fix NameError by importing `Syncing_And_IDs` in core fallback path
- bump version to 0.2.26 and document in README

## Testing
- `radon cc mainappsrc/core/automl_core.py -s -j`
- `pytest` *(fails: 221 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68abdb15f90c832783fe182a2012c956