### PR TITLE
Fix DataAccess_Queries import and validation helper initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.29 - Instantiate validation consistency helper during application start-up.
 - 0.2.28 - Avoid circular import by using application helper in probability calculations.
 - 0.2.27 - Import Probability_Reliability in fallback path to avoid initialization error.
 - 0.2.26 - Import Syncing_And_IDs in fallback path to avoid initialization error.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -272,6 +272,7 @@ from .ui_setup import UISetupMixin
 from .event_handlers import EventHandlersMixin
 from .persistence_wrappers import PersistenceWrappersMixin
 from .analysis_utils import AnalysisUtilsMixin
+from .data_access_queries import DataAccess_Queries
 from analysis.mechanisms import (
     DiagnosticMechanism,
     MechanismLibrary,
@@ -828,6 +829,9 @@ class AutoMLApp(UISetupMixin, EventHandlersMixin, PersistenceWrappersMixin, Anal
 
         # Centralise data lookups in a dedicated helper
         self.data_access_queries = DataAccess_Queries(self)
+
+        # Helper for input validation and work product management
+        self.validation_consistency = Validation_Consistency(self)
 
         self.mechanism_libraries = []
         self.selected_mechanism_libraries = []

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.28"
+VERSION = "0.2.29"
 
 __all__ = ["VERSION"]

--- a/tests/test_data_access_queries_import.py
+++ b/tests/test_data_access_queries_import.py
@@ -1,0 +1,13 @@
+import ast
+from pathlib import Path
+
+
+def test_automl_core_imports_data_access_queries():
+    code = Path("mainappsrc/core/automl_core.py").read_text()
+    tree = ast.parse(code)
+    assert any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "data_access_queries"
+        and any(alias.name == "DataAccess_Queries" for alias in node.names)
+        for node in ast.walk(tree)
+    ), "DataAccess_Queries import missing in automl_core"

--- a/tests/test_validation_consistency_init.py
+++ b/tests/test_validation_consistency_init.py
@@ -1,0 +1,14 @@
+import ast
+from pathlib import Path
+
+
+def test_automl_core_initialises_validation_consistency():
+    code = Path("mainappsrc/core/automl_core.py").read_text()
+    tree = ast.parse(code)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            if any(isinstance(t, ast.Attribute) and t.attr == "validation_consistency" and isinstance(t.value, ast.Name) and t.value.id == "self" for t in node.targets):
+                if isinstance(node.value, ast.Call) and getattr(node.value.func, "id", None) == "Validation_Consistency":
+                    break
+    else:
+        raise AssertionError("AutoMLApp.__init__ does not assign Validation_Consistency to self.validation_consistency")


### PR DESCRIPTION
## Summary
- import `DataAccess_Queries` in `AutoMLApp` to avoid NameError on startup
- instantiate `Validation_Consistency` during app initialization to ensure validation helpers are available
- bump project version to 0.2.29 and document the change
- add regression tests confirming the `DataAccess_Queries` import and `Validation_Consistency` setup

## Testing
- `radon cc mainappsrc/core/automl_core.py --json`
- `pytest` *(fails: 221 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68abdfb6facc8327803fbe44b783af6e