### PR TITLE
Provide FMEA settings export stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.25
+version: 0.2.28
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,9 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.28 - Provide stub FMEA settings export to prevent AttributeError during model export.
+- 0.2.27 - Import Probability_Reliability in fallback path to avoid initialization error.
+- 0.2.26 - Import Syncing_And_IDs in fallback path to avoid initialization error.
 - 0.2.25 - Extract page and PAA helpers into dedicated module and delegate from core.
 - 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.
 - 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -449,6 +449,7 @@ try:  # pragma: no cover - support direct module import
     from .project_editor_subapp import ProjectEditorSubApp
     from .risk_assessment_subapp import RiskAssessmentSubApp
     from .reliability_subapp import ReliabilitySubApp
+    from .probability_reliability import Probability_Reliability
     from .syncing_and_ids import Syncing_And_IDs
     from .version import VERSION
 except Exception:  # pragma: no cover
@@ -465,6 +466,8 @@ except Exception:  # pragma: no cover
         from mainappsrc.subapps.project_editor_subapp import ProjectEditorSubApp
         from mainappsrc.subapps.risk_assessment_subapp import RiskAssessmentSubApp
         from mainappsrc.subapps.reliability_subapp import ReliabilitySubApp
+        from mainappsrc.core.probability_reliability import Probability_Reliability
+        from mainappsrc.core.syncing_and_ids import Syncing_And_IDs
         from mainappsrc.version import VERSION
 try:  # pragma: no cover
     from .models.fta.fault_tree_node import FaultTreeNode

--- a/mainappsrc/core/fmea_service.py
+++ b/mainappsrc/core/fmea_service.py
@@ -182,3 +182,16 @@ class FMEAService:
         ttk.Button(btn_frame, text="Rename", command=rename_fmea).pack(fill=tk.X)
         ttk.Button(btn_frame, text="Delete", command=delete_fmea).pack(fill=tk.X)
 
+
+    # ------------------------------------------------------------------
+    def get_settings_dict(self) -> dict:
+        """Return a serialisable representation of FMEA settings.
+
+        The FMEA subsystem currently does not expose configurable options,
+        but project export expects a settings dictionary.  Providing this
+        method avoids :class:`AttributeError` during export and offers a
+        future extension point for persisting user configuration.
+        """
+
+        return {}
+

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.25"
+VERSION = "0.2.28"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- add `get_settings_dict` to FMEAService to supply export settings and avoid AttributeError
- bump version to 0.2.28 and record change in README

## Testing
- `radon cc mainappsrc/core/automl_core.py -s -j`
- `radon cc mainappsrc/core/fmea_service.py -s -j`
- `pytest` *(fails: 303 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68abdb15f90c832783fe182a2012c956