### PR TITLE
Fix DataAccess_Queries import and add regression test

### DIFF
--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -272,6 +272,7 @@ from .ui_setup import UISetupMixin
 from .event_handlers import EventHandlersMixin
 from .persistence_wrappers import PersistenceWrappersMixin
 from .analysis_utils import AnalysisUtilsMixin
+from .data_access_queries import DataAccess_Queries
 from analysis.mechanisms import (
     DiagnosticMechanism,
     MechanismLibrary,

--- a/tests/test_data_access_queries_import.py
+++ b/tests/test_data_access_queries_import.py
@@ -1,0 +1,13 @@
+import ast
+from pathlib import Path
+
+
+def test_automl_core_imports_data_access_queries():
+    code = Path("mainappsrc/core/automl_core.py").read_text()
+    tree = ast.parse(code)
+    assert any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "data_access_queries"
+        and any(alias.name == "DataAccess_Queries" for alias in node.names)
+        for node in ast.walk(tree)
+    ), "DataAccess_Queries import missing in automl_core"


### PR DESCRIPTION
## Summary
- import `DataAccess_Queries` in `AutoMLApp` to avoid NameError on startup
- add regression test checking that `automl_core` imports `DataAccess_Queries`

## Testing
- `radon cc mainappsrc/core/automl_core.py | head -n 20`
- `pytest` *(fails: 221 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68abdfb6facc8327803fbe44b783af6e