### PR TITLE
Fix DataAccess_Queries and reporting export initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.28
+version: 0.2.32
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,10 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.32 - Provide SysML repository export placeholder to prevent export error.
+- 0.2.31 - Provide requirements editor export placeholder to prevent export error.
+- 0.2.30 - Instantiate reporting export helper during application start-up.
+- 0.2.29 - Instantiate validation consistency helper during application start-up.
 - 0.2.28 - Avoid circular import by using application helper in probability calculations.
 - 0.2.27 - Import Probability_Reliability in fallback path to avoid initialization error.
 - 0.2.26 - Import Syncing_And_IDs in fallback path to avoid initialization error.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -272,6 +272,7 @@ from .ui_setup import UISetupMixin
 from .event_handlers import EventHandlersMixin
 from .persistence_wrappers import PersistenceWrappersMixin
 from .analysis_utils import AnalysisUtilsMixin
+from .data_access_queries import DataAccess_Queries
 from analysis.mechanisms import (
     DiagnosticMechanism,
     MechanismLibrary,
@@ -296,6 +297,7 @@ from mainappsrc.managers.review_manager import ReviewManager
 from .versioning_review import Versioning_Review
 from mainappsrc.core.diagram_renderer import DiagramRenderer
 from .validation_consistency import Validation_Consistency
+from .reporting_export import Reporting_Export
 from analysis.user_config import (
     load_user_config,
     save_user_config,
@@ -828,6 +830,12 @@ class AutoMLApp(UISetupMixin, EventHandlersMixin, PersistenceWrappersMixin, Anal
 
         # Centralise data lookups in a dedicated helper
         self.data_access_queries = DataAccess_Queries(self)
+
+        # Helper for input validation and work product management
+        self.validation_consistency = Validation_Consistency(self)
+
+        # Reporting and export operations
+        self.reporting_export = Reporting_Export(self)
 
         self.mechanism_libraries = []
         self.selected_mechanism_libraries = []

--- a/mainappsrc/managers/requirements_manager.py
+++ b/mainappsrc/managers/requirements_manager.py
@@ -18,6 +18,17 @@ class RequirementsManagerSubApp:
         self.app = app
 
     # ------------------------------------------------------------------
+    def export_state(self) -> Dict[str, Any]:
+        """Serialize requirement editor state for project export.
+
+        The requirements manager currently stores no mutable state beyond what
+        is held in the main application model. The export therefore returns an
+        empty mapping, acting as a placeholder for future requirement editor
+        data.
+        """
+        return {}
+
+    # ------------------------------------------------------------------
     def get_requirement_allocation_names(self, req_id: str) -> list[str]:
         """Return names of model elements linked to ``req_id``."""
         names: list[str] = []

--- a/mainappsrc/models/sysml/sysml_repository.py
+++ b/mainappsrc/models/sysml/sysml_repository.py
@@ -147,6 +147,23 @@ class SysMLRepository:
         return cls._instance
 
     # ------------------------------------------------------------
+    # Export helpers
+    # ------------------------------------------------------------
+    def export_state(self) -> dict:
+        """Return a JSON-serialisable snapshot of the repository."""
+
+        return {
+            "elements": [asdict(e) for e in self.elements.values()],
+            "relationships": [asdict(r) for r in self.relationships],
+            "diagrams": [asdict(d) for d in self.diagrams.values()],
+            "element_diagrams": dict(self.element_diagrams),
+            "active_phase": self.active_phase,
+            "reuse_phases": list(self.reuse_phases),
+            "reuse_products": list(self.reuse_products),
+            "frozen_diagrams": list(self.frozen_diagrams),
+        }
+
+    # ------------------------------------------------------------
     # Undo support
     # ------------------------------------------------------------
     def _strip_object_positions(self, data: dict) -> dict:

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.28"
+VERSION = "0.2.32"
 
 __all__ = ["VERSION"]

--- a/tests/test_data_access_queries_import.py
+++ b/tests/test_data_access_queries_import.py
@@ -1,0 +1,13 @@
+import ast
+from pathlib import Path
+
+
+def test_automl_core_imports_data_access_queries():
+    code = Path("mainappsrc/core/automl_core.py").read_text()
+    tree = ast.parse(code)
+    assert any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "data_access_queries"
+        and any(alias.name == "DataAccess_Queries" for alias in node.names)
+        for node in ast.walk(tree)
+    ), "DataAccess_Queries import missing in automl_core"

--- a/tests/test_reporting_export_import.py
+++ b/tests/test_reporting_export_import.py
@@ -1,0 +1,13 @@
+import ast
+from pathlib import Path
+
+
+def test_automl_core_imports_reporting_export():
+    code = Path("mainappsrc/core/automl_core.py").read_text()
+    tree = ast.parse(code)
+    assert any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "reporting_export"
+        and any(alias.name == "Reporting_Export" for alias in node.names)
+        for node in ast.walk(tree)
+    ), "Reporting_Export import missing in automl_core"

--- a/tests/test_reporting_export_init.py
+++ b/tests/test_reporting_export_init.py
@@ -1,0 +1,25 @@
+import ast
+from pathlib import Path
+
+
+def test_automl_core_initialises_reporting_export():
+    code = Path("mainappsrc/core/automl_core.py").read_text()
+    tree = ast.parse(code)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            if any(
+                isinstance(t, ast.Attribute)
+                and t.attr == "reporting_export"
+                and isinstance(t.value, ast.Name)
+                and t.value.id == "self"
+                for t in node.targets
+            ):
+                if (
+                    isinstance(node.value, ast.Call)
+                    and getattr(node.value.func, "id", None) == "Reporting_Export"
+                ):
+                    break
+    else:
+        raise AssertionError(
+            "AutoMLApp.__init__ does not assign Reporting_Export to self.reporting_export"
+        )

--- a/tests/test_requirements_manager_export_state.py
+++ b/tests/test_requirements_manager_export_state.py
@@ -1,0 +1,13 @@
+import ast
+from pathlib import Path
+
+
+def test_requirements_manager_defines_export_state():
+    code = Path("mainappsrc/managers/requirements_manager.py").read_text()
+    tree = ast.parse(code)
+    class_node = next(
+        node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "RequirementsManagerSubApp"
+    )
+    assert any(
+        isinstance(node, ast.FunctionDef) and node.name == "export_state" for node in class_node.body
+    ), "RequirementsManagerSubApp.export_state missing"

--- a/tests/test_sysml_repository_export_state.py
+++ b/tests/test_sysml_repository_export_state.py
@@ -1,0 +1,13 @@
+import ast
+from pathlib import Path
+
+
+def test_sysml_repository_defines_export_state():
+    code = Path("mainappsrc/models/sysml/sysml_repository.py").read_text()
+    tree = ast.parse(code)
+    class_node = next(
+        node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "SysMLRepository"
+    )
+    assert any(
+        isinstance(node, ast.FunctionDef) and node.name == "export_state" for node in class_node.body
+    ), "SysMLRepository.export_state missing"

--- a/tests/test_validation_consistency_init.py
+++ b/tests/test_validation_consistency_init.py
@@ -1,0 +1,14 @@
+import ast
+from pathlib import Path
+
+
+def test_automl_core_initialises_validation_consistency():
+    code = Path("mainappsrc/core/automl_core.py").read_text()
+    tree = ast.parse(code)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            if any(isinstance(t, ast.Attribute) and t.attr == "validation_consistency" and isinstance(t.value, ast.Name) and t.value.id == "self" for t in node.targets):
+                if isinstance(node.value, ast.Call) and getattr(node.value.func, "id", None) == "Validation_Consistency":
+                    break
+    else:
+        raise AssertionError("AutoMLApp.__init__ does not assign Validation_Consistency to self.validation_consistency")


### PR DESCRIPTION
## Summary
- import `DataAccess_Queries` in `AutoMLApp` to avoid NameError on startup
- instantiate `Validation_Consistency` during app initialization to ensure validation helpers are available
- instantiate `Reporting_Export` during app initialization to provide reporting/export capabilities
- provide `RequirementsManagerSubApp.export_state` placeholder so reporting export can serialize requirement data
- add `SysMLRepository.export_state` placeholder so model exports serialize SysML data
- bump project version to 0.2.32 and document the change
- add regression tests confirming the reporting export setup, requirements manager export state, and SysML repository export support

## Testing
- `radon cc mainappsrc/core/automl_core.py --json | jq '."mainappsrc/core/automl_core.py"[:20]'`
- `pytest` *(fails: 221 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68abdfb6facc8327803fbe44b783af6e