### PR TITLE
refactor: extract dialog classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.33 - Extract dialog classes into dedicated modules and update mixins.
 - 0.2.32 - Refactor core initialization into mixins for style, services, and icons.
 - 0.2.31 - Provide requirements editor export placeholder to prevent export error.
 - 0.2.30 - Instantiate reporting export helper during application start-up.

--- a/gui/dialogs/__init__.py
+++ b/gui/dialogs/__init__.py
@@ -13,9 +13,15 @@ def __getattr__(name: str):
     if name == "FMEARowDialog":
         from .fmea_row_dialog import FMEARowDialog as dlg
         return dlg
+    if name == "ReqDialog":
+        from .req_dialog import ReqDialog as dlg
+        return dlg
+    if name == "SelectBaseEventDialog":
+        from .select_base_event_dialog import SelectBaseEventDialog as dlg
+        return dlg
     if _module is None:
         _module = importlib.import_module("mainappsrc.automl_core")
     return getattr(_module, name)
 
 
-__all__ = ["FMEARowDialog"]
+__all__ = ["FMEARowDialog", "ReqDialog", "SelectBaseEventDialog"]

--- a/gui/dialogs/select_base_event_dialog.py
+++ b/gui/dialogs/select_base_event_dialog.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Dialog for selecting a base event from a list.
+
+This dialog was previously defined within :mod:`automl_core` but has been
+extracted to keep the core module compact and easier to maintain.
+"""
+
+import tkinter as tk
+from tkinter import simpledialog
+
+
+class SelectBaseEventDialog(simpledialog.Dialog):
+    """Allow the user to choose an existing base event or create a new one."""
+
+    def __init__(self, parent: tk.Widget, events, allow_new: bool = False):
+        self.events = events
+        self.allow_new = allow_new
+        self.selected = None
+        super().__init__(parent, title="Select Base Event")
+
+    def body(self, master: tk.Widget):  # type: ignore[override]
+        self.listbox = tk.Listbox(master, height=10, width=40)
+        self._visible_events = []
+        for be in self.events:
+            desc = getattr(be, "description", "").strip()
+            if not desc:
+                continue
+            self._visible_events.append(be)
+            self.listbox.insert(tk.END, desc)
+        if self.allow_new:
+            self.listbox.insert(tk.END, "<Create New Failure Mode>")
+        self.listbox.grid(row=0, column=0, padx=5, pady=5)
+        return self.listbox
+
+    def apply(self) -> None:  # type: ignore[override]
+        sel = self.listbox.curselection()
+        if sel:
+            idx = sel[0]
+            if self.allow_new and idx == len(self._visible_events):
+                self.selected = "NEW"
+            else:
+                self.selected = self._visible_events[idx]
+
+
+__all__ = ["SelectBaseEventDialog"]

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -523,6 +523,8 @@ AutoML_Helper = AutoMLHelper()
 ##########################################
 from gui.dialogs.edit_node_dialog import EditNodeDialog, DecompositionDialog
 from gui.dialogs.fmea_row_dialog import FMEARowDialog
+from gui.dialogs.req_dialog import ReqDialog
+from gui.dialogs.select_base_event_dialog import SelectBaseEventDialog
 from .safety_ui import SafetyUIMixin
 
 ##########################################
@@ -3703,7 +3705,7 @@ class AutoMLApp(SafetyUIMixin, UISetupMixin, EventHandlersMixin, PersistenceWrap
         if not events:
             messagebox.showinfo("No Failure Modes", "No FMEA or FMEDA failure modes available.")
             return
-        dialog = self.SelectBaseEventDialog(self.root, events)
+        dialog = SelectBaseEventDialog(self.root, events)
         selected = dialog.selected
         if not selected:
             return
@@ -3746,7 +3748,7 @@ class AutoMLApp(SafetyUIMixin, UISetupMixin, EventHandlersMixin, PersistenceWrap
         if not events:
             messagebox.showinfo("No Failure Modes", "No FMEA or FMEDA failure modes available.")
             return
-        dialog = self.SelectBaseEventDialog(self.root, events)
+        dialog = SelectBaseEventDialog(self.root, events)
         selected = dialog.selected
         if not selected:
             return
@@ -3789,7 +3791,7 @@ class AutoMLApp(SafetyUIMixin, UISetupMixin, EventHandlersMixin, PersistenceWrap
         if not events:
             messagebox.showinfo("No Failure Modes", "No FMEA or FMEDA failure modes available.")
             return
-        dialog = self.SelectBaseEventDialog(self.root, events)
+        dialog = SelectBaseEventDialog(self.root, events)
         selected = dialog.selected
         if not selected:
             return
@@ -4237,106 +4239,6 @@ class AutoMLApp(SafetyUIMixin, UISetupMixin, EventHandlersMixin, PersistenceWrap
                 )
             style.configure("ReqEditor.Treeview", rowheight=20 * max_lines)
 
-        class ReqDialog(simpledialog.Dialog):
-            def __init__(self, parent, title, initial=None):
-                self.initial = initial or {}
-                super().__init__(parent, title=title)
-
-            def body(self, master):
-                ttk.Label(master, text="ID:").grid(row=0, column=0, sticky="e")
-                self.id_var = tk.StringVar(value=self.initial.get("id", ""))
-                tk.Entry(master, textvariable=self.id_var).grid(row=0, column=1, padx=5, pady=5)
-
-                ttk.Label(master, text="Type:").grid(row=1, column=0, sticky="e")
-                self.type_var = tk.StringVar(value=self.initial.get("req_type", "vehicle"))
-                self.type_cb = ttk.Combobox(
-                    master,
-                    textvariable=self.type_var,
-                    values=REQUIREMENT_TYPE_OPTIONS,
-                    state="readonly",
-                    width=20,
-                )
-                self.type_cb.grid(row=1, column=1, padx=5, pady=5)
-                self.type_cb.bind("<<ComboboxSelected>>", self._toggle_fields)
-
-                self.asil_label = ttk.Label(master, text="ASIL:")
-                self.asil_label.grid(row=2, column=0, sticky="e")
-                self.asil_var = tk.StringVar(value=self.initial.get("asil", "QM"))
-                self.asil_combo = ttk.Combobox(master, textvariable=self.asil_var, values=ASIL_LEVEL_OPTIONS, state="readonly", width=8)
-                self.asil_combo.grid(row=2, column=1, padx=5, pady=5)
-
-                self.cal_label = ttk.Label(master, text="CAL:")
-                self.cal_label.grid(row=3, column=0, sticky="e")
-                self.cal_var = tk.StringVar(value=self.initial.get("cal", CAL_LEVEL_OPTIONS[0]))
-                self.cal_combo = ttk.Combobox(master, textvariable=self.cal_var, values=CAL_LEVEL_OPTIONS, state="readonly", width=8)
-                self.cal_combo.grid(row=3, column=1, padx=5, pady=5)
-                self._toggle_fields()
-
-                ttk.Label(master, text="Parent ID:").grid(row=4, column=0, sticky="e")
-                self.parent_var = tk.StringVar(value=self.initial.get("parent_id", ""))
-                tk.Entry(master, textvariable=self.parent_var).grid(row=4, column=1, padx=5, pady=5)
-
-                ttk.Label(master, text="Status:").grid(row=5, column=0, sticky="e")
-                self.status_var = tk.StringVar(value=self.initial.get("status", "draft"))
-                ttk.Combobox(master, textvariable=self.status_var,
-                             values=["draft", "in review", "peer reviewed", "pending approval", "approved"],
-                             state="readonly").grid(row=5, column=1, padx=5, pady=5)
-
-                ttk.Label(master, text="Text:").grid(row=6, column=0, sticky="e")
-                self.text_var = tk.StringVar(value=self.initial.get("text", ""))
-                tk.Entry(master, textvariable=self.text_var, width=40).grid(row=6, column=1, padx=5, pady=5)
-                return master
-
-            def apply(self):
-                rid = self.id_var.get().strip() or str(uuid.uuid4())
-                req_type = self.type_var.get().strip()
-                self.result = {
-                    "id": rid,
-                    "req_type": req_type,
-                    "parent_id": self.parent_var.get().strip(),
-                    "status": self.status_var.get().strip(),
-                    "text": self.text_var.get().strip(),
-                }
-                if req_type not in (
-                    "operational",
-                    "functional modification",
-                    "production",
-                    "service",
-                    "product",
-                    "legal",
-                    "organizational",
-                ):
-                    self.result["asil"] = self.asil_var.get().strip()
-                    self.result["cal"] = self.cal_var.get().strip()
-
-            def validate(self):
-                rid = self.id_var.get().strip()
-                if rid and rid != self.initial.get("id") and rid in global_requirements:
-                    messagebox.showerror("ID", "ID already exists")
-                    return False
-                return True
-
-            def _toggle_fields(self, event=None):
-                req_type = self.type_var.get()
-                hide = req_type in (
-                    "operational",
-                    "functional modification",
-                    "production",
-                    "service",
-                    "product",
-                    "legal",
-                    "organizational",
-                )
-                widgets = [self.asil_label, self.asil_combo, self.cal_label, self.cal_combo]
-                if hide:
-                    for w in widgets:
-                        w.grid_remove()
-                else:
-                    self.asil_label.grid(row=2, column=0, sticky="e")
-                    self.asil_combo.grid(row=2, column=1, padx=5, pady=5)
-                    self.cal_label.grid(row=3, column=0, sticky="e")
-                    self.cal_combo.grid(row=3, column=1, padx=5, pady=5)
-
         def add_req():
             dlg = ReqDialog(win, "Add Requirement")
             if dlg.result:
@@ -4544,36 +4446,6 @@ class AutoMLApp(SafetyUIMixin, UISetupMixin, EventHandlersMixin, PersistenceWrap
 
     def show_hazard_list(self):
         self.risk_app.show_hazard_list(self)
-
-    class SelectBaseEventDialog(simpledialog.Dialog):
-        def __init__(self, parent, events, allow_new=False):
-            self.events = events
-            self.allow_new = allow_new
-            self.selected = None
-            super().__init__(parent, title="Select Base Event")
-
-        def body(self, master):
-            self.listbox = tk.Listbox(master, height=10, width=40)
-            self._visible_events = []
-            for be in self.events:
-                desc = getattr(be, "description", "").strip()
-                if not desc:
-                    continue
-                self._visible_events.append(be)
-                self.listbox.insert(tk.END, desc)
-            if self.allow_new:
-                self.listbox.insert(tk.END, "<Create New Failure Mode>")
-            self.listbox.grid(row=0, column=0, padx=5, pady=5)
-            return self.listbox
-
-        def apply(self):
-            sel = self.listbox.curselection()
-            if sel:
-                idx = sel[0]
-                if self.allow_new and idx == len(self._visible_events):
-                    self.selected = "NEW"
-                else:
-                    self.selected = self._visible_events[idx]
 
     class SelectFailureModeDialog(simpledialog.Dialog):
         def __init__(self, parent, app, modes):
@@ -5058,7 +4930,7 @@ class AutoMLApp(SafetyUIMixin, UISetupMixin, EventHandlersMixin, PersistenceWrap
         tree.bind("<Double-1>", on_double)
 
         def add_failure_mode():
-            dialog = self.SelectBaseEventDialog(win, basic_events, allow_new=True)
+            dialog = SelectBaseEventDialog(win, basic_events, allow_new=True)
             node = dialog.selected
             if node == "NEW":
                 node = FaultTreeNode("", "Basic Event")

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.32"
+VERSION = "0.2.33"
 
 __all__ = ["VERSION"]

--- a/metrics.json
+++ b/metrics.json
@@ -1,33 +1,20359 @@
 {
-  "total_files": 26,
-  "total_loc": 13558,
-  "total_functions": 991,
-  "average_complexity": 4.49,
+  "total_files": 572,
+  "total_loc": 93402,
+  "total_functions": 6278,
+  "average_complexity": 3.52,
   "files": [
     {
-      "file": "mainappsrc/core/event_dispatcher.py",
-      "loc": 84,
+      "file": "AutoML.py",
+      "loc": 169,
       "functions": [
+        {
+          "name": "parse_args",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "_install_ghostscript_via_winget",
+          "lineno": 71,
+          "complexity": 2
+        },
+        {
+          "name": "_install_ghostscript_via_choco",
+          "lineno": 87,
+          "complexity": 2
+        },
+        {
+          "name": "_install_ghostscript_via_powershell",
+          "lineno": 96,
+          "complexity": 2
+        },
+        {
+          "name": "_install_ghostscript_via_pip",
+          "lineno": 110,
+          "complexity": 2
+        },
+        {
+          "name": "ensure_ghostscript",
+          "lineno": 119,
+          "complexity": 6
+        },
+        {
+          "name": "ensure_packages",
+          "lineno": 143,
+          "complexity": 6
+        },
+        {
+          "name": "_bootstrap",
+          "lineno": 172,
+          "complexity": 5
+        },
+        {
+          "name": "main",
+          "lineno": 201,
+          "complexity": 1
+        },
+        {
+          "name": "install",
+          "lineno": 162,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "__init__.py",
+      "loc": 32,
+      "functions": []
+    },
+    {
+      "file": "mainappsrc/__init__.py",
+      "loc": 44,
+      "functions": []
+    },
+    {
+      "file": "mainappsrc/version.py",
+      "loc": 3,
+      "functions": []
+    },
+    {
+      "file": "styles/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "tools/metrics_generator.py",
+      "loc": 139,
+      "functions": [
+        {
+          "name": "_sloc",
+          "lineno": 30,
+          "complexity": 4
+        },
+        {
+          "name": "analyze_file",
+          "lineno": 85,
+          "complexity": 5
+        },
+        {
+          "name": "collect_metrics",
+          "lineno": 105,
+          "complexity": 8
+        },
+        {
+          "name": "generate_plots",
+          "lineno": 124,
+          "complexity": 8
+        },
+        {
+          "name": "main",
+          "lineno": 157,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "visit_If",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "visit_With",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "visit_Try",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "visit_BoolOp",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "visit_IfExp",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "visit_comprehension",
+          "lineno": 73,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tools/__init__.py",
+      "loc": 17,
+      "functions": []
+    },
+    {
+      "file": "tools/create_installer.py",
+      "loc": 112,
+      "functions": [
+        {
+          "name": "_collect_files",
+          "lineno": 20,
+          "complexity": 5
+        },
+        {
+          "name": "create_installer_zip",
+          "lineno": 40,
+          "complexity": 4
+        },
+        {
+          "name": "create_installer_tar",
+          "lineno": 56,
+          "complexity": 4
+        },
+        {
+          "name": "create_installer_shutil_zip",
+          "lineno": 72,
+          "complexity": 4
+        },
+        {
+          "name": "create_installer_shutil_targz",
+          "lineno": 91,
+          "complexity": 4
+        },
+        {
+          "name": "main",
+          "lineno": 110,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tools/crash_report_logger.py",
+      "loc": 122,
+      "functions": [
+        {
+          "name": "crash_handler_v1",
+          "lineno": 17,
+          "complexity": 3
+        },
+        {
+          "name": "crash_handler_v2",
+          "lineno": 26,
+          "complexity": 2
+        },
+        {
+          "name": "crash_handler_v3",
+          "lineno": 49,
+          "complexity": 2
+        },
+        {
+          "name": "watchdog_v1",
+          "lineno": 98,
+          "complexity": 2
+        },
+        {
+          "name": "watchdog_v2",
+          "lineno": 107,
+          "complexity": 2
+        },
+        {
+          "name": "watchdog_v3",
+          "lineno": 116,
+          "complexity": 2
+        },
+        {
+          "name": "watchdog_v4",
+          "lineno": 125,
+          "complexity": 1
+        },
+        {
+          "name": "install_v1",
+          "lineno": 138,
+          "complexity": 1
+        },
+        {
+          "name": "install_v2",
+          "lineno": 142,
+          "complexity": 1
+        },
+        {
+          "name": "install_v3",
+          "lineno": 146,
+          "complexity": 1
+        },
+        {
+          "name": "install_v4",
+          "lineno": 150,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "__call__",
+          "lineno": 42,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "__call__",
+          "lineno": 61,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 74,
+          "complexity": 1
+        },
+        {
+          "name": "_trigger",
+          "lineno": 79,
+          "complexity": 1
+        },
+        {
+          "name": "_reset",
+          "lineno": 84,
+          "complexity": 2
+        },
+        {
+          "name": "start",
+          "lineno": 91,
+          "complexity": 1
+        },
+        {
+          "name": "feed",
+          "lineno": 94,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tools/splash_launcher.py",
+      "loc": 65,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "_load_module",
+          "lineno": 44,
+          "complexity": 2
+        },
+        {
+          "name": "launch",
+          "lineno": 53,
+          "complexity": 7
+        }
+      ]
+    },
+    {
+      "file": "tools/icon_builder.py",
+      "loc": 217,
+      "functions": [
+        {
+          "name": "_write_ico",
+          "lineno": 27,
+          "complexity": 3
+        },
+        {
+          "name": "_blank",
+          "lineno": 60,
+          "complexity": 3
+        },
+        {
+          "name": "_put",
+          "lineno": 64,
+          "complexity": 3
+        },
+        {
+          "name": "_fill_top",
+          "lineno": 69,
+          "complexity": 3
+        },
+        {
+          "name": "_fill_front",
+          "lineno": 77,
+          "complexity": 3
+        },
+        {
+          "name": "_fill_side",
+          "lineno": 84,
+          "complexity": 3
+        },
+        {
+          "name": "_outline_cube",
+          "lineno": 92,
+          "complexity": 7
+        },
+        {
+          "name": "_draw_cube",
+          "lineno": 110,
+          "complexity": 2
+        },
+        {
+          "name": "_fill_gear_body",
+          "lineno": 126,
+          "complexity": 4
+        },
+        {
+          "name": "_draw_teeth",
+          "lineno": 133,
+          "complexity": 3
+        },
+        {
+          "name": "_punch_hole",
+          "lineno": 140,
+          "complexity": 3
+        },
+        {
+          "name": "_draw_gear",
+          "lineno": 146,
+          "complexity": 2
+        },
+        {
+          "name": "_cube_with_gear",
+          "lineno": 164,
+          "complexity": 1
+        },
+        {
+          "name": "build_icon_v1",
+          "lineno": 183,
+          "complexity": 1
+        },
+        {
+          "name": "build_icon_v2",
+          "lineno": 197,
+          "complexity": 1
+        },
+        {
+          "name": "build_icon_v3",
+          "lineno": 210,
+          "complexity": 1
+        },
+        {
+          "name": "build_icon_v4",
+          "lineno": 224,
+          "complexity": 1
+        },
+        {
+          "name": "build_icon",
+          "lineno": 246,
+          "complexity": 1
+        },
+        {
+          "name": "main",
+          "lineno": 253,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tools/memory_manager.py",
+      "loc": 80,
+      "functions": [
+        {
+          "name": "lazy_import",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "lazy_widget",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "lazy_load",
+          "lineno": 33,
+          "complexity": 2
+        },
+        {
+          "name": "mark_active",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "register_process",
+          "lineno": 44,
+          "complexity": 3
+        },
+        {
+          "name": "cleanup",
+          "lineno": 51,
+          "complexity": 12
+        },
+        {
+          "name": "__getattr__",
+          "lineno": 88,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tools/diagnostics_manager.py",
+      "loc": 185,
+      "functions": [
+        {
+          "name": "_handle_failure",
+          "lineno": 46,
+          "complexity": 3
+        },
+        {
+          "name": "_attempt_recover",
+          "lineno": 60,
+          "complexity": 4
+        },
+        {
+          "name": "_attempt_mitigate",
+          "lineno": 73,
+          "complexity": 4
+        },
+        {
+          "name": "raise_errors",
+          "lineno": 88,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 97,
+          "complexity": 1
+        },
+        {
+          "name": "register_check",
+          "lineno": 104,
+          "complexity": 1
+        },
+        {
+          "name": "start",
+          "lineno": 115,
+          "complexity": 3
+        },
+        {
+          "name": "_run",
+          "lineno": 122,
+          "complexity": 5
+        },
+        {
+          "name": "stop",
+          "lineno": 132,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 141,
+          "complexity": 1
+        },
+        {
+          "name": "register_check",
+          "lineno": 146,
+          "complexity": 1
+        },
+        {
+          "name": "record_event",
+          "lineno": 156,
+          "complexity": 1
+        },
+        {
+          "name": "process_events",
+          "lineno": 159,
+          "complexity": 4
+        },
+        {
+          "name": "run_check",
+          "lineno": 173,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 192,
+          "complexity": 1
+        },
+        {
+          "name": "register_check",
+          "lineno": 196,
+          "complexity": 1
+        },
+        {
+          "name": "run_once",
+          "lineno": 207,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "reportlab/__init__.py",
+      "loc": 26,
+      "functions": []
+    },
+    {
+      "file": "tests/test_page_diagram_color_mode.py",
+      "loc": 46,
+      "functions": [
+        {
+          "name": "test_page_diagram_uses_own_mode",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 4,
+          "complexity": 1
+        },
+        {
+          "name": "get_node_fill_color",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "draw_circle_event_shape",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "config",
+          "lineno": 47,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_requirements_generator.py",
+      "loc": 154,
+      "functions": [
+        {
+          "name": "test_generate_requirements_from_governance_diagram",
+          "lineno": 11,
+          "complexity": 5
+        },
+        {
+          "name": "test_ai_training_and_curation_requirements",
+          "lineno": 45,
+          "complexity": 4
+        },
+        {
+          "name": "test_acquisition_pattern_requirement",
+          "lineno": 81,
+          "complexity": 2
+        },
+        {
+          "name": "test_propagate_by_review_pattern",
+          "lineno": 90,
+          "complexity": 2
+        },
+        {
+          "name": "test_data_acquisition_compartment_sources",
+          "lineno": 99,
+          "complexity": 6
+        },
+        {
+          "name": "test_data_acquisition_node_name_normalized",
+          "lineno": 119,
+          "complexity": 3
+        },
+        {
+          "name": "test_tasks_create_requirement_actions",
+          "lineno": 135,
+          "complexity": 4
+        },
+        {
+          "name": "test_generic_ai_relation_defaults_to_organizational",
+          "lineno": 154,
+          "complexity": 3
+        },
+        {
+          "name": "test_complies_with_between_work_products",
+          "lineno": 165,
+          "complexity": 2
+        },
+        {
+          "name": "test_constrained_by_between_work_products",
+          "lineno": 180,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_remove_part_visibility.py",
+      "loc": 34,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "_sync_to_repository",
+          "lineno": 15,
+          "complexity": 4
+        },
+        {
+          "name": "redraw",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "update_property_view",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "test_remove_part_diagram_marks_hidden",
+          "lineno": 32,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_relationship_validation.py",
+      "loc": 17,
+      "functions": [
+        {
+          "name": "test_context_between_goals_disallowed",
+          "lineno": 5,
+          "complexity": 2
+        },
+        {
+          "name": "test_solved_with_context_child_disallowed",
+          "lineno": 12,
+          "complexity": 2
+        },
+        {
+          "name": "test_assumption_cannot_have_children",
+          "lineno": 19,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_causal_bayesian_clipboard.py",
+      "loc": 82,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "test_cbn_copy_paste_shared_properties_independent_position",
+          "lineno": 23,
+          "complexity": 2
+        },
+        {
+          "name": "test_cbn_same_diagram_clone_independent_position",
+          "lineno": 77,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_diagram_refresh.py",
+      "loc": 61,
+      "functions": [
+        {
+          "name": "test_open_governance_diagram_refreshes_after_phase_activation",
+          "lineno": 10,
+          "complexity": 2
+        },
+        {
+          "name": "on_lifecycle_selected",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "fake_sysml_init",
+          "lineno": 42,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "cget",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 72,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_part_definition_limit.py",
+      "loc": 56,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "redraw",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "_sync_to_repository",
+          "lineno": 16,
+          "complexity": 2
+        },
+        {
+          "name": "setUp",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_limit_prevents_definition_change",
+          "lineno": 25,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_crash_report_logger.py",
+      "loc": 105,
+      "functions": [
+        {
+          "name": "_raise",
+          "lineno": 24,
+          "complexity": 2
+        },
+        {
+          "name": "test_crash_handler_v1",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "test_crash_handler_v2",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "test_crash_handler_v3",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "test_crash_handler_v4",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "_run_subprocess",
+          "lineno": 67,
+          "complexity": 2
+        },
+        {
+          "name": "test_watchdog_v1",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "test_watchdog_v2",
+          "lineno": 91,
+          "complexity": 1
+        },
+        {
+          "name": "test_watchdog_v3",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "test_watchdog_v4",
+          "lineno": 119,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_part_name_unique.py",
+      "loc": 33,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "test_detect_duplicate_name_across_diagrams",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_element_stereotype_label.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "measure",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "_wrap_text_to_width",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "test_task_label_includes_stereotype",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "test_gateway_labels_hidden",
+          "lineno": 46,
+          "complexity": 2
+        },
+        {
+          "name": "test_system_boundary_label_has_no_stereotype",
+          "lineno": 63,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_phase_registration.py",
+      "loc": 24,
+      "functions": [
+        {
+          "name": "test_add_new_requirement_records_phase",
+          "lineno": 18,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_toolbox_switch.py",
+      "loc": 28,
+      "functions": [
+        {
+          "name": "test_switch_toolbox_combines_governance_elements",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "pack_forget",
+          "lineno": 20,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_control_flow_label.py",
+      "loc": 58,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "create_image",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "test_existing_element_single_label",
+          "lineno": 51,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_text_dragging.py",
+      "loc": 28,
+      "functions": [
+        {
+          "name": "test_goal_text_has_obj_id_tag",
+          "lineno": 29,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "measure",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 37,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_project_load_undo.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "test_undo_after_project_load_keeps_project",
+          "lineno": 9,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_use_case_shape.py",
+      "loc": 58,
+      "functions": [
+        {
+          "name": "dummy_window",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "test_use_case_draws_oval",
+          "lineno": 56,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 35,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cbn_repository_integration.py",
+      "loc": 34,
+      "functions": [
+        {
+          "name": "_prep_window",
+          "lineno": 12,
+          "complexity": 7
+        },
+        {
+          "name": "test_new_triggering_condition_creates_repo_entry",
+          "lineno": 32,
+          "complexity": 2
+        },
+        {
+          "name": "test_new_functional_insufficiency_creates_repo_entry",
+          "lineno": 40,
+          "complexity": 2
+        },
+        {
+          "name": "add_tc",
+          "lineno": 18,
+          "complexity": 4
+        },
+        {
+          "name": "add_fi",
+          "lineno": 22,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_process_area_work_product_deletion.py",
+      "loc": 52,
+      "functions": [
+        {
+          "name": "test_delete_process_area_removes_children",
+          "lineno": 12,
+          "complexity": 3
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "enable_process_area",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "enable_work_product",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_tool_enablement",
+          "lineno": 34,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_requirements_error.py",
+      "loc": 50,
+      "functions": [
+        {
+          "name": "_raise_error",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_generate_requirements_error",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "test_generate_phase_requirements_error",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "display_stub",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "display_stub",
+          "lineno": 51,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_element_connection_rules.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "test_governance_element_connection_rules",
+          "lineno": 9,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_relation_direction.py",
+      "loc": 20,
+      "functions": [
+        {
+          "name": "_safety_ai_rules",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "test_data_acquisition_relation_direction",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_curation_process_data",
+          "lineno": 22,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_sotif_validation.py",
+      "loc": 19,
+      "functions": [
+        {
+          "name": "test_hazardous_behavior_rate_example",
+          "lineno": 14,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_generic_work_product.py",
+      "loc": 105,
+      "functions": [
+        {
+          "name": "test_add_generic_work_product",
+          "lineno": 13,
+          "complexity": 4
+        },
+        {
+          "name": "test_add_generic_work_product_name_conflict",
+          "lineno": 59,
+          "complexity": 2
+        },
+        {
+          "name": "test_connection_creates_generic_work_product",
+          "lineno": 103,
+          "complexity": 4
+        },
+        {
+          "name": "enable_work_product",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "enable_work_product",
+          "lineno": 86,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_glow.py",
+      "loc": 6,
+      "functions": [
+        {
+          "name": "test_lighten_adds_white_and_green",
+          "lineno": 4,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_tab_dedup.py",
+      "loc": 33,
+      "functions": [
+        {
+          "name": "test_new_tab_reuses_existing",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "tabs",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "tab",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "nametowidget",
+          "lineno": 34,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_malfunctions.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "test_append_unique_insensitive",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_button_utils_capsule.py",
+      "loc": 22,
+      "functions": [
+        {
+          "name": "test_uniform_width_for_capsule_button",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_task_consumes_requirement_spec.py",
+      "loc": 13,
+      "functions": [
+        {
+          "name": "test_task_consumes_requirement_specification",
+          "lineno": 6,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_port_connector_endpoint.py",
+      "loc": 20,
+      "functions": [
+        {
+          "name": "test_edge_point_on_port",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_sysml_selection.py",
+      "loc": 24,
+      "functions": [
+        {
+          "name": "test_sysml_find_object_strategies",
+          "lineno": 4,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_lifecycle_combobox_global.py",
+      "loc": 19,
+      "functions": [
+        {
+          "name": "test_global_phase_included_when_root_diagram_exists",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 17,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagnostics_manager.py",
+      "loc": 116,
+      "functions": [
+        {
+          "name": "test_polling_manager_detects_failure",
+          "lineno": 19,
+          "complexity": 2
+        },
+        {
+          "name": "test_event_manager_records_error",
+          "lineno": 29,
+          "complexity": 2
+        },
+        {
+          "name": "test_passive_manager_runs_checks",
+          "lineno": 37,
+          "complexity": 2
+        },
+        {
+          "name": "test_async_manager_detects_failure",
+          "lineno": 44,
+          "complexity": 2
+        },
+        {
+          "name": "test_recoverable_fault_recovers",
+          "lineno": 56,
+          "complexity": 1
+        },
+        {
+          "name": "test_nonrecoverable_fault_mitigates_and_notifies",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "test_polling_failed_recovery_triggers_mitigation",
+          "lineno": 89,
+          "complexity": 1
+        },
+        {
+          "name": "test_event_failed_recovery_triggers_mitigation",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "test_passive_failed_recovery_triggers_mitigation",
+          "lineno": 119,
+          "complexity": 1
+        },
+        {
+          "name": "test_async_failed_recovery_triggers_mitigation",
+          "lineno": 136,
+          "complexity": 1
+        },
+        {
+          "name": "bad",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "check",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "recover",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "check",
+          "lineno": 76,
+          "complexity": 1
+        },
+        {
+          "name": "mitigate",
+          "lineno": 79,
+          "complexity": 1
+        },
+        {
+          "name": "check",
+          "lineno": 122,
+          "complexity": 1
+        },
+        {
+          "name": "bad",
+          "lineno": 139,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_add_contained_parts.py",
+      "loc": 221,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "_sync_to_repository",
+          "lineno": 19,
+          "complexity": 8
+        },
+        {
+          "name": "redraw",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "test_new_parts_become_visible",
+          "lineno": 50,
+          "complexity": 2
+        },
+        {
+          "name": "test_new_parts_render_with_app",
+          "lineno": 73,
+          "complexity": 2
+        },
+        {
+          "name": "test_deleted_parts_remain_listed",
+          "lineno": 101,
+          "complexity": 3
+        },
+        {
+          "name": "test_unhide_existing_part",
+          "lineno": 132,
+          "complexity": 3
+        },
+        {
+          "name": "test_unhide_part_with_app",
+          "lineno": 149,
+          "complexity": 3
+        },
+        {
+          "name": "test_multiplicity_limit_enforced",
+          "lineno": 172,
+          "complexity": 7
+        },
+        {
+          "name": "test_rename_part_does_not_duplicate",
+          "lineno": 206,
+          "complexity": 2
+        },
+        {
+          "name": "test_definition_change_enforces_multiplicity",
+          "lineno": 226,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 82,
+          "complexity": 1
+        },
+        {
+          "name": "update_views",
+          "lineno": 85,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 91,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 110,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 123,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 143,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 158,
+          "complexity": 1
+        },
+        {
+          "name": "update_views",
+          "lineno": 160,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 166,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 190,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_drag_clone_positions.py",
+      "loc": 62,
+      "functions": [
+        {
+          "name": "_make_app_with_clone",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_dragging_clone_preserves_original_coordinates",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "test_dragging_original_preserves_clone_coordinates",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "test_sync_nodes_by_id_excludes_coordinates",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "sync_wrapper",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "capture",
+          "lineno": 77,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_delete_ports_on_part_removal.py",
+      "loc": 29,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "_sync_to_repository",
+          "lineno": 14,
+          "complexity": 4
+        },
+        {
+          "name": "setUp",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_ports_removed_with_part",
+          "lineno": 25,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_connection_label_offset.py",
+      "loc": 71,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "create_image",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "_label_offset",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "test_offset_multiple_labels",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "test_offset_vertical_labels",
+          "lineno": 66,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_validate_float.py",
+      "loc": 9,
+      "functions": [
+        {
+          "name": "test_allows_scientific_notation",
+          "lineno": 6,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_control_blend.py",
+      "loc": 18,
+      "functions": [
+        {
+          "name": "test_capsule_button_tints_parent_background",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_fault_undo.py",
+      "loc": 58,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_undo_redo_add_fault",
+          "lineno": 56,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_icons.py",
+      "loc": 50,
+      "functions": [
+        {
+          "name": "test_governance_shapes_and_relations",
+          "lineno": 10,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_analysis_input_diagram_filters.py",
+      "loc": 92,
+      "functions": [
+        {
+          "name": "test_stpa_dialog_respects_governance",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "test_threat_dialog_respects_governance",
+          "lineno": 93,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "combo_stub",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "combo_stub",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "analysis_inputs",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "document_visible",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 112,
+          "complexity": 1
+        },
+        {
+          "name": "analysis_inputs",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "document_visible",
+          "lineno": 119,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_button_hover_highlight.py",
+      "loc": 81,
+      "functions": [
+        {
+          "name": "_sum_rgb",
+          "lineno": 12,
+          "complexity": 3
+        },
+        {
+          "name": "_get_rgb",
+          "lineno": 18,
+          "complexity": 3
+        },
+        {
+          "name": "test_add_hover_highlight_swaps_to_lighter_image",
+          "lineno": 24,
+          "complexity": 2
+        },
+        {
+          "name": "test_add_hover_highlight_blends_white_and_green",
+          "lineno": 46,
+          "complexity": 5
+        },
+        {
+          "name": "test_add_hover_highlight_lightens_black_pixels",
+          "lineno": 73,
+          "complexity": 2
+        },
+        {
+          "name": "test_add_hover_highlight_preserves_transparency_and_glow",
+          "lineno": 92,
+          "complexity": 4
+        },
+        {
+          "name": "_rgb",
+          "lineno": 60,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cbn_table_clone_movement.py",
+      "loc": 86,
+      "functions": [
+        {
+          "name": "test_cbn_probability_tables_follow_each_clone",
+          "lineno": 65,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_reqwidth",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_reqheight",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "update_idletasks",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "create_window",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "itemconfigure",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "coords",
+          "lineno": 49,
+          "complexity": 2
+        },
+        {
+          "name": "delete",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "move",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "find_withtag",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "_place_table_stub",
+          "lineno": 83,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cause_effect_diagram.py",
+      "loc": 109,
+      "functions": [
+        {
+          "name": "_image_new",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "_array",
+          "lineno": 82,
+          "complexity": 1
+        },
+        {
+          "name": "_norm",
+          "lineno": 85,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "save",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "line",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "polygon",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "rectangle",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "multiline_textbbox",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "multiline_text",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "load_default",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "__sub__",
+          "lineno": 64,
+          "complexity": 1
+        },
+        {
+          "name": "__add__",
+          "lineno": 67,
+          "complexity": 1
+        },
+        {
+          "name": "__truediv__",
+          "lineno": 70,
+          "complexity": 1
+        },
+        {
+          "name": "__mul__",
+          "lineno": 73,
+          "complexity": 1
+        },
+        {
+          "name": "__iter__",
+          "lineno": 78,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 106,
+          "complexity": 2
+        },
+        {
+          "name": "setUp",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "tearDown",
+          "lineno": 127,
+          "complexity": 2
+        },
+        {
+          "name": "test_build_simplified_fta_model_includes_basic_events",
+          "lineno": 133,
+          "complexity": 3
+        },
+        {
+          "name": "test_auto_generate_diagram_canvas_large_enough",
+          "lineno": 146,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_app_drag_undo_redo.py",
+      "loc": 49,
+      "functions": [
+        {
+          "name": "test_drag_records_only_endpoints_and_undo_redo",
+          "lineno": 12,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_solution_work_product_clone.py",
+      "loc": 436,
+      "functions": [
+        {
+          "name": "test_solution_clones_existing_work_product",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "test_solution_requires_matching_spi_for_clone",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "test_format_text_shows_calculated_spi",
+          "lineno": 93,
+          "complexity": 1
+        },
+        {
+          "name": "test_format_text_shows_validation_target_when_no_probability",
+          "lineno": 113,
+          "complexity": 1
+        },
+        {
+          "name": "test_collect_work_products_returns_unique_sorted",
+          "lineno": 131,
+          "complexity": 1
+        },
+        {
+          "name": "test_collect_work_products_includes_toolbox_entries",
+          "lineno": 147,
+          "complexity": 1
+        },
+        {
+          "name": "test_collect_work_products_includes_toolbox_diagrams",
+          "lineno": 167,
+          "complexity": 1
+        },
+        {
+          "name": "test_collect_work_products_reuses_app_lists",
+          "lineno": 190,
+          "complexity": 1
+        },
+        {
+          "name": "test_collect_work_products_falls_back_to_app_objects",
+          "lineno": 206,
+          "complexity": 1
+        },
+        {
+          "name": "test_config_dialog_populates_comboboxes",
+          "lineno": 225,
+          "complexity": 1
+        },
+        {
+          "name": "test_config_dialog_lists_project_spis",
+          "lineno": 314,
+          "complexity": 1
+        },
+        {
+          "name": "test_config_dialog_lists_toolbox_work_products",
+          "lineno": 409,
+          "complexity": 1
+        },
+        {
+          "name": "test_config_dialog_lists_toolbox_diagrams",
+          "lineno": 498,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 13,
+          "complexity": 1
+        },
         {
           "name": "__init__",
           "lineno": 18,
           "complexity": 1
         },
         {
-          "name": "register_keyboard_shortcuts",
+          "name": "get",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "combo_stub",
+          "lineno": 270,
+          "complexity": 1
+        },
+        {
+          "name": "combo_stub",
+          "lineno": 370,
+          "complexity": 1
+        },
+        {
+          "name": "combo_stub",
+          "lineno": 457,
+          "complexity": 1
+        },
+        {
+          "name": "combo_stub",
+          "lineno": 550,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 121,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 155,
+          "complexity": 1
+        },
+        {
+          "name": "list_diagrams",
+          "lineno": 174,
+          "complexity": 1
+        },
+        {
+          "name": "get_work_products",
+          "lineno": 177,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 181,
+          "complexity": 1
+        },
+        {
+          "name": "get_architecture_box_list",
+          "lineno": 197,
+          "complexity": 1
+        },
+        {
+          "name": "get_analysis_box_list",
+          "lineno": 200,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 242,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 245,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 248,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 251,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 254,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 258,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 262,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 276,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 279,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 282,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 323,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 328,
+          "complexity": 1
+        },
+        {
+          "name": "get_spi_targets",
+          "lineno": 331,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 335,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 342,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 345,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 348,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 351,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 354,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 358,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 362,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 376,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 379,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 382,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 421,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 425,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 429,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 432,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 435,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 438,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 441,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 445,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 449,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 463,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 466,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 469,
+          "complexity": 1
+        },
+        {
+          "name": "list_diagrams",
+          "lineno": 507,
+          "complexity": 1
+        },
+        {
+          "name": "get_work_products",
+          "lineno": 510,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 514,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 518,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 522,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 525,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 528,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 531,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 534,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 538,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 542,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 556,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 559,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 562,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_multiline_requirements_editor.py",
+      "loc": 50,
+      "functions": [
+        {
+          "name": "test_requirements_text_multiline",
+          "lineno": 10,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "place",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "focus_set",
           "lineno": 24,
           "complexity": 1
         },
         {
-          "name": "register_tab_events",
+          "name": "bind",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 41,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_composite_aggregation.py",
+      "loc": 80,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_composite_part_to_ibd",
+          "lineno": 15,
+          "complexity": 3
+        },
+        {
+          "name": "test_remove_composite_part_from_ibd",
+          "lineno": 30,
+          "complexity": 3
+        },
+        {
+          "name": "test_set_father_links_and_renders_existing_parts",
+          "lineno": 46,
+          "complexity": 4
+        },
+        {
+          "name": "test_composite_part_created_without_ibd",
+          "lineno": 63,
+          "complexity": 7
+        }
+      ]
+    },
+    {
+      "file": "tests/test_name_uniqueness.py",
+      "loc": 31,
+      "functions": [
+        {
+          "name": "test_unique_name_variants",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_same_name_allowed_across_types",
+          "lineno": 26,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_add_block_relationships.py",
+      "loc": 63,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "redraw",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "_sync_to_repository",
+          "lineno": 16,
+          "complexity": 4
+        },
+        {
+          "name": "setUp",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "test_relationships_added_when_blocks_imported",
+          "lineno": 27,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_architecture_requirement_traceability.py",
+      "loc": 29,
+      "functions": [
+        {
+          "name": "test_requirement_traces_to_architecture_elements",
+          "lineno": 12,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_propagate_block_changes.py",
+      "loc": 84,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "test_changes_propagate_to_children",
+          "lineno": 22,
+          "complexity": 3
+        },
+        {
+          "name": "test_part_changes_propagate_to_child_ibd",
+          "lineno": 80,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_messagebox_noninteractive.py",
+      "loc": 34,
+      "functions": [
+        {
+          "name": "test_showinfo_does_not_popup",
+          "lineno": 4,
+          "complexity": 1
+        },
+        {
+          "name": "test_showwarning_does_not_popup",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "test_showerror_does_not_popup",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "test_askyesno_displays_popup",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "fake",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "fake",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "fake",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "fake",
+          "lineno": 43,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_risk_tables.py",
+      "loc": 16,
+      "functions": [
+        {
+          "name": "test_risk_level_table",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_cal_table",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_invalid_combo",
+          "lineno": 21,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_decision_transition_requirement.py",
+      "loc": 21,
+      "functions": [
+        {
+          "name": "test_decision_transition_requirement_mentions_source",
+          "lineno": 11,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_hazard_explorer_tab.py",
+      "loc": 39,
+      "functions": [
+        {
+          "name": "test_show_hazard_explorer_creates_tab",
+          "lineno": 7,
+          "complexity": 2
+        },
+        {
+          "name": "fake_new_tab",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "tabs",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 38,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_requirements_button.py",
+      "loc": 267,
+      "functions": [
+        {
+          "name": "test_requirements_button_opens_tab",
+          "lineno": 13,
+          "complexity": 7
+        },
+        {
+          "name": "test_requirements_button_no_change",
+          "lineno": 136,
+          "complexity": 3
+        },
+        {
+          "name": "test_other_diagram_requirements_preserved",
+          "lineno": 246,
+          "complexity": 4
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 159,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 275,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "rowconfigure",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "columnconfigure",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 67,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 74,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 86,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 89,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 92,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "xview",
+          "lineno": 98,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 104,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 107,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 153,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 156,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 163,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 168,
+          "complexity": 1
+        },
+        {
+          "name": "rowconfigure",
+          "lineno": 171,
+          "complexity": 1
+        },
+        {
+          "name": "columnconfigure",
+          "lineno": 174,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 177,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 180,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 184,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 188,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 191,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 194,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 198,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 202,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 205,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 208,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 211,
+          "complexity": 1
+        },
+        {
+          "name": "xview",
+          "lineno": 214,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 217,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 220,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 223,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 269,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 272,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 279,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 284,
+          "complexity": 1
+        },
+        {
+          "name": "rowconfigure",
+          "lineno": 287,
+          "complexity": 1
+        },
+        {
+          "name": "columnconfigure",
+          "lineno": 290,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 293,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 296,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 300,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 304,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 307,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 310,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 314,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 318,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 321,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 324,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 327,
+          "complexity": 1
+        },
+        {
+          "name": "xview",
+          "lineno": 330,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 333,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 336,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 339,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_tab_truncation.py",
+      "loc": 37,
+      "functions": [
+        {
+          "name": "test_long_tab_title_truncated",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "tabs",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "tab",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "nametowidget",
+          "lineno": 34,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_arch_window_focus.py",
+      "loc": 90,
+      "functions": [
+        {
+          "name": "make_window",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "setup_app",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "_make_obj",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "test_arch_window_strategies",
+          "lineno": 79,
+          "complexity": 1
+        },
+        {
+          "name": "test_paste_uses_focused_window",
+          "lineno": 100,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "diagram_read_only",
+          "lineno": 24,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_data_access_queries_import.py",
+      "loc": 11,
+      "functions": [
+        {
+          "name": "test_automl_core_imports_data_access_queries",
+          "lineno": 5,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cyber_risk_persistence.py",
+      "loc": 60,
+      "functions": [
+        {
+          "name": "test_cyber_risk_entry_persistence",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_rules_validation.py",
+      "loc": 21,
+      "functions": [
+        {
+          "name": "test_load_diagram_rules_rejects_invalid_connection_rules",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "test_validate_diagram_rules_accepts_valid_structure",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "test_validate_diagram_rules_flags_invalid_list",
+          "lineno": 28,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_log_button_visibility.py",
+      "loc": 18,
+      "functions": [
+        {
+          "name": "test_log_toggle_button_visible_with_pinned_explorer",
+          "lineno": 10,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_messagebox_style.py",
+      "loc": 126,
+      "functions": [
+        {
+          "name": "test_askyesno_uses_custom_dialog",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_askyesnocancel_uses_custom_dialog",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "test_askokcancel_uses_custom_dialog",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "test_create_dialog_uses_purple_button_style",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "test_create_dialog_keeps_existing_root",
+          "lineno": 114,
+          "complexity": 1
+        },
+        {
+          "name": "fake_dialog",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "fake_dialog",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "fake_dialog",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "title",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "resizable",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "transient",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "grab_set",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "geometry",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "update_idletasks",
+          "lineno": 75,
+          "complexity": 1
+        },
+        {
+          "name": "attributes",
+          "lineno": 78,
+          "complexity": 1
+        },
+        {
+          "name": "lift",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_screenwidth",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_screenheight",
+          "lineno": 87,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 90,
+          "complexity": 1
+        },
+        {
+          "name": "protocol",
+          "lineno": 93,
+          "complexity": 1
+        },
+        {
+          "name": "wait_window",
+          "lineno": 96,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "withdraw",
+          "lineno": 119,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 126,
+          "complexity": 1
+        },
+        {
+          "name": "title",
+          "lineno": 129,
+          "complexity": 1
+        },
+        {
+          "name": "resizable",
+          "lineno": 132,
+          "complexity": 1
+        },
+        {
+          "name": "transient",
+          "lineno": 135,
+          "complexity": 1
+        },
+        {
+          "name": "grab_set",
+          "lineno": 138,
+          "complexity": 1
+        },
+        {
+          "name": "geometry",
+          "lineno": 141,
+          "complexity": 1
+        },
+        {
+          "name": "update_idletasks",
+          "lineno": 144,
+          "complexity": 1
+        },
+        {
+          "name": "attributes",
+          "lineno": 147,
+          "complexity": 1
+        },
+        {
+          "name": "lift",
+          "lineno": 150,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_screenwidth",
+          "lineno": 153,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_screenheight",
+          "lineno": 156,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 159,
+          "complexity": 1
+        },
+        {
+          "name": "protocol",
+          "lineno": 162,
+          "complexity": 1
+        },
+        {
+          "name": "wait_window",
+          "lineno": 165,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_freeze_all_diagrams.py",
+      "loc": 17,
+      "functions": [
+        {
+          "name": "test_set_all_diagrams_frozen",
+          "lineno": 10,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cybersecurity_goals.py",
+      "loc": 46,
+      "functions": [
+        {
+          "name": "test_cal_aggregation",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "test_export_output",
+          "lineno": 33,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_explorer_panel_toggle.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "test_toggle_explorer_panel",
+          "lineno": 10,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_analysis_tree_grouping.py",
+      "loc": 75,
+      "functions": [
+        {
+          "name": "_setup_app_for_tree",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "test_cta_and_paa_groups_separate",
+          "lineno": 75,
+          "complexity": 3
+        },
+        {
+          "name": "test_get_node_fill_color_by_mode",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 14,
+          "complexity": 4
+        },
+        {
+          "name": "get_children",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "item",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "enabled_products",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "document_visible",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "list_diagrams",
+          "lineno": 63,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_toolboxes_syntax.py",
+      "loc": 8,
+      "functions": [
+        {
+          "name": "compile_file",
+          "lineno": 4,
+          "complexity": 1
+        },
+        {
+          "name": "test_gui_toolboxes_compiles",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_management_toolbox_compiles",
+          "lineno": 13,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_phase_requirement_dedup_content.py",
+      "loc": 54,
+      "functions": [
+        {
+          "name": "_setup_window",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "test_existing_requirement_reused",
+          "lineno": 40,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "generate_requirements",
+          "lineno": 16,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_generalization_validation.py",
+      "loc": 55,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "test_common_parent_invalid",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "test_reciprocal_generalization_invalid",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_cycle_generalization_invalid",
+          "lineno": 47,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_phase_requirements_menu.py",
+      "loc": 36,
+      "functions": [
+        {
+          "name": "test_phase_menu_binds_correct_phase",
+          "lineno": 32,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "add_command",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "add_separator",
+          "lineno": 28,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_non_action_objects.py",
+      "loc": 20,
+      "functions": [
+        {
+          "name": "test_requirements_with_non_action_objects",
+          "lineno": 10,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_relationship_stereotype.py",
+      "loc": 1018,
+      "functions": [
+        {
+          "name": "canvasx",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "tearDown",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "_create_window",
+          "lineno": 45,
+          "complexity": 2
+        },
+        {
+          "name": "test_propagate_relationship_stereotype",
+          "lineno": 67,
+          "complexity": 1
+        },
+        {
+          "name": "test_used_by_relationship_stereotype",
+          "lineno": 98,
+          "complexity": 1
+        },
+        {
+          "name": "test_used_after_review_relationship_stereotype",
+          "lineno": 129,
+          "complexity": 1
+        },
+        {
+          "name": "test_used_after_approval_relationship_stereotype",
+          "lineno": 160,
+          "complexity": 1
+        },
+        {
+          "name": "test_used_relations_reject_non_analysis_targets",
+          "lineno": 191,
+          "complexity": 2
+        },
+        {
+          "name": "test_stpa_to_architecture_used_relationships",
+          "lineno": 224,
+          "complexity": 2
+        },
+        {
+          "name": "test_used_relationship_validation",
+          "lineno": 257,
+          "complexity": 2
+        },
+        {
+          "name": "test_odd_scenario_library_used_relationships",
+          "lineno": 296,
+          "complexity": 2
+        },
+        {
+          "name": "test_scenario_library_odd_used_relationships_invalid",
+          "lineno": 325,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_targets_inputs_for_odd_scenario_library",
+          "lineno": 354,
+          "complexity": 2
+        },
+        {
+          "name": "test_used_relationship_requires_dependency",
+          "lineno": 393,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_inputs_used_after_approval_visibility",
+          "lineno": 422,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_inputs_specific_analyses",
+          "lineno": 462,
+          "complexity": 3
+        },
+        {
+          "name": "test_used_relationships_mutually_exclusive",
+          "lineno": 511,
+          "complexity": 1
+        },
+        {
+          "name": "test_analysis_targets_used_after_review_visibility",
+          "lineno": 569,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_targets_used_after_approval_visibility",
+          "lineno": 613,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_inputs_mapping",
+          "lineno": 657,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_inputs_trace_propagation",
+          "lineno": 695,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_inputs_cross_module",
+          "lineno": 737,
+          "complexity": 3
+        },
+        {
+          "name": "test_analysis_inputs_all_safety_analyses",
+          "lineno": 787,
+          "complexity": 5
+        },
+        {
+          "name": "test_hazop_functions_hidden_until_governed",
+          "lineno": 828,
+          "complexity": 2
+        },
+        {
+          "name": "test_hazop_functions_visible_via_traces",
+          "lineno": 853,
+          "complexity": 2
+        },
+        {
+          "name": "test_fi2tc_tc2fi_functions_hidden_until_governed",
+          "lineno": 890,
+          "complexity": 4
+        },
+        {
+          "name": "test_allowed_action_labels_respects_review_states",
+          "lineno": 918,
+          "complexity": 1
+        },
+        {
+          "name": "test_reliability_requires_mission_profile_connection",
+          "lineno": 949,
+          "complexity": 2
+        },
+        {
+          "name": "test_stpa_control_actions_hidden_until_governed",
+          "lineno": 970,
+          "complexity": 1
+        },
+        {
+          "name": "test_analysis_inputs_used_after_review_visibility",
+          "lineno": 1001,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_inputs_used_after_approval_visibility",
+          "lineno": 1041,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diamond_corners.py",
+      "loc": 19,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 5,
+          "complexity": 1
+        },
+        {
+          "name": "test_edge_point_nearest_corner",
+          "lineno": 14,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_report_templates.py",
+      "loc": 161,
+      "functions": [
+        {
+          "name": "_load",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_item_definition_template_valid",
+          "lineno": 16,
+          "complexity": 2
+        },
+        {
+          "name": "test_functional_cybersecurity_concept_template_valid",
+          "lineno": 33,
+          "complexity": 2
+        },
+        {
+          "name": "test_technical_cybersecurity_concept_template_valid",
+          "lineno": 58,
+          "complexity": 2
+        },
+        {
+          "name": "test_pdf_report_template_includes_diagram_sections",
+          "lineno": 81,
+          "complexity": 2
+        },
+        {
+          "name": "test_report_template_includes_item_definition_section",
+          "lineno": 97,
+          "complexity": 2
+        },
+        {
+          "name": "test_report_template_includes_odd_and_scenario_sections",
+          "lineno": 105,
+          "complexity": 2
+        },
+        {
+          "name": "test_report_template_includes_operational_safety_and_decommissioning_sections",
+          "lineno": 111,
+          "complexity": 2
+        },
+        {
+          "name": "test_safety_security_report_template_valid",
+          "lineno": 117,
+          "complexity": 2
+        },
+        {
+          "name": "test_report_template_includes_trigger_and_insufficiency_sections",
+          "lineno": 127,
+          "complexity": 2
+        },
+        {
+          "name": "test_production_service_decommissioning_template_valid",
+          "lineno": 137,
+          "complexity": 2
+        },
+        {
+          "name": "test_field_monitoring_template_valid",
+          "lineno": 147,
+          "complexity": 2
+        },
+        {
+          "name": "test_safety_security_management_template_valid",
+          "lineno": 153,
+          "complexity": 2
+        },
+        {
+          "name": "test_diagram_rules_include_lifecycle_requirements",
+          "lineno": 164,
+          "complexity": 2
+        },
+        {
+          "name": "test_safety_case_dynamic_sections",
+          "lineno": 177,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_relation_connection.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 24,
+          "complexity": 3
+        },
+        {
+          "name": "test_requirement_relation_tool_creates_connection",
+          "lineno": 62,
+          "complexity": 3
+        },
+        {
+          "name": "canvasx",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 20,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_fta_undo.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 18,
+          "complexity": 5
+        },
+        {
+          "name": "test_undo_redo_top_event_creation_and_deletion",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "test_undo_redo_add_node",
+          "lineno": 56,
+          "complexity": 1
+        },
+        {
+          "name": "apply_model_data",
+          "lineno": 34,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirements_manager_export_state.py",
+      "loc": 11,
+      "functions": [
+        {
+          "name": "test_requirements_manager_defines_export_state",
+          "lineno": 5,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_allocation.py",
+      "loc": 108,
+      "functions": [
+        {
+          "name": "test_requirement_allocation_disabled",
+          "lineno": 13,
+          "complexity": 2
+        },
+        {
+          "name": "dummy_tooltip",
+          "lineno": 100,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "curselection",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "selection_set",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 35,
+          "complexity": 2
+        },
+        {
+          "name": "add",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "create_window",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 65,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_action_drop.py",
+      "loc": 30,
+      "functions": [
+        {
+          "name": "test_drop_governance_diagram_creates_action",
+          "lineno": 6,
+          "complexity": 3
+        },
+        {
+          "name": "test_drop_non_governance_diagram_on_governance_fails",
+          "lineno": 27,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_toolbox_relation_dedup.py",
+      "loc": 233,
+      "functions": [
+        {
+          "name": "test_global_relation_not_duplicated",
+          "lineno": 12,
+          "complexity": 2
+        },
+        {
+          "name": "test_category_relations_deduplicated",
+          "lineno": 68,
+          "complexity": 2
+        },
+        {
+          "name": "test_governance_core_relations_deduplicated",
+          "lineno": 144,
+          "complexity": 2
+        },
+        {
+          "name": "test_relations_deduplicated_across_categories",
+          "lineno": 220,
+          "complexity": 2
+        },
+        {
+          "name": "fake_sysml_init",
+          "lineno": 41,
+          "complexity": 2
+        },
+        {
+          "name": "fake_sysml_init",
+          "lineno": 104,
+          "complexity": 2
+        },
+        {
+          "name": "fake_sysml_init",
+          "lineno": 180,
+          "complexity": 2
+        },
+        {
+          "name": "fake_sysml_init",
+          "lineno": 250,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "pack_forget",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 86,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 89,
+          "complexity": 1
+        },
+        {
+          "name": "pack_forget",
+          "lineno": 92,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 98,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 162,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 165,
+          "complexity": 1
+        },
+        {
+          "name": "pack_forget",
+          "lineno": 168,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 171,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 174,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 177,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 232,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 235,
+          "complexity": 1
+        },
+        {
+          "name": "pack_forget",
+          "lineno": 238,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 241,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 244,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 247,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_probability_config.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "test_update_probability_tables",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_normalize_probability_mapping",
+          "lineno": 27,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_lifecycle_phase_enforces_governance.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "test_diagram_and_elements_hidden_without_phase",
+          "lineno": 4,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_ghostscript_installation.py",
+      "loc": 39,
+      "functions": [
+        {
+          "name": "test_ensure_ghostscript_non_windows",
+          "lineno": 7,
+          "complexity": 2
+        },
+        {
+          "name": "test_ensure_ghostscript_already_present",
+          "lineno": 13,
+          "complexity": 3
+        },
+        {
+          "name": "test_ensure_ghostscript_installs",
+          "lineno": 22,
+          "complexity": 6
+        },
+        {
+          "name": "test_ensure_ghostscript_failure",
+          "lineno": 41,
+          "complexity": 5
+        },
+        {
+          "name": "fake_check_call",
+          "lineno": 29,
+          "complexity": 3
+        },
+        {
+          "name": "fail",
+          "lineno": 46,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_rules_reload.py",
+      "loc": 21,
+      "functions": [
+        {
+          "name": "test_connection_rules_reload",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_app_undo_move_coalesce.py",
+      "loc": 58,
+      "functions": [
+        {
+          "name": "_make_app",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "test_strategies_only_store_first_and_last",
+          "lineno": 22,
+          "complexity": 4
+        },
+        {
+          "name": "test_undo_redo_restore_endpoints",
+          "lineno": 34,
+          "complexity": 4
+        },
+        {
+          "name": "export_model_data",
+          "lineno": 15,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_label_positions.py",
+      "loc": 53,
+      "functions": [
+        {
+          "name": "test_governance_names_after_shape",
+          "lineno": 23,
+          "complexity": 2
+        },
+        {
+          "name": "test_bottom_label_shapes_fixed_size",
+          "lineno": 28,
+          "complexity": 2
+        },
+        {
+          "name": "canvasx",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 19,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_group_activation.py",
+      "loc": 82,
+      "functions": [
+        {
+          "name": "test_work_product_groups_follow_phase",
+          "lineno": 56,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 21,
+          "complexity": 2
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "size",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 38,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_partproperty_multiplicity.py",
+      "loc": 43,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_duplicates_ignored",
+          "lineno": 10,
+          "complexity": 2
+        },
+        {
+          "name": "test_multiplicity_limit",
+          "lineno": 20,
+          "complexity": 3
+        },
+        {
+          "name": "test_skip_existing_bracketed_parts",
+          "lineno": 31,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_size.py",
+      "loc": 158,
+      "functions": [
+        {
+          "name": "measure",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "test_part_width_expands_for_properties",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "test_action_width_does_not_expand_for_name",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "test_action_min_size",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "test_decision_and_merge_sizes_remain_fixed",
+          "lineno": 80,
+          "complexity": 2
+        },
+        {
+          "name": "test_role_size_remains_fixed",
+          "lineno": 106,
+          "complexity": 1
+        },
+        {
+          "name": "test_data_acquisition_default_and_resize",
+          "lineno": 122,
+          "complexity": 2
+        },
+        {
+          "name": "test_block_resizes_when_compartments_toggle",
+          "lineno": 144,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_version_sync.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "_readme_version",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "test_readme_matches_version",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "test_cli_reports_same_version",
+          "lineno": 29,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_constrained_by_rules.py",
+      "loc": 16,
+      "functions": [
+        {
+          "name": "test_constrained_by_rules",
+          "lineno": 9,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_reuse_visibility.py",
+      "loc": 105,
+      "functions": [
+        {
+          "name": "_setup_repo",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_work_product_reuse_visibility",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_phase_reuse_visibility",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "test_activity_diagram_reuse_read_only",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "test_phase_reuse_shows_diagrams_and_elements",
+          "lineno": 89,
+          "complexity": 1
+        },
+        {
+          "name": "test_activity_diagram_reuse_read_only",
+          "lineno": 121,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_cta_work_product.py",
+      "loc": 42,
+      "functions": [
+        {
+          "name": "test_governance_cta_work_product_enabled",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "enable_work_product",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 43,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_phase_labels.py",
+      "loc": 86,
+      "functions": [
+        {
+          "name": "measure",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "test_format_helper",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "test_object_label_omits_phase",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_governance_label_omits_phase",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_management_explorer_omits_phase",
+          "lineno": 65,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 80,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 87,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 90,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_work_product_removal.py",
+      "loc": 290,
+      "functions": [
+        {
+          "name": "test_delete_work_product_updates_toolbox",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_cancel_delete_work_product_keeps_toolbox",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "test_delete_process_area_removes_children",
+          "lineno": 109,
+          "complexity": 1
+        },
+        {
+          "name": "test_delete_process_area_removes_boundary_children",
+          "lineno": 160,
+          "complexity": 1
+        },
+        {
+          "name": "test_delete_one_of_multiple_work_products_keeps_enablement",
+          "lineno": 211,
+          "complexity": 1
+        },
+        {
+          "name": "test_delete_one_of_multiple_gsn_work_products",
+          "lineno": 263,
+          "complexity": 1
+        },
+        {
+          "name": "test_delete_work_product_in_one_diagram_keeps_other",
+          "lineno": 321,
+          "complexity": 3
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 75,
+          "complexity": 1
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 121,
+          "complexity": 1
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 124,
+          "complexity": 1
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 172,
+          "complexity": 1
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 175,
+          "complexity": 1
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 224,
+          "complexity": 1
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 227,
+          "complexity": 1
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 279,
+          "complexity": 1
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 282,
+          "complexity": 1
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 339,
+          "complexity": 1
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 342,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_control_flow_guard.py",
+      "loc": 64,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_guard_persistence",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "test_guard_label_with_operators",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "test_guard_string_coercion",
+          "lineno": 63,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_repo_push_undo_fallback.py",
+      "loc": 13,
+      "functions": [
+        {
+          "name": "test_push_undo_state_falls_back_when_strategy_missing",
+          "lineno": 5,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_properties_metadata.py",
+      "loc": 113,
+      "functions": [
+        {
+          "name": "test_analysis_tree_selection_shows_metadata",
+          "lineno": 12,
+          "complexity": 2
+        },
+        {
+          "name": "test_architecture_tree_selection_shows_metadata",
+          "lineno": 59,
+          "complexity": 2
+        },
+        {
+          "name": "test_diagram_selection_clears_tree_and_shows_object_properties",
+          "lineno": 105,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "focus",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "item",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 68,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 74,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 82,
+          "complexity": 1
+        },
+        {
+          "name": "focus",
+          "lineno": 88,
+          "complexity": 1
+        },
+        {
+          "name": "item",
+          "lineno": 91,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 115,
+          "complexity": 1
+        },
+        {
+          "name": "focus",
+          "lineno": 120,
+          "complexity": 2
+        },
+        {
+          "name": "item",
+          "lineno": 125,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 128,
+          "complexity": 1
+        },
+        {
+          "name": "selection_set",
+          "lineno": 131,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 135,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 138,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 141,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 144,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_app_mixins.py",
+      "loc": 9,
+      "functions": [
+        {
+          "name": "test_mixins_configure_app",
+          "lineno": 6,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_toolbox_no_select.py",
+      "loc": 13,
+      "functions": [
+        {
+          "name": "test_safety_ai_toolbox_excludes_select",
+          "lineno": 8,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_relationship_move.py",
+      "loc": 71,
+      "functions": [
+        {
+          "name": "canvasx",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "_create_window",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "test_connection_midpoint_drag_moves_line",
+          "lineno": 72,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_part_multiplicity_label.py",
+      "loc": 51,
+      "functions": [
+        {
+          "name": "measure",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "test_label_shows_index_and_range",
+          "lineno": 24,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_context_migration.py",
+      "loc": 24,
+      "functions": [
+        {
+          "name": "test_legacy_context_entries_load_as_context",
+          "lineno": 4,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_tab_data_loading.py",
+      "loc": 49,
+      "functions": [
+        {
+          "name": "test_tab_data_loading",
+          "lineno": 25,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "load_data",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "unload_data",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "event_generate",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 32,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_process_area_filter.py",
+      "loc": 30,
+      "functions": [
+        {
+          "name": "test_work_product_combo_filters_process_area",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 28,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_undo.py",
+      "loc": 50,
+      "functions": [
+        {
+          "name": "test_governance_diagram_undo_redo_work_product",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_tool_enablement",
+          "lineno": 34,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_clipboard.py",
+      "loc": 71,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 6,
+          "complexity": 2
+        },
+        {
+          "name": "test_gsn_copy_paste_clones_with_independent_positions",
+          "lineno": 22,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_cut_paste.py",
+      "loc": 70,
+      "functions": [
+        {
+          "name": "test_cut_paste_task_between_governance_diagrams",
+          "lineno": 8,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_phase_transition_requirements.py",
+      "loc": 33,
+      "functions": [
+        {
+          "name": "_texts",
+          "lineno": 9,
+          "complexity": 4
+        },
+        {
+          "name": "test_phase_transition_requirement_direct_flow",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_phase_transition_requirement_with_reuse_and_condition",
+          "lineno": 32,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_listbox_hover_highlight.py",
+      "loc": 33,
+      "functions": [
+        {
+          "name": "_rgb",
+          "lineno": 10,
+          "complexity": 3
+        },
+        {
+          "name": "test_listbox_row_highlight_on_hover",
+          "lineno": 16,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_part_definition_sync.py",
+      "loc": 24,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_rename_block_updates_name_based_definition",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_from_dict_converts_definition_names",
+          "lineno": 18,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_clone_relationships.py",
+      "loc": 78,
+      "functions": [
+        {
+          "name": "test_reset_clone_clears_relationships",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_reset_clone_preserves_away_properties",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "test_paste_node_clones_gsn_nodes",
+          "lineno": 45,
+          "complexity": 3
+        },
+        {
+          "name": "fake_find",
+          "lineno": 82,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "add_node",
+          "lineno": 75,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_role_produces_operation_connection_rule.py",
+      "loc": 11,
+      "functions": [
+        {
+          "name": "test_role_produces_operation_connection_rule",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance.py",
+      "loc": 19,
+      "functions": [
+        {
+          "name": "test_visibility_requires_all_relationships",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "test_visibility_fails_if_any_relationship_missing",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "test_gsn_safety_case_dependency_allowed",
+          "lineno": 23,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_sync_nodes_by_id.py",
+      "loc": 51,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "test_original_updates_clones",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "test_clone_updates_all",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "test_edit_description_propagates",
+          "lineno": 52,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_reporting_export_init.py",
+      "loc": 23,
+      "functions": [
+        {
+          "name": "test_automl_core_initialises_reporting_export",
+          "lineno": 5,
+          "complexity": 10
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cylinder_rendering.py",
+      "loc": 53,
+      "functions": [
+        {
+          "name": "window",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "test_cylinder_shapes_use_common_draw",
+          "lineno": 42,
+          "complexity": 2
+        },
+        {
+          "name": "configure",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 20,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_pattern_variables.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "test_requirement_pattern_variables_used",
+          "lineno": 11,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_user_dialog_buttons.py",
+      "loc": 45,
+      "functions": [
+        {
+          "name": "_collect_button_styles",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_user_info_dialog_purplish_buttons",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "test_user_select_dialog_purplish_buttons",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "test_base_dialog_purplish_buttons",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "fake_apply",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 23,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_create_installer.py",
+      "loc": 44,
+      "functions": [
+        {
+          "name": "setup_files",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_create_installer_zip",
+          "lineno": 18,
+          "complexity": 2
+        },
+        {
+          "name": "test_create_installer_tar",
+          "lineno": 28,
+          "complexity": 2
+        },
+        {
+          "name": "test_create_installer_shutil_zip",
+          "lineno": 39,
+          "complexity": 2
+        },
+        {
+          "name": "test_create_installer_shutil_targz",
+          "lineno": 48,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_copy_respects_active_arch_diagram.py",
+      "loc": 85,
+      "functions": [
+        {
+          "name": "make_arch_window",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_copy_paste_respects_active_arch_diagram_when_gsn_exists",
+          "lineno": 38,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "diagram_read_only",
+          "lineno": 17,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_rule_override.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "test_requirement_relation_respects_config",
+          "lineno": 6,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_invalid_relationship_migration.py",
+      "loc": 37,
+      "functions": [
+        {
+          "name": "test_invalid_solved_relationship_ignored_on_load",
+          "lineno": 4,
+          "complexity": 1
+        },
+        {
+          "name": "test_invalid_context_relationship_ignored_on_load",
+          "lineno": 28,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_boundary_port_selection.py",
+      "loc": 49,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_find_object_prefers_port_over_boundary",
+          "lineno": 10,
+          "complexity": 3
+        },
+        {
+          "name": "test_find_object_prefers_boundary_port_over_part",
+          "lineno": 24,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "tests/test_app_undo_task_lifecycle.py",
+      "loc": 71,
+      "functions": [
+        {
+          "name": "_make_app_repo",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_task_add_move_rename_resize_undo_redo",
+          "lineno": 29,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_functional_insufficiency_subtype.py",
+      "loc": 23,
+      "functions": [
+        {
+          "name": "test_subtype_nodes_listed",
+          "lineno": 13,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_pattern_relations_toolbox.py",
+      "loc": 8,
+      "functions": [
+        {
+          "name": "test_requirement_patterns_relations_present",
+          "lineno": 9,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_ports.py",
+      "loc": 123,
+      "functions": [
+        {
+          "name": "test_remove_orphan_ports",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "test_ports_follow_part_resize",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "test_incompatible_directions",
+          "lineno": 56,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "_create_window_with_port",
+          "lineno": 76,
+          "complexity": 3
+        },
+        {
+          "name": "test_rename_port_updates_parent",
+          "lineno": 99,
+          "complexity": 3
+        },
+        {
+          "name": "test_delete_port_updates_parent",
+          "lineno": 109,
+          "complexity": 3
+        },
+        {
+          "name": "test_sync_ports_removes_duplicates",
+          "lineno": 118,
+          "complexity": 5
+        },
+        {
+          "name": "__init__",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "sync",
+          "lineno": 91,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_relationship_multiplicity_update.py",
+      "loc": 16,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_update_relationship_multiplicity",
+          "lineno": 10,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_phase_display_and_freeze.py",
+      "loc": 37,
+      "functions": [
+        {
+          "name": "test_display_name_and_phase_rename_propagation",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_phase_freezes_after_work_product",
+          "lineno": 29,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_sysml_repository_export_state.py",
+      "loc": 11,
+      "functions": [
+        {
+          "name": "test_sysml_repository_defines_export_state",
+          "lineno": 5,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "tests/test_part_label_component.py",
+      "loc": 53,
+      "functions": [
+        {
+          "name": "measure",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "test_label_includes_component_and_multiplicity",
+          "lineno": 29,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_connection_surface.py",
+      "loc": 107,
+      "functions": [
+        {
+          "name": "test_connections_touch_shape_surface",
+          "lineno": 106,
+          "complexity": 1
+        },
+        {
+          "name": "test_context_connections_touch_shape_surface",
+          "lineno": 132,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "_update_rect",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 21,
+          "complexity": 2
+        },
+        {
+          "name": "create_oval",
+          "lineno": 25,
+          "complexity": 2
+        },
+        {
+          "name": "create_line",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "create_arc",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "tag_lower",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "tag_raise",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 55,
+          "complexity": 2
+        },
+        {
+          "name": "_scaled_font",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "draw_goal_shape",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "draw_context_shape",
+          "lineno": 90,
+          "complexity": 1
+        },
+        {
+          "name": "point_on_shape",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "draw_solved_by_connection",
+          "lineno": 99,
+          "complexity": 1
+        },
+        {
+          "name": "draw_in_context_connection",
+          "lineno": 102,
+          "complexity": 1
+        },
+        {
+          "name": "measure",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 66,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_pressed.py",
+      "loc": 29,
+      "functions": [
+        {
+          "name": "test_capsule_button_darkens_when_pressed",
+          "lineno": 8,
+          "complexity": 2
+        },
+        {
+          "name": "test_capsule_button_has_inner_outline",
+          "lineno": 26,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_odd_validation_targets.py",
+      "loc": 38,
+      "functions": [
+        {
+          "name": "test_traces_validation_targets_from_scenario_description",
+          "lineno": 8,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_no_empty_fta_tab.py",
+      "loc": 66,
+      "functions": [
+        {
+          "name": "_base_app",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "test_new_model_no_fta_tab",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "test_reset_on_load_no_fta_tab",
+          "lineno": 78,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "tabs",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "event_generate",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "forget",
+          "lineno": 28,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_requirement_dedup.py",
+      "loc": 17,
+      "functions": [
+        {
+          "name": "test_data_acquisition_default_requirement_removed_when_sources_present",
+          "lineno": 11,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_connection_deletion.py",
+      "loc": 33,
+      "functions": [
+        {
+          "name": "test_delete_connection_refreshes_enablement",
+          "lineno": 5,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_tool_enablement",
+          "lineno": 34,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_role_work_product_connection_rule.py",
+      "loc": 11,
+      "functions": [
+        {
+          "name": "test_role_responsible_for_work_product_connection",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_task_connection_rule.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "test_governance_task_rule_allows_action",
+          "lineno": 8,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_aggregation_ports.py",
+      "loc": 41,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_sync_aggregation_adds_ports",
+          "lineno": 14,
+          "complexity": 6
+        },
+        {
+          "name": "test_composite_part_adds_ports",
+          "lineno": 31,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_remove_element_model.py",
+      "loc": 51,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "_sync_to_repository",
+          "lineno": 16,
+          "complexity": 4
+        },
+        {
+          "name": "redraw",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "update_property_view",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "remove_object",
+          "lineno": 28,
+          "complexity": 2
+        },
+        {
+          "name": "setUp",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_remove_element_model",
+          "lineno": 38,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_splash_screen.py",
+      "loc": 47,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 8,
+          "complexity": 2
+        },
+        {
+          "name": "tearDown",
+          "lineno": 19,
+          "complexity": 3
+        },
+        {
+          "name": "test_gear_has_glow",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "test_title_background",
+          "lineno": 34,
+          "complexity": 2
+        },
+        {
+          "name": "test_close_fades_to_invisible",
+          "lineno": 43,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_hover_bright.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "test_hover_brightens_entire_button",
+          "lineno": 5,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_failure_prob_quantity.py",
+      "loc": 44,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "find_node_by_id_all",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "get_failure_mode_node",
+          "lineno": 20,
+          "complexity": 2
+        },
+        {
+          "name": "get_component_name_for_node",
+          "lineno": 26,
+          "complexity": 5
+        },
+        {
+          "name": "get_fit_for_fault",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_fit_divided_by_quantity",
+          "lineno": 38,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_architecture_temp_connection.py",
+      "loc": 56,
+      "functions": [
+        {
+          "name": "test_temp_connection_line_is_dotted_and_animated",
+          "lineno": 9,
+          "complexity": 3
+        },
+        {
+          "name": "edge_point",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "tag_raise",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "config",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 50,
+          "complexity": 1
+        },
+        {
+          "name": "find_withtag",
+          "lineno": 53,
+          "complexity": 3
+        },
+        {
+          "name": "itemconfigure",
+          "lineno": 56,
+          "complexity": 1
+        },
+        {
+          "name": "after",
+          "lineno": 59,
+          "complexity": 1
+        },
+        {
+          "name": "after_cancel",
+          "lineno": 63,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_behavior_elements.py",
+      "loc": 51,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_behavior_element_filtering",
+          "lineno": 15,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_sysml_context_menu_edit.py",
+      "loc": 85,
+      "functions": [
+        {
+          "name": "test_context_menu_edit_keeps_diagram_objects",
+          "lineno": 46,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "push_undo_state",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "object_visible",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "connection_visible",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "touch_diagram",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "visible_objects",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "visible_connections",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 87,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_hazard_undo.py",
+      "loc": 39,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_undo_redo_update_hazard_severity",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "apply_model_data",
+          "lineno": 31,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_review_toolbox_optional_pillow.py",
+      "loc": 15,
+      "functions": [
+        {
+          "name": "test_enable_stpa_without_pillow",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_connection_tags.py",
+      "loc": 37,
+      "functions": [
+        {
+          "name": "test_connection_tags_present",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 5,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "tag_lower",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "tag_raise",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "draw_solved_by_connection",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "draw_in_context_connection",
+          "lineno": 36,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_phase_reuse_read_only.py",
+      "loc": 77,
+      "functions": [
+        {
+          "name": "_setup_repo",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "_prepare",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "test_reused_element_read_only_blocks_modification",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "test_reused_diagram_read_only_blocks_modification",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "_prepare_product_reuse",
+          "lineno": 70,
+          "complexity": 1
+        },
+        {
+          "name": "test_reused_work_product_read_only_blocks_modification",
+          "lineno": 84,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_patterns_validation.py",
+      "loc": 21,
+      "functions": [
+        {
+          "name": "test_load_requirement_patterns_rejects_invalid_structure",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "test_validate_requirement_patterns_accepts_valid_structure",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "test_validate_requirement_patterns_requires_list",
+          "lineno": 27,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_clone_gsn_node.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "test_clone_preserves_gsn_node_attributes",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "test_clone_context_attaches_to_parent",
+          "lineno": 30,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_trace_work_product_lifecycle_phase.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "test_work_product_to_lifecycle_phase_trace_allowed",
+          "lineno": 5,
+          "complexity": 1
+        },
+        {
+          "name": "test_lifecycle_phase_to_work_product_trace_allowed",
+          "lineno": 25,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_work_product_name_read_only.py",
+      "loc": 146,
+      "functions": [
+        {
+          "name": "test_work_product_name_read_only",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "test_work_product_name_editable_when_unlocked",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "test_process_area_name_read_only",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "test_lifecycle_phase_name_read_only",
+          "lineno": 88,
+          "complexity": 1
+        },
+        {
+          "name": "_create_win",
+          "lineno": 113,
+          "complexity": 1
+        },
+        {
+          "name": "test_place_work_product_sets_name_locked",
+          "lineno": 135,
+          "complexity": 1
+        },
+        {
+          "name": "test_place_generic_work_product_unlocked",
+          "lineno": 141,
+          "complexity": 1
+        },
+        {
+          "name": "test_place_process_area_sets_name_locked",
+          "lineno": 147,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_lifecycle_phase_sets_name_locked",
+          "lineno": 153,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 157,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 165,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_sysml_clipboard.py",
+      "loc": 80,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "test_sysml_clone_and_paste",
+          "lineno": 47,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "diagram_read_only",
+          "lineno": 11,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_reuse.py",
+      "loc": 48,
+      "functions": [
+        {
+          "name": "_obj",
+          "lineno": 5,
+          "complexity": 1
+        },
+        {
+          "name": "test_work_product_reuse_visible",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "test_phase_reuse_shows_all_docs",
+          "lineno": 37,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_table_resize_wrap.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "test_description_wrap_updates_on_column_resize",
+          "lineno": 10,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_risk_assessment_filters.py",
+      "loc": 186,
+      "functions": [
+        {
+          "name": "test_row_dialog_filters_stpa_and_threat",
+          "lineno": 24,
+          "complexity": 5
+        },
+        {
+          "name": "get_hazop_by_name",
+          "lineno": 124,
+          "complexity": 2
+        },
+        {
+          "name": "combo_stub",
+          "lineno": 195,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 131,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 135,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 138,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 141,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 144,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 147,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 152,
+          "complexity": 1
+        },
+        {
+          "name": "after",
+          "lineno": 155,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 158,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 162,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 166,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 169,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 173,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 181,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 184,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 187,
+          "complexity": 1
+        },
+        {
+          "name": "trace_add",
+          "lineno": 190,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_risk_assessment_governance.py",
+      "loc": 60,
+      "functions": [
+        {
+          "name": "test_risk_assessment_dialog_hides_unrelated_inputs",
+          "lineno": 5,
+          "complexity": 3
+        },
+        {
+          "name": "grid",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 32,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_work_product_process_area_lock.py",
+      "loc": 62,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "_create_window",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "test_work_product_remains_in_process_area",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 21,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_clone_sync_nodes.py",
+      "loc": 41,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_clone_and_original_propagation",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "all_nodes",
+          "lineno": 30,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gui_classes.py",
+      "loc": 43,
+      "functions": [
+        {
+          "name": "test_rowdialog_has_add_func_existing",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "test_faults_window_has_double_click_handler",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "test_risk_assessment_double_click_binding",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "test_product_goals_editor_double_click_binding",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "test_matrix_has_all_columns_and_scrollbars",
+          "lineno": 35,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_case_explorer.py",
+      "loc": 117,
+      "functions": [
+        {
+          "name": "test_create_edit_delete_case",
+          "lineno": 45,
+          "complexity": 6
+        },
+        {
+          "name": "test_create_case_from_module",
+          "lineno": 94,
+          "complexity": 2
+        },
+        {
+          "name": "test_safety_case_explorer_refresh_calls_populate",
+          "lineno": 119,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_case_table_lists_solutions",
+          "lineno": 131,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 19,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 28,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "fake_populate",
+          "lineno": 122,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 64,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 80,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 112,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_node_at.py",
+      "loc": 83,
+      "functions": [
+        {
+          "name": "window",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "test_click_outside_returns_none",
+          "lineno": 89,
+          "complexity": 1
+        },
+        {
+          "name": "test_click_inside_returns_node",
+          "lineno": 104,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "register",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "find_overlapping",
+          "lineno": 35,
+          "complexity": 6
+        },
+        {
+          "name": "find_closest",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "gettags",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 49,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 58,
+          "complexity": 1
+        },
+        {
+          "name": "_traverse",
+          "lineno": 61,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_undo.py",
+      "loc": 69,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_undo_creation",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "test_undo_rename_block",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_undo_add_aggregation",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "test_redo_creation",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "test_redo_rename_block",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "test_undo_redo_relationship",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "test_undo_redo_link_diagram",
+          "lineno": 67,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_fmeda_metrics.py",
+      "loc": 47,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 3
+        },
+        {
+          "name": "test_basic_metrics",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "test_goal_targets",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "sg_to_asil",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "sg_to_asil",
+          "lineno": 42,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_multiplicity_parts.py",
+      "loc": 133,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_exact_multiplicity",
+          "lineno": 10,
+          "complexity": 4
+        },
+        {
+          "name": "test_unbounded_multiplicity",
+          "lineno": 26,
+          "complexity": 3
+        },
+        {
+          "name": "test_update_existing_parts",
+          "lineno": 40,
+          "complexity": 3
+        },
+        {
+          "name": "test_multiplicity_decrease_removes_parts",
+          "lineno": 55,
+          "complexity": 3
+        },
+        {
+          "name": "test_add_parts_up_to_multiplicity",
+          "lineno": 72,
+          "complexity": 3
+        },
+        {
+          "name": "test_multiplicity_decrease_removes_parts",
+          "lineno": 90,
+          "complexity": 3
+        },
+        {
+          "name": "test_add_parts_up_to_multiplicity",
+          "lineno": 107,
+          "complexity": 3
+        },
+        {
+          "name": "test_single_multiplicity_limit",
+          "lineno": 125,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_existing_element_governance.py",
+      "loc": 59,
+      "functions": [
+        {
+          "name": "test_existing_element_respects_governance",
+          "lineno": 12,
+          "complexity": 2
+        },
+        {
+          "name": "canvasx",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "find_object",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 57,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_active_phase_label.py",
+      "loc": 30,
+      "functions": [
+        {
+          "name": "test_active_phase_label_updates",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "config",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "set_active_module",
+          "lineno": 29,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_causal_bayesian_network_governance.py",
+      "loc": 16,
+      "functions": [
+        {
+          "name": "test_causal_bayesian_network_work_product",
+          "lineno": 14,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_ai_database_label.py",
+      "loc": 9,
+      "functions": [
+        {
+          "name": "test_ai_database_and_cylinder_icons",
+          "lineno": 6,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_clipboard_no_focus.py",
+      "loc": 65,
+      "functions": [
+        {
+          "name": "make_window",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_paste_without_active_window_uses_clipboard",
+          "lineno": 37,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "diagram_read_only",
+          "lineno": 17,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_phase_requirements_type_error.py",
+      "loc": 40,
+      "functions": [
+        {
+          "name": "test_generate_phase_requirements_non_string",
+          "lineno": 13,
+          "complexity": 5
+        },
+        {
+          "name": "display_stub",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "generate_requirements",
+          "lineno": 42,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_boundary_drag_move.py",
+      "loc": 63,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "_create_window",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "test_object_can_leave_boundary",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 21,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_tooltips.py",
+      "loc": 121,
+      "functions": [
+        {
+          "name": "_expected_text",
+          "lineno": 34,
+          "complexity": 14
+        },
+        {
+          "name": "test_governance_element_tooltips",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "test_tooltip_hides_during_drag",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "show",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "hide",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "hide",
+          "lineno": 142,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_diagram_visibility.py",
+      "loc": 31,
+      "functions": [
+        {
+          "name": "test_governance_elements_visible_all_phases",
+          "lineno": 12,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_trace_connections.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "test_link_trace_between_objects_creates_connection",
+          "lineno": 9,
+          "complexity": 10
+        }
+      ]
+    },
+    {
+      "file": "tests/test_actions.py",
+      "loc": 48,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "test_activity_actions",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_activity_actions_from_elements",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "test_call_behavior_action_names",
+          "lineno": 39,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_management_dedup.py",
+      "loc": 123,
+      "functions": [
+        {
+          "name": "test_safety_management_toolbox_single_instance",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "test_display_requirements_clears_existing",
+          "lineno": 74,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 90,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 94,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 99,
+          "complexity": 1
+        },
+        {
+          "name": "rowconfigure",
+          "lineno": 102,
+          "complexity": 1
+        },
+        {
+          "name": "columnconfigure",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 108,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 111,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 115,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 119,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 122,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 125,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 129,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 134,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 137,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 140,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 143,
+          "complexity": 1
+        },
+        {
+          "name": "xview",
+          "lineno": 146,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 149,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 152,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 155,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 158,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_diagram_draw.py",
+      "loc": 110,
+      "functions": [
+        {
+          "name": "_rect_for",
+          "lineno": 65,
+          "complexity": 3
+        },
+        {
+          "name": "test_draw_tags_and_zoom_scaling",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "test_draw_respects_context_links",
+          "lineno": 88,
+          "complexity": 1
+        },
+        {
+          "name": "test_solution_circle_expands_with_text",
+          "lineno": 110,
+          "complexity": 1
+        },
+        {
+          "name": "test_wrap_text_limits_line_width",
+          "lineno": 144,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 18,
+          "complexity": 3
+        },
+        {
+          "name": "tag_lower",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "tag_raise",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "draw_goal_shape",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "draw_solved_by_connection",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "draw_in_context_connection",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "point_on_shape",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "get_text_size",
+          "lineno": 58,
+          "complexity": 2
+        },
+        {
+          "name": "solved",
+          "lineno": 98,
+          "complexity": 1
+        },
+        {
+          "name": "ctx",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 133,
+          "complexity": 1
+        },
+        {
+          "name": "measure",
+          "lineno": 137,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 140,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 113,
+          "complexity": 1
+        },
+        {
+          "name": "measure",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 119,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_load_model_history.py",
+      "loc": 35,
+      "functions": [
+        {
+          "name": "_no_history_clear_v1",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "_no_history_clear_v2",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "_no_history_clear_v3",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "_no_history_clear_v4",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "_no_history_clear",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "test_load_model_preserves_history",
+          "lineno": 36,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirements_menu_activation.py",
+      "loc": 35,
+      "functions": [
+        {
+          "name": "test_requirement_menu_enabled_with_any_work_product",
+          "lineno": 22,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "enabled_products",
+          "lineno": 19,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_part_asil.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "measure",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "test_highest_asil",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_missing_asil_defaults_qm",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "test_part_asil_visible_without_dialog",
+          "lineno": 45,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_ai_relation_icons.py",
+      "loc": 18,
+      "functions": [
+        {
+          "name": "test_relation_icons_are_black",
+          "lineno": 14,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_management_double_click.py",
+      "loc": 111,
+      "functions": [
+        {
+          "name": "test_double_click_opens_diagram_with_phase",
+          "lineno": 9,
+          "complexity": 6
+        },
+        {
+          "name": "test_analysis_tree_double_click_opens_diagram",
+          "lineno": 63,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_tree_double_click_handles_extra_tags",
+          "lineno": 102,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 26,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 38,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 70,
+          "complexity": 1
+        },
+        {
+          "name": "focus",
+          "lineno": 77,
+          "complexity": 2
+        },
+        {
+          "name": "identify_row",
+          "lineno": 82,
+          "complexity": 1
+        },
+        {
+          "name": "item",
+          "lineno": 85,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 88,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 109,
+          "complexity": 1
+        },
+        {
+          "name": "focus",
+          "lineno": 124,
+          "complexity": 2
+        },
+        {
+          "name": "identify_row",
+          "lineno": 129,
+          "complexity": 1
+        },
+        {
+          "name": "item",
+          "lineno": 132,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 135,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_traceability.py",
+      "loc": 64,
+      "functions": [
+        {
+          "name": "_setup_toolbox_with_trace",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_trace_link_between_work_products_allows_traceability",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "test_requirement_link_respects_governance",
+          "lineno": 35,
+          "complexity": 2
+        },
+        {
+          "name": "test_requirement_and_element_update_after_unlink",
+          "lineno": 60,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirements_column_width.py",
+      "loc": 89,
+      "functions": [
+        {
+          "name": "test_display_requirements_column_widths",
+          "lineno": 11,
+          "complexity": 5
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "rowconfigure",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "columnconfigure",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 59,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 68,
+          "complexity": 2
+        },
+        {
+          "name": "set",
+          "lineno": 73,
+          "complexity": 2
+        },
+        {
+          "name": "configure",
+          "lineno": 78,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "xview",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 87,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 90,
+          "complexity": 2
+        },
+        {
+          "name": "delete",
+          "lineno": 93,
+          "complexity": 1
+        },
+        {
+          "name": "column",
+          "lineno": 96,
+          "complexity": 2
+        },
+        {
+          "name": "measure",
+          "lineno": 101,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_generalization_block_updates.py",
+      "loc": 52,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_block_change_propagates_to_children",
+          "lineno": 16,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cbn_new_doc_unique.py",
+      "loc": 18,
+      "functions": [
+        {
+          "name": "test_new_doc_rejects_duplicate_name",
+          "lineno": 9,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_ibd_part_sync.py",
+      "loc": 28,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_ibd_part_addition_updates_block_parts",
+          "lineno": 10,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_explorer_refresh.py",
+      "loc": 28,
+      "functions": [
+        {
+          "name": "test_new_diagram_refreshes_toolbox",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_diagrams",
+          "lineno": 19,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_window_focus.py",
+      "loc": 55,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 8,
+          "complexity": 3
+        },
+        {
+          "name": "setup_app",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_gsn_window_strategies",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "test_gsn_paste_uses_focused_window",
+          "lineno": 53,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_app_hotkey_task_lifecycle.py",
+      "loc": 95,
+      "functions": [
+        {
+          "name": "_make_app_repo",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_task_lifecycle_via_hotkeys",
+          "lineno": 30,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_shade.py",
+      "loc": 18,
+      "functions": [
+        {
+          "name": "test_capsule_button_has_background_shade",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_case_gsn_visibility.py",
+      "loc": 53,
+      "functions": [
+        {
+          "name": "_setup",
+          "lineno": 10,
+          "complexity": 2
+        },
+        {
+          "name": "test_gsn_diagram_visibility_for_safety_case",
+          "lineno": 48,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_connection_stereotype_label.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "test_association_label_stereotype",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_association_label_with_name",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "test_propagate_label_stereotype",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_governance_relationship_guard_label",
+          "lineno": 26,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_block_import_shared.py",
+      "loc": 42,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "test_imported_block_shares_element",
+          "lineno": 12,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_ai_requirement_type.py",
+      "loc": 91,
+      "functions": [
+        {
+          "name": "test_ai_elements_generate_ai_safety_requirements",
+          "lineno": 13,
+          "complexity": 3
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "rowconfigure",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "columnconfigure",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 67,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 74,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 86,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 89,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 92,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "xview",
+          "lineno": 98,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 104,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 107,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cross_diagram_clipboard.py",
+      "loc": 402,
+      "functions": [
+        {
+          "name": "make_window",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "make_gsn_window",
+          "lineno": 66,
+          "complexity": 3
+        },
+        {
+          "name": "test_copy_paste_between_same_type_diagrams",
+          "lineno": 108,
+          "complexity": 1
+        },
+        {
+          "name": "test_copy_paste_task_between_governance_diagrams",
+          "lineno": 151,
+          "complexity": 3
+        },
+        {
+          "name": "test_copy_paste_governance_with_selected_node",
+          "lineno": 224,
+          "complexity": 1
+        },
+        {
+          "name": "test_cut_paste_between_governance_diagrams",
+          "lineno": 269,
+          "complexity": 1
+        },
+        {
+          "name": "test_copy_paste_governance_replaces_node_clipboard",
+          "lineno": 313,
+          "complexity": 1
+        },
+        {
+          "name": "test_copy_paste_process_area_between_diagrams",
+          "lineno": 368,
+          "complexity": 1
+        },
+        {
+          "name": "test_copy_paste_between_gsn_diagrams",
+          "lineno": 411,
+          "complexity": 1
+        },
+        {
+          "name": "test_cut_paste_between_gsn_diagrams",
+          "lineno": 444,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "diagram_read_only",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "_stub_place_process_area",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 88,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 92,
+          "complexity": 2
+        },
+        {
+          "name": "select",
+          "lineno": 99,
+          "complexity": 2
+        },
+        {
+          "name": "nametowidget",
+          "lineno": 104,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_button_styles.py",
+      "loc": 45,
+      "functions": [
+        {
+          "name": "test_apply_purplish_button_style_configures_background",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "test_apply_translucid_button_style_sets_flat_relief",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_configure_table_style_uses_translucid",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "map",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "theme_use",
+          "lineno": 22,
+          "complexity": 2
+        },
+        {
+          "name": "fake_apply",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "theme_use",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "map",
+          "lineno": 51,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cbn_window_focus.py",
+      "loc": 70,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 12,
+          "complexity": 2
+        },
+        {
+          "name": "setup_app",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "test_cbn_window_strategies",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "test_cbn_paste_uses_focused_window",
+          "lineno": 68,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_user_data_threading.py",
+      "loc": 18,
+      "functions": [
+        {
+          "name": "test_load_user_data_parallel",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "fake_load_all_users",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "fake_load_user_config",
+          "lineno": 15,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_metrics_generator.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "test_collect_metrics_returns_data",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_cli_writes_metrics_and_plots",
+          "lineno": 18,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_core_actions.py",
+      "loc": 72,
+      "functions": [
+        {
+          "name": "test_governance_core_has_add_buttons",
+          "lineno": 11,
+          "complexity": 9
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 3
+        },
+        {
+          "name": "pack",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "pack_forget",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 30,
+          "complexity": 3
+        },
+        {
+          "name": "pack",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 43,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_shine.py",
+      "loc": 17,
+      "functions": [
+        {
+          "name": "test_capsule_button_has_diffused_circles_and_shade",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_tab_detach.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "test_tab_detach_and_reattach",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "test_tab_detach_without_motion",
+          "lineno": 48,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_dialog_instantiation.py",
+      "loc": 24,
+      "functions": [
+        {
+          "name": "_stub_init",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_req_dialog_instantiation",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "test_fmea_row_dialog_instantiation",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "test_select_base_event_dialog_instantiation",
+          "lineno": 30,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_solution_propagation.py",
+      "loc": 44,
+      "functions": [
+        {
+          "name": "_configure",
+          "lineno": 21,
+          "complexity": 6
+        },
+        {
+          "name": "test_updates_propagate_between_original_and_clones",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 17,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_phase_requirements_menu.py",
+      "loc": 110,
+      "functions": [
+        {
+          "name": "test_phase_requirements_menu",
+          "lineno": 13,
+          "complexity": 7
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "rowconfigure",
+          "lineno": 68,
+          "complexity": 1
+        },
+        {
+          "name": "columnconfigure",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 74,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 85,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 88,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 91,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 100,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 103,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 106,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 109,
+          "complexity": 1
+        },
+        {
+          "name": "xview",
+          "lineno": 112,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 115,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 118,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 121,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_case.py",
+      "loc": 494,
+      "functions": [
+        {
+          "name": "test_edit_probability_updates_spi",
+          "lineno": 112,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_case_shows_validation_target",
+          "lineno": 171,
+          "complexity": 1
+        },
+        {
+          "name": "test_pmfh_autopopulates_validation_target_and_probability",
+          "lineno": 210,
+          "complexity": 1
+        },
+        {
+          "name": "test_edit_probability_in_spi_explorer",
+          "lineno": 259,
+          "complexity": 1
+        },
+        {
+          "name": "test_spi_shows_pmhf_and_validation",
+          "lineno": 303,
+          "complexity": 2
+        },
+        {
+          "name": "test_pmhf_skips_sotif_probabilities",
+          "lineno": 337,
+          "complexity": 3
+        },
+        {
+          "name": "test_edit_notes_updates_node",
+          "lineno": 397,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_case_lists_and_toggles",
+          "lineno": 425,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_case_cancel_does_not_toggle",
+          "lineno": 459,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_case_edit_updates_table",
+          "lineno": 480,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_case_undo_redo_toggle",
+          "lineno": 517,
+          "complexity": 3
+        },
+        {
+          "name": "test_export_safety_case_writes_rows",
+          "lineno": 567,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 23,
+          "complexity": 2
+        },
+        {
+          "name": "heading",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "column",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 40,
+          "complexity": 2
+        },
+        {
+          "name": "get_children",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "identify_row",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "identify_column",
+          "lineno": 58,
+          "complexity": 1
+        },
+        {
+          "name": "item",
+          "lineno": 62,
+          "complexity": 3
+        },
+        {
+          "name": "set",
+          "lineno": 69,
+          "complexity": 2
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 75,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 78,
+          "complexity": 1
+        },
+        {
+          "name": "selection_set",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 86,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 89,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 94,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 97,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 102,
+          "complexity": 1
+        },
+        {
+          "name": "add_command",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "post",
+          "lineno": 108,
+          "complexity": 1
+        },
+        {
+          "name": "fake_prob",
+          "lineno": 368,
+          "complexity": 2
+        },
+        {
+          "name": "fake_config",
+          "lineno": 499,
+          "complexity": 1
+        },
+        {
+          "name": "export_model_data",
+          "lineno": 533,
+          "complexity": 2
+        },
+        {
+          "name": "apply_model_data",
+          "lineno": 539,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 158,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_scenario_description.py",
+      "loc": 69,
+      "functions": [
+        {
+          "name": "test_template_phrase_filters_and_single",
+          "lineno": 3,
+          "complexity": 1
+        },
+        {
+          "name": "test_template_phrase_no_params_word_when_none",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "test_template_phrase_filters_dict_strings",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "test_template_phrase_temporal_and_movable",
+          "lineno": 59,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_causal_bayesian_selection.py",
+      "loc": 84,
+      "functions": [
+        {
+          "name": "test_find_node_strategies_with_scroll",
+          "lineno": 6,
+          "complexity": 3
+        },
+        {
+          "name": "test_on_click_selects_node_and_drag_moves_only_clone",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "test_dragging_clone_moves_only_its_fill",
+          "lineno": 78,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "find_overlapping",
+          "lineno": 16,
+          "complexity": 3
+        },
+        {
+          "name": "find_closest",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "coords",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "move",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "coords",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "move",
+          "lineno": 82,
+          "complexity": 1
+        },
+        {
+          "name": "coords",
+          "lineno": 85,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_work_products.py",
+      "loc": 44,
+      "functions": [
+        {
+          "name": "_fmt",
+          "lineno": 9,
+          "complexity": 3
+        },
+        {
+          "name": "test_work_product_created_for_each_requirement_type",
+          "lineno": 15,
+          "complexity": 2
+        },
+        {
+          "name": "test_add_requirement_work_product",
+          "lineno": 21,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 48,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_control_flow_arrow.py",
+      "loc": 73,
+      "functions": [
+        {
+          "name": "reset_repo",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "test_arrow_up",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "test_arrow_up_offset",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "test_validate_connection_limits_offset",
+          "lineno": 64,
+          "complexity": 1
+        },
+        {
+          "name": "test_constrain_horizontal_movement",
+          "lineno": 75,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_phase_requirements_error.py",
+      "loc": 45,
+      "functions": [
+        {
+          "name": "test_generate_phase_requirements_handles_errors",
+          "lineno": 13,
+          "complexity": 5
+        },
+        {
+          "name": "display_stub",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "generate_requirements",
+          "lineno": 47,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_process_area_paste.py",
+      "loc": 112,
+      "functions": [
+        {
+          "name": "_setup_window",
+          "lineno": 27,
+          "complexity": 3
+        },
+        {
+          "name": "test_paste_work_product_creates_process_area",
+          "lineno": 54,
+          "complexity": 5
+        },
+        {
+          "name": "test_copy_process_area_includes_children",
+          "lineno": 73,
+          "complexity": 5
+        },
+        {
+          "name": "test_cut_process_area_includes_children",
+          "lineno": 90,
+          "complexity": 3
+        },
+        {
+          "name": "test_cross_diagram_paste_creates_process_area",
+          "lineno": 109,
+          "complexity": 3
+        },
+        {
+          "name": "measure",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 23,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_solution_link.py",
+      "loc": 222,
+      "functions": [
+        {
+          "name": "test_solution_config_sets_evidence_link",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "test_solution_config_sets_manager_notes",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "test_double_click_opens_evidence_link",
+          "lineno": 70,
+          "complexity": 1
+        },
+        {
+          "name": "test_double_click_opens_work_product",
+          "lineno": 104,
+          "complexity": 1
+        },
+        {
+          "name": "test_double_click_prompts_when_both",
+          "lineno": 136,
+          "complexity": 1
+        },
+        {
+          "name": "test_double_click_prompts_link_choice",
+          "lineno": 176,
+          "complexity": 1
+        },
+        {
+          "name": "test_double_click_uses_tool_action",
+          "lineno": 216,
+          "complexity": 1
+        },
+        {
+          "name": "test_double_click_falls_back_to_webbrowser",
+          "lineno": 248,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "fake_open",
+          "lineno": 73,
+          "complexity": 1
+        },
+        {
+          "name": "open_wp",
+          "lineno": 107,
+          "complexity": 1
+        },
+        {
+          "name": "open_wp",
+          "lineno": 144,
+          "complexity": 1
+        },
+        {
+          "name": "open_wp",
+          "lineno": 184,
+          "complexity": 1
+        },
+        {
+          "name": "action",
+          "lineno": 219,
+          "complexity": 1
+        },
+        {
+          "name": "fake_run",
+          "lineno": 251,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_listbox_class_event.py",
+      "loc": 42,
+      "functions": [
+        {
+          "name": "test_lb_on_motion_handles_widget_path",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "size",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "nearest",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "itemcget",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "cget",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "bind_class",
+          "lineno": 37,
+          "complexity": 2
+        },
+        {
+          "name": "nametowidget",
+          "lineno": 42,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_display_requirements_phase_column.py",
+      "loc": 76,
+      "functions": [
+        {
+          "name": "test_display_requirements_includes_phase",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "rowconfigure",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "columnconfigure",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 58,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 67,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 70,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 74,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "xview",
+          "lineno": 80,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 83,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 86,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 89,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_splash_launcher.py",
+      "loc": 8,
+      "functions": [
+        {
+          "name": "test_launcher_invokes_main",
+          "lineno": 6,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_phase_freezing.py",
+      "loc": 42,
+      "functions": [
+        {
+          "name": "_setup",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_freeze_after_work_product_blocks_changes",
+          "lineno": 22,
+          "complexity": 2
+        },
+        {
+          "name": "test_freeze_on_element_creation_blocks_changes",
+          "lineno": 38,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_diagram_lock.py",
+      "loc": 58,
+      "functions": [
+        {
+          "name": "test_frozen_governance_diagram_blocks_modifications",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 22,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_phase_visibility.py",
+      "loc": 127,
+      "functions": [
+        {
+          "name": "test_elements_follow_phase_visibility",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "test_diagram_objects_and_connections_follow_phase_visibility",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "test_diagram_window_respects_phase",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "test_on_lifecycle_selected_refreshes_diagrams",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "test_governance_diagram_refreshes_on_phase_change",
+          "lineno": 109,
+          "complexity": 2
+        },
+        {
+          "name": "refresh_from_repository",
+          "lineno": 91,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 98,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_paa_top_event_creation.py",
+      "loc": 24,
+      "functions": [
+        {
+          "name": "test_paa_diagram_has_top_event",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "fake_create_tab",
+          "lineno": 15,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_name_unique.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_names_include_type_when_conflict",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_repeated_name_does_not_duplicate",
+          "lineno": 18,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_undo_move_ignore_modified.py",
+      "loc": 24,
+      "functions": [
+        {
+          "name": "_prepare_repo",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_modified_fields_do_not_create_extra_states",
+          "lineno": 14,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_empty_fault_tree_load.py",
+      "loc": 52,
+      "functions": [
+        {
+          "name": "_minimal_app",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_apply_model_data_preserves_empty_fault_tree",
+          "lineno": 57,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cbn_fill_tag_strategies.py",
+      "loc": 13,
+      "functions": [
+        {
+          "name": "test_fill_tag_strategies_unique_and_ordered",
+          "lineno": 6,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_app_undo_overflow.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "test_undo_does_not_unload_project_when_stack_empty",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "_image_new",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "save",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "line",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "polygon",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "rectangle",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "multiline_textbbox",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "multiline_text",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "load_default",
+          "lineno": 42,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_role_develops_task_connection_rule.py",
+      "loc": 15,
+      "functions": [
+        {
+          "name": "test_role_develops_task_connection",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_work_product_process_area_containment.py",
+      "loc": 193,
+      "functions": [
+        {
+          "name": "test_work_product_clamped_to_process_area",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_work_product_existing_area_click",
+          "lineno": 42,
+          "complexity": 2
+        },
+        {
+          "name": "test_right_click_process_area_adds_work_product",
+          "lineno": 98,
+          "complexity": 2
+        },
+        {
+          "name": "test_process_area_drag_moves_work_product",
+          "lineno": 142,
+          "complexity": 1
+        },
+        {
+          "name": "test_process_area_multiple_drags_keep_work_product_offset",
+          "lineno": 192,
+          "complexity": 1
+        },
+        {
+          "name": "_select_process_area",
+          "lineno": 73,
+          "complexity": 1
+        },
+        {
+          "name": "_select_wp",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "_select_wp",
+          "lineno": 125,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 119,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 161,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 164,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 211,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 214,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_load_model_cleanup.py",
+      "loc": 61,
+      "functions": [
+        {
+          "name": "_minimal_app",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "test_reset_on_load_clears_state",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "test_load_model_invokes_reset",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "tabs",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "event_generate",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "forget",
+          "lineno": 25,
+          "complexity": 2
+        },
+        {
+          "name": "fake_create_tab",
+          "lineno": 45,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_boundary_size.py",
+      "loc": 18,
+      "functions": [
+        {
+          "name": "test_min_size_computes_extent",
+          "lineno": 5,
+          "complexity": 1
+        },
+        {
+          "name": "test_ensure_boundary_expands",
+          "lineno": 12,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirements_explorer_phase_filter.py",
+      "loc": 50,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "test_explorer_filters_by_active_phase",
+          "lineno": 47,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 29,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_pdf_template_export.py",
+      "loc": 146,
+      "functions": [
+        {
+          "name": "test_generate_pdf_report_exports_template",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "test_generate_pdf_report_handles_diagram_and_analysis",
+          "lineno": 82,
+          "complexity": 1
+        },
+        {
+          "name": "test_generate_pdf_report_handles_extended_placeholders",
+          "lineno": 113,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "build",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "setStyle",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 43,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_safety_management_process_area.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "test_safety_management_process_area_available",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 28,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_app_undo_task_multistep.py",
+      "loc": 91,
+      "functions": [
+        {
+          "name": "_make_app_repo",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_task_add_move_rename_resize_move_rename_undo_redo",
+          "lineno": 28,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cyber_risk_assessment.py",
+      "loc": 75,
+      "functions": [
+        {
+          "name": "test_computations",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_sync_to_goals",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "test_get_cyber_goal_cal",
+          "lineno": 53,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_name_uniqueness.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "test_unique_gsn_diagram_names",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_unique_cbn_doc_names",
+          "lineno": 27,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/dummy_module.py",
+      "loc": 3,
+      "functions": [
+        {
+          "name": "main",
+          "lineno": 3,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_work_product_enablement.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "test_governance_work_product_enablement",
+          "lineno": 24,
+          "complexity": 4
+        },
+        {
+          "name": "enable_work_product",
+          "lineno": 50,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 57,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_text_shadow.py",
+      "loc": 17,
+      "functions": [
+        {
+          "name": "test_capsule_button_renders_text_without_shadow",
+          "lineno": 11,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_launcher_threading.py",
+      "loc": 20,
+      "functions": [
+        {
+          "name": "test_ensure_packages_runs_in_parallel",
+          "lineno": 5,
+          "complexity": 1
+        },
+        {
+          "name": "fake_import_module",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "wait",
+          "lineno": 18,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_log_window_toggle.py",
+      "loc": 18,
+      "functions": [
+        {
+          "name": "test_toggle_log_area",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_phase_toggle.py",
+      "loc": 489,
+      "functions": [
+        {
+          "name": "test_open_governance_diagram_activates_phase",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "test_open_governance_diagram_refreshes_tools",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_process_area_lists_scenario",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "test_added_work_product_respects_phase",
+          "lineno": 119,
+          "complexity": 3
+        },
+        {
+          "name": "test_work_product_disables_when_leaving_phase",
+          "lineno": 237,
+          "complexity": 3
+        },
+        {
+          "name": "test_work_product_group_activation",
+          "lineno": 367,
+          "complexity": 7
+        },
+        {
+          "name": "test_open_diagram_updates_phase_combobox",
+          "lineno": 523,
+          "complexity": 1
+        },
+        {
+          "name": "test_select_document_updates_phase",
+          "lineno": 567,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "on_lifecycle_selected",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "on_lifecycle_selected",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_tool_enablement",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "capture_dialog",
+          "lineno": 108,
+          "complexity": 1
+        },
+        {
+          "name": "on_lifecycle_selected",
+          "lineno": 548,
+          "complexity": 1
+        },
+        {
+          "name": "on_lifecycle_selected",
+          "lineno": 589,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 75,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 78,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 145,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 149,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 152,
+          "complexity": 2
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 155,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 159,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 162,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 166,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 169,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 172,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 224,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 263,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 267,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 270,
+          "complexity": 2
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 273,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 277,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 280,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 284,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 287,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 290,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 342,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 382,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 386,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 389,
+          "complexity": 2
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 392,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 400,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 403,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 407,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 410,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 413,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 502,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 533,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 536,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 539,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 574,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 577,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 580,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_search_toolbox.py",
+      "loc": 115,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "select_clear",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "selection_set",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "activate",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "see",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "curselection",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes_in_model",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_fmea_entries",
+          "lineno": 56,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_connections",
+          "lineno": 59,
+          "complexity": 1
+        },
+        {
+          "name": "_make_tb",
+          "lineno": 64,
+          "complexity": 1
+        },
+        {
+          "name": "test_notifies_on_no_results",
+          "lineno": 83,
+          "complexity": 2
+        },
+        {
+          "name": "test_search_hazards",
+          "lineno": 92,
+          "complexity": 1
+        },
+        {
+          "name": "test_search_faults",
+          "lineno": 102,
+          "complexity": 1
+        },
+        {
+          "name": "test_search_connection_guard",
+          "lineno": 112,
+          "complexity": 1
+        },
+        {
+          "name": "test_search_extra_category",
+          "lineno": 132,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 114,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 120,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_connections",
+          "lineno": 123,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 134,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_sysml_elements",
+          "lineno": 138,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_repository.py",
+      "loc": 245,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_create_elements",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "test_create_relationship",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "test_default_element_names",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "test_author_metadata",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "test_serialize",
+          "lineno": 50,
+          "complexity": 1
+        },
+        {
+          "name": "test_sysml_properties_port",
+          "lineno": 56,
+          "complexity": 1
+        },
+        {
+          "name": "test_action_usage_property_removed",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "test_packages_and_save_load",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "test_diagram_creation_and_persistence",
+          "lineno": 83,
+          "complexity": 1
+        },
+        {
+          "name": "test_element_diagram_linking",
+          "lineno": 96,
+          "complexity": 1
+        },
+        {
+          "name": "test_diagram_package",
+          "lineno": 110,
+          "complexity": 1
+        },
+        {
+          "name": "test_delete_package_reassign",
+          "lineno": 122,
+          "complexity": 1
+        },
+        {
+          "name": "test_diagram_object_persistence",
+          "lineno": 131,
+          "complexity": 1
+        },
+        {
+          "name": "test_object_requirements_persistence",
+          "lineno": 157,
+          "complexity": 1
+        },
+        {
+          "name": "test_find_requirements",
+          "lineno": 183,
+          "complexity": 1
+        },
+        {
+          "name": "test_connection_persistence",
+          "lineno": 204,
+          "complexity": 1
+        },
+        {
+          "name": "test_unique_diagram_names",
+          "lineno": 227,
+          "complexity": 1
+        },
+        {
+          "name": "test_unique_element_names",
+          "lineno": 232,
+          "complexity": 1
+        },
+        {
+          "name": "test_to_from_dict",
+          "lineno": 237,
+          "complexity": 1
+        },
+        {
+          "name": "test_save_load_consistency",
+          "lineno": 248,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_copy_paste_selection.py",
+      "loc": 61,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "item",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "test_copy_uses_tree_selection_when_no_selected_node",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "test_cut_uses_tree_selection_when_no_selected_node",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "test_copy_prefers_tree_selection_over_root",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "test_cut_prefers_tree_selection_over_root",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "test_paste_warns_when_clipboard_empty_first",
+          "lineno": 63,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_horizontal_connection.py",
+      "loc": 58,
+      "functions": [
+        {
+          "name": "test_horizontal_connection_uses_side_and_arrow_points_right",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 16,
+          "complexity": 2
+        },
+        {
+          "name": "create_line",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "tag_lower",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "tag_raise",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "draw_goal_shape",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_arrow",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "draw_solved_by_connection",
+          "lineno": 64,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_edit_risk_assessment.py",
+      "loc": 37,
+      "functions": [
+        {
+          "name": "test_edit_doc_updates_selections",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 35,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_validation_target.py",
+      "loc": 41,
+      "functions": [
+        {
+          "name": "test_derive_validation_target_example",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_invalid_probabilities",
+          "lineno": 17,
+          "complexity": 2
+        },
+        {
+          "name": "test_wrapper",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_fault_tree_node_update",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "test_probability_mappings",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_serialization_of_operational_hours_and_profile",
+          "lineno": 39,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_app_undo_move_creation.py",
+      "loc": 44,
+      "functions": [
+        {
+          "name": "_make_app_repo",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_move_undo_restores_creation_position",
+          "lineno": 27,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_decision_connection_corners.py",
+      "loc": 65,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "test_unique_corners_and_limit",
+          "lineno": 38,
+          "complexity": 3
+        },
+        {
+          "name": "test_bidirectional_connections_use_opposite_corners",
+          "lineno": 63,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_phase_requirements_main_menu.py",
+      "loc": 93,
+      "functions": [
+        {
+          "name": "test_phase_requirements_menu_populated",
+          "lineno": 18,
+          "complexity": 9
+        },
+        {
+          "name": "test_generate_phase_requirements_delegates",
+          "lineno": 67,
+          "complexity": 1
+        },
+        {
+          "name": "test_generate_lifecycle_requirements_delegates",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "test_apply_model_data_refreshes_phase_menu",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "fake_generate_phase",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "fake_generate_lifecycle",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "fake_open",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "fake_open",
+          "lineno": 88,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "add_command",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "add_separator",
+          "lineno": 45,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_clone_cross_diagram_sync.py",
+      "loc": 37,
+      "functions": [
+        {
+          "name": "_configure",
+          "lineno": 20,
+          "complexity": 4
+        },
+        {
+          "name": "test_clone_sync_on_tab_focus",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 16,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_confusion_matrix.py",
+      "loc": 60,
+      "functions": [
+        {
+          "name": "test_compute_metrics_basic",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_compute_metrics_zero_division",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "test_compute_rates_basic",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "test_compute_rates_auto_counts",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "test_compute_rates_zero_hours",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "test_compute_metrics_from_target",
+          "lineno": 63,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_role_system_boundary_connection_rule.py",
+      "loc": 11,
+      "functions": [
+        {
+          "name": "test_role_responsible_for_system_boundary_connection",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_validation_consistency_init.py",
+      "loc": 12,
+      "functions": [
+        {
+          "name": "test_automl_core_initialises_validation_consistency",
+          "lineno": 5,
+          "complexity": 10
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_glow_outline.py",
+      "loc": 53,
+      "functions": [
+        {
+          "name": "test_glow_edges_only",
+          "lineno": 11,
+          "complexity": 3
+        },
+        {
+          "name": "test_glow_matches_button_width",
+          "lineno": 25,
+          "complexity": 2
+        },
+        {
+          "name": "test_glow_bottom_highlight",
+          "lineno": 42,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_management_persistence.py",
+      "loc": 177,
+      "functions": [
+        {
+          "name": "_minimal_app",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_management_roundtrip_serialisation",
+          "lineno": 73,
+          "complexity": 2
+        },
+        {
+          "name": "test_apply_model_enables_governed_work_products",
+          "lineno": 96,
+          "complexity": 1
+        },
+        {
+          "name": "test_apply_model_enables_multiple_work_products",
+          "lineno": 112,
+          "complexity": 1
+        },
+        {
+          "name": "test_apply_model_without_governance_disables_work_products",
+          "lineno": 136,
+          "complexity": 2
+        },
+        {
+          "name": "test_work_product_phase_roundtrip",
+          "lineno": 151,
+          "complexity": 1
+        },
+        {
+          "name": "test_enabled_work_products_roundtrip",
+          "lineno": 169,
+          "complexity": 1
+        },
+        {
+          "name": "test_only_active_phase_work_products_enabled_on_load",
+          "lineno": 177,
+          "complexity": 1
+        },
+        {
+          "name": "record_enable",
+          "lineno": 99,
+          "complexity": 1
+        },
+        {
+          "name": "record_enable",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "enable_wp",
+          "lineno": 197,
+          "complexity": 1
+        },
+        {
+          "name": "disable_wp",
+          "lineno": 200,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_stpa_combobox.py",
+      "loc": 123,
+      "functions": [
+        {
+          "name": "test_row_dialog_populates_control_actions",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_row_dialog_control_action_tooltip",
+          "lineno": 86,
+          "complexity": 1
+        },
+        {
+          "name": "combo_stub",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "combo_stub",
+          "lineno": 125,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 99,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 102,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 108,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 111,
+          "complexity": 1
+        },
+        {
+          "name": "after",
+          "lineno": 114,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 118,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 133,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 148,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 151,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 154,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_decision_connection_limit.py",
+      "loc": 35,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "get_object",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 19,
+          "complexity": 2
+        },
+        {
+          "name": "test_unique_corners_and_limit",
+          "lineno": 30,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_actions.py",
+      "loc": 54,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_drop_creates_action",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "test_toolbox_creates_action",
+          "lineno": 27,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_load_model_save_prompt.py",
+      "loc": 40,
+      "functions": [
+        {
+          "name": "test_load_model_cancel",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "test_load_model_no_save",
+          "lineno": 34,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_traceability.py",
+      "loc": 29,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_find_requirement_traces_returns_diagram_objects",
+          "lineno": 15,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_relations.py",
+      "loc": 63,
+      "functions": [
+        {
+          "name": "setup_toolbox",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_requirement_spec_cannot_trace",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "test_requirement_relation_governance",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "test_link_requirements_creates_bidirectional_relation",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "test_link_requirements_respects_governance",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "test_non_requirement_work_product_ignored",
+          "lineno": 60,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cbn_cross_diagram_sync.py",
+      "loc": 66,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "test_cross_diagram_clone_keeps_data_in_sync",
+          "lineno": 23,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_report_template_toolbox.py",
+      "loc": 223,
+      "functions": [
+        {
+          "name": "test_report_template_toolbox_single_instance",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "test_validate_report_template_with_elements",
+          "lineno": 70,
+          "complexity": 1
+        },
+        {
+          "name": "test_validate_report_template_unknown_element",
+          "lineno": 78,
+          "complexity": 2
+        },
+        {
+          "name": "test_validate_report_template_ignores_html_tags",
+          "lineno": 87,
+          "complexity": 1
+        },
+        {
+          "name": "test_layout_report_template_basic",
+          "lineno": 101,
+          "complexity": 4
+        },
+        {
+          "name": "test_layout_report_template_ignores_html_tags",
+          "lineno": 112,
+          "complexity": 2
+        },
+        {
+          "name": "test_validate_report_template_allows_analysis_types",
+          "lineno": 124,
+          "complexity": 1
+        },
+        {
+          "name": "test_layout_report_template_fta_placeholder",
+          "lineno": 140,
+          "complexity": 3
+        },
+        {
+          "name": "test_validate_report_template_requirement_elements",
+          "lineno": 149,
+          "complexity": 1
+        },
+        {
+          "name": "test_report_template_editor_add_delete_sections",
+          "lineno": 157,
+          "complexity": 5
+        },
+        {
+          "name": "test_validate_report_template_allows_images_and_links",
+          "lineno": 208,
+          "complexity": 1
+        },
+        {
+          "name": "test_layout_report_template_handles_images_and_links",
+          "lineno": 221,
+          "complexity": 3
+        },
+        {
+          "name": "test_layout_report_template_supports_diagram_and_analysis_types",
+          "lineno": 236,
+          "complexity": 3
+        },
+        {
+          "name": "test_layout_report_template_supports_additional_diagram_types",
+          "lineno": 246,
+          "complexity": 2
+        },
+        {
+          "name": "test_validate_report_template_allows_new_elements",
+          "lineno": 264,
+          "complexity": 1
+        },
+        {
+          "name": "fake_init",
+          "lineno": 194,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 58,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 164,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 170,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 174,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 177,
+          "complexity": 3
+        },
+        {
+          "name": "get_children",
+          "lineno": 183,
+          "complexity": 2
+        },
+        {
+          "name": "selection_set",
+          "lineno": 186,
+          "complexity": 1
+        },
+        {
+          "name": "focus",
+          "lineno": 189,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_review_timer.py",
+      "loc": 39,
+      "functions": [
+        {
+          "name": "test_mark_done_records_time",
+          "lineno": 8,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "update_hara_statuses",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "review_is_closed",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "find_node_by_id_all",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "focus_on_node",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "get_review_targets",
+          "lineno": 35,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_operations.py",
+      "loc": 28,
+      "functions": [
+        {
+          "name": "test_parse_json",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_parse_comma",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_json_round_trip",
+          "lineno": 26,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_selection.py",
+      "loc": 62,
+      "functions": [
+        {
+          "name": "test_gsn_find_node_strategies",
+          "lineno": 6,
+          "complexity": 4
+        },
+        {
+          "name": "test_gsn_find_node_strategies_far_click",
+          "lineno": 47,
+          "complexity": 2
+        },
+        {
+          "name": "canvasx",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "find_overlapping",
+          "lineno": 16,
+          "complexity": 3
+        },
+        {
+          "name": "find_closest",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 24,
+          "complexity": 2
+        },
+        {
+          "name": "gettags",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "find_overlapping",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "find_closest",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 63,
+          "complexity": 2
+        },
+        {
+          "name": "gettags",
+          "lineno": 68,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_app_hotkey_undo_redo.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "bind_all",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "event_generate",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_ctrl_z_y_trigger_actions",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "undo",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "redo",
+          "lineno": 27,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_block_port_propagation.py",
+      "loc": 44,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_port_propagates_to_parts",
+          "lineno": 13,
+          "complexity": 4
+        },
+        {
+          "name": "test_remove_port_propagates_to_parts",
+          "lineno": 30,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_metrics_tab_missing_backend.py",
+      "loc": 18,
+      "functions": [
+        {
+          "name": "test_open_metrics_tab_without_matplotlib",
+          "lineno": 8,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_connection_rule_enforcement.py",
+      "loc": 37,
+      "functions": [
+        {
+          "name": "test_connection_rules_enforced_on_reload",
+          "lineno": 11,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_unique_phase_names.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "test_add_module_enforces_unique_names",
+          "lineno": 4,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_report_template_manager.py",
+      "loc": 135,
+      "functions": [
+        {
+          "name": "test_report_template_manager_lists_templates",
+          "lineno": 35,
+          "complexity": 2
+        },
+        {
+          "name": "test_report_template_manager_add_delete",
+          "lineno": 62,
+          "complexity": 2
+        },
+        {
+          "name": "test_report_template_manager_load",
+          "lineno": 82,
+          "complexity": 2
+        },
+        {
+          "name": "test_report_template_manager_edit_uses_editor",
+          "lineno": 104,
+          "complexity": 3
+        },
+        {
+          "name": "test_report_template_manager_meipass_default",
+          "lineno": 155,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "size",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "curselection",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "selection_set",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 111,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 114,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 118,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 122,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 131,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 135,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_sync_notes.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "test_sync_notes_and_description",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "test_original_syncs_clone_when_model_missing",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "all_nodes",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "all_nodes_in_model",
+          "lineno": 32,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_multiplicity_placeholder.py",
+      "loc": 49,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "redraw",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "_sync_to_repository",
+          "lineno": 17,
+          "complexity": 2
+        },
+        {
+          "name": "setUp",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "test_placeholder_listed_and_creates_part",
+          "lineno": 26,
+          "complexity": 7
+        },
+        {
+          "name": "__init__",
+          "lineno": 43,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_toolbox_no_fork_join.py",
+      "loc": 43,
+      "functions": [
+        {
+          "name": "test_governance_toolbox_excludes_fork_and_join",
+          "lineno": 12,
+          "complexity": 2
+        },
+        {
+          "name": "fake_sysml_init",
+          "lineno": 36,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "pack_forget",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 33,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_trace_relationship.py",
+      "loc": 288,
+      "functions": [
+        {
+          "name": "canvasx",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "tearDown",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "_create_window",
+          "lineno": 33,
+          "complexity": 2
+        },
+        {
+          "name": "test_trace_relationship_creates_bidirectional_link",
+          "lineno": 56,
+          "complexity": 2
+        },
+        {
+          "name": "test_trace_between_requirements_disallowed",
+          "lineno": 92,
+          "complexity": 1
+        },
+        {
+          "name": "test_trace_between_safety_analyses_disallowed",
+          "lineno": 123,
+          "complexity": 1
+        },
+        {
+          "name": "test_used_between_dependent_analyses_allowed",
+          "lineno": 151,
+          "complexity": 1
+        },
+        {
+          "name": "test_used_between_safety_analyses_requires_dependency",
+          "lineno": 178,
+          "complexity": 1
+        },
+        {
+          "name": "test_used_allows_odd_to_scenario_library",
+          "lineno": 218,
+          "complexity": 2
+        },
+        {
+          "name": "test_used_allows_scenario_library_to_hazop",
+          "lineno": 248,
+          "complexity": 2
+        },
+        {
+          "name": "test_used_disallows_scenario_library_to_odd",
+          "lineno": 278,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_partproperty_visibility.py",
+      "loc": 41,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_partproperty_hidden_by_default",
+          "lineno": 10,
+          "complexity": 3
+        },
+        {
+          "name": "test_partproperty_default_size",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "test_partproperty_visible_flag",
+          "lineno": 34,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_log_window_default_height.py",
+      "loc": 36,
+      "functions": [
+        {
+          "name": "test_log_window_uses_default_height_for_messages",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "test_log_window_default_height_with_pinned_explorer",
+          "lineno": 32,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirements_matrix_enablement.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "test_matrix_menu_enabled_with_work_product",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 16,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_persistence.py",
+      "loc": 77,
+      "functions": [
+        {
+          "name": "_minimal_app",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_gsn_roundtrip_serialisation",
+          "lineno": 63,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_no_select_button.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "test_governance_diagram_has_no_select_button",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "fake_sysml_init",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 15,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_process_area_resize.py",
+      "loc": 67,
+      "functions": [
+        {
+          "name": "_setup_window",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "test_process_area_resize_clamped_to_children",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "test_process_area_resize_respects_text_size",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "measure",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 22,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_causal_bayesian_ui.py",
+      "loc": 469,
+      "functions": [
+        {
+          "name": "_setup_window",
+          "lineno": 137,
+          "complexity": 6
+        },
+        {
+          "name": "_setup_window_real",
+          "lineno": 196,
+          "complexity": 1
+        },
+        {
+          "name": "test_fill_moves_with_node",
+          "lineno": 223,
+          "complexity": 1
+        },
+        {
+          "name": "test_fill_tag_sanitizes_name",
+          "lineno": 235,
+          "complexity": 2
+        },
+        {
+          "name": "test_node_selectable_from_fill_area",
+          "lineno": 250,
+          "complexity": 1
+        },
+        {
+          "name": "test_table_resizes_for_new_rows",
+          "lineno": 273,
+          "complexity": 1
+        },
+        {
+          "name": "test_table_auto_fills_missing_rows",
+          "lineno": 296,
+          "complexity": 2
+        },
+        {
+          "name": "test_node_colors_by_type",
+          "lineno": 313,
+          "complexity": 1
+        },
+        {
+          "name": "test_node_label_includes_stereotype",
+          "lineno": 329,
+          "complexity": 1
+        },
+        {
+          "name": "test_click_adds_existing_malfunction_nodes",
+          "lineno": 338,
+          "complexity": 3
+        },
+        {
+          "name": "test_click_adds_existing_triggering_condition_nodes",
+          "lineno": 350,
+          "complexity": 3
+        },
+        {
+          "name": "test_click_adds_existing_functional_insufficiency_nodes",
+          "lineno": 363,
+          "complexity": 3
+        },
+        {
+          "name": "test_update_all_tables_refreshes_dependencies",
+          "lineno": 376,
+          "complexity": 1
+        },
+        {
+          "name": "test_drag_relationship_creates_edge",
+          "lineno": 398,
+          "complexity": 1
+        },
+        {
+          "name": "test_disallow_insufficiency_to_trigger_relationship",
+          "lineno": 414,
+          "complexity": 2
+        },
+        {
+          "name": "test_disallow_malfunction_relationship",
+          "lineno": 436,
+          "complexity": 2
+        },
+        {
+          "name": "test_add_node_returns_to_select",
+          "lineno": 458,
+          "complexity": 2
+        },
+        {
+          "name": "test_joint_probabilities_refresh_on_parent_change",
+          "lineno": 473,
+          "complexity": 1
+        },
+        {
+          "name": "test_node_tool_cursor_and_reset",
+          "lineno": 493,
+          "complexity": 2
+        },
+        {
+          "name": "test_relationship_cursor_and_reset",
+          "lineno": 515,
+          "complexity": 2
+        },
+        {
+          "name": "test_delete_node_from_diagram_only",
+          "lineno": 537,
+          "complexity": 2
+        },
+        {
+          "name": "test_delete_node_from_model",
+          "lineno": 556,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 50,
+          "complexity": 2
+        },
+        {
+          "name": "coords",
+          "lineno": 56,
+          "complexity": 4
+        },
+        {
+          "name": "move",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "itemconfigure",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "update_idletasks",
+          "lineno": 70,
+          "complexity": 1
+        },
+        {
+          "name": "create_window",
+          "lineno": 73,
+          "complexity": 1
+        },
+        {
+          "name": "find_overlapping",
+          "lineno": 79,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 88,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 91,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 94,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 98,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 102,
+          "complexity": 1
+        },
+        {
+          "name": "column",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 108,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 111,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "update_idletasks",
+          "lineno": 120,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_reqwidth",
+          "lineno": 123,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_reqheight",
+          "lineno": 126,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 129,
+          "complexity": 1
+        },
+        {
+          "name": "capture",
+          "lineno": 256,
+          "complexity": 1
+        },
+        {
+          "name": "capture",
+          "lineno": 317,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 159,
+          "complexity": 1
+        },
+        {
+          "name": "add_node",
+          "lineno": 164,
+          "complexity": 1
+        },
+        {
+          "name": "cpd_rows",
+          "lineno": 168,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 499,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 502,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 521,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 524,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_explorer.py",
+      "loc": 544,
+      "functions": [
+        {
+          "name": "test_gsn_explorer_has_root_item",
+          "lineno": 11,
+          "complexity": 3
+        },
+        {
+          "name": "test_gsn_explorer_populates_modules_and_diagrams",
+          "lineno": 55,
+          "complexity": 4
+        },
+        {
+          "name": "test_orphan_nodes_displayed_in_explorer",
+          "lineno": 102,
+          "complexity": 4
+        },
+        {
+          "name": "test_new_diagram_only_in_module",
+          "lineno": 148,
+          "complexity": 5
+        },
+        {
+          "name": "test_new_diagram_rejects_duplicate_name",
+          "lineno": 199,
+          "complexity": 5
+        },
+        {
+          "name": "test_rename_diagram_makes_name_unique",
+          "lineno": 253,
+          "complexity": 6
+        },
+        {
+          "name": "test_open_item_delegates_to_app",
+          "lineno": 304,
+          "complexity": 5
+        },
+        {
+          "name": "test_rename_node",
+          "lineno": 357,
+          "complexity": 5
+        },
+        {
+          "name": "_setup_dummy_tree",
+          "lineno": 412,
+          "complexity": 3
+        },
+        {
+          "name": "test_rename_module_disallowed",
+          "lineno": 440,
+          "complexity": 3
+        },
+        {
+          "name": "test_rename_module_node_disallowed",
+          "lineno": 460,
+          "complexity": 3
+        },
+        {
+          "name": "test_delete_node",
+          "lineno": 484,
+          "complexity": 5
+        },
+        {
+          "name": "test_delete_item_without_parent_diagram",
+          "lineno": 538,
+          "complexity": 5
+        },
+        {
+          "name": "test_drag_diagram_into_module",
+          "lineno": 591,
+          "complexity": 6
+        },
+        {
+          "name": "test_drag_diagram_to_root",
+          "lineno": 651,
+          "complexity": 5
+        },
+        {
+          "name": "test_gsn_explorer_binds_undo_redo",
+          "lineno": 709,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 23,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 35,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 64,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 72,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 75,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 84,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 111,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 119,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 122,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 128,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 131,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 153,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 158,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 161,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 164,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 170,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 173,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 206,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 211,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 214,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 217,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 223,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 226,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 259,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 264,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 267,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 270,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 276,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 279,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 311,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 316,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 319,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 322,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 328,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 331,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 367,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 372,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 375,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 378,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 384,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 387,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 414,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 419,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 422,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 425,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 431,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 434,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 494,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 499,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 502,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 505,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 511,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 514,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 547,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 552,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 555,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 558,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 564,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 567,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 599,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 605,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 608,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 611,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 617,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 620,
+          "complexity": 2
+        },
+        {
+          "name": "identify_row",
+          "lineno": 623,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 660,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 666,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 669,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 672,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 678,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 681,
+          "complexity": 2
+        },
+        {
+          "name": "identify_row",
+          "lineno": 684,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_reporting_export_import.py",
+      "loc": 11,
+      "functions": [
+        {
+          "name": "test_automl_core_imports_reporting_export",
+          "lineno": 5,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_clone_movement.py",
+      "loc": 71,
+      "functions": [
+        {
+          "name": "test_moving_gsn_clone_preserves_original_position",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_moving_gsn_original_preserves_clone_position",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "test_moving_parent_with_clone_child_keeps_clone_static",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_fmea",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_fmea",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes",
+          "lineno": 76,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_fmea",
           "lineno": 79,
           "complexity": 1
         }
       ]
     },
     {
-      "file": "mainappsrc/core/probability_reliability.py",
-      "loc": 329,
+      "file": "tests/test_stpa_control_actions.py",
+      "loc": 109,
+      "functions": [
+        {
+          "name": "test_get_control_actions_returns_only_control_action_connections",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_get_control_actions_from_relationship_stereotype",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "test_diagram_lookup_prefers_control_flow_diagrams",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "test_get_control_actions_ignores_non_cfd_diagrams",
+          "lineno": 118,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 97,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 109,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_diagram_window.py",
+      "loc": 387,
+      "functions": [
+        {
+          "name": "test_gsn_diagram_window_button_labels",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_zoom_methods_adjust_factor",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "test_temp_connection_line_is_dotted",
+          "lineno": 32,
+          "complexity": 2
+        },
+        {
+          "name": "test_temp_connection_line_has_arrow_in_context_mode",
+          "lineno": 61,
+          "complexity": 2
+        },
+        {
+          "name": "test_on_release_creates_context_link",
+          "lineno": 90,
+          "complexity": 2
+        },
+        {
+          "name": "test_solved_by_cursor_and_reset",
+          "lineno": 128,
+          "complexity": 2
+        },
+        {
+          "name": "test_on_release_uses_raw_coords_for_connection",
+          "lineno": 173,
+          "complexity": 4
+        },
+        {
+          "name": "test_refresh_updates_scrollregion",
+          "lineno": 216,
+          "complexity": 1
+        },
+        {
+          "name": "test_click_and_drag_uses_canvas_coordinates",
+          "lineno": 253,
+          "complexity": 5
+        },
+        {
+          "name": "test_add_module_uses_existing_modules",
+          "lineno": 310,
+          "complexity": 2
+        },
+        {
+          "name": "test_right_click_node_shows_menu",
+          "lineno": 328,
+          "complexity": 1
+        },
+        {
+          "name": "test_right_click_connection_shows_menu",
+          "lineno": 369,
+          "complexity": 1
+        },
+        {
+          "name": "test_refresh_sets_app_for_spi_lookup",
+          "lineno": 415,
+          "complexity": 1
+        },
+        {
+          "name": "test_export_csv_writes_nodes",
+          "lineno": 464,
+          "complexity": 2
+        },
+        {
+          "name": "test_gsn_diagram_window_binds_undo_redo",
+          "lineno": 482,
+          "complexity": 2
+        },
+        {
+          "name": "node_at",
+          "lineno": 199,
+          "complexity": 2
+        },
+        {
+          "name": "draw",
+          "lineno": 441,
+          "complexity": 1
+        },
+        {
+          "name": "fake_bind",
+          "lineno": 486,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 74,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 80,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 98,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 104,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 107,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 110,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 136,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 139,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 142,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 145,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 148,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 181,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 184,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 187,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 190,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 193,
+          "complexity": 2
+        },
+        {
+          "name": "_traverse",
+          "lineno": 223,
+          "complexity": 1
+        },
+        {
+          "name": "draw",
+          "lineno": 226,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 232,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 235,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 238,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 241,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 244,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 262,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 266,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 269,
+          "complexity": 1
+        },
+        {
+          "name": "find_overlapping",
+          "lineno": 272,
+          "complexity": 3
+        },
+        {
+          "name": "find_closest",
+          "lineno": 277,
+          "complexity": 1
+        },
+        {
+          "name": "gettags",
+          "lineno": 280,
+          "complexity": 2
+        },
+        {
+          "name": "delete",
+          "lineno": 283,
+          "complexity": 1
+        },
+        {
+          "name": "after",
+          "lineno": 286,
+          "complexity": 1
+        },
+        {
+          "name": "after_cancel",
+          "lineno": 289,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 292,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 295,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 319,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 348,
+          "complexity": 1
+        },
+        {
+          "name": "add_command",
+          "lineno": 352,
+          "complexity": 1
+        },
+        {
+          "name": "tk_popup",
+          "lineno": 355,
+          "complexity": 1
+        },
+        {
+          "name": "grab_release",
+          "lineno": 358,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 394,
+          "complexity": 1
+        },
+        {
+          "name": "add_command",
+          "lineno": 398,
+          "complexity": 1
+        },
+        {
+          "name": "tk_popup",
+          "lineno": 401,
+          "complexity": 1
+        },
+        {
+          "name": "grab_release",
+          "lineno": 404,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 424,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 448,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 451,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 454,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_name_enforcement.py",
+      "loc": 30,
+      "functions": [
+        {
+          "name": "test_gsn_new_diagram_duplicate_name",
+          "lineno": 8,
+          "complexity": 3
+        },
+        {
+          "name": "test_cbn_new_doc_duplicate_name",
+          "lineno": 23,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirements_explorer_enablement.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "test_explorer_menu_enabled_with_work_product",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 16,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_mode_enforcement.py",
+      "loc": 116,
+      "functions": [
+        {
+          "name": "_make_page_diagram",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "test_context_menu_cta",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "test_context_menu_fta",
+          "lineno": 83,
+          "complexity": 1
+        },
+        {
+          "name": "test_top_level_menu_gating",
+          "lineno": 95,
+          "complexity": 5
+        },
+        {
+          "name": "test_invalid_node_addition",
+          "lineno": 135,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "add_command",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "add_separator",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "tk_popup",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 41,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 52,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 58,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 99,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 102,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_fta_clone_paste.py",
+      "loc": 125,
+      "functions": [
+        {
+          "name": "_make_app_with_nodes",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "test_fta_copy_paste_creates_clone",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "test_fta_copy_paste_clone_across_module",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "test_fta_clone_draws_original_shape",
+          "lineno": 122,
+          "complexity": 1
+        },
+        {
+          "name": "measure",
+          "lineno": 98,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 106,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 109,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 112,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 115,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 118,
+          "complexity": 1
+        },
+        {
+          "name": "fake_or_clone",
+          "lineno": 146,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_clone_reject.py",
+      "loc": 35,
+      "functions": [
+        {
+          "name": "test_clone_rejects_unsupported_types",
+          "lineno": 13,
+          "complexity": 3
+        },
+        {
+          "name": "test_paste_rejects_disallowed_clone",
+          "lineno": 22,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_add_blocks.py",
+      "loc": 49,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "_sync_to_repository",
+          "lineno": 17,
+          "complexity": 2
+        },
+        {
+          "name": "redraw",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "ensure_text_fits",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_block_from_other_diagram",
+          "lineno": 32,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 48,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_icon_builder.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "test_all_strategies",
+          "lineno": 9,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_flow_guard.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_guard_label_with_operators",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "test_guard_used_in_generation",
+          "lineno": 21,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_relationship_label.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "test_label_relationship_between_database_nodes",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_product_goal_requirement_menu.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "test_product_goal_enables_requirement_menu",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "enabled_products",
+          "lineno": 18,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_clone_paste.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "test_copy_paste_creates_clone",
+          "lineno": 7,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_remove_partproperty.py",
+      "loc": 38,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_remove_partproperty_updates_child_ibds",
+          "lineno": 14,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_connection_edit.py",
+      "loc": 88,
+      "functions": [
+        {
+          "name": "test_connection_tags_and_arrow_fill",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "test_move_connection_updates_links",
+          "lineno": 67,
+          "complexity": 1
+        },
+        {
+          "name": "test_move_connection_cancelled_on_empty_drop",
+          "lineno": 85,
+          "complexity": 1
+        },
+        {
+          "name": "test_delete_connection_removes_links",
+          "lineno": 100,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "find_withtag",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "itemconfigure",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "find_overlapping",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "gettags",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "tag_lower",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "tag_raise",
+          "lineno": 50,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_input_block_addition.py",
+      "loc": 20,
+      "functions": [
+        {
+          "name": "test_existing_elements_require_governance",
+          "lineno": 8,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_self_connection_square.py",
+      "loc": 50,
+      "functions": [
+        {
+          "name": "test_gsn_self_connection_square",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "test_relationship_self_connection_square",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 27,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_quality.py",
+      "loc": 26,
+      "functions": [
+        {
+          "name": "test_detects_bad_verb_form",
+          "lineno": 6,
+          "complexity": 2
+        },
+        {
+          "name": "test_detects_missing_connectors",
+          "lineno": 13,
+          "complexity": 2
+        },
+        {
+          "name": "test_accepts_well_formed_requirement",
+          "lineno": 25,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_requirement_rule_subject.py",
+      "loc": 12,
+      "functions": [
+        {
+          "name": "test_requirement_rule_subject_overrides_node_roles",
+          "lineno": 11,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "tests/test_listbox_hover_invalid_widget.py",
+      "loc": 19,
+      "functions": [
+        {
+          "name": "test_listbox_highlight_ignores_non_listbox",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "bind_class",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 23,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_relation_icon_orientation.py",
+      "loc": 24,
+      "functions": [
+        {
+          "name": "test_relation_icon_arrowhead_shape",
+          "lineno": 9,
+          "complexity": 11
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "put",
+          "lineno": 13,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_clone_context_relation.py",
+      "loc": 12,
+      "functions": [
+        {
+          "name": "test_clone_uses_context_relationship",
+          "lineno": 10,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_standard_shape_label.py",
+      "loc": 50,
+      "functions": [
+        {
+          "name": "dummy_window",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_standard_shape_has_iso_label",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 29,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_toolbox_button_size.py",
+      "loc": 74,
+      "functions": [
+        {
+          "name": "_button_data",
+          "lineno": 15,
+          "complexity": 7
+        },
+        {
+          "name": "test_governance_toolbox_buttons_same_width",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "test_block_toolbox_buttons_same_width",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "test_gsn_toolbox_buttons_same_width",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "test_cbn_toolbox_buttons_same_width",
+          "lineno": 78,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_safety_ai_connections.py",
+      "loc": 103,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "tearDown",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "_window",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "_make_nodes",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "_make_ai_pair",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_ai_relationship_between_governance_and_ai",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "test_flow_from_governance_to_ai_allowed",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "test_ai_training_direction",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "test_model_evaluation_direction",
+          "lineno": 67,
+          "complexity": 1
+        },
+        {
+          "name": "test_tune_connection",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "test_hyperparameter_validation_connection",
+          "lineno": 85,
+          "complexity": 1
+        },
+        {
+          "name": "test_field_risk_evaluation_enforces_allowed_targets",
+          "lineno": 95,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_causal_bayesian_toolbox_visibility.py",
+      "loc": 48,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "test_toolbox_hidden_without_analysis",
+          "lineno": 59,
+          "complexity": 1
+        },
+        {
+          "name": "test_toolbox_shown_with_analysis",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 20,
+          "complexity": 2
+        },
+        {
+          "name": "bind",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "pack_forget",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_ismapped",
+          "lineno": 43,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_architecture_open_diagram.py",
+      "loc": 20,
+      "functions": [
+        {
+          "name": "test_open_diagram_uses_diag_id",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "fake_open_arch_window",
+          "lineno": 14,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_patterns_toolbox.py",
+      "loc": 63,
+      "functions": [
+        {
+          "name": "test_requirement_patterns_toolbox_single_instance",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "test_pattern_tree_wraps_text",
+          "lineno": 69,
+          "complexity": 2
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 60,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_away_shapes.py",
+      "loc": 134,
+      "functions": [
+        {
+          "name": "test_away_shapes_receive_module_identifier",
+          "lineno": 73,
+          "complexity": 1
+        },
+        {
+          "name": "test_away_shapes_without_module_identifier",
+          "lineno": 85,
+          "complexity": 1
+        },
+        {
+          "name": "test_goal_clone_with_original_but_primary_flag_draws_away_shape",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "test_away_solution_module_box_adjacent",
+          "lineno": 113,
+          "complexity": 2
+        },
+        {
+          "name": "test_module_box_defaults_to_root",
+          "lineno": 136,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "create_arc",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "tag_lower",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "tag_raise",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "get_text_size",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_goal_shape",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_solution_shape",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_context_shape",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_assumption_shape",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_justification_shape",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "draw_goal_shape",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "draw_solution_shape",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "draw_module_shape",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "draw_assumption_shape",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "draw_justification_shape",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "draw_context_shape",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "draw_solved_by_connection",
+          "lineno": 59,
+          "complexity": 1
+        },
+        {
+          "name": "draw_in_context_connection",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "point_on_shape",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "measure",
+          "lineno": 106,
+          "complexity": 1
+        },
+        {
+          "name": "metrics",
+          "lineno": 109,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_toolbox_dynamic_relations.py",
+      "loc": 87,
+      "functions": [
+        {
+          "name": "test_toolbox_updates_with_new_relation",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "test_irrelevant_relations_filtered",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_cross_category_relations_surface",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "test_governance_core_relations_and_externals",
+          "lineno": 54,
+          "complexity": 2
+        },
+        {
+          "name": "test_bidirectional_external_relations",
+          "lineno": 88,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_effects.py",
+      "loc": 58,
+      "functions": [
+        {
+          "name": "test_text_without_shadow_or_highlight",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "test_icon_without_highlight_or_shadow",
+          "lineno": 24,
+          "complexity": 2
+        },
+        {
+          "name": "test_glow_on_hover_and_press",
+          "lineno": 38,
+          "complexity": 2
+        },
+        {
+          "name": "test_glow_outline_matches_button_size",
+          "lineno": 56,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_structure_tree_operations_init.py",
+      "loc": 23,
+      "functions": [
+        {
+          "name": "test_automl_core_initialises_structure_tree_operations",
+          "lineno": 5,
+          "complexity": 10
+        }
+      ]
+    },
+    {
+      "file": "tests/test_aggregation_part_creation.py",
+      "loc": 95,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_aggregation_creates_part",
+          "lineno": 16,
+          "complexity": 4
+        },
+        {
+          "name": "test_part_updates_with_block",
+          "lineno": 34,
+          "complexity": 4
+        },
+        {
+          "name": "test_part_name_sync_on_block_rename",
+          "lineno": 52,
+          "complexity": 4
+        },
+        {
+          "name": "test_remove_aggregation_part_object",
+          "lineno": 70,
+          "complexity": 8
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_rule_generator.py",
+      "loc": 368,
+      "functions": [
+        {
+          "name": "test_generate_patterns_from_config",
+          "lineno": 13,
+          "complexity": 2
+        },
+        {
+          "name": "test_reload_config_updates_patterns",
+          "lineno": 38,
+          "complexity": 2
+        },
+        {
+          "name": "test_field_data_collection_uses_from",
+          "lineno": 56,
+          "complexity": 2
+        },
+        {
+          "name": "test_rule_with_multiple_targets",
+          "lineno": 80,
+          "complexity": 2
+        },
+        {
+          "name": "test_grouped_actions_single_pattern",
+          "lineno": 97,
+          "complexity": 3
+        },
+        {
+          "name": "test_grouped_actions_across_relations",
+          "lineno": 119,
+          "complexity": 3
+        },
+        {
+          "name": "test_rule_with_custom_template_and_variables",
+          "lineno": 141,
+          "complexity": 2
+        },
+        {
+          "name": "test_rule_role_subject_variant",
+          "lineno": 162,
+          "complexity": 3
+        },
+        {
+          "name": "test_sequence_rule_generation",
+          "lineno": 185,
+          "complexity": 4
+        },
+        {
+          "name": "test_sequence_role_subject_variants",
+          "lineno": 210,
+          "complexity": 3
+        },
+        {
+          "name": "test_sequence_organization_subject_variants",
+          "lineno": 238,
+          "complexity": 3
+        },
+        {
+          "name": "test_sequence_business_unit_subject_variants",
+          "lineno": 266,
+          "complexity": 3
+        },
+        {
+          "name": "test_complex_sequences",
+          "lineno": 297,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_document_phase_used_by.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "_window",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_standard_used_by_phase_valid",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "test_phase_used_by_standard_invalid",
+          "lineno": 26,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_copy_paste_active_diagram.py",
+      "loc": 51,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "_make_app",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "test_copy_and_cut_paste_use_focused_diagram",
+          "lineno": 24,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_copy_paste.py",
+      "loc": 138,
+      "functions": [
+        {
+          "name": "selection",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "item",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "tearDown",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "test_pasted_unsupported_node_rejected",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "test_context_relation_preserved_on_paste",
+          "lineno": 68,
+          "complexity": 3
+        },
+        {
+          "name": "test_context_relation_preserved_on_paste",
+          "lineno": 97,
+          "complexity": 2
+        },
+        {
+          "name": "test_context_relation_preserved_on_paste",
+          "lineno": 126,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_additional_relationship_requirements.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "test_generate_requirements_for_additional_relationships",
+          "lineno": 26,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_elements_toolbox_no_select.py",
+      "loc": 13,
+      "functions": [
+        {
+          "name": "test_governance_elements_toolbox_excludes_select",
+          "lineno": 8,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_metrics_tab_zero_division.py",
+      "loc": 46,
+      "functions": [
+        {
+          "name": "__getitem__",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "test_line_chart_variants_handle_zero_max",
+          "lineno": 47,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_generalization_part_updates.py",
+      "loc": 67,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_aggregation_updates_child",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_composite_updates_child",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "test_remove_aggregation_updates_child",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "test_multiplicity_change_updates_child",
+          "lineno": 56,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_clone_data_sync.py",
+      "loc": 38,
+      "functions": [
+        {
+          "name": "_configure",
+          "lineno": 19,
+          "complexity": 4
+        },
+        {
+          "name": "test_goal_clone_and_original_sync",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 15,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_navigation_buttons_style.py",
+      "loc": 17,
+      "functions": [
+        {
+          "name": "test_nav_button_style_has_active_and_pressed_background",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "map",
+          "lineno": 14,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_decision_phase_flow.py",
+      "loc": 41,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "_window",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "test_decision_to_phase_flow_allowed",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 21,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_phase_requirement_updates.py",
+      "loc": 131,
+      "functions": [
+        {
+          "name": "_setup_window",
+          "lineno": 20,
+          "complexity": 4
+        },
+        {
+          "name": "test_phase_requirement_updates_existing",
+          "lineno": 40,
+          "complexity": 2
+        },
+        {
+          "name": "test_phase_requirement_no_change",
+          "lineno": 73,
+          "complexity": 1
+        },
+        {
+          "name": "test_lifecycle_requirements_visible_in_phases",
+          "lineno": 91,
+          "complexity": 1
+        },
+        {
+          "name": "test_delete_obsolete",
+          "lineno": 122,
+          "complexity": 1
+        },
+        {
+          "name": "test_lifecycle_tab_refresh",
+          "lineno": 145,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "generate_requirements",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "from_repo",
+          "lineno": 99,
+          "complexity": 1
+        },
+        {
+          "name": "display_stub",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "_info",
+          "lineno": 134,
+          "complexity": 1
+        },
+        {
+          "name": "display_stub",
+          "lineno": 155,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_table",
+          "lineno": 158,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_render_cause_effect_diagram.py",
+      "loc": 70,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "test_render_cause_effect_diagram_size",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "test_graph_includes_threats_and_attack_paths",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "test_no_orphan_threat_node",
+          "lineno": 60,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "tests/test_item_definition_persistence.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "_minimal_app",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "test_item_definition_persistence",
+          "lineno": 54,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_role_label_position.py",
+      "loc": 33,
+      "functions": [
+        {
+          "name": "test_role_label_position",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 16,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cbn_table_drag.py",
+      "loc": 98,
+      "functions": [
+        {
+          "name": "_make_window",
+          "lineno": 61,
+          "complexity": 2
+        },
+        {
+          "name": "test_drag_table_strategies_move_table",
+          "lineno": 109,
+          "complexity": 1
+        },
+        {
+          "name": "test_on_drag_moves_table",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_reqwidth",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_reqheight",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "update_idletasks",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "create_window",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "create_oval",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "itemconfigure",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "coords",
+          "lineno": 48,
+          "complexity": 2
+        },
+        {
+          "name": "move",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 57,
+          "complexity": 1
+        },
+        {
+          "name": "_place_table_stub",
+          "lineno": 82,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_global_phase_persistence.py",
+      "loc": 26,
+      "functions": [
+        {
+          "name": "test_global_phase_assigned_to_new_items",
+          "lineno": 4,
+          "complexity": 1
+        },
+        {
+          "name": "test_set_diagram_phase_propagates_to_contents",
+          "lineno": 16,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_testsuite_label_position.py",
+      "loc": 37,
+      "functions": [
+        {
+          "name": "test_testsuite_label_position",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 21,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_trace_reuse_rule_override.py",
+      "loc": 51,
+      "functions": [
+        {
+          "name": "test_trace_relation_respects_config",
+          "lineno": 6,
+          "complexity": 3
+        },
+        {
+          "name": "test_reuse_relation_respects_config",
+          "lineno": 35,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_unique_node_names.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "test_gsn_unique_node_names",
+          "lineno": 4,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_management.py",
+      "loc": 2077,
+      "functions": [
+        {
+          "name": "test_work_product_registration",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "test_lifecycle_and_workflow_storage",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "test_activity_boundary_label_rotated_left_inside",
+          "lineno": 93,
+          "complexity": 1
+        },
+        {
+          "name": "test_process_area_boundary_title_clipped_inside",
+          "lineno": 137,
+          "complexity": 1
+        },
+        {
+          "name": "test_toolbox_manages_diagram_lifecycle",
+          "lineno": 173,
+          "complexity": 1
+        },
+        {
+          "name": "test_sync_diagrams_updates_module_references",
+          "lineno": 192,
+          "complexity": 1
+        },
+        {
+          "name": "test_rename_module_updates_active",
+          "lineno": 210,
+          "complexity": 1
+        },
+        {
+          "name": "test_rename_module_updates_phase_references",
+          "lineno": 219,
+          "complexity": 1
+        },
+        {
+          "name": "test_disable_work_product_rejects_existing_docs",
+          "lineno": 245,
+          "complexity": 1
+        },
+        {
+          "name": "test_open_safety_management_toolbox_uses_browser",
+          "lineno": 270,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_diagrams_hidden_and_immutable_in_explorer",
+          "lineno": 312,
+          "complexity": 5
+        },
+        {
+          "name": "test_work_product_enabling_and_deletion_guard",
+          "lineno": 365,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_diagrams_visible_in_analysis_tree",
+          "lineno": 386,
+          "complexity": 4
+        },
+        {
+          "name": "test_gsn_diagrams_visible_in_analysis_tree",
+          "lineno": 434,
+          "complexity": 4
+        },
+        {
+          "name": "test_explorers_removed_from_safety_concept_group",
+          "lineno": 484,
+          "complexity": 4
+        },
+        {
+          "name": "test_joint_reviews_visible_in_analysis_tree",
+          "lineno": 527,
+          "complexity": 4
+        },
+        {
+          "name": "test_external_safety_diagrams_load_in_toolbox_list",
+          "lineno": 577,
+          "complexity": 1
+        },
+        {
+          "name": "test_toolbox_serializes_modules",
+          "lineno": 588,
+          "complexity": 1
+        },
+        {
+          "name": "test_enabled_products_respect_active_module_and_reuse",
+          "lineno": 604,
+          "complexity": 1
+        },
+        {
+          "name": "test_disabled_work_products_absent_from_analysis_tree",
+          "lineno": 626,
+          "complexity": 5
+        },
+        {
+          "name": "test_enable_work_product_refreshes_views",
+          "lineno": 682,
+          "complexity": 1
+        },
+        {
+          "name": "test_open_work_product_requires_enablement",
+          "lineno": 699,
+          "complexity": 1
+        },
+        {
+          "name": "test_phase_without_diagrams_disables_products",
+          "lineno": 714,
+          "complexity": 1
+        },
+        {
+          "name": "test_menu_work_products_toggle_and_guard_existing_docs",
+          "lineno": 722,
+          "complexity": 4
+        },
+        {
+          "name": "test_governance_diagram_opens_with_governance_toolbox",
+          "lineno": 764,
+          "complexity": 1
+        },
+        {
+          "name": "test_diagram_hierarchy_orders_levels",
+          "lineno": 811,
+          "complexity": 2
+        },
+        {
+          "name": "test_diagram_hierarchy_from_object_properties",
+          "lineno": 842,
+          "complexity": 2
+        },
+        {
+          "name": "test_work_products_filtered_by_phase_in_tree",
+          "lineno": 872,
+          "complexity": 10
+        },
+        {
+          "name": "test_governance_enables_tools_per_phase",
+          "lineno": 956,
+          "complexity": 7
+        },
+        {
+          "name": "test_phase_without_governance_disables_tools",
+          "lineno": 1073,
+          "complexity": 3
+        },
+        {
+          "name": "test_phase_selection_updates_app",
+          "lineno": 1169,
+          "complexity": 1
+        },
+        {
+          "name": "test_phase_selection_refreshes_menus",
+          "lineno": 1208,
+          "complexity": 2
+        },
+        {
+          "name": "test_child_work_product_enables_parent_menu",
+          "lineno": 1265,
+          "complexity": 1
+        },
+        {
+          "name": "test_refresh_tool_enablement_enables_parent_menus",
+          "lineno": 1299,
+          "complexity": 1
+        },
+        {
+          "name": "test_phase_without_diagrams_disables_tools",
+          "lineno": 1341,
+          "complexity": 3
+        },
+        {
+          "name": "test_governance_without_declarations_keeps_tools_enabled",
+          "lineno": 1440,
+          "complexity": 4
+        },
+        {
+          "name": "test_safety_management_explorer_creates_folders_and_diagrams",
+          "lineno": 1508,
+          "complexity": 7
+        },
+        {
+          "name": "test_safety_management_explorer_refresh_calls_populate",
+          "lineno": 1563,
+          "complexity": 1
+        },
+        {
+          "name": "test_explorer_renames_folders_and_diagrams",
+          "lineno": 1575,
+          "complexity": 12
+        },
+        {
+          "name": "test_explorer_prevents_diagrams_outside_folders",
+          "lineno": 1651,
+          "complexity": 1
+        },
+        {
+          "name": "test_explorer_allows_diagram_at_root",
+          "lineno": 1681,
+          "complexity": 4
+        },
+        {
+          "name": "test_explorer_handles_duplicate_names",
+          "lineno": 1720,
+          "complexity": 10
+        },
+        {
+          "name": "test_tools_include_safety_management_explorer",
+          "lineno": 1779,
+          "complexity": 1
+        },
+        {
+          "name": "test_diagram_drag_and_drop_between_modules",
+          "lineno": 1808,
+          "complexity": 2
+        },
+        {
+          "name": "test_governance_hierarchy_in_analysis_tree",
+          "lineno": 1856,
+          "complexity": 8
+        },
+        {
+          "name": "test_folder_double_click_opens_safety_management_explorer",
+          "lineno": 1924,
+          "complexity": 7
+        },
+        {
+          "name": "test_add_work_product_uses_half_width",
+          "lineno": 1997,
+          "complexity": 3
+        },
+        {
+          "name": "test_work_product_color_and_text_wrapping",
+          "lineno": 2025,
+          "complexity": 1
+        },
+        {
+          "name": "test_work_product_shapes_fixed_size",
+          "lineno": 2060,
+          "complexity": 1
+        },
+        {
+          "name": "test_propagation_connection_validation",
+          "lineno": 2096,
+          "complexity": 1
+        },
+        {
+          "name": "test_can_propagate_respects_review_states",
+          "lineno": 2114,
+          "complexity": 1
+        },
+        {
+          "name": "test_can_use_as_input_respects_review_states",
+          "lineno": 2134,
+          "complexity": 1
+        },
+        {
+          "name": "test_can_use_as_input_via_traces",
+          "lineno": 2154,
+          "complexity": 1
+        },
+        {
+          "name": "test_propagation_type_uses_stereotype_when_conn_type_missing",
+          "lineno": 2172,
+          "complexity": 1
+        },
+        {
+          "name": "test_can_trace_filters_by_phase",
+          "lineno": 2186,
+          "complexity": 2
+        },
+        {
+          "name": "test_object_dialog_creates_trace_relationship",
+          "lineno": 2221,
+          "complexity": 2
+        },
+        {
+          "name": "test_use_case_dialog_creates_trace_relationship",
+          "lineno": 2290,
+          "complexity": 2
+        },
+        {
+          "name": "test_list_modules_includes_submodules",
+          "lineno": 2362,
+          "complexity": 1
+        },
+        {
+          "name": "test_enabled_products_only_active_module",
+          "lineno": 2370,
+          "complexity": 1
+        },
+        {
+          "name": "test_fi2tc_not_enabled_in_other_modules",
+          "lineno": 2388,
+          "complexity": 1
+        },
+        {
+          "name": "test_each_analysis_enabled_only_in_own_phase",
+          "lineno": 2400,
+          "complexity": 1
+        },
+        {
+          "name": "test_work_product_info_includes_requirement_types",
+          "lineno": 2421,
+          "complexity": 2
+        },
+        {
+          "name": "test_disable_requirement_work_product_keeps_editor",
+          "lineno": 2426,
+          "complexity": 1
+        },
+        {
+          "name": "test_focus_governance_diagram_sets_phase_and_hides_functions",
+          "lineno": 2446,
+          "complexity": 3
+        },
+        {
+          "name": "test_tab_focus_triggers_refresh",
+          "lineno": 2528,
+          "complexity": 1
+        },
+        {
+          "name": "test_requirement_trace_lookup",
+          "lineno": 2567,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "create_rectangle",
+          "lineno": 74,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 80,
+          "complexity": 1
+        },
+        {
+          "name": "create_arc",
+          "lineno": 83,
+          "complexity": 1
+        },
+        {
+          "name": "canvasx",
+          "lineno": 86,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 89,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 786,
+          "complexity": 1
+        },
+        {
+          "name": "fake_governance",
+          "lineno": 795,
+          "complexity": 1
+        },
+        {
+          "name": "fake_activity",
+          "lineno": 799,
+          "complexity": 1
+        },
+        {
+          "name": "on_lifecycle_selected",
+          "lineno": 1190,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_tool_enablement",
+          "lineno": 1243,
+          "complexity": 2
+        },
+        {
+          "name": "on_lifecycle_selected",
+          "lineno": 1249,
+          "complexity": 1
+        },
+        {
+          "name": "fake_populate",
+          "lineno": 1566,
+          "complexity": 1
+        },
+        {
+          "name": "fake_error",
+          "lineno": 1672,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 2484,
+          "complexity": 1
+        },
+        {
+          "name": "_fmt",
+          "lineno": 2489,
+          "complexity": 2
+        },
+        {
+          "name": "fake_map",
+          "lineno": 2570,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 257,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 260,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 275,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 278,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 282,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 285,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 289,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 299,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 302,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 319,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 322,
+          "complexity": 2
+        },
+        {
+          "name": "get_children",
+          "lineno": 326,
+          "complexity": 3
+        },
+        {
+          "name": "exists",
+          "lineno": 331,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 334,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 347,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 394,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 398,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 401,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 404,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 439,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 443,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 446,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 449,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 489,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 493,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 496,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 499,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 532,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 536,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 539,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 542,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 631,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 635,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 638,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 641,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 730,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 733,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 776,
+          "complexity": 1
+        },
+        {
+          "name": "tabs",
+          "lineno": 778,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 780,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 890,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 894,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 897,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 900,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 925,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 928,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 931,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 972,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 976,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 981,
+          "complexity": 1
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 985,
+          "complexity": 1
+        },
+        {
+          "name": "size",
+          "lineno": 988,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 991,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 996,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 999,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1003,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 1006,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 1009,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1087,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 1091,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 1096,
+          "complexity": 1
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 1100,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 1103,
+          "complexity": 1
+        },
+        {
+          "name": "size",
+          "lineno": 1107,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1111,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 1114,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1118,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 1121,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 1124,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1179,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 1182,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 1185,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1218,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 1221,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 1224,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1228,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 1231,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1269,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 1272,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1308,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 1311,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1355,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 1359,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 1364,
+          "complexity": 1
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 1368,
+          "complexity": 1
+        },
+        {
+          "name": "size",
+          "lineno": 1371,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 1374,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1379,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 1382,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1386,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 1389,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 1392,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1446,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 1450,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 1455,
+          "complexity": 1
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 1459,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1463,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 1466,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1516,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 1521,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 1524,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 1527,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 1533,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 1536,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 1583,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 1588,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 1591,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 1594,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 1600,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 1603,
+          "complexity": 2
+        },
+        {
+          "name": "selection",
+          "lineno": 1659,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1686,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 1691,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 1694,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 1697,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 1703,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 1727,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 1732,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 1735,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 1738,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 1744,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 1747,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 1816,
+          "complexity": 1
+        },
+        {
+          "name": "identify_row",
+          "lineno": 1820,
+          "complexity": 1
+        },
+        {
+          "name": "move",
+          "lineno": 1823,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 1826,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1867,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 1871,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 1874,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 1877,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 1932,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 1937,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 1940,
+          "complexity": 2
+        },
+        {
+          "name": "get_children",
+          "lineno": 1948,
+          "complexity": 2
+        },
+        {
+          "name": "item",
+          "lineno": 1951,
+          "complexity": 3
+        },
+        {
+          "name": "parent",
+          "lineno": 1959,
+          "complexity": 1
+        },
+        {
+          "name": "focus",
+          "lineno": 1962,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 2011,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 2272,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 2275,
+          "complexity": 1
+        },
+        {
+          "name": "curselection",
+          "lineno": 2278,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 2344,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 2347,
+          "complexity": 1
+        },
+        {
+          "name": "curselection",
+          "lineno": 2350,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 2457,
+          "complexity": 1
+        },
+        {
+          "name": "tabs",
+          "lineno": 2462,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 2465,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 2468,
+          "complexity": 2
+        },
+        {
+          "name": "nametowidget",
+          "lineno": 2474,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 2478,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 2481,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 2493,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 2496,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 2530,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_from_repository",
+          "lineno": 2533,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 2537,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 2541,
+          "complexity": 1
+        },
+        {
+          "name": "refresh",
+          "lineno": 2544,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 2548,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 2551,
+          "complexity": 1
+        },
+        {
+          "name": "nametowidget",
+          "lineno": 2554,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_analysis_input_visibility.py",
+      "loc": 444,
+      "functions": [
+        {
+          "name": "_create_window",
+          "lineno": 34,
+          "complexity": 2
+        },
+        {
+          "name": "_cfd_tools",
+          "lineno": 58,
+          "complexity": 2
+        },
+        {
+          "name": "test_used_by_input_visibility",
+          "lineno": 78,
+          "complexity": 2
+        },
+        {
+          "name": "test_used_after_review_input_visibility",
+          "lineno": 103,
+          "complexity": 2
+        },
+        {
+          "name": "test_used_after_approval_input_visibility",
+          "lineno": 130,
+          "complexity": 2
+        },
+        {
+          "name": "test_stpa_to_architecture_used_by_input_visibility",
+          "lineno": 156,
+          "complexity": 2
+        },
+        {
+          "name": "test_stpa_to_architecture_used_after_review_input_visibility",
+          "lineno": 180,
+          "complexity": 2
+        },
+        {
+          "name": "test_stpa_to_architecture_used_after_approval_input_visibility",
+          "lineno": 206,
+          "complexity": 2
+        },
+        {
+          "name": "test_analysis_inputs_respect_phase",
+          "lineno": 233,
+          "complexity": 2
+        },
+        {
+          "name": "test_scenario_library_inputs_require_relationship",
+          "lineno": 261,
+          "complexity": 2
+        },
+        {
+          "name": "test_scenario_library_inputs_respect_phase",
+          "lineno": 289,
+          "complexity": 2
+        },
+        {
+          "name": "test_scenario_library_used_relationships_expose_hazop_inputs",
+          "lineno": 317,
+          "complexity": 5
+        },
+        {
+          "name": "test_stpa_button_requires_relationship",
+          "lineno": 371,
+          "complexity": 2
+        },
+        {
+          "name": "test_stpa_button_respects_review_and_approval",
+          "lineno": 402,
+          "complexity": 3
+        },
+        {
+          "name": "test_stpa_button_respects_phase",
+          "lineno": 462,
+          "complexity": 2
+        },
+        {
+          "name": "canvasx",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "fake_init",
+          "lineno": 63,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_spi_work_product.py",
+      "loc": 47,
+      "functions": [
+        {
+          "name": "test_governance_spi_work_product_disabled",
+          "lineno": 12,
+          "complexity": 3
+        },
+        {
+          "name": "enable_work_product",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 45,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_treeview_hover_highlight.py",
+      "loc": 55,
+      "functions": [
+        {
+          "name": "_rgb",
+          "lineno": 11,
+          "complexity": 3
+        },
+        {
+          "name": "test_treeview_row_highlight_on_hover",
+          "lineno": 17,
+          "complexity": 2
+        },
+        {
+          "name": "test_treeview_hover_after_item_deleted",
+          "lineno": 43,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_auto_paste_gsn_clone.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "test_paste_node_creates_clone",
+          "lineno": 8,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_paa_work_product.py",
+      "loc": 42,
+      "functions": [
+        {
+          "name": "test_governance_paa_work_product_enabled",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "enable_work_product",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 43,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_sysml_requirements.py",
+      "loc": 67,
+      "functions": [
+        {
+          "name": "setup_repo",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "test_activity_diagram_requirements",
+          "lineno": 12,
+          "complexity": 3
+        },
+        {
+          "name": "test_call_behavior_action_dependencies",
+          "lineno": 28,
+          "complexity": 3
+        },
+        {
+          "name": "test_non_activity_diagram_requirement_type",
+          "lineno": 65,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_rules_requirement_mappings.py",
+      "loc": 15,
+      "functions": [
+        {
+          "name": "test_all_connectors_have_requirement_rules",
+          "lineno": 8,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_multiplicity_default.py",
+      "loc": 28,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "test_default_multiplicity_enforced",
+          "lineno": 11,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_confirm_close_preserves_loaded_files.py",
+      "loc": 23,
+      "functions": [
+        {
+          "name": "test_confirm_close_preserves_loaded_files",
+          "lineno": 14,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 9,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_statusbar_transparency.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "app",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "test_status_bar_transparency",
+          "lineno": 15,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_decision_guard.py",
+      "loc": 35,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_decision_flow_guard_generation",
+          "lineno": 17,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_shadows.py",
+      "loc": 27,
+      "functions": [
+        {
+          "name": "test_text_shadow_removed",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "test_icon_shadow_removed",
+          "lineno": 23,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_format_diagram_name.py",
+      "loc": 11,
+      "functions": [
+        {
+          "name": "test_format_diagram_name_adds_abbreviation",
+          "lineno": 5,
+          "complexity": 1
+        },
+        {
+          "name": "test_format_diagram_name_ibd",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_format_diagram_name_does_not_duplicate",
+          "lineno": 15,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_undo.py",
+      "loc": 109,
+      "functions": [
+        {
+          "name": "test_gsn_diagram_undo_redo_rename",
+          "lineno": 17,
+          "complexity": 4
+        },
+        {
+          "name": "test_gsn_explorer_refreshes_after_undo",
+          "lineno": 64,
+          "complexity": 11
+        },
+        {
+          "name": "export_model_data",
+          "lineno": 28,
+          "complexity": 3
+        },
+        {
+          "name": "apply_model_data",
+          "lineno": 34,
+          "complexity": 2
+        },
+        {
+          "name": "export_model_data",
+          "lineno": 75,
+          "complexity": 3
+        },
+        {
+          "name": "apply_model_data",
+          "lineno": 81,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 100,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 103,
+          "complexity": 2
+        },
+        {
+          "name": "insert",
+          "lineno": 106,
+          "complexity": 1
+        },
+        {
+          "name": "parent",
+          "lineno": 112,
+          "complexity": 1
+        },
+        {
+          "name": "selection",
+          "lineno": 115,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_gsn_clone_independence.py",
+      "loc": 50,
+      "functions": [
+        {
+          "name": "_make_app",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "test_paste_clone_is_away_and_independent",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "test_only_name_description_notes_sync",
+          "lineno": 51,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_operation_executes_work_product_connection_rule.py",
+      "loc": 16,
+      "functions": [
+        {
+          "name": "test_operation_executes_work_product_connection",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_role_uses_work_product_connection_rule.py",
+      "loc": 29,
+      "functions": [
+        {
+          "name": "test_role_uses_work_product",
+          "lineno": 8,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_block_boundary.py",
+      "loc": 88,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "test_boundary_created_with_ports",
+          "lineno": 15,
+          "complexity": 5
+        },
+        {
+          "name": "test_boundary_created_via_block_link",
+          "lineno": 30,
+          "complexity": 2
+        },
+        {
+          "name": "test_rename_block_updates_boundary_name",
+          "lineno": 38,
+          "complexity": 2
+        },
+        {
+          "name": "test_add_port_updates_block_and_boundary",
+          "lineno": 47,
+          "complexity": 4
+        },
+        {
+          "name": "test_edit_boundary_name_updates_block",
+          "lineno": 63,
+          "complexity": 2
+        },
+        {
+          "name": "test_edit_boundary_name_updates_block_object",
+          "lineno": 73,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_metrics_tab_menu.py",
+      "loc": 12,
+      "functions": [
+        {
+          "name": "test_app_has_open_metrics_tab",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "test_view_menu_includes_metrics_option",
+          "lineno": 10,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirements_editor_multiline.py",
+      "loc": 90,
+      "functions": [
+        {
+          "name": "test_multiline_edit_uses_text_widget",
+          "lineno": 92,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 17,
+          "complexity": 2
+        },
+        {
+          "name": "set",
+          "lineno": 23,
+          "complexity": 2
+        },
+        {
+          "name": "get_children",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "identify",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "identify_row",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "identify_column",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "bbox",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "index",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "cget",
+          "lineno": 40,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "place",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "focus_set",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 64,
+          "complexity": 1
+        },
+        {
+          "name": "place",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "focus_set",
+          "lineno": 68,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 70,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 79,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 86,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_confirm_close_quits.py",
+      "loc": 21,
+      "functions": [
+        {
+          "name": "test_confirm_close_quits_and_destroys",
+          "lineno": 9,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_control_flow_drag.py",
+      "loc": 43,
+      "functions": [
+        {
+          "name": "reset_repo",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "test_horizontal_move_unrestricted",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "test_unconnected_move_free",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "test_connector_move_unrestricted",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "test_connector_move_constrained",
+          "lineno": 47,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_layer_menu.py",
+      "loc": 66,
+      "functions": [
+        {
+          "name": "fake_init",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "test_governance_context_menu_has_layer_commands",
+          "lineno": 60,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "add_command",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "add_separator",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "tk_popup",
+          "lineno": 20,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_control_flow_vertical.py",
+      "loc": 28,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_vertical_connection_valid",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "test_connection_too_offset_invalid",
+          "lineno": 24,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_boundary_partprop_propagation.py",
+      "loc": 37,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_new_parts_show_in_boundary_diagrams",
+          "lineno": 10,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_control_flow_stereotype.py",
+      "loc": 83,
+      "functions": [
+        {
+          "name": "canvasx",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "tearDown",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "_create_window",
+          "lineno": 29,
+          "complexity": 2
+        },
+        {
+          "name": "test_control_action_relationship_stereotype",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "test_feedback_relationship_stereotype",
+          "lineno": 71,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_case_tab.py",
+      "loc": 36,
+      "functions": [
+        {
+          "name": "test_open_case_uses_app_tab",
+          "lineno": 5,
+          "complexity": 2
+        },
+        {
+          "name": "fake_new_tab",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 30,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_aggregation_validation.py",
+      "loc": 115,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_direct_relationship",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "test_inherited_relationship",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "test_father_part_definition",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "test_negative_case",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 68,
+          "complexity": 1
+        },
+        {
+          "name": "test_reciprocal_aggregation_invalid",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "test_reciprocal_composite_aggregation_invalid",
+          "lineno": 83,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 96,
+          "complexity": 1
+        },
+        {
+          "name": "test_parent_as_part_ignored",
+          "lineno": 100,
+          "complexity": 4
+        },
+        {
+          "name": "test_self_part_ignored",
+          "lineno": 117,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 62,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_inherit_parts.py",
+      "loc": 310,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "test_extend_block_parts_with_parents",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "test_inherit_father_parts",
+          "lineno": 69,
+          "complexity": 3
+        },
+        {
+          "name": "test_inherit_father_parts_copies_ports",
+          "lineno": 94,
+          "complexity": 4
+        },
+        {
+          "name": "test_inherit_father_parts_skips_existing",
+          "lineno": 148,
+          "complexity": 4
+        },
+        {
+          "name": "test_generalization_inherits_properties",
+          "lineno": 182,
+          "complexity": 1
+        },
+        {
+          "name": "test_remove_generalization_clears_properties",
+          "lineno": 195,
+          "complexity": 1
+        },
+        {
+          "name": "test_reroute_generalization_updates_properties",
+          "lineno": 211,
+          "complexity": 1
+        },
+        {
+          "name": "test_sync_partproperty_parts",
+          "lineno": 233,
+          "complexity": 4
+        },
+        {
+          "name": "test_sync_partproperty_parts_with_multiplicity",
+          "lineno": 250,
+          "complexity": 4
+        },
+        {
+          "name": "test_sync_aggregation_parts_with_parent",
+          "lineno": 268,
+          "complexity": 3
+        },
+        {
+          "name": "test_sync_composite_parts_with_parent",
+          "lineno": 283,
+          "complexity": 3
+        },
+        {
+          "name": "test_partproperty_names_with_brackets",
+          "lineno": 298,
+          "complexity": 4
+        },
+        {
+          "name": "test_partproperty_name_with_colon",
+          "lineno": 314,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "tests/test_behaviors.py",
+      "loc": 12,
+      "functions": [
+        {
+          "name": "test_round_trip",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_flow_connection_display.py",
+      "loc": 15,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "test_flow_arrow_and_label",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_rules_toolbox.py",
+      "loc": 45,
+      "functions": [
+        {
+          "name": "test_diagram_rules_toolbox_single_instance",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "select",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_exists",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 58,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_safety_concept_persistence.py",
+      "loc": 63,
+      "functions": [
+        {
+          "name": "_minimal_app",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_safety_concept_persistence",
+          "lineno": 55,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_project_properties_persistence.py",
+      "loc": 80,
+      "functions": [
+        {
+          "name": "_minimal_app",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "test_project_properties_probabilities_roundtrip",
+          "lineno": 69,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_partproperty_new_ibd.py",
+      "loc": 43,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_parts_visible_when_ibd_created_later",
+          "lineno": 10,
+          "complexity": 4
+        },
+        {
+          "name": "test_boundary_receives_parts_on_creation",
+          "lineno": 23,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_hover_icon.py",
+      "loc": 65,
+      "functions": [
+        {
+          "name": "test_capsule_button_lightens_icon_on_hover",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "test_capsule_button_preserves_transparency_on_hover",
+          "lineno": 37,
+          "complexity": 2
+        },
+        {
+          "name": "test_lighten_image_preserves_alpha_with_png",
+          "lineno": 56,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_diagram_freeze_toggle.py",
+      "loc": 22,
+      "functions": [
+        {
+          "name": "test_manual_freeze_persists_across_save",
+          "lineno": 10,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_ibd_part_block_update.py",
+      "loc": 33,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 6,
+          "complexity": 1
+        },
+        {
+          "name": "test_part_definition_adds_block_part",
+          "lineno": 10,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_rename_block.py",
+      "loc": 106,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "test_rename_block_updates_part_usage",
+          "lineno": 17,
+          "complexity": 3
+        },
+        {
+          "name": "test_rename_block_propagates_to_generalization",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "test_rename_block_updates_aggregation_without_ibd",
+          "lineno": 55,
+          "complexity": 4
+        },
+        {
+          "name": "test_rename_aggregated_block_updates_generalized_parent",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "test_rename_empty_block_syncs_and_removes",
+          "lineno": 96,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_diagram_rules_requirements_section.py",
+      "loc": 17,
+      "functions": [
+        {
+          "name": "test_requirement_rules_section_loaded",
+          "lineno": 11,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cause_effect_tool_enablement.py",
+      "loc": 69,
+      "functions": [
+        {
+          "name": "test_cause_effect_tool_enabled_with_safety_analysis",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "test_cause_effect_tool_opens_on_double_click",
+          "lineno": 76,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 18,
+          "complexity": 3
+        },
+        {
+          "name": "insert",
+          "lineno": 25,
+          "complexity": 2
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "curselection",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "selection_set",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "selection_clear",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "nearest",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "action",
+          "lineno": 79,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_phase_membership_infer.py",
+      "loc": 56,
+      "functions": [
+        {
+          "name": "test_repository_phase_enables_work_product",
+          "lineno": 35,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 20,
+          "complexity": 2
+        },
+        {
+          "name": "itemconfig",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "entryconfig",
+          "lineno": 31,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_requirement_traces_persistence.py",
+      "loc": 66,
+      "functions": [
+        {
+          "name": "_minimal_app",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "test_requirement_traces_roundtrip",
+          "lineno": 64,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_causal_bayesian_network_analysis.py",
+      "loc": 79,
+      "functions": [
+        {
+          "name": "build_network",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "test_slippery_road_probability",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "test_slippery_road_given_rain",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "test_intervention_matches_conditioning_for_root",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "test_missing_cpd_defaults_to_uniform_probability",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "test_truth_table_auto_fill",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "test_marginal_probability_propagation",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "test_cpd_rows_respect_parent_dependencies",
+          "lineno": 84,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_capsule_button_outline.py",
+      "loc": 15,
+      "functions": [
+        {
+          "name": "test_capsule_button_has_inner_outline",
+          "lineno": 8,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "tests/test_multiplicity_across_boundary.py",
+      "loc": 53,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "test_limit_counts_parts_in_all_diagrams",
+          "lineno": 12,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_hazard_severity.py",
+      "loc": 41,
+      "functions": [
+        {
+          "name": "test_update_hazard_list_uses_entry_severity",
+          "lineno": 23,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_threat_assets.py",
+      "loc": 29,
+      "functions": [
+        {
+          "name": "setUp",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "test_connections_and_flows_included",
+          "lineno": 16,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_drawing_helper_colors.py",
+      "loc": 13,
+      "functions": [
+        {
+          "name": "test_fill_gradient_rect_accepts_named_color",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 10,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_add_boundary_port.py",
+      "loc": 55,
+      "functions": [
+        {
+          "name": "canvasx",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "canvasy",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "setUp",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "test_add_port_to_boundary_via_button",
+          "lineno": 23,
+          "complexity": 7
+        },
+        {
+          "name": "sync",
+          "lineno": 42,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "tests/test_usecase_actor_edit.py",
+      "loc": 90,
+      "functions": [
+        {
+          "name": "test_edit_actor_keeps_diagram_objects",
+          "lineno": 47,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "push_undo_state",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "object_visible",
+          "lineno": 31,
+          "complexity": 1
+        },
+        {
+          "name": "connection_visible",
+          "lineno": 34,
+          "complexity": 1
+        },
+        {
+          "name": "touch_diagram",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "visible_objects",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "visible_connections",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 92,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_governance_lifecycle_requirements_menu.py",
+      "loc": 111,
+      "functions": [
+        {
+          "name": "test_lifecycle_requirements_menu",
+          "lineno": 13,
+          "complexity": 7
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "winfo_children",
+          "lineno": 66,
+          "complexity": 1
+        },
+        {
+          "name": "rowconfigure",
+          "lineno": 69,
+          "complexity": 1
+        },
+        {
+          "name": "columnconfigure",
+          "lineno": 72,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 75,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 78,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 82,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 86,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 89,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 92,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 96,
+          "complexity": 1
+        },
+        {
+          "name": "heading",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "insert",
+          "lineno": 104,
+          "complexity": 1
+        },
+        {
+          "name": "configure",
+          "lineno": 107,
+          "complexity": 1
+        },
+        {
+          "name": "yview",
+          "lineno": 110,
+          "complexity": 1
+        },
+        {
+          "name": "xview",
+          "lineno": 113,
+          "complexity": 1
+        },
+        {
+          "name": "grid",
+          "lineno": 116,
+          "complexity": 1
+        },
+        {
+          "name": "get_children",
+          "lineno": 119,
+          "complexity": 1
+        },
+        {
+          "name": "delete",
+          "lineno": 122,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_role_executes_operation_connection_rule.py",
+      "loc": 15,
+      "functions": [
+        {
+          "name": "test_role_executes_operation_connection",
+          "lineno": 5,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_tooltip_leave.py",
+      "loc": 20,
+      "functions": [
+        {
+          "name": "test_manual_tooltip_hides_on_leave",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "bind",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "after_cancel",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "destroy",
+          "lineno": 21,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_cbn_undo.py",
+      "loc": 89,
+      "functions": [
+        {
+          "name": "test_cbn_diagram_undo_redo_node_add_and_move",
+          "lineno": 16,
+          "complexity": 19
+        },
+        {
+          "name": "export_model_data",
+          "lineno": 36,
+          "complexity": 10
+        },
+        {
+          "name": "apply_model_data",
+          "lineno": 61,
+          "complexity": 10
+        }
+      ]
+    },
+    {
+      "file": "tests/test_pas8800_mechanisms.py",
+      "loc": 55,
+      "functions": [
+        {
+          "name": "_stub_review_toolbox",
+          "lineno": 6,
+          "complexity": 2
+        },
+        {
+          "name": "test_pas8800_contains_fault_aware_training",
+          "lineno": 30,
+          "complexity": 2
+        },
+        {
+          "name": "test_pas8800_contains_new_diagnostics",
+          "lineno": 35,
+          "complexity": 3
+        },
+        {
+          "name": "test_pas8800_library_non_empty",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "test_default_mechanisms_include_pas8800",
+          "lineno": 52,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 57,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_tab_refresh.py",
+      "loc": 32,
+      "functions": [
+        {
+          "name": "test_tab_refresh_on_focus",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_from_repository",
+          "lineno": 23,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "tests/test_work_product_shading.py",
+      "loc": 28,
+      "functions": [
+        {
+          "name": "test_work_product_shape_uses_gradient",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "create_polygon",
+          "lineno": 8,
+          "complexity": 1
+        },
+        {
+          "name": "create_line",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "create_text",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "create_arc",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "create_image",
+          "lineno": 16,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "analysis/__init__.py",
+      "loc": 21,
+      "functions": [
+        {
+          "name": "__getattr__",
+          "lineno": 21,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "analysis/mechanisms.py",
+      "loc": 539,
+      "functions": []
+    },
+    {
+      "file": "analysis/causal_bayesian_network.py",
+      "loc": 215,
+      "functions": [
+        {
+          "name": "add_node",
+          "lineno": 41,
+          "complexity": 8
+        },
+        {
+          "name": "query",
+          "lineno": 80,
+          "complexity": 2
+        },
+        {
+          "name": "intervention",
+          "lineno": 90,
+          "complexity": 2
+        },
+        {
+          "name": "_query",
+          "lineno": 102,
+          "complexity": 3
+        },
+        {
+          "name": "_enumerate_all",
+          "lineno": 118,
+          "complexity": 3
+        },
+        {
+          "name": "_probability",
+          "lineno": 142,
+          "complexity": 6
+        },
+        {
+          "name": "_topological",
+          "lineno": 161,
+          "complexity": 5
+        },
+        {
+          "name": "marginal_probabilities",
+          "lineno": 184,
+          "complexity": 2
+        },
+        {
+          "name": "_cpd_rows_only",
+          "lineno": 200,
+          "complexity": 3
+        },
+        {
+          "name": "cpd_rows",
+          "lineno": 219,
+          "complexity": 4
+        },
+        {
+          "name": "joint_probability",
+          "lineno": 248,
+          "complexity": 1
+        },
+        {
+          "name": "visit",
+          "lineno": 168,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "analysis/user_config.py",
+      "loc": 58,
+      "functions": [
+        {
+          "name": "load_all_users",
+          "lineno": 9,
+          "complexity": 6
+        },
+        {
+          "name": "get_last_user",
+          "lineno": 24,
+          "complexity": 2
+        },
+        {
+          "name": "load_user_config",
+          "lineno": 30,
+          "complexity": 4
+        },
+        {
+          "name": "save_user_config",
+          "lineno": 40,
+          "complexity": 5
+        },
+        {
+          "name": "set_last_user",
+          "lineno": 53,
+          "complexity": 4
+        },
+        {
+          "name": "set_current_user",
+          "lineno": 63,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "analysis/constants.py",
+      "loc": 2,
+      "functions": []
+    },
+    {
+      "file": "analysis/fmeda_utils.py",
+      "loc": 96,
+      "functions": [
+        {
+          "name": "reload_config",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "_aggregate_goal_metrics",
+          "lineno": 19,
+          "complexity": 14
+        },
+        {
+          "name": "compute_fmeda_metrics",
+          "lineno": 80,
+          "complexity": 9
+        }
+      ]
+    },
+    {
+      "file": "analysis/requirement_quality.py",
+      "loc": 72,
+      "functions": [
+        {
+          "name": "check_requirement_quality",
+          "lineno": 58,
+          "complexity": 13
+        }
+      ]
+    },
+    {
+      "file": "analysis/governance.py",
+      "loc": 673,
+      "functions": [
+        {
+          "name": "_is_ai_specific_relation",
+          "lineno": 21,
+          "complexity": 4
+        },
+        {
+          "name": "_apply_pattern",
+          "lineno": 79,
+          "complexity": 18
+        },
+        {
+          "name": "_select_pattern",
+          "lineno": 125,
+          "complexity": 26
+        },
+        {
+          "name": "reload_config",
+          "lineno": 162,
+          "complexity": 6
+        },
+        {
+          "name": "_requirement_complexity",
+          "lineno": 273,
+          "complexity": 3
+        },
+        {
+          "name": "repl",
+          "lineno": 99,
+          "complexity": 17
+        },
+        {
+          "name": "text",
+          "lineno": 225,
+          "complexity": 11
+        },
+        {
+          "name": "__iter__",
+          "lineno": 254,
+          "complexity": 1
+        },
+        {
+          "name": "__getitem__",
+          "lineno": 258,
+          "complexity": 1
+        },
+        {
+          "name": "__str__",
+          "lineno": 261,
+          "complexity": 1
+        },
+        {
+          "name": "__contains__",
+          "lineno": 264,
+          "complexity": 6
+        },
+        {
+          "name": "_role_for",
+          "lineno": 319,
+          "complexity": 1
+        },
+        {
+          "name": "_default_action",
+          "lineno": 324,
+          "complexity": 2
+        },
+        {
+          "name": "add_task",
+          "lineno": 340,
+          "complexity": 3
+        },
+        {
+          "name": "add_flow",
+          "lineno": 363,
+          "complexity": 3
+        },
+        {
+          "name": "add_relationship",
+          "lineno": 392,
+          "complexity": 3
+        },
+        {
+          "name": "tasks",
+          "lineno": 427,
+          "complexity": 1
+        },
+        {
+          "name": "flows",
+          "lineno": 431,
+          "complexity": 4
+        },
+        {
+          "name": "relationships",
+          "lineno": 440,
+          "complexity": 2
+        },
+        {
+          "name": "generate_requirements",
+          "lineno": 448,
+          "complexity": 70
+        },
+        {
+          "name": "default_from_work_products",
+          "lineno": 665,
+          "complexity": 3
+        },
+        {
+          "name": "from_repository",
+          "lineno": 676,
+          "complexity": 47
+        }
+      ]
+    },
+    {
+      "file": "analysis/risk_tables.py",
+      "loc": 54,
+      "functions": [
+        {
+          "name": "determine_risk_level",
+          "lineno": 45,
+          "complexity": 2
+        },
+        {
+          "name": "determine_cal",
+          "lineno": 57,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "analysis/safety_case.py",
+      "loc": 63,
+      "functions": [
+        {
+          "name": "collect_solutions",
+          "lineno": 21,
+          "complexity": 2
+        },
+        {
+          "name": "build_report_template",
+          "lineno": 25,
+          "complexity": 7
+        },
+        {
+          "name": "create_case",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "delete_case",
+          "lineno": 77,
+          "complexity": 2
+        },
+        {
+          "name": "rename_case",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "list_cases",
+          "lineno": 84,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "analysis/utils.py",
+      "loc": 117,
+      "functions": [
+        {
+          "name": "update_probability_tables",
+          "lineno": 19,
+          "complexity": 7
+        },
+        {
+          "name": "normalize_probability_mapping",
+          "lineno": 49,
+          "complexity": 3
+        },
+        {
+          "name": "exposure_to_probability",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "controllability_to_probability",
+          "lineno": 71,
+          "complexity": 1
+        },
+        {
+          "name": "severity_to_probability",
+          "lineno": 80,
+          "complexity": 1
+        },
+        {
+          "name": "append_unique_insensitive",
+          "lineno": 88,
+          "complexity": 5
+        },
+        {
+          "name": "derive_validation_target",
+          "lineno": 102,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "analysis/sotif_validation.py",
+      "loc": 87,
+      "functions": [
+        {
+          "name": "hazardous_behavior_rate",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "acceptance_rate",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "validation_time",
+          "lineno": 97,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "analysis/safety_management.py",
+      "loc": 1159,
+      "functions": [
+        {
+          "name": "to_dict",
+          "lineno": 127,
+          "complexity": 1
+        },
+        {
+          "name": "from_dict",
+          "lineno": 132,
+          "complexity": 1
+        },
+        {
+          "name": "to_dict",
+          "lineno": 168,
+          "complexity": 2
+        },
+        {
+          "name": "from_dict",
+          "lineno": 179,
+          "complexity": 2
+        },
+        {
+          "name": "__post_init__",
+          "lineno": 217,
+          "complexity": 1
+        },
+        {
+          "name": "module_frozen",
+          "lineno": 222,
+          "complexity": 3
+        },
+        {
+          "name": "set_diagram_frozen",
+          "lineno": 229,
+          "complexity": 3
+        },
+        {
+          "name": "set_all_diagrams_frozen",
+          "lineno": 243,
+          "complexity": 2
+        },
+        {
+          "name": "diagram_frozen",
+          "lineno": 249,
+          "complexity": 1
+        },
+        {
+          "name": "freeze_active_phase",
+          "lineno": 254,
+          "complexity": 8
+        },
+        {
+          "name": "add_work_product",
+          "lineno": 276,
+          "complexity": 3
+        },
+        {
+          "name": "remove_work_product",
+          "lineno": 286,
+          "complexity": 7
+        },
+        {
+          "name": "register_created_work_product",
+          "lineno": 319,
+          "complexity": 2
+        },
+        {
+          "name": "register_loaded_work_product",
+          "lineno": 327,
+          "complexity": 1
+        },
+        {
+          "name": "register_deleted_work_product",
+          "lineno": 332,
+          "complexity": 3
+        },
+        {
+          "name": "_freeze_active_phase",
+          "lineno": 340,
+          "complexity": 5
+        },
+        {
+          "name": "rename_document",
+          "lineno": 355,
+          "complexity": 2
+        },
+        {
+          "name": "_reuse_map",
+          "lineno": 362,
+          "complexity": 11
+        },
+        {
+          "name": "document_visible",
+          "lineno": 395,
+          "complexity": 10
+        },
+        {
+          "name": "document_read_only",
+          "lineno": 423,
+          "complexity": 10
+        },
+        {
+          "name": "enabled_products",
+          "lineno": 456,
+          "complexity": 7
+        },
+        {
+          "name": "is_enabled",
+          "lineno": 487,
+          "complexity": 1
+        },
+        {
+          "name": "set_active_module",
+          "lineno": 492,
+          "complexity": 3
+        },
+        {
+          "name": "_find_module",
+          "lineno": 508,
+          "complexity": 4
+        },
+        {
+          "name": "diagrams_in_module",
+          "lineno": 518,
+          "complexity": 9
+        },
+        {
+          "name": "diagrams_for_module",
+          "lineno": 561,
+          "complexity": 1
+        },
+        {
+          "name": "module_for_diagram",
+          "lineno": 569,
+          "complexity": 8
+        },
+        {
+          "name": "phase_for_document",
+          "lineno": 604,
+          "complexity": 7
+        },
+        {
+          "name": "activate_phase",
+          "lineno": 621,
+          "complexity": 16
+        },
+        {
+          "name": "activate_document_phase",
+          "lineno": 653,
+          "complexity": 2
+        },
+        {
+          "name": "list_modules",
+          "lineno": 660,
+          "complexity": 3
+        },
+        {
+          "name": "_unique_module_name",
+          "lineno": 679,
+          "complexity": 3
+        },
+        {
+          "name": "add_module",
+          "lineno": 701,
+          "complexity": 2
+        },
+        {
+          "name": "rename_module",
+          "lineno": 717,
+          "complexity": 12
+        },
+        {
+          "name": "propagation_type",
+          "lineno": 755,
+          "complexity": 16
+        },
+        {
+          "name": "can_propagate",
+          "lineno": 799,
+          "complexity": 4
+        },
+        {
+          "name": "_trace_mapping",
+          "lineno": 824,
+          "complexity": 13
+        },
+        {
+          "name": "_analysis_mapping",
+          "lineno": 855,
+          "complexity": 19
+        },
+        {
+          "name": "_req_relation_mapping",
+          "lineno": 895,
+          "complexity": 15
+        },
+        {
+          "name": "_normalize_work_product",
+          "lineno": 935,
+          "complexity": 2
+        },
+        {
+          "name": "can_trace",
+          "lineno": 946,
+          "complexity": 8
+        },
+        {
+          "name": "can_link_requirements",
+          "lineno": 966,
+          "complexity": 8
+        },
+        {
+          "name": "requirement_work_product",
+          "lineno": 988,
+          "complexity": 1
+        },
+        {
+          "name": "requirement_targets",
+          "lineno": 993,
+          "complexity": 2
+        },
+        {
+          "name": "analysis_targets",
+          "lineno": 1002,
+          "complexity": 7
+        },
+        {
+          "name": "analysis_inputs",
+          "lineno": 1039,
+          "complexity": 23
+        },
+        {
+          "name": "analysis_usage_type",
+          "lineno": 1099,
+          "complexity": 5
+        },
+        {
+          "name": "can_use_as_input",
+          "lineno": 1129,
+          "complexity": 5
+        },
+        {
+          "name": "requirement_diagram_targets",
+          "lineno": 1148,
+          "complexity": 2
+        },
+        {
+          "name": "build_lifecycle",
+          "lineno": 1157,
+          "complexity": 1
+        },
+        {
+          "name": "define_workflow",
+          "lineno": 1161,
+          "complexity": 1
+        },
+        {
+          "name": "get_work_products",
+          "lineno": 1165,
+          "complexity": 3
+        },
+        {
+          "name": "get_workflow",
+          "lineno": 1180,
+          "complexity": 1
+        },
+        {
+          "name": "create_diagram",
+          "lineno": 1187,
+          "complexity": 2
+        },
+        {
+          "name": "delete_diagram",
+          "lineno": 1212,
+          "complexity": 4
+        },
+        {
+          "name": "rename_diagram",
+          "lineno": 1225,
+          "complexity": 8
+        },
+        {
+          "name": "list_diagrams",
+          "lineno": 1261,
+          "complexity": 1
+        },
+        {
+          "name": "to_dict",
+          "lineno": 1276,
+          "complexity": 5
+        },
+        {
+          "name": "from_dict",
+          "lineno": 1297,
+          "complexity": 7
+        },
+        {
+          "name": "diagram_hierarchy",
+          "lineno": 1330,
+          "complexity": 19
+        },
+        {
+          "name": "_replace_name_in_modules",
+          "lineno": 1399,
+          "complexity": 4
+        },
+        {
+          "name": "_prune_module_diagrams",
+          "lineno": 1407,
+          "complexity": 3
+        },
+        {
+          "name": "_sync_diagrams",
+          "lineno": 1414,
+          "complexity": 6
+        },
+        {
+          "name": "_search",
+          "lineno": 583,
+          "complexity": 4
+        },
+        {
+          "name": "_collect",
+          "lineno": 668,
+          "complexity": 2
+        },
+        {
+          "name": "_rename",
+          "lineno": 733,
+          "complexity": 5
+        },
+        {
+          "name": "_remove_mods",
+          "lineno": 528,
+          "complexity": 2
+        },
+        {
+          "name": "_collect",
+          "lineno": 544,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "analysis/confusion_matrix.py",
+      "loc": 179,
+      "functions": [
+        {
+          "name": "compute_metrics",
+          "lineno": 7,
+          "complexity": 5
+        },
+        {
+          "name": "compute_rates",
+          "lineno": 44,
+          "complexity": 8
+        },
+        {
+          "name": "compute_metrics_from_target",
+          "lineno": 128,
+          "complexity": 7
+        }
+      ]
+    },
+    {
+      "file": "analysis/models.py",
+      "loc": 599,
+      "functions": [
+        {
+          "name": "safe_float",
+          "lineno": 93,
+          "complexity": 4
+        },
+        {
+          "name": "ensure_requirement_defaults",
+          "lineno": 562,
+          "complexity": 1
+        },
+        {
+          "name": "calc_asil",
+          "lineno": 702,
+          "complexity": 1
+        },
+        {
+          "name": "component_fit_map",
+          "lineno": 707,
+          "complexity": 4
+        },
+        {
+          "name": "temperature",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "temperature",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "tau",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "__hash__",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "compute_cal",
+          "lineno": 227,
+          "complexity": 7
+        },
+        {
+          "name": "__post_init__",
+          "lineno": 344,
+          "complexity": 1
+        },
+        {
+          "name": "compute_overall_impact",
+          "lineno": 349,
+          "complexity": 2
+        },
+        {
+          "name": "compute_risk_level",
+          "lineno": 360,
+          "complexity": 1
+        },
+        {
+          "name": "compute_cal",
+          "lineno": 365,
+          "complexity": 3
+        },
+        {
+          "name": "add",
+          "lineno": 717,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "analysis/requirement_rule_generator.py",
+      "loc": 568,
+      "functions": [
+        {
+          "name": "clean_and_load_json",
+          "lineno": 39,
+          "complexity": 5
+        },
+        {
+          "name": "tidy_sentence",
+          "lineno": 104,
+          "complexity": 4
+        },
+        {
+          "name": "normalize_base_template",
+          "lineno": 115,
+          "complexity": 5
+        },
+        {
+          "name": "build_cond_template",
+          "lineno": 128,
+          "complexity": 2
+        },
+        {
+          "name": "build_const_template",
+          "lineno": 135,
+          "complexity": 2
+        },
+        {
+          "name": "build_cond_const_template",
+          "lineno": 142,
+          "complexity": 1
+        },
+        {
+          "name": "ensure_variables",
+          "lineno": 146,
+          "complexity": 7
+        },
+        {
+          "name": "id_token",
+          "lineno": 163,
+          "complexity": 2
+        },
+        {
+          "name": "make_trigger",
+          "lineno": 167,
+          "complexity": 1
+        },
+        {
+          "name": "is_action_type",
+          "lineno": 171,
+          "complexity": 2
+        },
+        {
+          "name": "_objects_phrase",
+          "lineno": 179,
+          "complexity": 4
+        },
+        {
+          "name": "make_sa_template",
+          "lineno": 190,
+          "complexity": 4
+        },
+        {
+          "name": "make_sa_variables_base",
+          "lineno": 206,
+          "complexity": 3
+        },
+        {
+          "name": "make_sequence_template",
+          "lineno": 230,
+          "complexity": 6
+        },
+        {
+          "name": "make_grouped_action_template",
+          "lineno": 253,
+          "complexity": 2
+        },
+        {
+          "name": "make_gov_variables_base",
+          "lineno": 266,
+          "complexity": 1
+        },
+        {
+          "name": "gov_template_for_relation",
+          "lineno": 270,
+          "complexity": 6
+        },
+        {
+          "name": "rule_info",
+          "lineno": 313,
+          "complexity": 5
+        },
+        {
+          "name": "generate_patterns_from_rules",
+          "lineno": 340,
+          "complexity": 91
+        },
+        {
+          "name": "generate_patterns_from_config",
+          "lineno": 617,
+          "complexity": 1
+        },
+        {
+          "name": "regenerate_requirement_patterns",
+          "lineno": 621,
+          "complexity": 5
+        },
+        {
+          "name": "main",
+          "lineno": 650,
+          "complexity": 4
+        },
+        {
+          "name": "_sq_to_dq",
+          "lineno": 54,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "analysis/risk_assessment.py",
+      "loc": 458,
+      "functions": [
+        {
+          "name": "calculate_validation_target",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "boolify",
+          "lineno": 49,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "aggregate_clone_requirements",
+          "lineno": 68,
+          "complexity": 19
+        },
+        {
+          "name": "fix_clone_references",
+          "lineno": 137,
+          "complexity": 8
+        },
+        {
+          "name": "get_next_unique_id",
+          "lineno": 168,
+          "complexity": 1
+        },
+        {
+          "name": "update_unique_id_counter_for_top_events",
+          "lineno": 173,
+          "complexity": 4
+        },
+        {
+          "name": "round_to_half",
+          "lineno": 188,
+          "complexity": 2
+        },
+        {
+          "name": "discretize_level",
+          "lineno": 196,
+          "complexity": 5
+        },
+        {
+          "name": "scale_severity",
+          "lineno": 210,
+          "complexity": 2
+        },
+        {
+          "name": "scale_controllability",
+          "lineno": 219,
+          "complexity": 2
+        },
+        {
+          "name": "combine_values",
+          "lineno": 228,
+          "complexity": 4
+        },
+        {
+          "name": "combine_rigor_or",
+          "lineno": 239,
+          "complexity": 2
+        },
+        {
+          "name": "combine_rigor_and",
+          "lineno": 246,
+          "complexity": 1
+        },
+        {
+          "name": "combine_generic_values",
+          "lineno": 249,
+          "complexity": 4
+        },
+        {
+          "name": "is_effectively_confidence",
+          "lineno": 261,
+          "complexity": 5
+        },
+        {
+          "name": "is_effectively_robustness",
+          "lineno": 273,
+          "complexity": 5
+        },
+        {
+          "name": "aggregate_assurance_and",
+          "lineno": 285,
+          "complexity": 3
+        },
+        {
+          "name": "aggregate_assurance_or",
+          "lineno": 299,
+          "complexity": 2
+        },
+        {
+          "name": "derive_assurance_from_base",
+          "lineno": 305,
+          "complexity": 3
+        },
+        {
+          "name": "get_highest_parent_severity_for_node",
+          "lineno": 329,
+          "complexity": 20
+        },
+        {
+          "name": "aggregate_assurance_or_adjusted",
+          "lineno": 378,
+          "complexity": 2
+        },
+        {
+          "name": "calculate_assurance_recursive",
+          "lineno": 390,
+          "complexity": 30
+        },
+        {
+          "name": "calculate_probability_recursive",
+          "lineno": 503,
+          "complexity": 11
+        },
+        {
+          "name": "collect_primary",
+          "lineno": 140,
+          "complexity": 3
+        },
+        {
+          "name": "fix",
+          "lineno": 150,
+          "complexity": 4
+        },
+        {
+          "name": "traverse",
+          "lineno": 174,
+          "complexity": 2
+        },
+        {
+          "name": "collect_instances",
+          "lineno": 340,
+          "complexity": 7
+        },
+        {
+          "name": "dfs_up",
+          "lineno": 356,
+          "complexity": 10
+        },
+        {
+          "name": "walk",
+          "lineno": 341,
+          "complexity": 7
+        },
+        {
+          "name": "collect_reqs",
+          "lineno": 93,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "analysis/scenario_description.py",
+      "loc": 112,
+      "functions": [
+        {
+          "name": "_phrase_insufficiency",
+          "lineno": 20,
+          "complexity": 10
+        },
+        {
+          "name": "_combine_segments",
+          "lineno": 38,
+          "complexity": 4
+        },
+        {
+          "name": "_normalize_params",
+          "lineno": 51,
+          "complexity": 10
+        },
+        {
+          "name": "_build_odd_phrase",
+          "lineno": 74,
+          "complexity": 12
+        },
+        {
+          "name": "template_phrases",
+          "lineno": 109,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "matplotlib/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "matplotlib/pyplot.py",
+      "loc": 87,
+      "functions": [
+        {
+          "name": "figure",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "title",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "bar",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "hist",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "xlabel",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "ylabel",
+          "lineno": 56,
+          "complexity": 1
+        },
+        {
+          "name": "xticks",
+          "lineno": 59,
+          "complexity": 1
+        },
+        {
+          "name": "savefig",
+          "lineno": 62,
+          "complexity": 3
+        },
+        {
+          "name": "close",
+          "lineno": 85,
+          "complexity": 1
+        },
+        {
+          "name": "text",
+          "lineno": 88,
+          "complexity": 1
+        },
+        {
+          "name": "axis",
+          "lineno": 93,
+          "complexity": 1
+        },
+        {
+          "name": "gca",
+          "lineno": 96,
+          "complexity": 1
+        },
+        {
+          "name": "tight_layout",
+          "lineno": 121,
+          "complexity": 1
+        },
+        {
+          "name": "clear",
+          "lineno": 4,
+          "complexity": 1
+        },
+        {
+          "name": "plot",
+          "lineno": 7,
+          "complexity": 1
+        },
+        {
+          "name": "set_title",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "bar",
+          "lineno": 13,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "add_subplot",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "tight_layout",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "annotate",
+          "lineno": 107,
+          "complexity": 1
+        },
+        {
+          "name": "scatter",
+          "lineno": 110,
+          "complexity": 1
+        },
+        {
+          "name": "text",
+          "lineno": 113,
+          "complexity": 1
+        },
+        {
+          "name": "axis",
+          "lineno": 116,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "config/__init__.py",
+      "loc": 18,
+      "functions": []
+    },
+    {
+      "file": "config/automl_constants.py",
+      "loc": 532,
+      "functions": []
+    },
+    {
+      "file": "config/config_loader.py",
+      "loc": 327,
+      "functions": [
+        {
+          "name": "_ensure_list_of_strings",
+          "lineno": 22,
+          "complexity": 4
+        },
+        {
+          "name": "validate_diagram_rules",
+          "lineno": 28,
+          "complexity": 55
+        },
+        {
+          "name": "validate_requirement_patterns",
+          "lineno": 182,
+          "complexity": 11
+        },
+        {
+          "name": "validate_report_template",
+          "lineno": 225,
+          "complexity": 16
+        },
+        {
+          "name": "_strip_comments",
+          "lineno": 278,
+          "complexity": 11
+        },
+        {
+          "name": "load_json_with_comments",
+          "lineno": 324,
+          "complexity": 6
+        },
+        {
+          "name": "load_diagram_rules",
+          "lineno": 355,
+          "complexity": 3
+        },
+        {
+          "name": "load_requirement_patterns",
+          "lineno": 373,
+          "complexity": 1
+        },
+        {
+          "name": "load_report_template",
+          "lineno": 379,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/__init__.py",
+      "loc": 151,
+      "functions": [
+        {
+          "name": "_dialog_init_with_color",
+          "lineno": 26,
+          "complexity": 4
+        },
+        {
+          "name": "add_listbox_hover_highlight",
+          "lineno": 86,
+          "complexity": 6
+        },
+        {
+          "name": "format_name_with_phase",
+          "lineno": 138,
+          "complexity": 3
+        },
+        {
+          "name": "add_treeview_scrollbars",
+          "lineno": 146,
+          "complexity": 2
+        },
+        {
+          "name": "_sortable_heading",
+          "lineno": 177,
+          "complexity": 12
+        },
+        {
+          "name": "__init__",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 59,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 70,
+          "complexity": 2
+        },
+        {
+          "name": "_restore",
+          "lineno": 97,
+          "complexity": 4
+        },
+        {
+          "name": "_on_motion",
+          "lineno": 108,
+          "complexity": 3
+        },
+        {
+          "name": "_on_leave",
+          "lineno": 119,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 130,
+          "complexity": 1
+        },
+        {
+          "name": "sort_column",
+          "lineno": 181,
+          "complexity": 9
+        },
+        {
+          "name": "_is_number",
+          "lineno": 184,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "networkx/__init__.py",
+      "loc": 64,
+      "functions": [
+        {
+          "name": "draw_networkx_edges",
+          "lineno": 93,
+          "complexity": 1
+        },
+        {
+          "name": "draw_networkx_nodes",
+          "lineno": 97,
+          "complexity": 1
+        },
+        {
+          "name": "draw",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "draw_networkx_edge_labels",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "add_node",
+          "lineno": 63,
+          "complexity": 1
+        },
+        {
+          "name": "add_edge",
+          "lineno": 68,
+          "complexity": 1
+        },
+        {
+          "name": "has_node",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "successors",
+          "lineno": 80,
+          "complexity": 1
+        },
+        {
+          "name": "predecessors",
+          "lineno": 83,
+          "complexity": 1
+        },
+        {
+          "name": "nodes",
+          "lineno": 86,
+          "complexity": 1
+        },
+        {
+          "name": "edges",
+          "lineno": 89,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "mainappsrc/subapps/project_editor_subapp.py",
+      "loc": 171,
+      "functions": [
+        {
+          "name": "build_probability_frame",
+          "lineno": 16,
+          "complexity": 3
+        },
+        {
+          "name": "apply_project_properties",
+          "lineno": 53,
+          "complexity": 8
+        },
+        {
+          "name": "edit_project_properties",
+          "lineno": 84,
+          "complexity": 12
+        },
+        {
+          "name": "save_props",
+          "lineno": 149,
+          "complexity": 9
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/tree_subapp.py",
+      "loc": 310,
+      "functions": [
+        {
+          "name": "on_treeview_click",
+          "lineno": 17,
+          "complexity": 4
+        },
+        {
+          "name": "on_analysis_tree_double_click",
+          "lineno": 29,
+          "complexity": 51
+        },
+        {
+          "name": "on_analysis_tree_right_click",
+          "lineno": 145,
+          "complexity": 2
+        },
+        {
+          "name": "on_analysis_tree_select",
+          "lineno": 157,
+          "complexity": 8
+        },
+        {
+          "name": "rename_selected_tree_item",
+          "lineno": 198,
+          "complexity": 52
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/reliability_subapp.py",
+      "loc": 28,
+      "functions": [
+        {
+          "name": "open_reliability_window",
+          "lineno": 13,
+          "complexity": 3
+        },
+        {
+          "name": "open_fmeda_window",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "open_fault_prioritization_window",
+          "lineno": 28,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/activity_diagram_subapp.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "open",
+          "lineno": 14,
+          "complexity": 3
+        },
+        {
+          "name": "create_export_window",
+          "lineno": 30,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/control_flow_diagram_subapp.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "open",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "create_export_window",
+          "lineno": 30,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/use_case_diagram_subapp.py",
+      "loc": 21,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "open",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "create_export_window",
+          "lineno": 26,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/fta_subapp.py",
+      "loc": 641,
+      "functions": [
+        {
+          "name": "generate_recommendations_for_top_event",
+          "lineno": 16,
+          "complexity": 4
+        },
+        {
+          "name": "back_all_pages",
+          "lineno": 30,
+          "complexity": 3
+        },
+        {
+          "name": "move_top_event_up",
+          "lineno": 40,
+          "complexity": 6
+        },
+        {
+          "name": "move_top_event_down",
+          "lineno": 59,
+          "complexity": 6
+        },
+        {
+          "name": "get_top_level_nodes",
+          "lineno": 78,
+          "complexity": 2
+        },
+        {
+          "name": "get_all_nodes_no_filter",
+          "lineno": 82,
+          "complexity": 2
+        },
+        {
+          "name": "derive_requirements_for_event",
+          "lineno": 88,
+          "complexity": 4
+        },
+        {
+          "name": "get_combined_safety_requirements",
+          "lineno": 96,
+          "complexity": 6
+        },
+        {
+          "name": "get_top_event",
+          "lineno": 104,
+          "complexity": 4
+        },
+        {
+          "name": "aggregate_safety_requirements",
+          "lineno": 113,
+          "complexity": 7
+        },
+        {
+          "name": "generate_top_event_summary",
+          "lineno": 129,
+          "complexity": 18
+        },
+        {
+          "name": "get_all_nodes",
+          "lineno": 171,
+          "complexity": 8
+        },
+        {
+          "name": "get_all_nodes_table",
+          "lineno": 193,
+          "complexity": 2
+        },
+        {
+          "name": "get_all_nodes_in_model",
+          "lineno": 204,
+          "complexity": 2
+        },
+        {
+          "name": "get_all_basic_events",
+          "lineno": 212,
+          "complexity": 2
+        },
+        {
+          "name": "get_all_gates",
+          "lineno": 215,
+          "complexity": 2
+        },
+        {
+          "name": "metric_to_text",
+          "lineno": 218,
+          "complexity": 11
+        },
+        {
+          "name": "assurance_level_text",
+          "lineno": 231,
+          "complexity": 1
+        },
+        {
+          "name": "calculate_cut_sets",
+          "lineno": 235,
+          "complexity": 12
+        },
+        {
+          "name": "build_hierarchical_argumentation",
+          "lineno": 260,
+          "complexity": 9
+        },
+        {
+          "name": "build_hierarchical_argumentation_common",
+          "lineno": 278,
+          "complexity": 11
+        },
+        {
+          "name": "build_page_argumentation",
+          "lineno": 302,
+          "complexity": 1
+        },
+        {
+          "name": "build_unified_recommendation_table",
+          "lineno": 305,
+          "complexity": 17
+        },
+        {
+          "name": "get_extra_recommendations_list",
+          "lineno": 382,
+          "complexity": 4
+        },
+        {
+          "name": "get_extra_recommendations_from_level",
+          "lineno": 393,
+          "complexity": 7
+        },
+        {
+          "name": "get_recommendation_from_description",
+          "lineno": 409,
+          "complexity": 4
+        },
+        {
+          "name": "build_argumentation",
+          "lineno": 420,
+          "complexity": 14
+        },
+        {
+          "name": "auto_create_argumentation",
+          "lineno": 468,
+          "complexity": 22
+        },
+        {
+          "name": "analyze_common_causes",
+          "lineno": 515,
+          "complexity": 8
+        },
+        {
+          "name": "build_text_report",
+          "lineno": 539,
+          "complexity": 5
+        },
+        {
+          "name": "all_children_are_base_events",
+          "lineno": 554,
+          "complexity": 4
+        },
+        {
+          "name": "build_simplified_fta_model",
+          "lineno": 563,
+          "complexity": 6
+        },
+        {
+          "name": "auto_generate_fta_diagram",
+          "lineno": 587,
+          "complexity": 35
+        },
+        {
+          "name": "rec",
+          "lineno": 180,
+          "complexity": 6
+        },
+        {
+          "name": "rec",
+          "lineno": 196,
+          "complexity": 2
+        },
+        {
+          "name": "map_nodes",
+          "lineno": 437,
+          "complexity": 2
+        },
+        {
+          "name": "traverse",
+          "lineno": 518,
+          "complexity": 3
+        },
+        {
+          "name": "traverse",
+          "lineno": 568,
+          "complexity": 6
+        },
+        {
+          "name": "get_node_bbox",
+          "lineno": 668,
+          "complexity": 1
+        },
+        {
+          "name": "bboxes_overlap",
+          "lineno": 671,
+          "complexity": 4
+        },
+        {
+          "name": "avg_parent_position",
+          "lineno": 655,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/style_subapp.py",
+      "loc": 189,
       "functions": [
         {
           "name": "__init__",
@@ -35,59 +20361,3877 @@
           "complexity": 1
         },
         {
-          "name": "compute_failure_prob",
-          "lineno": 21,
-          "complexity": 14
+          "name": "apply",
+          "lineno": 22,
+          "complexity": 10
         },
         {
-          "name": "update_basic_event_probabilities",
-          "lineno": 62,
-          "complexity": 2
+          "name": "_build_pill",
+          "lineno": 154,
+          "complexity": 8
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/diagram_export_subapp.py",
+      "loc": 498,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
         },
         {
-          "name": "calculate_pmfh",
-          "lineno": 68,
-          "complexity": 21
+          "name": "save_diagram_png",
+          "lineno": 15,
+          "complexity": 12
         },
         {
-          "name": "calculate_overall",
-          "lineno": 127,
+          "name": "get_page_nodes",
+          "lineno": 70,
           "complexity": 4
         },
         {
-          "name": "_build_probability_frame",
-          "lineno": 143,
+          "name": "capture_page_diagram",
+          "lineno": 80,
+          "complexity": 4
+        },
+        {
+          "name": "capture_gsn_diagram",
+          "lineno": 121,
+          "complexity": 5
+        },
+        {
+          "name": "capture_sysml_diagram",
+          "lineno": 162,
+          "complexity": 10
+        },
+        {
+          "name": "capture_cbn_diagram",
+          "lineno": 209,
+          "complexity": 5
+        },
+        {
+          "name": "capture_diff_diagram",
+          "lineno": 241,
+          "complexity": 87
+        },
+        {
+          "name": "filter_events",
+          "lineno": 258,
+          "complexity": 2
+        },
+        {
+          "name": "build_conn_set",
+          "lineno": 267,
           "complexity": 3
         },
         {
-          "name": "assurance_level_text",
-          "lineno": 177,
+          "name": "collect_ids",
+          "lineno": 313,
+          "complexity": 2
+        },
+        {
+          "name": "collect_nodes",
+          "lineno": 323,
+          "complexity": 3
+        },
+        {
+          "name": "draw_connections",
+          "lineno": 341,
+          "complexity": 10
+        },
+        {
+          "name": "draw_node",
+          "lineno": 370,
+          "complexity": 25
+        },
+        {
+          "name": "diff_segments",
+          "lineno": 473,
+          "complexity": 6
+        },
+        {
+          "name": "draw_segment_text",
+          "lineno": 488,
+          "complexity": 8
+        },
+        {
+          "name": "visit",
+          "lineno": 269,
+          "complexity": 2
+        },
+        {
+          "name": "req_lines",
+          "lineno": 388,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/risk_assessment_subapp.py",
+      "loc": 700,
+      "functions": [
+        {
+          "name": "get_hazop_by_name",
+          "lineno": 27,
+          "complexity": 3
+        },
+        {
+          "name": "get_hara_by_name",
+          "lineno": 33,
+          "complexity": 3
+        },
+        {
+          "name": "update_hara_statuses",
+          "lineno": 39,
+          "complexity": 7
+        },
+        {
+          "name": "update_fta_statuses",
+          "lineno": 57,
+          "complexity": 7
+        },
+        {
+          "name": "get_safety_goal_asil",
+          "lineno": 74,
+          "complexity": 15
+        },
+        {
+          "name": "get_hara_goal_asil",
+          "lineno": 89,
+          "complexity": 6
+        },
+        {
+          "name": "get_cyber_goal_cal",
+          "lineno": 98,
+          "complexity": 9
+        },
+        {
+          "name": "get_top_event_safety_goals",
+          "lineno": 113,
+          "complexity": 7
+        },
+        {
+          "name": "_replace_in_mal_list",
+          "lineno": 128,
+          "complexity": 6
+        },
+        {
+          "name": "_replace_entry_mal",
+          "lineno": 146,
+          "complexity": 5
+        },
+        {
+          "name": "_replace_name_in_list",
+          "lineno": 153,
+          "complexity": 5
+        },
+        {
+          "name": "_remove_name_from_list",
+          "lineno": 167,
+          "complexity": 4
+        },
+        {
+          "name": "add_malfunction",
+          "lineno": 175,
+          "complexity": 9
+        },
+        {
+          "name": "add_fault",
+          "lineno": 193,
           "complexity": 1
         },
         {
-          "name": "metric_to_text",
-          "lineno": 181,
+          "name": "add_failure",
+          "lineno": 198,
           "complexity": 1
         },
         {
-          "name": "analyze_common_causes",
-          "lineno": 185,
-          "complexity": 1
+          "name": "add_hazard",
+          "lineno": 203,
+          "complexity": 4
         },
         {
-          "name": "build_cause_effect_data",
-          "lineno": 189,
-          "complexity": 27
+          "name": "add_triggering_condition",
+          "lineno": 215,
+          "complexity": 5
         },
         {
-          "name": "_build_cause_effect_graph",
-          "lineno": 267,
+          "name": "delete_triggering_condition",
+          "lineno": 227,
+          "complexity": 6
+        },
+        {
+          "name": "rename_triggering_condition",
+          "lineno": 243,
+          "complexity": 9
+        },
+        {
+          "name": "add_functional_insufficiency",
+          "lineno": 262,
+          "complexity": 5
+        },
+        {
+          "name": "delete_functional_insufficiency",
+          "lineno": 275,
+          "complexity": 6
+        },
+        {
+          "name": "rename_functional_insufficiency",
+          "lineno": 291,
+          "complexity": 9
+        },
+        {
+          "name": "rename_malfunction",
+          "lineno": 310,
+          "complexity": 15
+        },
+        {
+          "name": "rename_hazard",
+          "lineno": 336,
+          "complexity": 15
+        },
+        {
+          "name": "update_hazard_severity",
+          "lineno": 359,
+          "complexity": 8
+        },
+        {
+          "name": "rename_fault",
+          "lineno": 376,
+          "complexity": 13
+        },
+        {
+          "name": "rename_failure",
+          "lineno": 397,
+          "complexity": 9
+        },
+        {
+          "name": "calculate_fmeda_metrics",
+          "lineno": 412,
+          "complexity": 8
+        },
+        {
+          "name": "compute_fmeda_metrics",
+          "lineno": 441,
+          "complexity": 17
+        },
+        {
+          "name": "sync_hara_to_safety_goals",
+          "lineno": 512,
           "complexity": 27
         },
         {
           "name": "sync_cyber_risk_to_goals",
-          "lineno": 373,
+          "lineno": 585,
+          "complexity": 9
+        },
+        {
+          "name": "open_hazop_window",
+          "lineno": 604,
+          "complexity": 3
+        },
+        {
+          "name": "open_risk_assessment_window",
+          "lineno": 612,
+          "complexity": 3
+        },
+        {
+          "name": "open_stpa_window",
+          "lineno": 620,
+          "complexity": 3
+        },
+        {
+          "name": "open_threat_window",
+          "lineno": 628,
+          "complexity": 3
+        },
+        {
+          "name": "open_causal_bayesian_network_window",
+          "lineno": 636,
+          "complexity": 3
+        },
+        {
+          "name": "create_cbn_export_window",
+          "lineno": 646,
           "complexity": 1
+        },
+        {
+          "name": "open_fi2tc_window",
+          "lineno": 652,
+          "complexity": 3
+        },
+        {
+          "name": "open_tc2fi_window",
+          "lineno": 660,
+          "complexity": 3
+        },
+        {
+          "name": "show_hazard_list",
+          "lineno": 668,
+          "complexity": 12
+        },
+        {
+          "name": "show_hazard_editor",
+          "lineno": 759,
+          "complexity": 1
+        },
+        {
+          "name": "show_hazard_explorer",
+          "lineno": 762,
+          "complexity": 3
+        },
+        {
+          "name": "refresh",
+          "lineno": 712,
+          "complexity": 2
+        },
+        {
+          "name": "add",
+          "lineno": 717,
+          "complexity": 3
+        },
+        {
+          "name": "rename",
+          "lineno": 726,
+          "complexity": 5
+        },
+        {
+          "name": "delete",
+          "lineno": 741,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 685,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 690,
+          "complexity": 1
+        },
+        {
+          "name": "apply",
+          "lineno": 706,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/block_diagram_subapp.py",
+      "loc": 21,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "open",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "create_export_window",
+          "lineno": 26,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/subapps/internal_block_diagram_subapp.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "open",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "create_export_window",
+          "lineno": 30,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "mainappsrc/managers/gsn_manager.py",
+      "loc": 52,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "manage_gsn",
+          "lineno": 28,
+          "complexity": 3
+        },
+        {
+          "name": "open_diagram",
+          "lineno": 39,
+          "complexity": 4
+        },
+        {
+          "name": "refresh",
+          "lineno": 55,
+          "complexity": 10
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/fmeda_manager.py",
+      "loc": 135,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 9,
+          "complexity": 1
+        },
+        {
+          "name": "add_fmeda",
+          "lineno": 14,
+          "complexity": 2
+        },
+        {
+          "name": "delete_fmeda",
+          "lineno": 35,
+          "complexity": 3
+        },
+        {
+          "name": "rename_fmeda",
+          "lineno": 44,
+          "complexity": 2
+        },
+        {
+          "name": "show_fmeda_list",
+          "lineno": 54,
+          "complexity": 11
+        },
+        {
+          "name": "open_selected",
+          "lineno": 84,
+          "complexity": 2
+        },
+        {
+          "name": "add",
+          "lineno": 93,
+          "complexity": 2
+        },
+        {
+          "name": "delete",
+          "lineno": 110,
+          "complexity": 2
+        },
+        {
+          "name": "rename",
+          "lineno": 119,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/review_manager.py",
+      "loc": 930,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "start_peer_review",
+          "lineno": 35,
+          "complexity": 10
+        },
+        {
+          "name": "start_joint_review",
+          "lineno": 94,
+          "complexity": 32
+        },
+        {
+          "name": "open_review_document",
+          "lineno": 220,
+          "complexity": 3
+        },
+        {
+          "name": "open_review_toolbox",
+          "lineno": 230,
+          "complexity": 6
+        },
+        {
+          "name": "send_review_email",
+          "lineno": 247,
+          "complexity": 61
+        },
+        {
+          "name": "review_is_closed",
+          "lineno": 487,
+          "complexity": 6
+        },
+        {
+          "name": "review_is_closed_for",
+          "lineno": 501,
+          "complexity": 6
+        },
+        {
+          "name": "get_requirements_for_review",
+          "lineno": 515,
+          "complexity": 10
+        },
+        {
+          "name": "invalidate_reviews_for_hara",
+          "lineno": 533,
+          "complexity": 4
+        },
+        {
+          "name": "invalidate_reviews_for_requirement",
+          "lineno": 546,
+          "complexity": 4
+        },
+        {
+          "name": "merge_review_comments",
+          "lineno": 557,
+          "complexity": 18
+        },
+        {
+          "name": "add_version",
+          "lineno": 617,
+          "complexity": 2
+        },
+        {
+          "name": "compare_versions",
+          "lineno": 628,
+          "complexity": 4
+        },
+        {
+          "name": "get_review_targets",
+          "lineno": 638,
+          "complexity": 21
+        },
+        {
+          "name": "calculate_diff_nodes",
+          "lineno": 684,
+          "complexity": 5
+        },
+        {
+          "name": "calculate_diff_between",
+          "lineno": 693,
+          "complexity": 4
+        },
+        {
+          "name": "node_map_from_data",
+          "lineno": 702,
+          "complexity": 3
+        },
+        {
+          "name": "capture_diff_diagram",
+          "lineno": 713,
+          "complexity": 86
+        },
+        {
+          "name": "visit",
+          "lineno": 705,
+          "complexity": 2
+        },
+        {
+          "name": "filter_events",
+          "lineno": 724,
+          "complexity": 2
+        },
+        {
+          "name": "build_conn_set",
+          "lineno": 733,
+          "complexity": 3
+        },
+        {
+          "name": "collect_ids",
+          "lineno": 782,
+          "complexity": 2
+        },
+        {
+          "name": "collect_nodes",
+          "lineno": 794,
+          "complexity": 3
+        },
+        {
+          "name": "diff_segments",
+          "lineno": 803,
+          "complexity": 6
+        },
+        {
+          "name": "draw_segment_text",
+          "lineno": 818,
+          "complexity": 8
+        },
+        {
+          "name": "draw_connections",
+          "lineno": 844,
+          "complexity": 10
+        },
+        {
+          "name": "draw_node",
+          "lineno": 871,
+          "complexity": 24
+        },
+        {
+          "name": "peer_completed",
+          "lineno": 133,
+          "complexity": 4
+        },
+        {
+          "name": "visit",
+          "lineno": 736,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/paa_manager.py",
+      "loc": 24,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "enable_paa_actions",
+          "lineno": 13,
+          "complexity": 4
+        },
+        {
+          "name": "_create_paa_tab",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "create_paa_diagram",
+          "lineno": 26,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/sotif_manager.py",
+      "loc": 133,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "build_goal_dialog",
+          "lineno": 30,
+          "complexity": 5
+        },
+        {
+          "name": "collect_goal_data",
+          "lineno": 107,
+          "complexity": 1
+        },
+        {
+          "name": "get_spi_targets_for_goal",
+          "lineno": 124,
+          "complexity": 2
+        },
+        {
+          "name": "iter_spi_rows",
+          "lineno": 130,
+          "complexity": 9
+        },
+        {
+          "name": "probabilities_for",
+          "lineno": 159,
+          "complexity": 1
+        },
+        {
+          "name": "_update_val",
+          "lineno": 82,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/requirements_manager.py",
+      "loc": 177,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "export_state",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "get_requirement_allocation_names",
+          "lineno": 32,
+          "complexity": 31
+        },
+        {
+          "name": "_collect_goal_names",
+          "lineno": 68,
+          "complexity": 5
+        },
+        {
+          "name": "get_requirement_goal_names",
+          "lineno": 74,
+          "complexity": 17
+        },
+        {
+          "name": "format_requirement_with_trace",
+          "lineno": 96,
+          "complexity": 1
+        },
+        {
+          "name": "collect_reqs",
+          "lineno": 105,
+          "complexity": 5
+        },
+        {
+          "name": "build_requirement_diff_html",
+          "lineno": 114,
+          "complexity": 45
+        },
+        {
+          "name": "filter_data",
+          "lineno": 120,
+          "complexity": 4
+        },
+        {
+          "name": "html_diff",
+          "lineno": 168,
+          "complexity": 6
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/user_manager.py",
+      "loc": 54,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "edit_user_name",
+          "lineno": 15,
+          "complexity": 4
+        },
+        {
+          "name": "set_current_user",
+          "lineno": 35,
+          "complexity": 5
+        },
+        {
+          "name": "get_current_user_role",
+          "lineno": 53,
+          "complexity": 6
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/repository_manager.py",
+      "loc": 196,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "capture_sysml_diagram",
+          "lineno": 36,
+          "complexity": 10
+        },
+        {
+          "name": "open_arch_window",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "open_management_window",
+          "lineno": 85,
+          "complexity": 12
+        },
+        {
+          "name": "_create_fta_tab",
+          "lineno": 117,
+          "complexity": 4
+        },
+        {
+          "name": "create_fta_diagram",
+          "lineno": 168,
+          "complexity": 2
+        },
+        {
+          "name": "enable_fta_actions",
+          "lineno": 175,
+          "complexity": 4
+        },
+        {
+          "name": "_reset_fta_state",
+          "lineno": 188,
+          "complexity": 1
+        },
+        {
+          "name": "ensure_fta_tab",
+          "lineno": 197,
+          "complexity": 3
+        },
+        {
+          "name": "update_fta_statuses",
+          "lineno": 209,
+          "complexity": 7
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/governance_manager.py",
+      "loc": 133,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "attach_toolbox",
+          "lineno": 30,
+          "complexity": 2
+        },
+        {
+          "name": "freeze_governance_diagrams",
+          "lineno": 37,
+          "complexity": 2
+        },
+        {
+          "name": "set_active_module",
+          "lineno": 43,
+          "complexity": 5
+        },
+        {
+          "name": "update_lifecycle_cb",
+          "lineno": 52,
+          "complexity": 7
+        },
+        {
+          "name": "apply_governance_rules",
+          "lineno": 74,
+          "complexity": 2
+        },
+        {
+          "name": "create_export_window",
+          "lineno": 82,
+          "complexity": 1
+        },
+        {
+          "name": "_on_toolbox_change",
+          "lineno": 89,
+          "complexity": 4
+        },
+        {
+          "name": "refresh_tool_enablement",
+          "lineno": 102,
+          "complexity": 28
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/project_manager.py",
+      "loc": 257,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "new_model",
+          "lineno": 22,
+          "complexity": 10
+        },
+        {
+          "name": "_reset_on_load",
+          "lineno": 84,
+          "complexity": 8
+        },
+        {
+          "name": "_prompt_save_before_load",
+          "lineno": 131,
+          "complexity": 1
+        },
+        {
+          "name": "save_model",
+          "lineno": 136,
+          "complexity": 13
+        },
+        {
+          "name": "load_model",
+          "lineno": 201,
+          "complexity": 15
+        },
+        {
+          "name": "clean",
+          "lineno": 258,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/cyber_manager.py",
+      "loc": 58,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "add_goal_dialog_fields",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "build_risk_entry",
+          "lineno": 31,
+          "complexity": 2
+        },
+        {
+          "name": "export_goal_requirements",
+          "lineno": 50,
+          "complexity": 6
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/managers/cta_manager.py",
+      "loc": 29,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "register_menu",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "_create_tab",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "create_diagram",
+          "lineno": 26,
+          "complexity": 2
+        },
+        {
+          "name": "enable_actions",
+          "lineno": 33,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "mainappsrc/core/pages_and_paa.py",
+      "loc": 206,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "__getattr__",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "enable_paa_actions",
+          "lineno": 28,
+          "complexity": 4
+        },
+        {
+          "name": "_create_paa_tab",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "create_paa_diagram",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "open_page_diagram",
+          "lineno": 46,
+          "complexity": 1
+        },
+        {
+          "name": "draw_page_subtree",
+          "lineno": 50,
+          "complexity": 2
+        },
+        {
+          "name": "draw_page_grid",
+          "lineno": 60,
+          "complexity": 5
+        },
+        {
+          "name": "draw_page_connections_subtree",
+          "lineno": 69,
+          "complexity": 4
+        },
+        {
+          "name": "draw_page_nodes_subtree",
+          "lineno": 92,
+          "complexity": 2
+        },
+        {
+          "name": "draw_node_on_page_canvas",
+          "lineno": 97,
+          "complexity": 8
+        },
+        {
+          "name": "_draw_non_page_node",
+          "lineno": 148,
+          "complexity": 4
+        },
+        {
+          "name": "_draw_review_marker",
+          "lineno": 193,
+          "complexity": 4
+        },
+        {
+          "name": "capture_page_diagram",
+          "lineno": 207,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/automl_core.py",
+      "loc": 8252,
+      "functions": [
+        {
+          "name": "format_requirement",
+          "lineno": 476,
+          "complexity": 6
+        },
+        {
+          "name": "_reload_local_config",
+          "lineno": 506,
+          "complexity": 1
+        },
+        {
+          "name": "load_user_data",
+          "lineno": 9474,
+          "complexity": 2
+        },
+        {
+          "name": "main",
+          "lineno": 9482,
+          "complexity": 8
+        },
+        {
+          "name": "fmedas",
+          "lineno": 545,
+          "complexity": 1
+        },
+        {
+          "name": "fmedas",
+          "lineno": 549,
+          "complexity": 1
+        },
+        {
+          "name": "window_controllers",
+          "lineno": 586,
+          "complexity": 2
+        },
+        {
+          "name": "top_event_workflows",
+          "lineno": 592,
+          "complexity": 2
+        },
+        {
+          "name": "__getattr__",
+          "lineno": 597,
+          "complexity": 5
+        },
+        {
+          "name": "__init__",
+          "lineno": 617,
+          "complexity": 9
+        },
+        {
+          "name": "show_properties",
+          "lineno": 1458,
+          "complexity": 1
+        },
+        {
+          "name": "_add_tool_category",
+          "lineno": 1461,
+          "complexity": 1
+        },
+        {
+          "name": "_add_lifecycle_requirements_menu",
+          "lineno": 1464,
+          "complexity": 1
+        },
+        {
+          "name": "_init_nav_button_style",
+          "lineno": 1467,
+          "complexity": 1
+        },
+        {
+          "name": "_limit_explorer_size",
+          "lineno": 1470,
+          "complexity": 1
+        },
+        {
+          "name": "_animate_explorer_show",
+          "lineno": 1473,
+          "complexity": 1
+        },
+        {
+          "name": "_animate_explorer_hide",
+          "lineno": 1476,
+          "complexity": 1
+        },
+        {
+          "name": "_schedule_explorer_hide",
+          "lineno": 1479,
+          "complexity": 1
+        },
+        {
+          "name": "_cancel_explorer_hide",
+          "lineno": 1482,
+          "complexity": 1
+        },
+        {
+          "name": "show_explorer",
+          "lineno": 1485,
+          "complexity": 1
+        },
+        {
+          "name": "hide_explorer",
+          "lineno": 1488,
+          "complexity": 1
+        },
+        {
+          "name": "toggle_explorer_pin",
+          "lineno": 1491,
+          "complexity": 1
+        },
+        {
+          "name": "toggle_logs",
+          "lineno": 1494,
+          "complexity": 1
+        },
+        {
+          "name": "open_metrics_tab",
+          "lineno": 1497,
+          "complexity": 1
+        },
+        {
+          "name": "open_management_window",
+          "lineno": 1500,
+          "complexity": 1
+        },
+        {
+          "name": "_register_close",
+          "lineno": 1503,
+          "complexity": 1
+        },
+        {
+          "name": "_reregister_document",
+          "lineno": 1506,
+          "complexity": 1
+        },
+        {
+          "name": "touch_doc",
+          "lineno": 1509,
+          "complexity": 1
+        },
+        {
+          "name": "show_about",
+          "lineno": 1512,
+          "complexity": 1
+        },
+        {
+          "name": "_window_has_focus",
+          "lineno": 1515,
+          "complexity": 1
+        },
+        {
+          "name": "_window_in_selected_tab",
+          "lineno": 1518,
+          "complexity": 1
+        },
+        {
+          "name": "_on_tab_change",
+          "lineno": 1521,
+          "complexity": 1
+        },
+        {
+          "name": "_on_tab_close",
+          "lineno": 1524,
+          "complexity": 1
+        },
+        {
+          "name": "_on_doc_tab_motion",
+          "lineno": 1527,
+          "complexity": 1
+        },
+        {
+          "name": "_on_tool_tab_motion",
+          "lineno": 1530,
+          "complexity": 1
+        },
+        {
+          "name": "_make_doc_tab_visible",
+          "lineno": 1533,
+          "complexity": 1
+        },
+        {
+          "name": "_update_doc_tab_visibility",
+          "lineno": 1536,
+          "complexity": 1
+        },
+        {
+          "name": "_update_tool_tab_visibility",
+          "lineno": 1539,
+          "complexity": 1
+        },
+        {
+          "name": "_truncate_tab_title",
+          "lineno": 1542,
+          "complexity": 1
+        },
+        {
+          "name": "_select_next_tab",
+          "lineno": 1545,
+          "complexity": 1
+        },
+        {
+          "name": "_select_prev_tab",
+          "lineno": 1548,
+          "complexity": 1
+        },
+        {
+          "name": "_select_next_tool_tab",
+          "lineno": 1551,
+          "complexity": 1
+        },
+        {
+          "name": "_select_prev_tool_tab",
+          "lineno": 1554,
+          "complexity": 1
+        },
+        {
+          "name": "_new_tab",
+          "lineno": 1557,
+          "complexity": 1
+        },
+        {
+          "name": "edit_controllability",
+          "lineno": 1563,
+          "complexity": 1
+        },
+        {
+          "name": "edit_description",
+          "lineno": 1566,
+          "complexity": 1
+        },
+        {
+          "name": "edit_gate_type",
+          "lineno": 1569,
+          "complexity": 1
+        },
+        {
+          "name": "edit_page_flag",
+          "lineno": 1572,
+          "complexity": 1
+        },
+        {
+          "name": "edit_rationale",
+          "lineno": 1575,
+          "complexity": 1
+        },
+        {
+          "name": "edit_selected",
+          "lineno": 1578,
+          "complexity": 1
+        },
+        {
+          "name": "edit_user_name",
+          "lineno": 1581,
+          "complexity": 1
+        },
+        {
+          "name": "edit_value",
+          "lineno": 1584,
+          "complexity": 1
+        },
+        {
+          "name": "rename_failure",
+          "lineno": 1587,
+          "complexity": 1
+        },
+        {
+          "name": "rename_fault",
+          "lineno": 1590,
+          "complexity": 1
+        },
+        {
+          "name": "rename_functional_insufficiency",
+          "lineno": 1593,
+          "complexity": 1
+        },
+        {
+          "name": "rename_hazard",
+          "lineno": 1596,
+          "complexity": 1
+        },
+        {
+          "name": "rename_malfunction",
+          "lineno": 1599,
+          "complexity": 1
+        },
+        {
+          "name": "rename_selected_tree_item",
+          "lineno": 1602,
+          "complexity": 1
+        },
+        {
+          "name": "rename_triggering_condition",
+          "lineno": 1605,
+          "complexity": 1
+        },
+        {
+          "name": "apply_style",
+          "lineno": 1608,
+          "complexity": 1
+        },
+        {
+          "name": "format_failure_mode_label",
+          "lineno": 1611,
+          "complexity": 1
+        },
+        {
+          "name": "_resize_prop_columns",
+          "lineno": 1614,
+          "complexity": 1
+        },
+        {
+          "name": "_spi_label",
+          "lineno": 1617,
+          "complexity": 1
+        },
+        {
+          "name": "_product_goal_name",
+          "lineno": 1620,
+          "complexity": 1
+        },
+        {
+          "name": "_create_icon",
+          "lineno": 1623,
+          "complexity": 1
+        },
+        {
+          "name": "fmeas",
+          "lineno": 1627,
+          "complexity": 2
+        },
+        {
+          "name": "fmeas",
+          "lineno": 1633,
+          "complexity": 2
+        },
+        {
+          "name": "show_fmea_list",
+          "lineno": 1638,
+          "complexity": 1
+        },
+        {
+          "name": "get_requirement_allocation_names",
+          "lineno": 1643,
+          "complexity": 1
+        },
+        {
+          "name": "get_requirement_goal_names",
+          "lineno": 1646,
+          "complexity": 1
+        },
+        {
+          "name": "format_requirement_with_trace",
+          "lineno": 1649,
+          "complexity": 1
+        },
+        {
+          "name": "build_requirement_diff_html",
+          "lineno": 1652,
+          "complexity": 1
+        },
+        {
+          "name": "generate_recommendations_for_top_event",
+          "lineno": 1655,
+          "complexity": 1
+        },
+        {
+          "name": "back_all_pages",
+          "lineno": 1658,
+          "complexity": 1
+        },
+        {
+          "name": "move_top_event_up",
+          "lineno": 1661,
+          "complexity": 1
+        },
+        {
+          "name": "move_top_event_down",
+          "lineno": 1664,
+          "complexity": 1
+        },
+        {
+          "name": "get_top_level_nodes",
+          "lineno": 1667,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes_no_filter",
+          "lineno": 1670,
+          "complexity": 1
+        },
+        {
+          "name": "derive_requirements_for_event",
+          "lineno": 1673,
+          "complexity": 1
+        },
+        {
+          "name": "get_combined_safety_requirements",
+          "lineno": 1676,
+          "complexity": 1
+        },
+        {
+          "name": "get_top_event",
+          "lineno": 1679,
+          "complexity": 1
+        },
+        {
+          "name": "aggregate_safety_requirements",
+          "lineno": 1682,
+          "complexity": 1
+        },
+        {
+          "name": "generate_top_event_summary",
+          "lineno": 1685,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes",
+          "lineno": 1688,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes_table",
+          "lineno": 1691,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes_in_model",
+          "lineno": 1694,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_basic_events",
+          "lineno": 1697,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_gates",
+          "lineno": 1700,
+          "complexity": 1
+        },
+        {
+          "name": "metric_to_text",
+          "lineno": 1703,
+          "complexity": 1
+        },
+        {
+          "name": "assurance_level_text",
+          "lineno": 1706,
+          "complexity": 1
+        },
+        {
+          "name": "calculate_cut_sets",
+          "lineno": 1709,
+          "complexity": 1
+        },
+        {
+          "name": "build_hierarchical_argumentation",
+          "lineno": 1712,
+          "complexity": 1
+        },
+        {
+          "name": "build_hierarchical_argumentation_common",
+          "lineno": 1715,
+          "complexity": 1
+        },
+        {
+          "name": "build_page_argumentation",
+          "lineno": 1718,
+          "complexity": 1
+        },
+        {
+          "name": "build_unified_recommendation_table",
+          "lineno": 1721,
+          "complexity": 1
+        },
+        {
+          "name": "build_dynamic_recommendations_table",
+          "lineno": 1724,
+          "complexity": 1
+        },
+        {
+          "name": "build_base_events_table_html",
+          "lineno": 1727,
+          "complexity": 1
+        },
+        {
+          "name": "get_extra_recommendations_list",
+          "lineno": 1730,
+          "complexity": 1
+        },
+        {
+          "name": "get_extra_recommendations_from_level",
+          "lineno": 1733,
+          "complexity": 1
+        },
+        {
+          "name": "get_recommendation_from_description",
+          "lineno": 1736,
+          "complexity": 1
+        },
+        {
+          "name": "build_argumentation",
+          "lineno": 1739,
+          "complexity": 1
+        },
+        {
+          "name": "auto_create_argumentation",
+          "lineno": 1742,
+          "complexity": 1
+        },
+        {
+          "name": "analyze_common_causes",
+          "lineno": 1745,
+          "complexity": 1
+        },
+        {
+          "name": "build_text_report",
+          "lineno": 1748,
+          "complexity": 1
+        },
+        {
+          "name": "all_children_are_base_events",
+          "lineno": 1751,
+          "complexity": 1
+        },
+        {
+          "name": "build_simplified_fta_model",
+          "lineno": 1754,
+          "complexity": 1
+        },
+        {
+          "name": "auto_generate_fta_diagram",
+          "lineno": 1758,
+          "complexity": 1
+        },
+        {
+          "name": "find_node_by_id_all",
+          "lineno": 1761,
+          "complexity": 1
+        },
+        {
+          "name": "get_hazop_by_name",
+          "lineno": 1764,
+          "complexity": 1
+        },
+        {
+          "name": "get_hara_by_name",
+          "lineno": 1767,
+          "complexity": 1
+        },
+        {
+          "name": "update_hara_statuses",
+          "lineno": 1770,
+          "complexity": 1
+        },
+        {
+          "name": "update_fta_statuses",
+          "lineno": 1773,
+          "complexity": 1
+        },
+        {
+          "name": "get_safety_goal_asil",
+          "lineno": 1776,
+          "complexity": 1
+        },
+        {
+          "name": "get_hara_goal_asil",
+          "lineno": 1779,
+          "complexity": 1
+        },
+        {
+          "name": "get_cyber_goal_cal",
+          "lineno": 1782,
+          "complexity": 1
+        },
+        {
+          "name": "get_top_event_safety_goals",
+          "lineno": 1785,
+          "complexity": 1
+        },
+        {
+          "name": "get_safety_goals_for_malfunctions",
+          "lineno": 1788,
+          "complexity": 8
+        },
+        {
+          "name": "is_malfunction_used",
+          "lineno": 1799,
+          "complexity": 7
+        },
+        {
+          "name": "add_malfunction",
+          "lineno": 1812,
+          "complexity": 1
+        },
+        {
+          "name": "add_fault",
+          "lineno": 1815,
+          "complexity": 1
+        },
+        {
+          "name": "add_failure",
+          "lineno": 1818,
+          "complexity": 1
+        },
+        {
+          "name": "add_hazard",
+          "lineno": 1821,
+          "complexity": 1
+        },
+        {
+          "name": "add_triggering_condition",
+          "lineno": 1824,
+          "complexity": 1
+        },
+        {
+          "name": "delete_triggering_condition",
+          "lineno": 1827,
+          "complexity": 1
+        },
+        {
+          "name": "add_functional_insufficiency",
+          "lineno": 1831,
+          "complexity": 1
+        },
+        {
+          "name": "delete_functional_insufficiency",
+          "lineno": 1834,
+          "complexity": 1
+        },
+        {
+          "name": "_update_shared_product_goals",
+          "lineno": 1838,
+          "complexity": 7
+        },
+        {
+          "name": "update_hazard_severity",
+          "lineno": 1862,
+          "complexity": 1
+        },
+        {
+          "name": "calculate_fmeda_metrics",
+          "lineno": 1866,
+          "complexity": 1
+        },
+        {
+          "name": "compute_fmeda_metrics",
+          "lineno": 1870,
+          "complexity": 1
+        },
+        {
+          "name": "sync_hara_to_safety_goals",
+          "lineno": 1874,
+          "complexity": 1
+        },
+        {
+          "name": "sync_cyber_risk_to_goals",
+          "lineno": 1878,
+          "complexity": 1
+        },
+        {
+          "name": "add_top_level_event",
+          "lineno": 1882,
+          "complexity": 4
+        },
+        {
+          "name": "_build_probability_frame",
+          "lineno": 1905,
+          "complexity": 1
+        },
+        {
+          "name": "_apply_project_properties",
+          "lineno": 1908,
+          "complexity": 8
+        },
+        {
+          "name": "edit_project_properties",
+          "lineno": 1938,
+          "complexity": 12
+        },
+        {
+          "name": "create_diagram_image",
+          "lineno": 2042,
+          "complexity": 1
+        },
+        {
+          "name": "get_page_nodes",
+          "lineno": 2045,
+          "complexity": 1
+        },
+        {
+          "name": "capture_page_diagram",
+          "lineno": 2048,
+          "complexity": 1
+        },
+        {
+          "name": "capture_gsn_diagram",
+          "lineno": 2051,
+          "complexity": 5
+        },
+        {
+          "name": "capture_sysml_diagram",
+          "lineno": 2087,
+          "complexity": 10
+        },
+        {
+          "name": "capture_cbn_diagram",
+          "lineno": 2132,
+          "complexity": 5
+        },
+        {
+          "name": "draw_subtree_with_filter",
+          "lineno": 2164,
+          "complexity": 2
+        },
+        {
+          "name": "draw_subtree",
+          "lineno": 2169,
+          "complexity": 2
+        },
+        {
+          "name": "draw_connections_subtree",
+          "lineno": 2176,
+          "complexity": 6
+        },
+        {
+          "name": "draw_node_on_canvas_pdf",
+          "lineno": 2194,
+          "complexity": 13
+        },
+        {
+          "name": "rename_selected_tree_item",
+          "lineno": 2300,
+          "complexity": 1
+        },
+        {
+          "name": "save_diagram_png",
+          "lineno": 2303,
+          "complexity": 1
+        },
+        {
+          "name": "on_treeview_click",
+          "lineno": 2306,
+          "complexity": 1
+        },
+        {
+          "name": "on_analysis_tree_double_click",
+          "lineno": 2309,
+          "complexity": 1
+        },
+        {
+          "name": "on_analysis_tree_right_click",
+          "lineno": 2312,
+          "complexity": 1
+        },
+        {
+          "name": "on_analysis_tree_select",
+          "lineno": 2315,
+          "complexity": 1
+        },
+        {
+          "name": "on_tool_list_double_click",
+          "lineno": 2318,
+          "complexity": 1
+        },
+        {
+          "name": "_on_toolbox_change",
+          "lineno": 2321,
+          "complexity": 1
+        },
+        {
+          "name": "apply_governance_rules",
+          "lineno": 2324,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_tool_enablement",
+          "lineno": 2328,
+          "complexity": 1
+        },
+        {
+          "name": "update_lifecycle_cb",
+          "lineno": 2331,
+          "complexity": 1
+        },
+        {
+          "name": "_export_toolbox_dict",
+          "lineno": 2334,
+          "complexity": 2
+        },
+        {
+          "name": "on_lifecycle_selected",
+          "lineno": 2342,
+          "complexity": 13
+        },
+        {
+          "name": "enable_process_area",
+          "lineno": 2380,
+          "complexity": 1
+        },
+        {
+          "name": "enable_work_product",
+          "lineno": 2383,
+          "complexity": 1
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 2386,
+          "complexity": 1
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 2389,
+          "complexity": 1
+        },
+        {
+          "name": "open_work_product",
+          "lineno": 2392,
+          "complexity": 17
+        },
+        {
+          "name": "on_ctrl_mousewheel",
+          "lineno": 2433,
+          "complexity": 1
+        },
+        {
+          "name": "new_model",
+          "lineno": 2436,
+          "complexity": 1
+        },
+        {
+          "name": "compute_occurrence_counts",
+          "lineno": 2439,
+          "complexity": 4
+        },
+        {
+          "name": "get_node_fill_color",
+          "lineno": 2458,
+          "complexity": 4
+        },
+        {
+          "name": "on_right_mouse_press",
+          "lineno": 2477,
+          "complexity": 1
+        },
+        {
+          "name": "on_right_mouse_drag",
+          "lineno": 2480,
+          "complexity": 1
+        },
+        {
+          "name": "on_right_mouse_release",
+          "lineno": 2483,
+          "complexity": 1
+        },
+        {
+          "name": "show_context_menu",
+          "lineno": 2486,
+          "complexity": 1
+        },
+        {
+          "name": "on_canvas_click",
+          "lineno": 2489,
+          "complexity": 1
+        },
+        {
+          "name": "on_canvas_double_click",
+          "lineno": 2492,
+          "complexity": 1
+        },
+        {
+          "name": "on_canvas_drag",
+          "lineno": 2495,
+          "complexity": 1
+        },
+        {
+          "name": "on_canvas_release",
+          "lineno": 2498,
+          "complexity": 1
+        },
+        {
+          "name": "move_subtree",
+          "lineno": 2501,
+          "complexity": 1
+        },
+        {
+          "name": "zoom_in",
+          "lineno": 2504,
+          "complexity": 1
+        },
+        {
+          "name": "zoom_out",
+          "lineno": 2509,
+          "complexity": 1
+        },
+        {
+          "name": "auto_arrange",
+          "lineno": 2518,
+          "complexity": 9
+        },
+        {
+          "name": "get_all_triggering_conditions",
+          "lineno": 2549,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_functional_insufficiencies",
+          "lineno": 2552,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_scenario_names",
+          "lineno": 2555,
+          "complexity": 1
+        },
+        {
+          "name": "get_validation_targets_for_odd",
+          "lineno": 2558,
+          "complexity": 22
+        },
+        {
+          "name": "get_scenario_exposure",
+          "lineno": 2610,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_scenery_names",
+          "lineno": 2613,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_function_names",
+          "lineno": 2617,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_action_names",
+          "lineno": 2620,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_action_labels",
+          "lineno": 2623,
+          "complexity": 1
+        },
+        {
+          "name": "get_use_case_for_function",
+          "lineno": 2626,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_component_names",
+          "lineno": 2629,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_part_names",
+          "lineno": 2632,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_malfunction_names",
+          "lineno": 2635,
+          "complexity": 1
+        },
+        {
+          "name": "get_hazards_for_malfunction",
+          "lineno": 2638,
+          "complexity": 9
+        },
+        {
+          "name": "update_odd_elements",
+          "lineno": 2653,
+          "complexity": 2
+        },
+        {
+          "name": "update_hazard_list",
+          "lineno": 2659,
+          "complexity": 17
+        },
+        {
+          "name": "update_failure_list",
+          "lineno": 2708,
+          "complexity": 4
+        },
+        {
+          "name": "update_triggering_condition_list",
+          "lineno": 2717,
+          "complexity": 9
+        },
+        {
+          "name": "update_functional_insufficiency_list",
+          "lineno": 2733,
+          "complexity": 9
+        },
+        {
+          "name": "get_entry_field",
+          "lineno": 2749,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_failure_modes",
+          "lineno": 2752,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_fmea_entries",
+          "lineno": 2755,
+          "complexity": 1
+        },
+        {
+          "name": "get_non_basic_failure_modes",
+          "lineno": 2758,
+          "complexity": 1
+        },
+        {
+          "name": "get_available_failure_modes_for_gates",
+          "lineno": 2761,
+          "complexity": 4
+        },
+        {
+          "name": "get_failure_mode_node",
+          "lineno": 2771,
+          "complexity": 1
+        },
+        {
+          "name": "get_component_name_for_node",
+          "lineno": 2774,
+          "complexity": 1
+        },
+        {
+          "name": "get_failure_modes_for_malfunction",
+          "lineno": 2777,
+          "complexity": 1
+        },
+        {
+          "name": "get_faults_for_failure_mode",
+          "lineno": 2780,
+          "complexity": 5
+        },
+        {
+          "name": "get_fit_for_fault",
+          "lineno": 2792,
+          "complexity": 6
+        },
+        {
+          "name": "update_views",
+          "lineno": 2808,
+          "complexity": 113
+        },
+        {
+          "name": "update_basic_event_probabilities",
+          "lineno": 3195,
+          "complexity": 1
+        },
+        {
+          "name": "validate_float",
+          "lineno": 3198,
+          "complexity": 7
+        },
+        {
+          "name": "compute_failure_prob",
+          "lineno": 3227,
+          "complexity": 1
+        },
+        {
+          "name": "propagate_failure_mode_attributes",
+          "lineno": 3231,
+          "complexity": 3
+        },
+        {
+          "name": "refresh_model",
+          "lineno": 3242,
+          "complexity": 14
+        },
+        {
+          "name": "refresh_all",
+          "lineno": 3288,
+          "complexity": 7
+        },
+        {
+          "name": "insert_node_in_tree",
+          "lineno": 3310,
+          "complexity": 1
+        },
+        {
+          "name": "redraw_canvas",
+          "lineno": 3313,
+          "complexity": 8
+        },
+        {
+          "name": "create_diagram_image_without_grid",
+          "lineno": 3330,
+          "complexity": 1
+        },
+        {
+          "name": "draw_connections",
+          "lineno": 3333,
+          "complexity": 7
+        },
+        {
+          "name": "draw_node",
+          "lineno": 3350,
+          "complexity": 35
+        },
+        {
+          "name": "find_node_by_id",
+          "lineno": 3616,
+          "complexity": 1
+        },
+        {
+          "name": "is_descendant",
+          "lineno": 3619,
+          "complexity": 1
+        },
+        {
+          "name": "add_node_of_type",
+          "lineno": 3622,
+          "complexity": 16
+        },
+        {
+          "name": "add_basic_event_from_fmea",
+          "lineno": 3698,
+          "complexity": 11
+        },
+        {
+          "name": "add_basic_event_from_fmea",
+          "lineno": 3741,
+          "complexity": 11
+        },
+        {
+          "name": "add_basic_event_from_fmea",
+          "lineno": 3784,
+          "complexity": 11
+        },
+        {
+          "name": "remove_node",
+          "lineno": 3828,
+          "complexity": 1
+        },
+        {
+          "name": "remove_connection",
+          "lineno": 3831,
+          "complexity": 1
+        },
+        {
+          "name": "delete_node_and_subtree",
+          "lineno": 3834,
+          "complexity": 1
+        },
+        {
+          "name": "create_top_event_for_malfunction",
+          "lineno": 3840,
+          "complexity": 1
+        },
+        {
+          "name": "delete_top_events_for_malfunction",
+          "lineno": 3843,
+          "complexity": 9
+        },
+        {
+          "name": "add_gate_from_failure_mode",
+          "lineno": 3866,
+          "complexity": 1
+        },
+        {
+          "name": "add_fault_event",
+          "lineno": 3869,
+          "complexity": 15
+        },
+        {
+          "name": "calculate_overall",
+          "lineno": 3923,
+          "complexity": 1
+        },
+        {
+          "name": "calculate_pmfh",
+          "lineno": 3926,
+          "complexity": 1
+        },
+        {
+          "name": "show_requirements_matrix",
+          "lineno": 3929,
+          "complexity": 58
+        },
+        {
+          "name": "show_item_definition_editor",
+          "lineno": 4089,
+          "complexity": 3
+        },
+        {
+          "name": "show_safety_concept_editor",
+          "lineno": 4111,
+          "complexity": 3
+        },
+        {
+          "name": "show_requirements_editor",
+          "lineno": 4160,
+          "complexity": 60
+        },
+        {
+          "name": "show_hazard_list",
+          "lineno": 4447,
+          "complexity": 1
+        },
+        {
+          "name": "show_fmea_table",
+          "lineno": 4515,
+          "complexity": 109
+        },
+        {
+          "name": "export_fmea_to_csv",
+          "lineno": 5041,
+          "complexity": 10
+        },
+        {
+          "name": "export_fmeda_to_csv",
+          "lineno": 5057,
+          "complexity": 11
+        },
+        {
+          "name": "show_traceability_matrix",
+          "lineno": 5110,
+          "complexity": 6
+        },
+        {
+          "name": "collect_requirements_recursive",
+          "lineno": 5131,
+          "complexity": 2
+        },
+        {
+          "name": "show_safety_goals_matrix",
+          "lineno": 5137,
+          "complexity": 10
+        },
+        {
+          "name": "show_product_goals_editor",
+          "lineno": 5255,
+          "complexity": 23
+        },
+        {
+          "name": "_parse_spi_target",
+          "lineno": 5448,
+          "complexity": 3
+        },
+        {
+          "name": "get_spi_targets",
+          "lineno": 5455,
+          "complexity": 3
+        },
+        {
+          "name": "show_safety_performance_indicators",
+          "lineno": 5466,
+          "complexity": 9
+        },
+        {
+          "name": "refresh_safety_performance_indicators",
+          "lineno": 5523,
+          "complexity": 14
+        },
+        {
+          "name": "refresh_safety_case_table",
+          "lineno": 5569,
+          "complexity": 21
+        },
+        {
+          "name": "show_safety_case",
+          "lineno": 5640,
+          "complexity": 32
+        },
+        {
+          "name": "export_product_goal_requirements",
+          "lineno": 5801,
+          "complexity": 1
+        },
+        {
+          "name": "generate_phase_requirements",
+          "lineno": 5803,
+          "complexity": 2
+        },
+        {
+          "name": "generate_lifecycle_requirements",
+          "lineno": 5810,
+          "complexity": 2
+        },
+        {
+          "name": "_refresh_phase_requirements_menu",
+          "lineno": 5818,
+          "complexity": 5
+        },
+        {
+          "name": "export_cybersecurity_goal_requirements",
+          "lineno": 5840,
+          "complexity": 1
+        },
+        {
+          "name": "show_cut_sets",
+          "lineno": 5843,
+          "complexity": 12
+        },
+        {
+          "name": "show_common_cause_view",
+          "lineno": 5887,
+          "complexity": 21
+        },
+        {
+          "name": "build_cause_effect_data",
+          "lineno": 5955,
+          "complexity": 1
+        },
+        {
+          "name": "_build_cause_effect_graph",
+          "lineno": 5958,
+          "complexity": 1
+        },
+        {
+          "name": "render_cause_effect_diagram",
+          "lineno": 5961,
+          "complexity": 8
+        },
+        {
+          "name": "show_cause_effect_chain",
+          "lineno": 6033,
+          "complexity": 11
+        },
+        {
+          "name": "show_cut_sets",
+          "lineno": 6214,
+          "complexity": 12
+        },
+        {
+          "name": "show_common_cause_view",
+          "lineno": 6258,
+          "complexity": 21
+        },
+        {
+          "name": "show_cut_sets",
+          "lineno": 6326,
+          "complexity": 12
+        },
+        {
+          "name": "show_common_cause_view",
+          "lineno": 6370,
+          "complexity": 21
+        },
+        {
+          "name": "show_cut_sets",
+          "lineno": 6438,
+          "complexity": 12
+        },
+        {
+          "name": "show_common_cause_view",
+          "lineno": 6482,
+          "complexity": 21
+        },
+        {
+          "name": "manage_mission_profiles",
+          "lineno": 6550,
+          "complexity": 41
+        },
+        {
+          "name": "manage_mechanism_libraries",
+          "lineno": 6691,
+          "complexity": 1
+        },
+        {
+          "name": "manage_scenario_libraries",
+          "lineno": 6694,
+          "complexity": 62
+        },
+        {
+          "name": "manage_odd_libraries",
+          "lineno": 7057,
+          "complexity": 52
+        },
+        {
+          "name": "open_reliability_window",
+          "lineno": 7414,
+          "complexity": 1
+        },
+        {
+          "name": "open_fmeda_window",
+          "lineno": 7417,
+          "complexity": 1
+        },
+        {
+          "name": "open_hazop_window",
+          "lineno": 7420,
+          "complexity": 1
+        },
+        {
+          "name": "open_risk_assessment_window",
+          "lineno": 7423,
+          "complexity": 1
+        },
+        {
+          "name": "open_stpa_window",
+          "lineno": 7426,
+          "complexity": 1
+        },
+        {
+          "name": "open_threat_window",
+          "lineno": 7429,
+          "complexity": 1
+        },
+        {
+          "name": "open_fi2tc_window",
+          "lineno": 7432,
+          "complexity": 1
+        },
+        {
+          "name": "open_tc2fi_window",
+          "lineno": 7435,
+          "complexity": 1
+        },
+        {
+          "name": "open_fault_prioritization_window",
+          "lineno": 7438,
+          "complexity": 1
+        },
+        {
+          "name": "open_safety_management_toolbox",
+          "lineno": 7441,
+          "complexity": 1
+        },
+        {
+          "name": "open_diagram_rules_toolbox",
+          "lineno": 7444,
+          "complexity": 5
+        },
+        {
+          "name": "open_requirement_patterns_toolbox",
+          "lineno": 7466,
+          "complexity": 5
+        },
+        {
+          "name": "open_report_template_toolbox",
+          "lineno": 7490,
+          "complexity": 5
+        },
+        {
+          "name": "open_report_template_manager",
+          "lineno": 7514,
+          "complexity": 5
+        },
+        {
+          "name": "reload_config",
+          "lineno": 7539,
+          "complexity": 8
+        },
+        {
+          "name": "open_search_toolbox",
+          "lineno": 7559,
+          "complexity": 1
+        },
+        {
+          "name": "open_style_editor",
+          "lineno": 7562,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_styles",
+          "lineno": 7568,
+          "complexity": 5
+        },
+        {
+          "name": "show_hazard_explorer",
+          "lineno": 7577,
+          "complexity": 1
+        },
+        {
+          "name": "show_requirements_explorer",
+          "lineno": 7580,
+          "complexity": 3
+        },
+        {
+          "name": "_create_fta_tab",
+          "lineno": 7589,
+          "complexity": 4
+        },
+        {
+          "name": "create_fta_diagram",
+          "lineno": 7647,
+          "complexity": 2
+        },
+        {
+          "name": "create_cta_diagram",
+          "lineno": 7654,
+          "complexity": 1
+        },
+        {
+          "name": "enable_fta_actions",
+          "lineno": 7658,
+          "complexity": 4
+        },
+        {
+          "name": "enable_paa_actions",
+          "lineno": 7671,
+          "complexity": 1
+        },
+        {
+          "name": "_update_analysis_menus",
+          "lineno": 7675,
+          "complexity": 2
+        },
+        {
+          "name": "_create_paa_tab",
+          "lineno": 7683,
+          "complexity": 1
+        },
+        {
+          "name": "create_paa_diagram",
+          "lineno": 7687,
+          "complexity": 1
+        },
+        {
+          "name": "paa_manager",
+          "lineno": 7692,
+          "complexity": 2
+        },
+        {
+          "name": "pages_and_paa",
+          "lineno": 7699,
+          "complexity": 2
+        },
+        {
+          "name": "_reset_fta_state",
+          "lineno": 7707,
+          "complexity": 1
+        },
+        {
+          "name": "ensure_fta_tab",
+          "lineno": 7716,
+          "complexity": 1
+        },
+        {
+          "name": "_format_diag_title",
+          "lineno": 7719,
+          "complexity": 2
+        },
+        {
+          "name": "open_use_case_diagram",
+          "lineno": 7725,
+          "complexity": 1
+        },
+        {
+          "name": "open_activity_diagram",
+          "lineno": 7728,
+          "complexity": 1
+        },
+        {
+          "name": "open_block_diagram",
+          "lineno": 7731,
+          "complexity": 1
+        },
+        {
+          "name": "open_internal_block_diagram",
+          "lineno": 7734,
+          "complexity": 1
+        },
+        {
+          "name": "open_control_flow_diagram",
+          "lineno": 7737,
+          "complexity": 1
+        },
+        {
+          "name": "open_causal_bayesian_network_window",
+          "lineno": 7740,
+          "complexity": 1
+        },
+        {
+          "name": "open_gsn_diagram",
+          "lineno": 7743,
+          "complexity": 1
+        },
+        {
+          "name": "open_arch_window",
+          "lineno": 7746,
+          "complexity": 1
+        },
+        {
+          "name": "open_page_diagram",
+          "lineno": 7749,
+          "complexity": 1
+        },
+        {
+          "name": "manage_architecture",
+          "lineno": 7752,
+          "complexity": 1
+        },
+        {
+          "name": "manage_gsn",
+          "lineno": 7755,
+          "complexity": 1
+        },
+        {
+          "name": "manage_safety_management",
+          "lineno": 7758,
+          "complexity": 1
+        },
+        {
+          "name": "manage_safety_cases",
+          "lineno": 7761,
+          "complexity": 4
+        },
+        {
+          "name": "_diagram_copy_strategy1",
+          "lineno": 7777,
+          "complexity": 4
+        },
+        {
+          "name": "_diagram_copy_strategy2",
+          "lineno": 7787,
+          "complexity": 4
+        },
+        {
+          "name": "_diagram_copy_strategy3",
+          "lineno": 7797,
+          "complexity": 4
+        },
+        {
+          "name": "_diagram_copy_strategy4",
+          "lineno": 7807,
+          "complexity": 5
+        },
+        {
+          "name": "_diagram_cut_strategy1",
+          "lineno": 7818,
+          "complexity": 4
+        },
+        {
+          "name": "_diagram_cut_strategy2",
+          "lineno": 7828,
+          "complexity": 4
+        },
+        {
+          "name": "_diagram_cut_strategy3",
+          "lineno": 7838,
+          "complexity": 4
+        },
+        {
+          "name": "_diagram_cut_strategy4",
+          "lineno": 7848,
+          "complexity": 5
+        },
+        {
+          "name": "copy_node",
+          "lineno": 7859,
+          "complexity": 12
+        },
+        {
+          "name": "cut_node",
+          "lineno": 7889,
+          "complexity": 14
+        },
+        {
+          "name": "_reset_gsn_clone",
+          "lineno": 7923,
+          "complexity": 4
+        },
+        {
+          "name": "_clone_for_paste_strategy1",
+          "lineno": 7937,
+          "complexity": 4
+        },
+        {
+          "name": "_clone_for_paste_strategy2",
+          "lineno": 7947,
+          "complexity": 4
+        },
+        {
+          "name": "_clone_for_paste_strategy3",
+          "lineno": 7957,
+          "complexity": 4
+        },
+        {
+          "name": "_clone_for_paste_strategy4",
+          "lineno": 7968,
+          "complexity": 1
+        },
+        {
+          "name": "_clone_for_paste",
+          "lineno": 7974,
+          "complexity": 5
+        },
+        {
+          "name": "_prepare_node_for_paste",
+          "lineno": 7993,
+          "complexity": 5
+        },
+        {
+          "name": "paste_node",
+          "lineno": 8009,
+          "complexity": 58
+        },
+        {
+          "name": "_get_diag_type",
+          "lineno": 8134,
+          "complexity": 4
+        },
+        {
+          "name": "clone_node_preserving_id",
+          "lineno": 8144,
+          "complexity": 6
+        },
+        {
+          "name": "_find_gsn_diagram",
+          "lineno": 8196,
+          "complexity": 7
+        },
+        {
+          "name": "_copy_attrs_no_xy_strategy1",
+          "lineno": 8222,
+          "complexity": 4
+        },
+        {
+          "name": "_copy_attrs_no_xy_strategy2",
+          "lineno": 8231,
+          "complexity": 5
+        },
+        {
+          "name": "_copy_attrs_no_xy_strategy3",
+          "lineno": 8241,
+          "complexity": 5
+        },
+        {
+          "name": "_copy_attrs_no_xy_strategy4",
+          "lineno": 8252,
+          "complexity": 5
+        },
+        {
+          "name": "_copy_attrs_no_xy",
+          "lineno": 8264,
+          "complexity": 3
+        },
+        {
+          "name": "sync_nodes_by_id",
+          "lineno": 8277,
+          "complexity": 1
+        },
+        {
+          "name": "edit_severity",
+          "lineno": 8287,
+          "complexity": 1
+        },
+        {
+          "name": "set_last_saved_state",
+          "lineno": 8295,
+          "complexity": 1
+        },
+        {
+          "name": "has_unsaved_changes",
+          "lineno": 8299,
+          "complexity": 1
+        },
+        {
+          "name": "_strip_object_positions",
+          "lineno": 8307,
+          "complexity": 6
+        },
+        {
+          "name": "push_undo_state",
+          "lineno": 8325,
+          "complexity": 8
+        },
+        {
+          "name": "_push_undo_state_v1",
+          "lineno": 8352,
+          "complexity": 6
+        },
+        {
+          "name": "_push_undo_state_v2",
+          "lineno": 8373,
+          "complexity": 6
+        },
+        {
+          "name": "_push_undo_state_v3",
+          "lineno": 8387,
+          "complexity": 6
+        },
+        {
+          "name": "_push_undo_state_v4",
+          "lineno": 8401,
+          "complexity": 5
+        },
+        {
+          "name": "_undo_hotkey",
+          "lineno": 8412,
+          "complexity": 1
+        },
+        {
+          "name": "_redo_hotkey",
+          "lineno": 8417,
+          "complexity": 1
+        },
+        {
+          "name": "undo",
+          "lineno": 8422,
+          "complexity": 6
+        },
+        {
+          "name": "redo",
+          "lineno": 8439,
+          "complexity": 6
+        },
+        {
+          "name": "clear_undo_history",
+          "lineno": 8456,
+          "complexity": 1
+        },
+        {
+          "name": "_undo_v1",
+          "lineno": 8465,
+          "complexity": 6
+        },
+        {
+          "name": "_undo_v2",
+          "lineno": 8481,
+          "complexity": 6
+        },
+        {
+          "name": "_undo_v3",
+          "lineno": 8497,
+          "complexity": 6
+        },
+        {
+          "name": "_undo_v4",
+          "lineno": 8513,
+          "complexity": 7
+        },
+        {
+          "name": "_redo_v1",
+          "lineno": 8532,
+          "complexity": 3
+        },
+        {
+          "name": "_redo_v2",
+          "lineno": 8544,
+          "complexity": 3
+        },
+        {
+          "name": "_redo_v3",
+          "lineno": 8556,
+          "complexity": 3
+        },
+        {
+          "name": "_redo_v4",
+          "lineno": 8568,
+          "complexity": 3
+        },
+        {
+          "name": "confirm_close",
+          "lineno": 8580,
+          "complexity": 4
+        },
+        {
+          "name": "export_model_data",
+          "lineno": 8596,
+          "complexity": 1
+        },
+        {
+          "name": "_load_project_properties",
+          "lineno": 8599,
+          "complexity": 4
+        },
+        {
+          "name": "_load_fault_tree_events",
+          "lineno": 8618,
+          "complexity": 11
+        },
+        {
+          "name": "apply_model_data",
+          "lineno": 8642,
+          "complexity": 124
+        },
+        {
+          "name": "_reset_on_load",
+          "lineno": 9177,
+          "complexity": 8
+        },
+        {
+          "name": "_prompt_save_before_load_v1",
+          "lineno": 9224,
+          "complexity": 1
+        },
+        {
+          "name": "_prompt_save_before_load_v2",
+          "lineno": 9229,
+          "complexity": 1
+        },
+        {
+          "name": "_prompt_save_before_load_v3",
+          "lineno": 9234,
+          "complexity": 1
+        },
+        {
+          "name": "_prompt_save_before_load_v4",
+          "lineno": 9238,
+          "complexity": 1
+        },
+        {
+          "name": "_prompt_save_before_load",
+          "lineno": 9245,
+          "complexity": 1
+        },
+        {
+          "name": "update_global_requirements_from_nodes",
+          "lineno": 9249,
+          "complexity": 5
+        },
+        {
+          "name": "_generate_pdf_report",
+          "lineno": 9261,
+          "complexity": 1
+        },
+        {
+          "name": "generate_pdf_report",
+          "lineno": 9264,
+          "complexity": 1
+        },
+        {
+          "name": "generate_report",
+          "lineno": 9267,
+          "complexity": 1
+        },
+        {
+          "name": "build_html_report",
+          "lineno": 9270,
+          "complexity": 1
+        },
+        {
+          "name": "resolve_original",
+          "lineno": 9272,
+          "complexity": 4
+        },
+        {
+          "name": "go_back",
+          "lineno": 9278,
+          "complexity": 1
+        },
+        {
+          "name": "draw_page_subtree",
+          "lineno": 9281,
+          "complexity": 1
+        },
+        {
+          "name": "draw_page_grid",
+          "lineno": 9284,
+          "complexity": 1
+        },
+        {
+          "name": "draw_page_connections_subtree",
+          "lineno": 9287,
+          "complexity": 1
+        },
+        {
+          "name": "draw_page_nodes_subtree",
+          "lineno": 9290,
+          "complexity": 1
+        },
+        {
+          "name": "draw_node_on_page_canvas",
+          "lineno": 9293,
+          "complexity": 1
+        },
+        {
+          "name": "on_ctrl_mousewheel_page",
+          "lineno": 9296,
+          "complexity": 1
+        },
+        {
+          "name": "close_page_diagram",
+          "lineno": 9299,
+          "complexity": 5
+        },
+        {
+          "name": "start_peer_review",
+          "lineno": 9346,
+          "complexity": 1
+        },
+        {
+          "name": "start_joint_review",
+          "lineno": 9349,
+          "complexity": 1
+        },
+        {
+          "name": "open_review_document",
+          "lineno": 9352,
+          "complexity": 1
+        },
+        {
+          "name": "open_review_toolbox",
+          "lineno": 9355,
+          "complexity": 1
+        },
+        {
+          "name": "send_review_email",
+          "lineno": 9358,
+          "complexity": 1
+        },
+        {
+          "name": "review_is_closed",
+          "lineno": 9361,
+          "complexity": 1
+        },
+        {
+          "name": "review_is_closed_for",
+          "lineno": 9364,
+          "complexity": 1
+        },
+        {
+          "name": "capture_diff_diagram",
+          "lineno": 9367,
+          "complexity": 1
+        },
+        {
+          "name": "compute_requirement_asil",
+          "lineno": 9372,
+          "complexity": 3
+        },
+        {
+          "name": "find_safety_goal_node",
+          "lineno": 9382,
+          "complexity": 3
+        },
+        {
+          "name": "compute_validation_criteria",
+          "lineno": 9388,
+          "complexity": 1
+        },
+        {
+          "name": "update_validation_criteria",
+          "lineno": 9391,
+          "complexity": 1
+        },
+        {
+          "name": "update_requirement_asil",
+          "lineno": 9394,
+          "complexity": 2
+        },
+        {
+          "name": "update_all_validation_criteria",
+          "lineno": 9400,
+          "complexity": 1
+        },
+        {
+          "name": "update_all_requirement_asil",
+          "lineno": 9403,
+          "complexity": 3
+        },
+        {
+          "name": "update_base_event_requirement_asil",
+          "lineno": 9409,
+          "complexity": 6
+        },
+        {
+          "name": "ensure_asil_consistency",
+          "lineno": 9423,
+          "complexity": 1
+        },
+        {
+          "name": "invalidate_reviews_for_hara",
+          "lineno": 9431,
+          "complexity": 1
+        },
+        {
+          "name": "invalidate_reviews_for_requirement",
+          "lineno": 9434,
+          "complexity": 1
+        },
+        {
+          "name": "add_version",
+          "lineno": 9437,
+          "complexity": 1
+        },
+        {
+          "name": "compare_versions",
+          "lineno": 9441,
+          "complexity": 1
+        },
+        {
+          "name": "merge_review_comments",
+          "lineno": 9445,
+          "complexity": 1
+        },
+        {
+          "name": "calculate_diff_nodes",
+          "lineno": 9449,
+          "complexity": 1
+        },
+        {
+          "name": "calculate_diff_between",
+          "lineno": 9453,
+          "complexity": 1
+        },
+        {
+          "name": "node_map_from_data",
+          "lineno": 9457,
+          "complexity": 1
+        },
+        {
+          "name": "set_current_user",
+          "lineno": 9461,
+          "complexity": 1
+        },
+        {
+          "name": "get_current_user_role",
+          "lineno": 9464,
+          "complexity": 1
+        },
+        {
+          "name": "focus_on_node",
+          "lineno": 9467,
+          "complexity": 1
+        },
+        {
+          "name": "get_review_targets",
+          "lineno": 9470,
+          "complexity": 1
+        },
+        {
+          "name": "_wrapped_select",
+          "lineno": 1391,
+          "complexity": 2
+        },
+        {
+          "name": "save_props",
+          "lineno": 2001,
+          "complexity": 9
+        },
+        {
+          "name": "_refresh_children",
+          "lineno": 2370,
+          "complexity": 3
+        },
+        {
+          "name": "rec",
+          "lineno": 2446,
+          "complexity": 3
+        },
+        {
+          "name": "layout",
+          "lineno": 2524,
+          "complexity": 3
+        },
+        {
+          "name": "iter_analysis_events",
+          "lineno": 3257,
+          "complexity": 7
+        },
+        {
+          "name": "alloc_from_data",
+          "lineno": 3984,
+          "complexity": 12
+        },
+        {
+          "name": "goals_from_data",
+          "lineno": 4002,
+          "complexity": 21
+        },
+        {
+          "name": "insert_diff",
+          "lineno": 4036,
+          "complexity": 6
+        },
+        {
+          "name": "insert_list_diff",
+          "lineno": 4049,
+          "complexity": 9
+        },
+        {
+          "name": "save",
+          "lineno": 4105,
+          "complexity": 1
+        },
+        {
+          "name": "save",
+          "lineno": 4153,
+          "complexity": 1
+        },
+        {
+          "name": "_get_requirement_allocations",
+          "lineno": 4201,
+          "complexity": 6
+        },
+        {
+          "name": "refresh_tree",
+          "lineno": 4213,
+          "complexity": 3
+        },
+        {
+          "name": "add_req",
+          "lineno": 4242,
+          "complexity": 2
+        },
+        {
+          "name": "edit_req",
+          "lineno": 4248,
+          "complexity": 3
+        },
+        {
+          "name": "del_req",
+          "lineno": 4258,
+          "complexity": 8
+        },
+        {
+          "name": "link_to_diagram",
+          "lineno": 4274,
+          "complexity": 21
+        },
+        {
+          "name": "link_requirement",
+          "lineno": 4339,
+          "complexity": 7
+        },
+        {
+          "name": "save_csv",
+          "lineno": 4364,
+          "complexity": 6
+        },
+        {
+          "name": "__init__",
+          "lineno": 4451,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 4457,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 4465,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 4471,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 4477,
+          "complexity": 3
+        },
+        {
+          "name": "apply",
+          "lineno": 4486,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 4496,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 4502,
+          "complexity": 4
+        },
+        {
+          "name": "apply",
+          "lineno": 4512,
+          "complexity": 2
+        },
+        {
+          "name": "refresh_tree",
+          "lineno": 4777,
+          "complexity": 39
+        },
+        {
+          "name": "on_double",
+          "lineno": 4918,
+          "complexity": 5
+        },
+        {
+          "name": "add_failure_mode",
+          "lineno": 4932,
+          "complexity": 19
+        },
+        {
+          "name": "remove_from_fmea",
+          "lineno": 4979,
+          "complexity": 5
+        },
+        {
+          "name": "delete_failure_mode",
+          "lineno": 4994,
+          "complexity": 6
+        },
+        {
+          "name": "comment_fmea_entry",
+          "lineno": 5011,
+          "complexity": 3
+        },
+        {
+          "name": "on_close",
+          "lineno": 5025,
+          "complexity": 4
+        },
+        {
+          "name": "refresh_tree",
+          "lineno": 5284,
+          "complexity": 5
+        },
+        {
+          "name": "add_sg",
+          "lineno": 5385,
+          "complexity": 4
+        },
+        {
+          "name": "edit_sg",
+          "lineno": 5403,
+          "complexity": 5
+        },
+        {
+          "name": "del_sg",
+          "lineno": 5425,
+          "complexity": 5
+        },
+        {
+          "name": "edit_selected",
+          "lineno": 5494,
+          "complexity": 5
+        },
+        {
+          "name": "on_double_click",
+          "lineno": 5692,
+          "complexity": 16
+        },
+        {
+          "name": "edit_selected",
+          "lineno": 5748,
+          "complexity": 5
+        },
+        {
+          "name": "export_csv",
+          "lineno": 5768,
+          "complexity": 4
+        },
+        {
+          "name": "on_right_click",
+          "lineno": 5791,
+          "complexity": 2
+        },
+        {
+          "name": "export_csv",
+          "lineno": 5874,
+          "complexity": 4
+        },
+        {
+          "name": "refresh",
+          "lineno": 5913,
+          "complexity": 17
+        },
+        {
+          "name": "export_csv",
+          "lineno": 5939,
+          "complexity": 4
+        },
+        {
+          "name": "to_canvas",
+          "lineno": 5996,
+          "complexity": 1
+        },
+        {
+          "name": "draw_row",
+          "lineno": 6105,
+          "complexity": 3
+        },
+        {
+          "name": "on_select",
+          "lineno": 6181,
+          "complexity": 3
+        },
+        {
+          "name": "export_csv",
+          "lineno": 6201,
+          "complexity": 4
+        },
+        {
+          "name": "export_csv",
+          "lineno": 6245,
+          "complexity": 4
+        },
+        {
+          "name": "refresh",
+          "lineno": 6284,
+          "complexity": 17
+        },
+        {
+          "name": "export_csv",
+          "lineno": 6310,
+          "complexity": 4
+        },
+        {
+          "name": "export_csv",
+          "lineno": 6357,
+          "complexity": 4
+        },
+        {
+          "name": "refresh",
+          "lineno": 6396,
+          "complexity": 17
+        },
+        {
+          "name": "export_csv",
+          "lineno": 6422,
+          "complexity": 4
+        },
+        {
+          "name": "export_csv",
+          "lineno": 6469,
+          "complexity": 4
+        },
+        {
+          "name": "refresh",
+          "lineno": 6508,
+          "complexity": 17
+        },
+        {
+          "name": "export_csv",
+          "lineno": 6534,
+          "complexity": 4
+        },
+        {
+          "name": "refresh",
+          "lineno": 6562,
+          "complexity": 3
+        },
+        {
+          "name": "add_profile",
+          "lineno": 6657,
+          "complexity": 4
+        },
+        {
+          "name": "edit_profile",
+          "lineno": 6665,
+          "complexity": 5
+        },
+        {
+          "name": "delete_profile",
+          "lineno": 6676,
+          "complexity": 4
+        },
+        {
+          "name": "refresh_libs",
+          "lineno": 6730,
+          "complexity": 2
+        },
+        {
+          "name": "refresh_scenarios",
+          "lineno": 6736,
+          "complexity": 4
+        },
+        {
+          "name": "add_lib",
+          "lineno": 6991,
+          "complexity": 2
+        },
+        {
+          "name": "edit_lib",
+          "lineno": 6997,
+          "complexity": 2
+        },
+        {
+          "name": "delete_lib",
+          "lineno": 7006,
+          "complexity": 2
+        },
+        {
+          "name": "add_scen",
+          "lineno": 7013,
+          "complexity": 3
+        },
+        {
+          "name": "edit_scen",
+          "lineno": 7023,
+          "complexity": 3
+        },
+        {
+          "name": "del_scen",
+          "lineno": 7035,
+          "complexity": 3
+        },
+        {
+          "name": "refresh_libs",
+          "lineno": 7079,
+          "complexity": 2
+        },
+        {
+          "name": "refresh_elems",
+          "lineno": 7085,
+          "complexity": 7
+        },
+        {
+          "name": "add_lib",
+          "lineno": 7323,
+          "complexity": 12
+        },
+        {
+          "name": "edit_lib",
+          "lineno": 7350,
+          "complexity": 3
+        },
+        {
+          "name": "delete_lib",
+          "lineno": 7360,
+          "complexity": 2
+        },
+        {
+          "name": "add_elem",
+          "lineno": 7368,
+          "complexity": 2
+        },
+        {
+          "name": "edit_elem",
+          "lineno": 7378,
+          "complexity": 3
+        },
+        {
+          "name": "del_elem",
+          "lineno": 7391,
+          "complexity": 3
+        },
+        {
+          "name": "_search_modules",
+          "lineno": 8210,
+          "complexity": 5
+        },
+        {
+          "name": "scrub",
+          "lineno": 8312,
+          "complexity": 6
+        },
+        {
+          "name": "_visible",
+          "lineno": 2851,
+          "complexity": 1
+        },
+        {
+          "name": "_in_any_module",
+          "lineno": 2859,
+          "complexity": 4
+        },
+        {
+          "name": "_add_module",
+          "lineno": 2865,
+          "complexity": 4
+        },
+        {
+          "name": "_collect_gsn_diagrams",
+          "lineno": 2902,
+          "complexity": 2
+        },
+        {
+          "name": "add_gsn_module",
+          "lineno": 2922,
+          "complexity": 4
+        },
+        {
+          "name": "add_gsn_diagram",
+          "lineno": 2940,
+          "complexity": 2
+        },
+        {
+          "name": "add_pkg",
+          "lineno": 2994,
+          "complexity": 14
+        },
+        {
+          "name": "_ensure_haz_root",
+          "lineno": 3068,
+          "complexity": 2
+        },
+        {
+          "name": "_ensure_risk_root",
+          "lineno": 3110,
+          "complexity": 2
+        },
+        {
+          "name": "_ensure_safety_root",
+          "lineno": 3127,
+          "complexity": 2
+        },
+        {
+          "name": "traverse",
+          "lineno": 3988,
+          "complexity": 5
+        },
+        {
+          "name": "gather",
+          "lineno": 4006,
+          "complexity": 2
+        },
+        {
+          "name": "collect_goal_names",
+          "lineno": 4013,
+          "complexity": 7
+        },
+        {
+          "name": "calculate_fmeda",
+          "lineno": 4590,
+          "complexity": 5
+        },
+        {
+          "name": "add_component",
+          "lineno": 4626,
+          "complexity": 5
+        },
+        {
+          "name": "choose_libs",
+          "lineno": 4695,
+          "complexity": 4
+        },
+        {
+          "name": "load_bom",
+          "lineno": 4717,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 5311,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 5316,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 5372,
+          "complexity": 2
+        },
+        {
+          "name": "map_nodes",
+          "lineno": 5858,
+          "complexity": 2
+        },
+        {
+          "name": "to_canvas",
+          "lineno": 6133,
+          "complexity": 1
+        },
+        {
+          "name": "map_nodes",
+          "lineno": 6229,
+          "complexity": 2
+        },
+        {
+          "name": "map_nodes",
+          "lineno": 6341,
+          "complexity": 2
+        },
+        {
+          "name": "map_nodes",
+          "lineno": 6453,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 6574,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 6578,
+          "complexity": 8
+        },
+        {
+          "name": "apply",
+          "lineno": 6620,
+          "complexity": 20
+        },
+        {
+          "name": "__init__",
+          "lineno": 6764,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 6769,
+          "complexity": 6
+        },
+        {
+          "name": "apply",
+          "lineno": 6790,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 6798,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 6815,
+          "complexity": 23
+        },
+        {
+          "name": "update_description",
+          "lineno": 6919,
+          "complexity": 4
+        },
+        {
+          "name": "load_desc_links",
+          "lineno": 6951,
+          "complexity": 2
+        },
+        {
+          "name": "show_elem",
+          "lineno": 6964,
+          "complexity": 9
+        },
+        {
+          "name": "apply",
+          "lineno": 6976,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 7103,
+          "complexity": 2
+        },
+        {
+          "name": "add_attr_row",
+          "lineno": 7108,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 7143,
+          "complexity": 19
+        },
+        {
+          "name": "apply",
+          "lineno": 7297,
+          "complexity": 3
+        },
+        {
+          "name": "load_comp",
+          "lineno": 8751,
+          "complexity": 3
+        },
+        {
+          "name": "_popup",
+          "lineno": 4412,
+          "complexity": 3
+        },
+        {
+          "name": "_on_double",
+          "lineno": 4422,
+          "complexity": 2
+        },
+        {
+          "name": "refresh_attr_fields",
+          "lineno": 4654,
+          "complexity": 4
+        },
+        {
+          "name": "ok",
+          "lineno": 4672,
+          "complexity": 2
+        },
+        {
+          "name": "ok",
+          "lineno": 4704,
+          "complexity": 3
+        },
+        {
+          "name": "update_dc",
+          "lineno": 6606,
+          "complexity": 5
+        },
+        {
+          "name": "remove_row",
+          "lineno": 7119,
+          "complexity": 2
+        },
+        {
+          "name": "update_metrics",
+          "lineno": 7212,
+          "complexity": 1
+        },
+        {
+          "name": "on_vt_select",
+          "lineno": 7253,
+          "complexity": 5
+        },
+        {
+          "name": "refresh_vt",
+          "lineno": 7273,
+          "complexity": 4
         }
       ]
     },
@@ -238,6 +24382,52 @@
       ]
     },
     {
+      "file": "mainappsrc/core/fmea_service.py",
+      "loc": 175,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "load_fmeas",
+          "lineno": 22,
+          "complexity": 6
+        },
+        {
+          "name": "show_fmea_list",
+          "lineno": 56,
+          "complexity": 20
+        },
+        {
+          "name": "get_settings_dict",
+          "lineno": 187,
+          "complexity": 1
+        },
+        {
+          "name": "open_selected",
+          "lineno": 91,
+          "complexity": 2
+        },
+        {
+          "name": "add_fmea",
+          "lineno": 100,
+          "complexity": 3
+        },
+        {
+          "name": "delete_fmea",
+          "lineno": 127,
+          "complexity": 5
+        },
+        {
+          "name": "rename_fmea",
+          "lineno": 144,
+          "complexity": 6
+        }
+      ]
+    },
+    {
       "file": "mainappsrc/core/reporting_export.py",
       "loc": 302,
       "functions": [
@@ -324,103 +24514,1014 @@
       ]
     },
     {
-      "file": "mainappsrc/core/structure_tree_operations.py",
-      "loc": 174,
+      "file": "mainappsrc/core/validation_consistency.py",
+      "loc": 204,
       "functions": [
         {
           "name": "__init__",
-          "lineno": 11,
+          "lineno": 12,
           "complexity": 1
         },
         {
-          "name": "insert_node_in_tree",
-          "lineno": 14,
-          "complexity": 6
-        },
-        {
-          "name": "_move_subtree_strategy1",
-          "lineno": 25,
-          "complexity": 3
-        },
-        {
-          "name": "_move_subtree_strategy2",
-          "lineno": 33,
-          "complexity": 3
-        },
-        {
-          "name": "_move_subtree_strategy3",
-          "lineno": 39,
-          "complexity": 3
-        },
-        {
-          "name": "_move_subtree_strategy4",
-          "lineno": 48,
-          "complexity": 3
-        },
-        {
-          "name": "move_subtree",
-          "lineno": 56,
-          "complexity": 3
-        },
-        {
-          "name": "find_node_by_id",
-          "lineno": 69,
-          "complexity": 6
-        },
-        {
-          "name": "is_descendant",
-          "lineno": 83,
-          "complexity": 4
-        },
-        {
-          "name": "remove_node",
-          "lineno": 91,
-          "complexity": 8
-        },
-        {
-          "name": "remove_connection",
-          "lineno": 111,
+          "name": "validate_float",
+          "lineno": 16,
           "complexity": 7
         },
         {
-          "name": "delete_node_and_subtree",
-          "lineno": 132,
-          "complexity": 5
+          "name": "compute_validation_criteria",
+          "lineno": 41,
+          "complexity": 7
         },
         {
-          "name": "find_node_by_id_all",
-          "lineno": 148,
-          "complexity": 11
+          "name": "update_validation_criteria",
+          "lineno": 64,
+          "complexity": 2
         },
         {
-          "name": "get_all_nodes_no_filter",
-          "lineno": 171,
+          "name": "update_all_validation_criteria",
+          "lineno": 70,
+          "complexity": 2
+        },
+        {
+          "name": "enable_process_area",
+          "lineno": 75,
+          "complexity": 2
+        },
+        {
+          "name": "enable_work_product",
+          "lineno": 81,
+          "complexity": 14
+        },
+        {
+          "name": "can_remove_work_product",
+          "lineno": 118,
+          "complexity": 4
+        },
+        {
+          "name": "disable_work_product",
+          "lineno": 153,
+          "complexity": 25
+        },
+        {
+          "name": "ensure_fta_tab",
+          "lineno": 207,
+          "complexity": 3
+        },
+        {
+          "name": "enable_paa_actions",
+          "lineno": 219,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/probability_reliability.py",
+      "loc": 329,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 17,
           "complexity": 1
         },
         {
-          "name": "get_all_nodes",
-          "lineno": 174,
-          "complexity": 8
+          "name": "compute_failure_prob",
+          "lineno": 21,
+          "complexity": 14
+        },
+        {
+          "name": "update_basic_event_probabilities",
+          "lineno": 62,
+          "complexity": 2
+        },
+        {
+          "name": "calculate_pmfh",
+          "lineno": 68,
+          "complexity": 21
+        },
+        {
+          "name": "calculate_overall",
+          "lineno": 127,
+          "complexity": 4
+        },
+        {
+          "name": "_build_probability_frame",
+          "lineno": 143,
+          "complexity": 3
+        },
+        {
+          "name": "assurance_level_text",
+          "lineno": 177,
+          "complexity": 1
+        },
+        {
+          "name": "metric_to_text",
+          "lineno": 181,
+          "complexity": 1
+        },
+        {
+          "name": "analyze_common_causes",
+          "lineno": 185,
+          "complexity": 1
+        },
+        {
+          "name": "build_cause_effect_data",
+          "lineno": 189,
+          "complexity": 27
+        },
+        {
+          "name": "_build_cause_effect_graph",
+          "lineno": 267,
+          "complexity": 27
+        },
+        {
+          "name": "sync_cyber_risk_to_goals",
+          "lineno": 373,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/style_setup_mixin.py",
+      "loc": 19,
+      "functions": [
+        {
+          "name": "setup_style",
+          "lineno": 13,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/data_access_queries.py",
+      "loc": 335,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "get_top_level_nodes",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes_no_filter",
+          "lineno": 28,
+          "complexity": 1
         },
         {
           "name": "get_all_nodes_table",
-          "lineno": 196,
+          "lineno": 31,
           "complexity": 1
         },
         {
           "name": "get_all_nodes_in_model",
-          "lineno": 199,
+          "lineno": 34,
           "complexity": 1
         },
         {
-          "name": "node_map_from_data",
-          "lineno": 202,
+          "name": "get_all_basic_events",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_gates",
+          "lineno": 40,
+          "complexity": 1
+        },
+        {
+          "name": "get_extra_recommendations_list",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "get_extra_recommendations_from_level",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "get_recommendation_from_description",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "get_top_event_safety_goals",
+          "lineno": 58,
+          "complexity": 1
+        },
+        {
+          "name": "get_cyber_goal_cal",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "get_page_nodes",
+          "lineno": 67,
+          "complexity": 4
+        },
+        {
+          "name": "get_all_triggering_conditions",
+          "lineno": 75,
+          "complexity": 3
+        },
+        {
+          "name": "get_all_functional_insufficiencies",
+          "lineno": 85,
+          "complexity": 5
+        },
+        {
+          "name": "get_all_scenario_names",
+          "lineno": 97,
+          "complexity": 5
+        },
+        {
+          "name": "get_scenario_exposure",
+          "lineno": 109,
+          "complexity": 9
+        },
+        {
+          "name": "get_all_scenery_names",
+          "lineno": 125,
+          "complexity": 7
+        },
+        {
+          "name": "get_all_function_names",
+          "lineno": 137,
+          "complexity": 4
+        },
+        {
+          "name": "get_all_action_names",
+          "lineno": 145,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_action_labels",
+          "lineno": 149,
+          "complexity": 31
+        },
+        {
+          "name": "get_use_case_for_function",
+          "lineno": 200,
+          "complexity": 12
+        },
+        {
+          "name": "get_all_component_names",
+          "lineno": 221,
+          "complexity": 15
+        },
+        {
+          "name": "get_all_part_names",
+          "lineno": 249,
+          "complexity": 9
+        },
+        {
+          "name": "get_all_malfunction_names",
+          "lineno": 267,
+          "complexity": 3
+        },
+        {
+          "name": "get_entry_field",
+          "lineno": 275,
+          "complexity": 2
+        },
+        {
+          "name": "get_all_failure_modes",
+          "lineno": 280,
+          "complexity": 5
+        },
+        {
+          "name": "get_all_fmea_entries",
+          "lineno": 293,
+          "complexity": 3
+        },
+        {
+          "name": "get_non_basic_failure_modes",
+          "lineno": 301,
+          "complexity": 13
+        },
+        {
+          "name": "get_failure_mode_node",
+          "lineno": 328,
+          "complexity": 3
+        },
+        {
+          "name": "get_component_name_for_node",
+          "lineno": 336,
+          "complexity": 5
+        },
+        {
+          "name": "format_failure_mode_label",
+          "lineno": 346,
+          "complexity": 4
+        },
+        {
+          "name": "get_failure_modes_for_malfunction",
+          "lineno": 355,
+          "complexity": 4
+        },
+        {
+          "name": "get_all_nodes",
+          "lineno": 367,
+          "complexity": 8
+        },
+        {
+          "name": "get_current_user_role",
+          "lineno": 389,
           "complexity": 1
         },
         {
           "name": "rec",
-          "lineno": 183,
+          "lineno": 376,
           "complexity": 6
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/safety_ui.py",
+      "loc": 340,
+      "functions": [
+        {
+          "name": "show_fmeda_list",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "show_triggering_condition_list",
+          "lineno": 15,
+          "complexity": 13
+        },
+        {
+          "name": "show_hazard_list",
+          "lineno": 82,
+          "complexity": 1
+        },
+        {
+          "name": "show_malfunction_editor",
+          "lineno": 85,
+          "complexity": 11
+        },
+        {
+          "name": "show_fault_list",
+          "lineno": 143,
+          "complexity": 9
+        },
+        {
+          "name": "show_failure_list",
+          "lineno": 192,
+          "complexity": 9
+        },
+        {
+          "name": "show_hazard_editor",
+          "lineno": 241,
+          "complexity": 1
+        },
+        {
+          "name": "show_fault_editor",
+          "lineno": 244,
+          "complexity": 1
+        },
+        {
+          "name": "show_failure_editor",
+          "lineno": 248,
+          "complexity": 1
+        },
+        {
+          "name": "show_functional_insufficiency_list",
+          "lineno": 252,
+          "complexity": 13
+        },
+        {
+          "name": "show_malfunctions_editor",
+          "lineno": 323,
+          "complexity": 15
+        },
+        {
+          "name": "refresh",
+          "lineno": 25,
+          "complexity": 2
+        },
+        {
+          "name": "add_tc",
+          "lineno": 33,
+          "complexity": 2
+        },
+        {
+          "name": "edit_tc",
+          "lineno": 39,
+          "complexity": 4
+        },
+        {
+          "name": "del_tc",
+          "lineno": 51,
+          "complexity": 3
+        },
+        {
+          "name": "export_csv",
+          "lineno": 61,
+          "complexity": 4
+        },
+        {
+          "name": "refresh",
+          "lineno": 96,
+          "complexity": 2
+        },
+        {
+          "name": "add",
+          "lineno": 101,
+          "complexity": 2
+        },
+        {
+          "name": "rename",
+          "lineno": 107,
+          "complexity": 5
+        },
+        {
+          "name": "delete",
+          "lineno": 123,
+          "complexity": 3
+        },
+        {
+          "name": "refresh",
+          "lineno": 154,
+          "complexity": 2
+        },
+        {
+          "name": "add",
+          "lineno": 159,
+          "complexity": 2
+        },
+        {
+          "name": "rename",
+          "lineno": 165,
+          "complexity": 3
+        },
+        {
+          "name": "delete",
+          "lineno": 176,
+          "complexity": 3
+        },
+        {
+          "name": "refresh",
+          "lineno": 203,
+          "complexity": 2
+        },
+        {
+          "name": "add",
+          "lineno": 208,
+          "complexity": 2
+        },
+        {
+          "name": "rename",
+          "lineno": 214,
+          "complexity": 3
+        },
+        {
+          "name": "delete",
+          "lineno": 225,
+          "complexity": 3
+        },
+        {
+          "name": "refresh",
+          "lineno": 262,
+          "complexity": 2
+        },
+        {
+          "name": "export_csv",
+          "lineno": 270,
+          "complexity": 4
+        },
+        {
+          "name": "add_fi",
+          "lineno": 285,
+          "complexity": 2
+        },
+        {
+          "name": "edit_fi",
+          "lineno": 293,
+          "complexity": 4
+        },
+        {
+          "name": "del_fi",
+          "lineno": 305,
+          "complexity": 3
+        },
+        {
+          "name": "add_mal",
+          "lineno": 336,
+          "complexity": 5
+        },
+        {
+          "name": "edit_mal",
+          "lineno": 349,
+          "complexity": 6
+        },
+        {
+          "name": "del_mal",
+          "lineno": 374,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/icon_setup_mixin.py",
+      "loc": 22,
+      "functions": [
+        {
+          "name": "setup_icons",
+          "lineno": 11,
+          "complexity": 2
+        },
+        {
+          "name": "_color",
+          "lineno": 15,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/window_controllers.py",
+      "loc": 208,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "open_use_case_diagram",
+          "lineno": 38,
+          "complexity": 1
+        },
+        {
+          "name": "open_activity_diagram",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "open_block_diagram",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "open_internal_block_diagram",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "open_control_flow_diagram",
+          "lineno": 50,
+          "complexity": 1
+        },
+        {
+          "name": "open_causal_bayesian_network_window",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "open_gsn_diagram",
+          "lineno": 56,
+          "complexity": 1
+        },
+        {
+          "name": "open_arch_window",
+          "lineno": 59,
+          "complexity": 11
+        },
+        {
+          "name": "open_page_diagram",
+          "lineno": 89,
+          "complexity": 5
+        },
+        {
+          "name": "_gsn_window_strategy1",
+          "lineno": 131,
+          "complexity": 4
+        },
+        {
+          "name": "_gsn_window_strategy2",
+          "lineno": 137,
+          "complexity": 5
+        },
+        {
+          "name": "_gsn_window_strategy3",
+          "lineno": 144,
+          "complexity": 3
+        },
+        {
+          "name": "_gsn_window_strategy4",
+          "lineno": 150,
+          "complexity": 4
+        },
+        {
+          "name": "_focused_gsn_window",
+          "lineno": 157,
+          "complexity": 3
+        },
+        {
+          "name": "_cbn_window_strategy1",
+          "lineno": 169,
+          "complexity": 3
+        },
+        {
+          "name": "_cbn_window_strategy2",
+          "lineno": 175,
+          "complexity": 4
+        },
+        {
+          "name": "_cbn_window_strategy3",
+          "lineno": 182,
+          "complexity": 2
+        },
+        {
+          "name": "_cbn_window_strategy4",
+          "lineno": 188,
+          "complexity": 3
+        },
+        {
+          "name": "_focused_cbn_window",
+          "lineno": 195,
+          "complexity": 3
+        },
+        {
+          "name": "_arch_window_strategy1",
+          "lineno": 207,
+          "complexity": 6
+        },
+        {
+          "name": "_arch_window_strategy2",
+          "lineno": 214,
+          "complexity": 7
+        },
+        {
+          "name": "_arch_window_strategy3",
+          "lineno": 222,
+          "complexity": 5
+        },
+        {
+          "name": "_arch_window_strategy4",
+          "lineno": 229,
+          "complexity": 6
+        },
+        {
+          "name": "_focused_arch_window",
+          "lineno": 237,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/ui_setup.py",
+      "loc": 82,
+      "functions": [
+        {
+          "name": "enable_fta_actions",
+          "lineno": 19,
+          "complexity": 4
+        },
+        {
+          "name": "enable_paa_actions",
+          "lineno": 32,
+          "complexity": 4
+        },
+        {
+          "name": "_update_analysis_menus",
+          "lineno": 39,
+          "complexity": 2
+        },
+        {
+          "name": "_create_paa_tab",
+          "lineno": 47,
+          "complexity": 1
+        },
+        {
+          "name": "create_paa_diagram",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "paa_manager",
+          "lineno": 56,
+          "complexity": 2
+        },
+        {
+          "name": "_reset_fta_state",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "ensure_fta_tab",
+          "lineno": 71,
+          "complexity": 3
+        },
+        {
+          "name": "_format_diag_title",
+          "lineno": 83,
+          "complexity": 2
+        },
+        {
+          "name": "_create_icon",
+          "lineno": 95,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/analysis_utils.py",
+      "loc": 45,
+      "functions": [
+        {
+          "name": "classify_scenarios",
+          "lineno": 15,
+          "complexity": 9
+        },
+        {
+          "name": "load_default_mechanisms",
+          "lineno": 37,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/page_diagram.py",
+      "loc": 453,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "on_right_mouse_press",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "on_right_mouse_drag",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "on_right_mouse_release",
+          "lineno": 53,
+          "complexity": 2
+        },
+        {
+          "name": "find_node_at_position",
+          "lineno": 61,
+          "complexity": 3
+        },
+        {
+          "name": "on_ctrl_mousewheel",
+          "lineno": 69,
+          "complexity": 2
+        },
+        {
+          "name": "get_all_nodes",
+          "lineno": 75,
+          "complexity": 8
+        },
+        {
+          "name": "rc_on_press",
+          "lineno": 96,
+          "complexity": 1
+        },
+        {
+          "name": "rc_on_motion",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "rc_on_release",
+          "lineno": 105,
+          "complexity": 2
+        },
+        {
+          "name": "show_context_menu",
+          "lineno": 109,
+          "complexity": 8
+        },
+        {
+          "name": "context_edit",
+          "lineno": 145,
+          "complexity": 1
+        },
+        {
+          "name": "context_remove",
+          "lineno": 152,
+          "complexity": 1
+        },
+        {
+          "name": "context_delete",
+          "lineno": 158,
+          "complexity": 1
+        },
+        {
+          "name": "context_copy",
+          "lineno": 164,
+          "complexity": 1
+        },
+        {
+          "name": "context_cut",
+          "lineno": 168,
+          "complexity": 1
+        },
+        {
+          "name": "context_paste",
+          "lineno": 172,
+          "complexity": 1
+        },
+        {
+          "name": "context_edit_page_flag",
+          "lineno": 176,
+          "complexity": 1
+        },
+        {
+          "name": "context_add",
+          "lineno": 181,
+          "complexity": 1
+        },
+        {
+          "name": "context_add_gate_from_failure_mode",
+          "lineno": 187,
+          "complexity": 1
+        },
+        {
+          "name": "context_add_fault_event",
+          "lineno": 193,
+          "complexity": 1
+        },
+        {
+          "name": "on_canvas_click",
+          "lineno": 199,
+          "complexity": 6
+        },
+        {
+          "name": "on_canvas_double_click",
+          "lineno": 219,
+          "complexity": 4
+        },
+        {
+          "name": "on_canvas_drag",
+          "lineno": 235,
+          "complexity": 3
+        },
+        {
+          "name": "on_canvas_release",
+          "lineno": 250,
+          "complexity": 2
+        },
+        {
+          "name": "zoom_in",
+          "lineno": 260,
+          "complexity": 1
+        },
+        {
+          "name": "zoom_out",
+          "lineno": 265,
+          "complexity": 1
+        },
+        {
+          "name": "auto_arrange",
+          "lineno": 270,
+          "complexity": 9
+        },
+        {
+          "name": "redraw_canvas",
+          "lineno": 302,
+          "complexity": 8
+        },
+        {
+          "name": "draw_connections",
+          "lineno": 324,
+          "complexity": 8
+        },
+        {
+          "name": "draw_node",
+          "lineno": 346,
+          "complexity": 19
+        },
+        {
+          "name": "rec",
+          "lineno": 80,
+          "complexity": 7
+        },
+        {
+          "name": "layout",
+          "lineno": 277,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/editors.py",
+      "loc": 362,
+      "functions": [
+        {
+          "name": "show_item_definition_editor",
+          "lineno": 37,
+          "complexity": 3
+        },
+        {
+          "name": "show_safety_concept_editor",
+          "lineno": 63,
+          "complexity": 3
+        },
+        {
+          "name": "show_requirements_editor",
+          "lineno": 116,
+          "complexity": 60
+        },
+        {
+          "name": "save",
+          "lineno": 53,
+          "complexity": 1
+        },
+        {
+          "name": "save",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "_get_requirement_allocations",
+          "lineno": 155,
+          "complexity": 6
+        },
+        {
+          "name": "refresh_tree",
+          "lineno": 167,
+          "complexity": 3
+        },
+        {
+          "name": "add_req",
+          "lineno": 196,
+          "complexity": 2
+        },
+        {
+          "name": "edit_req",
+          "lineno": 202,
+          "complexity": 3
+        },
+        {
+          "name": "del_req",
+          "lineno": 212,
+          "complexity": 8
+        },
+        {
+          "name": "link_to_diagram",
+          "lineno": 228,
+          "complexity": 21
+        },
+        {
+          "name": "link_requirement",
+          "lineno": 293,
+          "complexity": 7
+        },
+        {
+          "name": "save_csv",
+          "lineno": 318,
+          "complexity": 6
+        },
+        {
+          "name": "_popup",
+          "lineno": 366,
+          "complexity": 3
+        },
+        {
+          "name": "_on_double",
+          "lineno": 376,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/top_event_workflows.py",
+      "loc": 92,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 19,
+          "complexity": 1
+        },
+        {
+          "name": "create_top_event_for_malfunction",
+          "lineno": 24,
+          "complexity": 3
+        },
+        {
+          "name": "add_gate_from_failure_mode",
+          "lineno": 45,
+          "complexity": 9
+        },
+        {
+          "name": "get_top_event",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "generate_top_event_summary",
+          "lineno": 104,
+          "complexity": 1
         }
       ]
     },
@@ -616,6 +25717,183 @@
       ]
     },
     {
+      "file": "mainappsrc/core/structure_tree_operations.py",
+      "loc": 174,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 11,
+          "complexity": 1
+        },
+        {
+          "name": "insert_node_in_tree",
+          "lineno": 14,
+          "complexity": 6
+        },
+        {
+          "name": "_move_subtree_strategy1",
+          "lineno": 25,
+          "complexity": 3
+        },
+        {
+          "name": "_move_subtree_strategy2",
+          "lineno": 33,
+          "complexity": 3
+        },
+        {
+          "name": "_move_subtree_strategy3",
+          "lineno": 39,
+          "complexity": 3
+        },
+        {
+          "name": "_move_subtree_strategy4",
+          "lineno": 48,
+          "complexity": 3
+        },
+        {
+          "name": "move_subtree",
+          "lineno": 56,
+          "complexity": 3
+        },
+        {
+          "name": "find_node_by_id",
+          "lineno": 69,
+          "complexity": 6
+        },
+        {
+          "name": "is_descendant",
+          "lineno": 83,
+          "complexity": 4
+        },
+        {
+          "name": "remove_node",
+          "lineno": 91,
+          "complexity": 8
+        },
+        {
+          "name": "remove_connection",
+          "lineno": 111,
+          "complexity": 7
+        },
+        {
+          "name": "delete_node_and_subtree",
+          "lineno": 132,
+          "complexity": 5
+        },
+        {
+          "name": "find_node_by_id_all",
+          "lineno": 148,
+          "complexity": 11
+        },
+        {
+          "name": "get_all_nodes_no_filter",
+          "lineno": 171,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes",
+          "lineno": 174,
+          "complexity": 8
+        },
+        {
+          "name": "get_all_nodes_table",
+          "lineno": 196,
+          "complexity": 1
+        },
+        {
+          "name": "get_all_nodes_in_model",
+          "lineno": 199,
+          "complexity": 1
+        },
+        {
+          "name": "node_map_from_data",
+          "lineno": 202,
+          "complexity": 1
+        },
+        {
+          "name": "rec",
+          "lineno": 183,
+          "complexity": 6
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/versioning_review.py",
+      "loc": 36,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "add_version",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "compare_versions",
+          "lineno": 21,
+          "complexity": 1
+        },
+        {
+          "name": "open_review_document",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "open_review_toolbox",
+          "lineno": 27,
+          "complexity": 1
+        },
+        {
+          "name": "start_joint_review",
+          "lineno": 30,
+          "complexity": 1
+        },
+        {
+          "name": "start_peer_review",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "merge_review_comments",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "send_review_email",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "review_is_closed",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "review_is_closed_for",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "invalidate_reviews_for_hara",
+          "lineno": 48,
+          "complexity": 1
+        },
+        {
+          "name": "invalidate_reviews_for_requirement",
+          "lineno": 51,
+          "complexity": 1
+        },
+        {
+          "name": "get_review_targets",
+          "lineno": 54,
+          "complexity": 1
+        }
+      ]
+    },
+    {
       "file": "mainappsrc/core/safety_analysis.py",
       "loc": 86,
       "functions": [
@@ -672,508 +25950,107 @@
       ]
     },
     {
-      "file": "mainappsrc/core/fmea_service.py",
-      "loc": 175,
+      "file": "mainappsrc/core/navigation_selection_input.py",
+      "loc": 201,
       "functions": [
         {
           "name": "__init__",
-          "lineno": 16,
+          "lineno": 17,
           "complexity": 1
         },
         {
-          "name": "load_fmeas",
-          "lineno": 22,
-          "complexity": 6
-        },
-        {
-          "name": "show_fmea_list",
-          "lineno": 56,
-          "complexity": 20
-        },
-        {
-          "name": "get_settings_dict",
-          "lineno": 187,
-          "complexity": 1
-        },
-        {
-          "name": "open_selected",
-          "lineno": 91,
+          "name": "go_back",
+          "lineno": 23,
           "complexity": 2
         },
         {
-          "name": "add_fmea",
-          "lineno": 100,
-          "complexity": 3
-        },
-        {
-          "name": "delete_fmea",
-          "lineno": 127,
-          "complexity": 5
-        },
-        {
-          "name": "rename_fmea",
-          "lineno": 144,
-          "complexity": 6
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/validation_consistency.py",
-      "loc": 204,
-      "functions": [
-        {
-          "name": "__init__",
-          "lineno": 12,
-          "complexity": 1
-        },
-        {
-          "name": "validate_float",
-          "lineno": 16,
-          "complexity": 7
-        },
-        {
-          "name": "compute_validation_criteria",
-          "lineno": 41,
-          "complexity": 7
-        },
-        {
-          "name": "update_validation_criteria",
-          "lineno": 64,
-          "complexity": 2
-        },
-        {
-          "name": "update_all_validation_criteria",
-          "lineno": 70,
-          "complexity": 2
-        },
-        {
-          "name": "enable_process_area",
-          "lineno": 75,
-          "complexity": 2
-        },
-        {
-          "name": "enable_work_product",
-          "lineno": 81,
-          "complexity": 14
-        },
-        {
-          "name": "can_remove_work_product",
-          "lineno": 118,
-          "complexity": 4
-        },
-        {
-          "name": "disable_work_product",
-          "lineno": 153,
-          "complexity": 25
-        },
-        {
-          "name": "ensure_fta_tab",
-          "lineno": 207,
-          "complexity": 3
-        },
-        {
-          "name": "enable_paa_actions",
-          "lineno": 219,
-          "complexity": 4
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/analysis_utils.py",
-      "loc": 45,
-      "functions": [
-        {
-          "name": "classify_scenarios",
-          "lineno": 15,
-          "complexity": 9
-        },
-        {
-          "name": "load_default_mechanisms",
-          "lineno": 37,
-          "complexity": 5
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/editing_labels_styling.py",
-      "loc": 187,
-      "functions": [
-        {
-          "name": "__init__",
-          "lineno": 26,
-          "complexity": 1
-        },
-        {
-          "name": "__getattr__",
+          "name": "back_all_pages",
           "lineno": 29,
           "complexity": 1
         },
         {
-          "name": "edit_controllability",
-          "lineno": 35,
-          "complexity": 1
-        },
-        {
-          "name": "edit_description",
-          "lineno": 41,
-          "complexity": 3
-        },
-        {
-          "name": "edit_gate_type",
-          "lineno": 57,
-          "complexity": 5
-        },
-        {
-          "name": "edit_page_flag",
-          "lineno": 74,
-          "complexity": 4
-        },
-        {
-          "name": "edit_rationale",
-          "lineno": 99,
-          "complexity": 3
-        },
-        {
-          "name": "edit_selected",
-          "lineno": 114,
-          "complexity": 8
-        },
-        {
-          "name": "edit_user_name",
-          "lineno": 140,
-          "complexity": 1
-        },
-        {
-          "name": "edit_value",
-          "lineno": 143,
+          "name": "focus_on_node",
+          "lineno": 32,
           "complexity": 6
-        },
-        {
-          "name": "rename_failure",
-          "lineno": 168,
-          "complexity": 1
-        },
-        {
-          "name": "rename_fault",
-          "lineno": 171,
-          "complexity": 1
-        },
-        {
-          "name": "rename_functional_insufficiency",
-          "lineno": 174,
-          "complexity": 1
-        },
-        {
-          "name": "rename_hazard",
-          "lineno": 177,
-          "complexity": 1
-        },
-        {
-          "name": "rename_malfunction",
-          "lineno": 180,
-          "complexity": 1
-        },
-        {
-          "name": "rename_selected_tree_item",
-          "lineno": 183,
-          "complexity": 1
-        },
-        {
-          "name": "rename_triggering_condition",
-          "lineno": 186,
-          "complexity": 1
-        },
-        {
-          "name": "apply_style",
-          "lineno": 189,
-          "complexity": 1
-        },
-        {
-          "name": "format_failure_mode_label",
-          "lineno": 194,
-          "complexity": 4
-        },
-        {
-          "name": "_resize_prop_columns",
-          "lineno": 203,
-          "complexity": 3
-        },
-        {
-          "name": "_spi_label",
-          "lineno": 224,
-          "complexity": 4
-        },
-        {
-          "name": "_product_goal_name",
-          "lineno": 233,
-          "complexity": 2
-        },
-        {
-          "name": "_create_icon",
-          "lineno": 237,
-          "complexity": 1
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/syncing_and_ids.py",
-      "loc": 157,
-      "functions": [
-        {
-          "name": "__init__",
-          "lineno": 13,
-          "complexity": 1
-        },
-        {
-          "name": "_collect_sync_nodes_strategy1",
-          "lineno": 19,
-          "complexity": 7
-        },
-        {
-          "name": "_collect_sync_nodes_strategy2",
-          "lineno": 38,
-          "complexity": 7
-        },
-        {
-          "name": "_collect_sync_nodes_strategy3",
-          "lineno": 57,
-          "complexity": 10
-        },
-        {
-          "name": "_collect_sync_nodes_strategy4",
-          "lineno": 80,
-          "complexity": 1
-        },
-        {
-          "name": "_collect_sync_nodes",
-          "lineno": 83,
-          "complexity": 4
-        },
-        {
-          "name": "_sync_nodes_by_id_strategy1",
-          "lineno": 101,
-          "complexity": 12
-        },
-        {
-          "name": "_sync_nodes_by_id_strategy2",
-          "lineno": 123,
-          "complexity": 10
-        },
-        {
-          "name": "_sync_nodes_by_id_strategy3",
-          "lineno": 140,
-          "complexity": 13
-        },
-        {
-          "name": "_sync_nodes_by_id_strategy4",
-          "lineno": 162,
-          "complexity": 1
-        },
-        {
-          "name": "sync_nodes_by_id",
-          "lineno": 165,
-          "complexity": 3
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/top_event_workflows.py",
-      "loc": 92,
-      "functions": [
-        {
-          "name": "__init__",
-          "lineno": 19,
-          "complexity": 1
-        },
-        {
-          "name": "create_top_event_for_malfunction",
-          "lineno": 24,
-          "complexity": 3
-        },
-        {
-          "name": "add_gate_from_failure_mode",
-          "lineno": 45,
-          "complexity": 9
-        },
-        {
-          "name": "get_top_event",
-          "lineno": 101,
-          "complexity": 1
-        },
-        {
-          "name": "generate_top_event_summary",
-          "lineno": 104,
-          "complexity": 1
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/page_diagram.py",
-      "loc": 453,
-      "functions": [
-        {
-          "name": "__init__",
-          "lineno": 19,
-          "complexity": 1
-        },
-        {
-          "name": "on_right_mouse_press",
-          "lineno": 45,
-          "complexity": 1
-        },
-        {
-          "name": "on_right_mouse_drag",
-          "lineno": 49,
-          "complexity": 1
-        },
-        {
-          "name": "on_right_mouse_release",
-          "lineno": 53,
-          "complexity": 2
-        },
-        {
-          "name": "find_node_at_position",
-          "lineno": 61,
-          "complexity": 3
-        },
-        {
-          "name": "on_ctrl_mousewheel",
-          "lineno": 69,
-          "complexity": 2
-        },
-        {
-          "name": "get_all_nodes",
-          "lineno": 75,
-          "complexity": 8
-        },
-        {
-          "name": "rc_on_press",
-          "lineno": 96,
-          "complexity": 1
-        },
-        {
-          "name": "rc_on_motion",
-          "lineno": 101,
-          "complexity": 1
-        },
-        {
-          "name": "rc_on_release",
-          "lineno": 105,
-          "complexity": 2
-        },
-        {
-          "name": "show_context_menu",
-          "lineno": 109,
-          "complexity": 8
-        },
-        {
-          "name": "context_edit",
-          "lineno": 145,
-          "complexity": 1
-        },
-        {
-          "name": "context_remove",
-          "lineno": 152,
-          "complexity": 1
-        },
-        {
-          "name": "context_delete",
-          "lineno": 158,
-          "complexity": 1
-        },
-        {
-          "name": "context_copy",
-          "lineno": 164,
-          "complexity": 1
-        },
-        {
-          "name": "context_cut",
-          "lineno": 168,
-          "complexity": 1
-        },
-        {
-          "name": "context_paste",
-          "lineno": 172,
-          "complexity": 1
-        },
-        {
-          "name": "context_edit_page_flag",
-          "lineno": 176,
-          "complexity": 1
-        },
-        {
-          "name": "context_add",
-          "lineno": 181,
-          "complexity": 1
-        },
-        {
-          "name": "context_add_gate_from_failure_mode",
-          "lineno": 187,
-          "complexity": 1
-        },
-        {
-          "name": "context_add_fault_event",
-          "lineno": 193,
-          "complexity": 1
         },
         {
           "name": "on_canvas_click",
-          "lineno": 199,
-          "complexity": 6
+          "lineno": 48,
+          "complexity": 5
         },
         {
           "name": "on_canvas_double_click",
-          "lineno": 219,
-          "complexity": 4
+          "lineno": 68,
+          "complexity": 7
         },
         {
           "name": "on_canvas_drag",
-          "lineno": 235,
+          "lineno": 88,
           "complexity": 3
         },
         {
           "name": "on_canvas_release",
-          "lineno": 250,
+          "lineno": 103,
           "complexity": 2
         },
         {
-          "name": "zoom_in",
-          "lineno": 260,
+          "name": "on_treeview_click",
+          "lineno": 116,
           "complexity": 1
         },
         {
-          "name": "zoom_out",
-          "lineno": 265,
+          "name": "on_analysis_tree_double_click",
+          "lineno": 119,
           "complexity": 1
         },
         {
-          "name": "auto_arrange",
-          "lineno": 270,
-          "complexity": 9
+          "name": "on_analysis_tree_right_click",
+          "lineno": 122,
+          "complexity": 1
         },
         {
-          "name": "redraw_canvas",
-          "lineno": 302,
-          "complexity": 8
+          "name": "on_analysis_tree_select",
+          "lineno": 125,
+          "complexity": 1
         },
         {
-          "name": "draw_connections",
-          "lineno": 324,
-          "complexity": 8
+          "name": "on_tool_list_double_click",
+          "lineno": 128,
+          "complexity": 10
         },
         {
-          "name": "draw_node",
-          "lineno": 346,
-          "complexity": 19
+          "name": "on_ctrl_mousewheel",
+          "lineno": 156,
+          "complexity": 2
         },
         {
-          "name": "rec",
-          "lineno": 80,
+          "name": "on_ctrl_mousewheel_page",
+          "lineno": 163,
+          "complexity": 2
+        },
+        {
+          "name": "on_right_mouse_press",
+          "lineno": 170,
+          "complexity": 1
+        },
+        {
+          "name": "on_right_mouse_drag",
+          "lineno": 175,
+          "complexity": 1
+        },
+        {
+          "name": "on_right_mouse_release",
+          "lineno": 180,
+          "complexity": 2
+        },
+        {
+          "name": "show_context_menu",
+          "lineno": 186,
           "complexity": 7
         },
         {
-          "name": "layout",
-          "lineno": 277,
+          "name": "open_search_toolbox",
+          "lineno": 234,
           "complexity": 3
         }
       ]
@@ -1340,3568 +26217,216 @@
       ]
     },
     {
-      "file": "mainappsrc/core/__init__.py",
-      "loc": 0,
-      "functions": []
-    },
-    {
-      "file": "mainappsrc/core/versioning_review.py",
-      "loc": 36,
+      "file": "mainappsrc/core/event_dispatcher.py",
+      "loc": 84,
       "functions": [
         {
           "name": "__init__",
-          "lineno": 14,
-          "complexity": 1
-        },
-        {
-          "name": "add_version",
           "lineno": 18,
           "complexity": 1
         },
         {
-          "name": "compare_versions",
-          "lineno": 21,
-          "complexity": 1
-        },
-        {
-          "name": "open_review_document",
+          "name": "register_keyboard_shortcuts",
           "lineno": 24,
           "complexity": 1
         },
         {
-          "name": "open_review_toolbox",
-          "lineno": 27,
-          "complexity": 1
-        },
-        {
-          "name": "start_joint_review",
-          "lineno": 30,
-          "complexity": 1
-        },
-        {
-          "name": "start_peer_review",
-          "lineno": 33,
-          "complexity": 1
-        },
-        {
-          "name": "merge_review_comments",
-          "lineno": 36,
-          "complexity": 1
-        },
-        {
-          "name": "send_review_email",
-          "lineno": 39,
-          "complexity": 1
-        },
-        {
-          "name": "review_is_closed",
-          "lineno": 42,
-          "complexity": 1
-        },
-        {
-          "name": "review_is_closed_for",
-          "lineno": 45,
-          "complexity": 1
-        },
-        {
-          "name": "invalidate_reviews_for_hara",
-          "lineno": 48,
-          "complexity": 1
-        },
-        {
-          "name": "invalidate_reviews_for_requirement",
-          "lineno": 51,
-          "complexity": 1
-        },
-        {
-          "name": "get_review_targets",
-          "lineno": 54,
+          "name": "register_tab_events",
+          "lineno": 79,
           "complexity": 1
         }
       ]
     },
     {
-      "file": "mainappsrc/core/editors.py",
-      "loc": 362,
-      "functions": [
-        {
-          "name": "show_item_definition_editor",
-          "lineno": 37,
-          "complexity": 3
-        },
-        {
-          "name": "show_safety_concept_editor",
-          "lineno": 63,
-          "complexity": 3
-        },
-        {
-          "name": "show_requirements_editor",
-          "lineno": 116,
-          "complexity": 60
-        },
-        {
-          "name": "save",
-          "lineno": 53,
-          "complexity": 1
-        },
-        {
-          "name": "save",
-          "lineno": 105,
-          "complexity": 1
-        },
-        {
-          "name": "_get_requirement_allocations",
-          "lineno": 155,
-          "complexity": 6
-        },
-        {
-          "name": "refresh_tree",
-          "lineno": 167,
-          "complexity": 3
-        },
-        {
-          "name": "add_req",
-          "lineno": 196,
-          "complexity": 2
-        },
-        {
-          "name": "edit_req",
-          "lineno": 202,
-          "complexity": 3
-        },
-        {
-          "name": "del_req",
-          "lineno": 212,
-          "complexity": 8
-        },
-        {
-          "name": "link_to_diagram",
-          "lineno": 228,
-          "complexity": 21
-        },
-        {
-          "name": "link_requirement",
-          "lineno": 293,
-          "complexity": 7
-        },
-        {
-          "name": "save_csv",
-          "lineno": 318,
-          "complexity": 6
-        },
-        {
-          "name": "_popup",
-          "lineno": 366,
-          "complexity": 3
-        },
-        {
-          "name": "_on_double",
-          "lineno": 376,
-          "complexity": 2
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/window_controllers.py",
-      "loc": 208,
+      "file": "mainappsrc/core/syncing_and_ids.py",
+      "loc": 157,
       "functions": [
         {
           "name": "__init__",
-          "lineno": 33,
+          "lineno": 13,
           "complexity": 1
         },
         {
-          "name": "open_use_case_diagram",
-          "lineno": 38,
-          "complexity": 1
-        },
-        {
-          "name": "open_activity_diagram",
-          "lineno": 41,
-          "complexity": 1
-        },
-        {
-          "name": "open_block_diagram",
-          "lineno": 44,
-          "complexity": 1
-        },
-        {
-          "name": "open_internal_block_diagram",
-          "lineno": 47,
-          "complexity": 1
-        },
-        {
-          "name": "open_control_flow_diagram",
-          "lineno": 50,
-          "complexity": 1
-        },
-        {
-          "name": "open_causal_bayesian_network_window",
-          "lineno": 53,
-          "complexity": 1
-        },
-        {
-          "name": "open_gsn_diagram",
-          "lineno": 56,
-          "complexity": 1
-        },
-        {
-          "name": "open_arch_window",
-          "lineno": 59,
-          "complexity": 11
-        },
-        {
-          "name": "open_page_diagram",
-          "lineno": 89,
-          "complexity": 5
-        },
-        {
-          "name": "_gsn_window_strategy1",
-          "lineno": 131,
-          "complexity": 4
-        },
-        {
-          "name": "_gsn_window_strategy2",
-          "lineno": 137,
-          "complexity": 5
-        },
-        {
-          "name": "_gsn_window_strategy3",
-          "lineno": 144,
-          "complexity": 3
-        },
-        {
-          "name": "_gsn_window_strategy4",
-          "lineno": 150,
-          "complexity": 4
-        },
-        {
-          "name": "_focused_gsn_window",
-          "lineno": 157,
-          "complexity": 3
-        },
-        {
-          "name": "_cbn_window_strategy1",
-          "lineno": 169,
-          "complexity": 3
-        },
-        {
-          "name": "_cbn_window_strategy2",
-          "lineno": 175,
-          "complexity": 4
-        },
-        {
-          "name": "_cbn_window_strategy3",
-          "lineno": 182,
-          "complexity": 2
-        },
-        {
-          "name": "_cbn_window_strategy4",
-          "lineno": 188,
-          "complexity": 3
-        },
-        {
-          "name": "_focused_cbn_window",
-          "lineno": 195,
-          "complexity": 3
-        },
-        {
-          "name": "_arch_window_strategy1",
-          "lineno": 207,
-          "complexity": 6
-        },
-        {
-          "name": "_arch_window_strategy2",
-          "lineno": 214,
+          "name": "_collect_sync_nodes_strategy1",
+          "lineno": 19,
           "complexity": 7
         },
         {
-          "name": "_arch_window_strategy3",
-          "lineno": 222,
-          "complexity": 5
+          "name": "_collect_sync_nodes_strategy2",
+          "lineno": 38,
+          "complexity": 7
         },
         {
-          "name": "_arch_window_strategy4",
-          "lineno": 229,
-          "complexity": 6
+          "name": "_collect_sync_nodes_strategy3",
+          "lineno": 57,
+          "complexity": 10
         },
         {
-          "name": "_focused_arch_window",
-          "lineno": 237,
+          "name": "_collect_sync_nodes_strategy4",
+          "lineno": 80,
+          "complexity": 1
+        },
+        {
+          "name": "_collect_sync_nodes",
+          "lineno": 83,
+          "complexity": 4
+        },
+        {
+          "name": "_sync_nodes_by_id_strategy1",
+          "lineno": 101,
+          "complexity": 12
+        },
+        {
+          "name": "_sync_nodes_by_id_strategy2",
+          "lineno": 123,
+          "complexity": 10
+        },
+        {
+          "name": "_sync_nodes_by_id_strategy3",
+          "lineno": 140,
+          "complexity": 13
+        },
+        {
+          "name": "_sync_nodes_by_id_strategy4",
+          "lineno": 162,
+          "complexity": 1
+        },
+        {
+          "name": "sync_nodes_by_id",
+          "lineno": 165,
           "complexity": 3
         }
       ]
     },
     {
-      "file": "mainappsrc/core/automl_core.py",
-      "loc": 8835,
+      "file": "mainappsrc/core/service_init_mixin.py",
+      "loc": 86,
       "functions": [
         {
-          "name": "format_requirement",
-          "lineno": 501,
-          "complexity": 6
-        },
-        {
-          "name": "_reload_local_config",
-          "lineno": 531,
-          "complexity": 1
-        },
-        {
-          "name": "load_user_data",
-          "lineno": 10134,
+          "name": "setup_services",
+          "lineno": 38,
           "complexity": 2
-        },
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/core/editing_labels_styling.py",
+      "loc": 187,
+      "functions": [
         {
-          "name": "main",
-          "lineno": 10142,
-          "complexity": 8
-        },
-        {
-          "name": "fmedas",
-          "lineno": 574,
+          "name": "__init__",
+          "lineno": 26,
           "complexity": 1
-        },
-        {
-          "name": "fmedas",
-          "lineno": 578,
-          "complexity": 1
-        },
-        {
-          "name": "window_controllers",
-          "lineno": 615,
-          "complexity": 2
-        },
-        {
-          "name": "top_event_workflows",
-          "lineno": 621,
-          "complexity": 2
         },
         {
           "name": "__getattr__",
-          "lineno": 626,
-          "complexity": 5
-        },
-        {
-          "name": "__init__",
-          "lineno": 646,
-          "complexity": 11
-        },
-        {
-          "name": "show_properties",
-          "lineno": 1547,
-          "complexity": 1
-        },
-        {
-          "name": "_add_tool_category",
-          "lineno": 1550,
-          "complexity": 1
-        },
-        {
-          "name": "_add_lifecycle_requirements_menu",
-          "lineno": 1553,
-          "complexity": 1
-        },
-        {
-          "name": "_init_nav_button_style",
-          "lineno": 1556,
-          "complexity": 1
-        },
-        {
-          "name": "_limit_explorer_size",
-          "lineno": 1559,
-          "complexity": 1
-        },
-        {
-          "name": "_animate_explorer_show",
-          "lineno": 1562,
-          "complexity": 1
-        },
-        {
-          "name": "_animate_explorer_hide",
-          "lineno": 1565,
-          "complexity": 1
-        },
-        {
-          "name": "_schedule_explorer_hide",
-          "lineno": 1568,
-          "complexity": 1
-        },
-        {
-          "name": "_cancel_explorer_hide",
-          "lineno": 1571,
-          "complexity": 1
-        },
-        {
-          "name": "show_explorer",
-          "lineno": 1574,
-          "complexity": 1
-        },
-        {
-          "name": "hide_explorer",
-          "lineno": 1577,
-          "complexity": 1
-        },
-        {
-          "name": "toggle_explorer_pin",
-          "lineno": 1580,
-          "complexity": 1
-        },
-        {
-          "name": "toggle_logs",
-          "lineno": 1583,
-          "complexity": 1
-        },
-        {
-          "name": "open_metrics_tab",
-          "lineno": 1586,
-          "complexity": 1
-        },
-        {
-          "name": "open_management_window",
-          "lineno": 1589,
-          "complexity": 1
-        },
-        {
-          "name": "_register_close",
-          "lineno": 1592,
-          "complexity": 1
-        },
-        {
-          "name": "_reregister_document",
-          "lineno": 1595,
-          "complexity": 1
-        },
-        {
-          "name": "touch_doc",
-          "lineno": 1598,
-          "complexity": 1
-        },
-        {
-          "name": "show_about",
-          "lineno": 1601,
-          "complexity": 1
-        },
-        {
-          "name": "_window_has_focus",
-          "lineno": 1604,
-          "complexity": 1
-        },
-        {
-          "name": "_window_in_selected_tab",
-          "lineno": 1607,
-          "complexity": 1
-        },
-        {
-          "name": "_on_tab_change",
-          "lineno": 1610,
-          "complexity": 1
-        },
-        {
-          "name": "_on_tab_close",
-          "lineno": 1613,
-          "complexity": 1
-        },
-        {
-          "name": "_on_doc_tab_motion",
-          "lineno": 1616,
-          "complexity": 1
-        },
-        {
-          "name": "_on_tool_tab_motion",
-          "lineno": 1619,
-          "complexity": 1
-        },
-        {
-          "name": "_make_doc_tab_visible",
-          "lineno": 1622,
-          "complexity": 1
-        },
-        {
-          "name": "_update_doc_tab_visibility",
-          "lineno": 1625,
-          "complexity": 1
-        },
-        {
-          "name": "_update_tool_tab_visibility",
-          "lineno": 1628,
-          "complexity": 1
-        },
-        {
-          "name": "_truncate_tab_title",
-          "lineno": 1631,
-          "complexity": 1
-        },
-        {
-          "name": "_select_next_tab",
-          "lineno": 1634,
-          "complexity": 1
-        },
-        {
-          "name": "_select_prev_tab",
-          "lineno": 1637,
-          "complexity": 1
-        },
-        {
-          "name": "_select_next_tool_tab",
-          "lineno": 1640,
-          "complexity": 1
-        },
-        {
-          "name": "_select_prev_tool_tab",
-          "lineno": 1643,
-          "complexity": 1
-        },
-        {
-          "name": "_new_tab",
-          "lineno": 1646,
+          "lineno": 29,
           "complexity": 1
         },
         {
           "name": "edit_controllability",
-          "lineno": 1652,
-          "complexity": 1
-        },
-        {
-          "name": "edit_description",
-          "lineno": 1655,
-          "complexity": 1
-        },
-        {
-          "name": "edit_gate_type",
-          "lineno": 1658,
-          "complexity": 1
-        },
-        {
-          "name": "edit_page_flag",
-          "lineno": 1661,
-          "complexity": 1
-        },
-        {
-          "name": "edit_rationale",
-          "lineno": 1664,
-          "complexity": 1
-        },
-        {
-          "name": "edit_selected",
-          "lineno": 1667,
-          "complexity": 1
-        },
-        {
-          "name": "edit_user_name",
-          "lineno": 1670,
-          "complexity": 1
-        },
-        {
-          "name": "edit_value",
-          "lineno": 1673,
-          "complexity": 1
-        },
-        {
-          "name": "rename_failure",
-          "lineno": 1676,
-          "complexity": 1
-        },
-        {
-          "name": "rename_fault",
-          "lineno": 1679,
-          "complexity": 1
-        },
-        {
-          "name": "rename_functional_insufficiency",
-          "lineno": 1682,
-          "complexity": 1
-        },
-        {
-          "name": "rename_hazard",
-          "lineno": 1685,
-          "complexity": 1
-        },
-        {
-          "name": "rename_malfunction",
-          "lineno": 1688,
-          "complexity": 1
-        },
-        {
-          "name": "rename_selected_tree_item",
-          "lineno": 1691,
-          "complexity": 1
-        },
-        {
-          "name": "rename_triggering_condition",
-          "lineno": 1694,
-          "complexity": 1
-        },
-        {
-          "name": "apply_style",
-          "lineno": 1697,
-          "complexity": 1
-        },
-        {
-          "name": "format_failure_mode_label",
-          "lineno": 1700,
-          "complexity": 1
-        },
-        {
-          "name": "_resize_prop_columns",
-          "lineno": 1703,
-          "complexity": 1
-        },
-        {
-          "name": "_spi_label",
-          "lineno": 1706,
-          "complexity": 1
-        },
-        {
-          "name": "_product_goal_name",
-          "lineno": 1709,
-          "complexity": 1
-        },
-        {
-          "name": "_create_icon",
-          "lineno": 1712,
-          "complexity": 1
-        },
-        {
-          "name": "fmeas",
-          "lineno": 1716,
-          "complexity": 2
-        },
-        {
-          "name": "fmeas",
-          "lineno": 1722,
-          "complexity": 2
-        },
-        {
-          "name": "show_fmea_list",
-          "lineno": 1727,
-          "complexity": 1
-        },
-        {
-          "name": "get_requirement_allocation_names",
-          "lineno": 1732,
-          "complexity": 1
-        },
-        {
-          "name": "get_requirement_goal_names",
-          "lineno": 1735,
-          "complexity": 1
-        },
-        {
-          "name": "format_requirement_with_trace",
-          "lineno": 1738,
-          "complexity": 1
-        },
-        {
-          "name": "build_requirement_diff_html",
-          "lineno": 1741,
-          "complexity": 1
-        },
-        {
-          "name": "generate_recommendations_for_top_event",
-          "lineno": 1744,
-          "complexity": 1
-        },
-        {
-          "name": "back_all_pages",
-          "lineno": 1747,
-          "complexity": 1
-        },
-        {
-          "name": "move_top_event_up",
-          "lineno": 1750,
-          "complexity": 1
-        },
-        {
-          "name": "move_top_event_down",
-          "lineno": 1753,
-          "complexity": 1
-        },
-        {
-          "name": "get_top_level_nodes",
-          "lineno": 1756,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_nodes_no_filter",
-          "lineno": 1759,
-          "complexity": 1
-        },
-        {
-          "name": "derive_requirements_for_event",
-          "lineno": 1762,
-          "complexity": 1
-        },
-        {
-          "name": "get_combined_safety_requirements",
-          "lineno": 1765,
-          "complexity": 1
-        },
-        {
-          "name": "get_top_event",
-          "lineno": 1768,
-          "complexity": 1
-        },
-        {
-          "name": "aggregate_safety_requirements",
-          "lineno": 1771,
-          "complexity": 1
-        },
-        {
-          "name": "generate_top_event_summary",
-          "lineno": 1774,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_nodes",
-          "lineno": 1777,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_nodes_table",
-          "lineno": 1780,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_nodes_in_model",
-          "lineno": 1783,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_basic_events",
-          "lineno": 1786,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_gates",
-          "lineno": 1789,
-          "complexity": 1
-        },
-        {
-          "name": "metric_to_text",
-          "lineno": 1792,
-          "complexity": 1
-        },
-        {
-          "name": "assurance_level_text",
-          "lineno": 1795,
-          "complexity": 1
-        },
-        {
-          "name": "calculate_cut_sets",
-          "lineno": 1798,
-          "complexity": 1
-        },
-        {
-          "name": "build_hierarchical_argumentation",
-          "lineno": 1801,
-          "complexity": 1
-        },
-        {
-          "name": "build_hierarchical_argumentation_common",
-          "lineno": 1804,
-          "complexity": 1
-        },
-        {
-          "name": "build_page_argumentation",
-          "lineno": 1807,
-          "complexity": 1
-        },
-        {
-          "name": "build_unified_recommendation_table",
-          "lineno": 1810,
-          "complexity": 1
-        },
-        {
-          "name": "build_dynamic_recommendations_table",
-          "lineno": 1813,
-          "complexity": 1
-        },
-        {
-          "name": "build_base_events_table_html",
-          "lineno": 1816,
-          "complexity": 1
-        },
-        {
-          "name": "get_extra_recommendations_list",
-          "lineno": 1819,
-          "complexity": 1
-        },
-        {
-          "name": "get_extra_recommendations_from_level",
-          "lineno": 1822,
-          "complexity": 1
-        },
-        {
-          "name": "get_recommendation_from_description",
-          "lineno": 1825,
-          "complexity": 1
-        },
-        {
-          "name": "build_argumentation",
-          "lineno": 1828,
-          "complexity": 1
-        },
-        {
-          "name": "auto_create_argumentation",
-          "lineno": 1831,
-          "complexity": 1
-        },
-        {
-          "name": "analyze_common_causes",
-          "lineno": 1834,
-          "complexity": 1
-        },
-        {
-          "name": "build_text_report",
-          "lineno": 1837,
-          "complexity": 1
-        },
-        {
-          "name": "all_children_are_base_events",
-          "lineno": 1840,
-          "complexity": 1
-        },
-        {
-          "name": "build_simplified_fta_model",
-          "lineno": 1843,
-          "complexity": 1
-        },
-        {
-          "name": "auto_generate_fta_diagram",
-          "lineno": 1847,
-          "complexity": 1
-        },
-        {
-          "name": "find_node_by_id_all",
-          "lineno": 1850,
-          "complexity": 1
-        },
-        {
-          "name": "get_hazop_by_name",
-          "lineno": 1853,
-          "complexity": 1
-        },
-        {
-          "name": "get_hara_by_name",
-          "lineno": 1856,
-          "complexity": 1
-        },
-        {
-          "name": "update_hara_statuses",
-          "lineno": 1859,
-          "complexity": 1
-        },
-        {
-          "name": "update_fta_statuses",
-          "lineno": 1862,
-          "complexity": 1
-        },
-        {
-          "name": "get_safety_goal_asil",
-          "lineno": 1865,
-          "complexity": 1
-        },
-        {
-          "name": "get_hara_goal_asil",
-          "lineno": 1868,
-          "complexity": 1
-        },
-        {
-          "name": "get_cyber_goal_cal",
-          "lineno": 1871,
-          "complexity": 1
-        },
-        {
-          "name": "get_top_event_safety_goals",
-          "lineno": 1874,
-          "complexity": 1
-        },
-        {
-          "name": "get_safety_goals_for_malfunctions",
-          "lineno": 1877,
-          "complexity": 8
-        },
-        {
-          "name": "is_malfunction_used",
-          "lineno": 1888,
-          "complexity": 7
-        },
-        {
-          "name": "add_malfunction",
-          "lineno": 1901,
-          "complexity": 1
-        },
-        {
-          "name": "add_fault",
-          "lineno": 1904,
-          "complexity": 1
-        },
-        {
-          "name": "add_failure",
-          "lineno": 1907,
-          "complexity": 1
-        },
-        {
-          "name": "add_hazard",
-          "lineno": 1910,
-          "complexity": 1
-        },
-        {
-          "name": "add_triggering_condition",
-          "lineno": 1913,
-          "complexity": 1
-        },
-        {
-          "name": "delete_triggering_condition",
-          "lineno": 1916,
-          "complexity": 1
-        },
-        {
-          "name": "add_functional_insufficiency",
-          "lineno": 1920,
-          "complexity": 1
-        },
-        {
-          "name": "delete_functional_insufficiency",
-          "lineno": 1923,
-          "complexity": 1
-        },
-        {
-          "name": "_update_shared_product_goals",
-          "lineno": 1927,
-          "complexity": 7
-        },
-        {
-          "name": "update_hazard_severity",
-          "lineno": 1951,
-          "complexity": 1
-        },
-        {
-          "name": "calculate_fmeda_metrics",
-          "lineno": 1955,
-          "complexity": 1
-        },
-        {
-          "name": "compute_fmeda_metrics",
-          "lineno": 1959,
-          "complexity": 1
-        },
-        {
-          "name": "sync_hara_to_safety_goals",
-          "lineno": 1963,
-          "complexity": 1
-        },
-        {
-          "name": "sync_cyber_risk_to_goals",
-          "lineno": 1967,
-          "complexity": 1
-        },
-        {
-          "name": "add_top_level_event",
-          "lineno": 1971,
-          "complexity": 4
-        },
-        {
-          "name": "_build_probability_frame",
-          "lineno": 1994,
-          "complexity": 1
-        },
-        {
-          "name": "_apply_project_properties",
-          "lineno": 1997,
-          "complexity": 8
-        },
-        {
-          "name": "edit_project_properties",
-          "lineno": 2027,
-          "complexity": 12
-        },
-        {
-          "name": "create_diagram_image",
-          "lineno": 2131,
-          "complexity": 1
-        },
-        {
-          "name": "get_page_nodes",
-          "lineno": 2134,
-          "complexity": 1
-        },
-        {
-          "name": "capture_page_diagram",
-          "lineno": 2137,
-          "complexity": 1
-        },
-        {
-          "name": "capture_gsn_diagram",
-          "lineno": 2140,
-          "complexity": 5
-        },
-        {
-          "name": "capture_sysml_diagram",
-          "lineno": 2176,
-          "complexity": 10
-        },
-        {
-          "name": "capture_cbn_diagram",
-          "lineno": 2221,
-          "complexity": 5
-        },
-        {
-          "name": "draw_subtree_with_filter",
-          "lineno": 2253,
-          "complexity": 2
-        },
-        {
-          "name": "draw_subtree",
-          "lineno": 2258,
-          "complexity": 2
-        },
-        {
-          "name": "draw_connections_subtree",
-          "lineno": 2265,
-          "complexity": 6
-        },
-        {
-          "name": "draw_node_on_canvas_pdf",
-          "lineno": 2283,
-          "complexity": 13
-        },
-        {
-          "name": "rename_selected_tree_item",
-          "lineno": 2389,
-          "complexity": 1
-        },
-        {
-          "name": "save_diagram_png",
-          "lineno": 2392,
-          "complexity": 1
-        },
-        {
-          "name": "on_treeview_click",
-          "lineno": 2395,
-          "complexity": 1
-        },
-        {
-          "name": "on_analysis_tree_double_click",
-          "lineno": 2398,
-          "complexity": 1
-        },
-        {
-          "name": "on_analysis_tree_right_click",
-          "lineno": 2401,
-          "complexity": 1
-        },
-        {
-          "name": "on_analysis_tree_select",
-          "lineno": 2404,
-          "complexity": 1
-        },
-        {
-          "name": "on_tool_list_double_click",
-          "lineno": 2407,
-          "complexity": 1
-        },
-        {
-          "name": "_on_toolbox_change",
-          "lineno": 2410,
-          "complexity": 1
-        },
-        {
-          "name": "apply_governance_rules",
-          "lineno": 2413,
-          "complexity": 1
-        },
-        {
-          "name": "refresh_tool_enablement",
-          "lineno": 2417,
-          "complexity": 1
-        },
-        {
-          "name": "update_lifecycle_cb",
-          "lineno": 2420,
-          "complexity": 1
-        },
-        {
-          "name": "_export_toolbox_dict",
-          "lineno": 2423,
-          "complexity": 2
-        },
-        {
-          "name": "on_lifecycle_selected",
-          "lineno": 2431,
-          "complexity": 13
-        },
-        {
-          "name": "enable_process_area",
-          "lineno": 2469,
-          "complexity": 1
-        },
-        {
-          "name": "enable_work_product",
-          "lineno": 2472,
-          "complexity": 1
-        },
-        {
-          "name": "can_remove_work_product",
-          "lineno": 2475,
-          "complexity": 1
-        },
-        {
-          "name": "disable_work_product",
-          "lineno": 2478,
-          "complexity": 1
-        },
-        {
-          "name": "open_work_product",
-          "lineno": 2481,
-          "complexity": 17
-        },
-        {
-          "name": "on_ctrl_mousewheel",
-          "lineno": 2522,
-          "complexity": 1
-        },
-        {
-          "name": "new_model",
-          "lineno": 2525,
-          "complexity": 1
-        },
-        {
-          "name": "compute_occurrence_counts",
-          "lineno": 2528,
-          "complexity": 4
-        },
-        {
-          "name": "get_node_fill_color",
-          "lineno": 2547,
-          "complexity": 4
-        },
-        {
-          "name": "on_right_mouse_press",
-          "lineno": 2566,
-          "complexity": 1
-        },
-        {
-          "name": "on_right_mouse_drag",
-          "lineno": 2569,
-          "complexity": 1
-        },
-        {
-          "name": "on_right_mouse_release",
-          "lineno": 2572,
-          "complexity": 1
-        },
-        {
-          "name": "show_context_menu",
-          "lineno": 2575,
-          "complexity": 1
-        },
-        {
-          "name": "on_canvas_click",
-          "lineno": 2578,
-          "complexity": 1
-        },
-        {
-          "name": "on_canvas_double_click",
-          "lineno": 2581,
-          "complexity": 1
-        },
-        {
-          "name": "on_canvas_drag",
-          "lineno": 2584,
-          "complexity": 1
-        },
-        {
-          "name": "on_canvas_release",
-          "lineno": 2587,
-          "complexity": 1
-        },
-        {
-          "name": "move_subtree",
-          "lineno": 2590,
-          "complexity": 1
-        },
-        {
-          "name": "zoom_in",
-          "lineno": 2593,
-          "complexity": 1
-        },
-        {
-          "name": "zoom_out",
-          "lineno": 2598,
-          "complexity": 1
-        },
-        {
-          "name": "auto_arrange",
-          "lineno": 2607,
-          "complexity": 9
-        },
-        {
-          "name": "get_all_triggering_conditions",
-          "lineno": 2638,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_functional_insufficiencies",
-          "lineno": 2641,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_scenario_names",
-          "lineno": 2644,
-          "complexity": 1
-        },
-        {
-          "name": "get_validation_targets_for_odd",
-          "lineno": 2647,
-          "complexity": 22
-        },
-        {
-          "name": "get_scenario_exposure",
-          "lineno": 2699,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_scenery_names",
-          "lineno": 2702,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_function_names",
-          "lineno": 2706,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_action_names",
-          "lineno": 2709,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_action_labels",
-          "lineno": 2712,
-          "complexity": 1
-        },
-        {
-          "name": "get_use_case_for_function",
-          "lineno": 2715,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_component_names",
-          "lineno": 2718,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_part_names",
-          "lineno": 2721,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_malfunction_names",
-          "lineno": 2724,
-          "complexity": 1
-        },
-        {
-          "name": "get_hazards_for_malfunction",
-          "lineno": 2727,
-          "complexity": 9
-        },
-        {
-          "name": "update_odd_elements",
-          "lineno": 2742,
-          "complexity": 2
-        },
-        {
-          "name": "update_hazard_list",
-          "lineno": 2748,
-          "complexity": 17
-        },
-        {
-          "name": "update_failure_list",
-          "lineno": 2797,
-          "complexity": 4
-        },
-        {
-          "name": "update_triggering_condition_list",
-          "lineno": 2806,
-          "complexity": 9
-        },
-        {
-          "name": "update_functional_insufficiency_list",
-          "lineno": 2822,
-          "complexity": 9
-        },
-        {
-          "name": "get_entry_field",
-          "lineno": 2838,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_failure_modes",
-          "lineno": 2841,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_fmea_entries",
-          "lineno": 2844,
-          "complexity": 1
-        },
-        {
-          "name": "get_non_basic_failure_modes",
-          "lineno": 2847,
-          "complexity": 1
-        },
-        {
-          "name": "get_available_failure_modes_for_gates",
-          "lineno": 2850,
-          "complexity": 4
-        },
-        {
-          "name": "get_failure_mode_node",
-          "lineno": 2860,
-          "complexity": 1
-        },
-        {
-          "name": "get_component_name_for_node",
-          "lineno": 2863,
-          "complexity": 1
-        },
-        {
-          "name": "get_failure_modes_for_malfunction",
-          "lineno": 2866,
-          "complexity": 1
-        },
-        {
-          "name": "get_faults_for_failure_mode",
-          "lineno": 2869,
-          "complexity": 5
-        },
-        {
-          "name": "get_fit_for_fault",
-          "lineno": 2881,
-          "complexity": 6
-        },
-        {
-          "name": "update_views",
-          "lineno": 2897,
-          "complexity": 113
-        },
-        {
-          "name": "update_basic_event_probabilities",
-          "lineno": 3284,
-          "complexity": 1
-        },
-        {
-          "name": "validate_float",
-          "lineno": 3287,
-          "complexity": 7
-        },
-        {
-          "name": "compute_failure_prob",
-          "lineno": 3316,
-          "complexity": 1
-        },
-        {
-          "name": "propagate_failure_mode_attributes",
-          "lineno": 3320,
-          "complexity": 3
-        },
-        {
-          "name": "refresh_model",
-          "lineno": 3331,
-          "complexity": 14
-        },
-        {
-          "name": "refresh_all",
-          "lineno": 3377,
-          "complexity": 7
-        },
-        {
-          "name": "insert_node_in_tree",
-          "lineno": 3399,
-          "complexity": 1
-        },
-        {
-          "name": "redraw_canvas",
-          "lineno": 3402,
-          "complexity": 8
-        },
-        {
-          "name": "create_diagram_image_without_grid",
-          "lineno": 3419,
-          "complexity": 1
-        },
-        {
-          "name": "draw_connections",
-          "lineno": 3422,
-          "complexity": 7
-        },
-        {
-          "name": "draw_node",
-          "lineno": 3439,
-          "complexity": 35
-        },
-        {
-          "name": "find_node_by_id",
-          "lineno": 3705,
-          "complexity": 1
-        },
-        {
-          "name": "is_descendant",
-          "lineno": 3708,
-          "complexity": 1
-        },
-        {
-          "name": "add_node_of_type",
-          "lineno": 3711,
-          "complexity": 16
-        },
-        {
-          "name": "add_basic_event_from_fmea",
-          "lineno": 3787,
-          "complexity": 11
-        },
-        {
-          "name": "add_basic_event_from_fmea",
-          "lineno": 3830,
-          "complexity": 11
-        },
-        {
-          "name": "add_basic_event_from_fmea",
-          "lineno": 3873,
-          "complexity": 11
-        },
-        {
-          "name": "remove_node",
-          "lineno": 3917,
-          "complexity": 1
-        },
-        {
-          "name": "remove_connection",
-          "lineno": 3920,
-          "complexity": 1
-        },
-        {
-          "name": "delete_node_and_subtree",
-          "lineno": 3923,
-          "complexity": 1
-        },
-        {
-          "name": "create_top_event_for_malfunction",
-          "lineno": 3929,
-          "complexity": 1
-        },
-        {
-          "name": "delete_top_events_for_malfunction",
-          "lineno": 3932,
-          "complexity": 9
-        },
-        {
-          "name": "add_gate_from_failure_mode",
-          "lineno": 3955,
-          "complexity": 1
-        },
-        {
-          "name": "add_fault_event",
-          "lineno": 3958,
-          "complexity": 15
-        },
-        {
-          "name": "calculate_overall",
-          "lineno": 4012,
-          "complexity": 1
-        },
-        {
-          "name": "calculate_pmfh",
-          "lineno": 4015,
-          "complexity": 1
-        },
-        {
-          "name": "show_requirements_matrix",
-          "lineno": 4018,
-          "complexity": 58
-        },
-        {
-          "name": "show_fmeda_list",
-          "lineno": 4178,
-          "complexity": 1
-        },
-        {
-          "name": "show_triggering_condition_list",
-          "lineno": 4181,
-          "complexity": 19
-        },
-        {
-          "name": "show_hazard_list",
-          "lineno": 4266,
-          "complexity": 1
-        },
-        {
-          "name": "show_malfunction_editor",
-          "lineno": 4269,
-          "complexity": 11
-        },
-        {
-          "name": "show_fault_list",
-          "lineno": 4324,
-          "complexity": 9
-        },
-        {
-          "name": "show_failure_list",
-          "lineno": 4374,
-          "complexity": 9
-        },
-        {
-          "name": "show_hazard_editor",
-          "lineno": 4429,
-          "complexity": 1
-        },
-        {
-          "name": "show_fault_editor",
-          "lineno": 4432,
-          "complexity": 1
-        },
-        {
-          "name": "show_failure_editor",
-          "lineno": 4436,
-          "complexity": 1
-        },
-        {
-          "name": "show_functional_insufficiency_list",
-          "lineno": 4440,
-          "complexity": 13
-        },
-        {
-          "name": "show_malfunctions_editor",
-          "lineno": 4499,
-          "complexity": 15
-        },
-        {
-          "name": "show_fmea_table",
-          "lineno": 5175,
-          "complexity": 109
-        },
-        {
-          "name": "export_fmea_to_csv",
-          "lineno": 5701,
-          "complexity": 10
-        },
-        {
-          "name": "export_fmeda_to_csv",
-          "lineno": 5717,
-          "complexity": 11
-        },
-        {
-          "name": "show_traceability_matrix",
-          "lineno": 5770,
-          "complexity": 6
-        },
-        {
-          "name": "collect_requirements_recursive",
-          "lineno": 5791,
-          "complexity": 2
-        },
-        {
-          "name": "show_safety_goals_matrix",
-          "lineno": 5797,
-          "complexity": 10
-        },
-        {
-          "name": "show_product_goals_editor",
-          "lineno": 5915,
-          "complexity": 23
-        },
-        {
-          "name": "_parse_spi_target",
-          "lineno": 6108,
-          "complexity": 3
-        },
-        {
-          "name": "get_spi_targets",
-          "lineno": 6115,
-          "complexity": 3
-        },
-        {
-          "name": "show_safety_performance_indicators",
-          "lineno": 6126,
-          "complexity": 9
-        },
-        {
-          "name": "refresh_safety_performance_indicators",
-          "lineno": 6183,
-          "complexity": 14
-        },
-        {
-          "name": "refresh_safety_case_table",
-          "lineno": 6229,
-          "complexity": 21
-        },
-        {
-          "name": "show_safety_case",
-          "lineno": 6300,
-          "complexity": 32
-        },
-        {
-          "name": "export_product_goal_requirements",
-          "lineno": 6461,
-          "complexity": 1
-        },
-        {
-          "name": "generate_phase_requirements",
-          "lineno": 6463,
-          "complexity": 2
-        },
-        {
-          "name": "generate_lifecycle_requirements",
-          "lineno": 6470,
-          "complexity": 2
-        },
-        {
-          "name": "_refresh_phase_requirements_menu",
-          "lineno": 6478,
-          "complexity": 5
-        },
-        {
-          "name": "export_cybersecurity_goal_requirements",
-          "lineno": 6500,
-          "complexity": 1
-        },
-        {
-          "name": "show_cut_sets",
-          "lineno": 6503,
-          "complexity": 12
-        },
-        {
-          "name": "show_common_cause_view",
-          "lineno": 6547,
-          "complexity": 21
-        },
-        {
-          "name": "build_cause_effect_data",
-          "lineno": 6615,
-          "complexity": 1
-        },
-        {
-          "name": "_build_cause_effect_graph",
-          "lineno": 6618,
-          "complexity": 1
-        },
-        {
-          "name": "render_cause_effect_diagram",
-          "lineno": 6621,
-          "complexity": 8
-        },
-        {
-          "name": "show_cause_effect_chain",
-          "lineno": 6693,
-          "complexity": 11
-        },
-        {
-          "name": "show_cut_sets",
-          "lineno": 6874,
-          "complexity": 12
-        },
-        {
-          "name": "show_common_cause_view",
-          "lineno": 6918,
-          "complexity": 21
-        },
-        {
-          "name": "show_cut_sets",
-          "lineno": 6986,
-          "complexity": 12
-        },
-        {
-          "name": "show_common_cause_view",
-          "lineno": 7030,
-          "complexity": 21
-        },
-        {
-          "name": "show_cut_sets",
-          "lineno": 7098,
-          "complexity": 12
-        },
-        {
-          "name": "show_common_cause_view",
-          "lineno": 7142,
-          "complexity": 21
-        },
-        {
-          "name": "manage_mission_profiles",
-          "lineno": 7210,
-          "complexity": 41
-        },
-        {
-          "name": "manage_mechanism_libraries",
-          "lineno": 7351,
-          "complexity": 1
-        },
-        {
-          "name": "manage_scenario_libraries",
-          "lineno": 7354,
-          "complexity": 62
-        },
-        {
-          "name": "manage_odd_libraries",
-          "lineno": 7717,
-          "complexity": 52
-        },
-        {
-          "name": "open_reliability_window",
-          "lineno": 8074,
-          "complexity": 1
-        },
-        {
-          "name": "open_fmeda_window",
-          "lineno": 8077,
-          "complexity": 1
-        },
-        {
-          "name": "open_hazop_window",
-          "lineno": 8080,
-          "complexity": 1
-        },
-        {
-          "name": "open_risk_assessment_window",
-          "lineno": 8083,
-          "complexity": 1
-        },
-        {
-          "name": "open_stpa_window",
-          "lineno": 8086,
-          "complexity": 1
-        },
-        {
-          "name": "open_threat_window",
-          "lineno": 8089,
-          "complexity": 1
-        },
-        {
-          "name": "open_fi2tc_window",
-          "lineno": 8092,
-          "complexity": 1
-        },
-        {
-          "name": "open_tc2fi_window",
-          "lineno": 8095,
-          "complexity": 1
-        },
-        {
-          "name": "open_fault_prioritization_window",
-          "lineno": 8098,
-          "complexity": 1
-        },
-        {
-          "name": "open_safety_management_toolbox",
-          "lineno": 8101,
-          "complexity": 1
-        },
-        {
-          "name": "open_diagram_rules_toolbox",
-          "lineno": 8104,
-          "complexity": 5
-        },
-        {
-          "name": "open_requirement_patterns_toolbox",
-          "lineno": 8126,
-          "complexity": 5
-        },
-        {
-          "name": "open_report_template_toolbox",
-          "lineno": 8150,
-          "complexity": 5
-        },
-        {
-          "name": "open_report_template_manager",
-          "lineno": 8174,
-          "complexity": 5
-        },
-        {
-          "name": "reload_config",
-          "lineno": 8199,
-          "complexity": 8
-        },
-        {
-          "name": "open_search_toolbox",
-          "lineno": 8219,
-          "complexity": 1
-        },
-        {
-          "name": "open_style_editor",
-          "lineno": 8222,
-          "complexity": 1
-        },
-        {
-          "name": "refresh_styles",
-          "lineno": 8228,
-          "complexity": 5
-        },
-        {
-          "name": "show_hazard_explorer",
-          "lineno": 8237,
-          "complexity": 1
-        },
-        {
-          "name": "show_requirements_explorer",
-          "lineno": 8240,
-          "complexity": 3
-        },
-        {
-          "name": "_create_fta_tab",
-          "lineno": 8249,
-          "complexity": 4
-        },
-        {
-          "name": "create_fta_diagram",
-          "lineno": 8307,
-          "complexity": 2
-        },
-        {
-          "name": "create_cta_diagram",
-          "lineno": 8314,
-          "complexity": 1
-        },
-        {
-          "name": "enable_fta_actions",
-          "lineno": 8318,
-          "complexity": 4
-        },
-        {
-          "name": "enable_paa_actions",
-          "lineno": 8331,
-          "complexity": 1
-        },
-        {
-          "name": "_update_analysis_menus",
-          "lineno": 8335,
-          "complexity": 2
-        },
-        {
-          "name": "_create_paa_tab",
-          "lineno": 8343,
-          "complexity": 1
-        },
-        {
-          "name": "create_paa_diagram",
-          "lineno": 8347,
-          "complexity": 1
-        },
-        {
-          "name": "paa_manager",
-          "lineno": 8352,
-          "complexity": 2
-        },
-        {
-          "name": "pages_and_paa",
-          "lineno": 8359,
-          "complexity": 2
-        },
-        {
-          "name": "_reset_fta_state",
-          "lineno": 8367,
-          "complexity": 1
-        },
-        {
-          "name": "ensure_fta_tab",
-          "lineno": 8376,
-          "complexity": 1
-        },
-        {
-          "name": "_format_diag_title",
-          "lineno": 8379,
-          "complexity": 2
-        },
-        {
-          "name": "open_use_case_diagram",
-          "lineno": 8385,
-          "complexity": 1
-        },
-        {
-          "name": "open_activity_diagram",
-          "lineno": 8388,
-          "complexity": 1
-        },
-        {
-          "name": "open_block_diagram",
-          "lineno": 8391,
-          "complexity": 1
-        },
-        {
-          "name": "open_internal_block_diagram",
-          "lineno": 8394,
-          "complexity": 1
-        },
-        {
-          "name": "open_control_flow_diagram",
-          "lineno": 8397,
-          "complexity": 1
-        },
-        {
-          "name": "open_causal_bayesian_network_window",
-          "lineno": 8400,
-          "complexity": 1
-        },
-        {
-          "name": "open_gsn_diagram",
-          "lineno": 8403,
-          "complexity": 1
-        },
-        {
-          "name": "open_arch_window",
-          "lineno": 8406,
-          "complexity": 1
-        },
-        {
-          "name": "open_page_diagram",
-          "lineno": 8409,
-          "complexity": 1
-        },
-        {
-          "name": "manage_architecture",
-          "lineno": 8412,
-          "complexity": 1
-        },
-        {
-          "name": "manage_gsn",
-          "lineno": 8415,
-          "complexity": 1
-        },
-        {
-          "name": "manage_safety_management",
-          "lineno": 8418,
-          "complexity": 1
-        },
-        {
-          "name": "manage_safety_cases",
-          "lineno": 8421,
-          "complexity": 4
-        },
-        {
-          "name": "_diagram_copy_strategy1",
-          "lineno": 8437,
-          "complexity": 4
-        },
-        {
-          "name": "_diagram_copy_strategy2",
-          "lineno": 8447,
-          "complexity": 4
-        },
-        {
-          "name": "_diagram_copy_strategy3",
-          "lineno": 8457,
-          "complexity": 4
-        },
-        {
-          "name": "_diagram_copy_strategy4",
-          "lineno": 8467,
-          "complexity": 5
-        },
-        {
-          "name": "_diagram_cut_strategy1",
-          "lineno": 8478,
-          "complexity": 4
-        },
-        {
-          "name": "_diagram_cut_strategy2",
-          "lineno": 8488,
-          "complexity": 4
-        },
-        {
-          "name": "_diagram_cut_strategy3",
-          "lineno": 8498,
-          "complexity": 4
-        },
-        {
-          "name": "_diagram_cut_strategy4",
-          "lineno": 8508,
-          "complexity": 5
-        },
-        {
-          "name": "copy_node",
-          "lineno": 8519,
-          "complexity": 12
-        },
-        {
-          "name": "cut_node",
-          "lineno": 8549,
-          "complexity": 14
-        },
-        {
-          "name": "_reset_gsn_clone",
-          "lineno": 8583,
-          "complexity": 4
-        },
-        {
-          "name": "_clone_for_paste_strategy1",
-          "lineno": 8597,
-          "complexity": 4
-        },
-        {
-          "name": "_clone_for_paste_strategy2",
-          "lineno": 8607,
-          "complexity": 4
-        },
-        {
-          "name": "_clone_for_paste_strategy3",
-          "lineno": 8617,
-          "complexity": 4
-        },
-        {
-          "name": "_clone_for_paste_strategy4",
-          "lineno": 8628,
-          "complexity": 1
-        },
-        {
-          "name": "_clone_for_paste",
-          "lineno": 8634,
-          "complexity": 5
-        },
-        {
-          "name": "_prepare_node_for_paste",
-          "lineno": 8653,
-          "complexity": 5
-        },
-        {
-          "name": "paste_node",
-          "lineno": 8669,
-          "complexity": 58
-        },
-        {
-          "name": "_get_diag_type",
-          "lineno": 8794,
-          "complexity": 4
-        },
-        {
-          "name": "clone_node_preserving_id",
-          "lineno": 8804,
-          "complexity": 6
-        },
-        {
-          "name": "_find_gsn_diagram",
-          "lineno": 8856,
-          "complexity": 7
-        },
-        {
-          "name": "_copy_attrs_no_xy_strategy1",
-          "lineno": 8882,
-          "complexity": 4
-        },
-        {
-          "name": "_copy_attrs_no_xy_strategy2",
-          "lineno": 8891,
-          "complexity": 5
-        },
-        {
-          "name": "_copy_attrs_no_xy_strategy3",
-          "lineno": 8901,
-          "complexity": 5
-        },
-        {
-          "name": "_copy_attrs_no_xy_strategy4",
-          "lineno": 8912,
-          "complexity": 5
-        },
-        {
-          "name": "_copy_attrs_no_xy",
-          "lineno": 8924,
-          "complexity": 3
-        },
-        {
-          "name": "sync_nodes_by_id",
-          "lineno": 8937,
-          "complexity": 1
-        },
-        {
-          "name": "edit_severity",
-          "lineno": 8947,
-          "complexity": 1
-        },
-        {
-          "name": "set_last_saved_state",
-          "lineno": 8955,
-          "complexity": 1
-        },
-        {
-          "name": "has_unsaved_changes",
-          "lineno": 8959,
-          "complexity": 1
-        },
-        {
-          "name": "_strip_object_positions",
-          "lineno": 8967,
-          "complexity": 6
-        },
-        {
-          "name": "push_undo_state",
-          "lineno": 8985,
-          "complexity": 8
-        },
-        {
-          "name": "_push_undo_state_v1",
-          "lineno": 9012,
-          "complexity": 6
-        },
-        {
-          "name": "_push_undo_state_v2",
-          "lineno": 9033,
-          "complexity": 6
-        },
-        {
-          "name": "_push_undo_state_v3",
-          "lineno": 9047,
-          "complexity": 6
-        },
-        {
-          "name": "_push_undo_state_v4",
-          "lineno": 9061,
-          "complexity": 5
-        },
-        {
-          "name": "_undo_hotkey",
-          "lineno": 9072,
-          "complexity": 1
-        },
-        {
-          "name": "_redo_hotkey",
-          "lineno": 9077,
-          "complexity": 1
-        },
-        {
-          "name": "undo",
-          "lineno": 9082,
-          "complexity": 6
-        },
-        {
-          "name": "redo",
-          "lineno": 9099,
-          "complexity": 6
-        },
-        {
-          "name": "clear_undo_history",
-          "lineno": 9116,
-          "complexity": 1
-        },
-        {
-          "name": "_undo_v1",
-          "lineno": 9125,
-          "complexity": 6
-        },
-        {
-          "name": "_undo_v2",
-          "lineno": 9141,
-          "complexity": 6
-        },
-        {
-          "name": "_undo_v3",
-          "lineno": 9157,
-          "complexity": 6
-        },
-        {
-          "name": "_undo_v4",
-          "lineno": 9173,
-          "complexity": 7
-        },
-        {
-          "name": "_redo_v1",
-          "lineno": 9192,
-          "complexity": 3
-        },
-        {
-          "name": "_redo_v2",
-          "lineno": 9204,
-          "complexity": 3
-        },
-        {
-          "name": "_redo_v3",
-          "lineno": 9216,
-          "complexity": 3
-        },
-        {
-          "name": "_redo_v4",
-          "lineno": 9228,
-          "complexity": 3
-        },
-        {
-          "name": "confirm_close",
-          "lineno": 9240,
-          "complexity": 4
-        },
-        {
-          "name": "export_model_data",
-          "lineno": 9256,
-          "complexity": 1
-        },
-        {
-          "name": "_load_project_properties",
-          "lineno": 9259,
-          "complexity": 4
-        },
-        {
-          "name": "_load_fault_tree_events",
-          "lineno": 9278,
-          "complexity": 11
-        },
-        {
-          "name": "apply_model_data",
-          "lineno": 9302,
-          "complexity": 124
-        },
-        {
-          "name": "_reset_on_load",
-          "lineno": 9837,
-          "complexity": 8
-        },
-        {
-          "name": "_prompt_save_before_load_v1",
-          "lineno": 9884,
-          "complexity": 1
-        },
-        {
-          "name": "_prompt_save_before_load_v2",
-          "lineno": 9889,
-          "complexity": 1
-        },
-        {
-          "name": "_prompt_save_before_load_v3",
-          "lineno": 9894,
-          "complexity": 1
-        },
-        {
-          "name": "_prompt_save_before_load_v4",
-          "lineno": 9898,
-          "complexity": 1
-        },
-        {
-          "name": "_prompt_save_before_load",
-          "lineno": 9905,
-          "complexity": 1
-        },
-        {
-          "name": "update_global_requirements_from_nodes",
-          "lineno": 9909,
-          "complexity": 5
-        },
-        {
-          "name": "_generate_pdf_report",
-          "lineno": 9921,
-          "complexity": 1
-        },
-        {
-          "name": "generate_pdf_report",
-          "lineno": 9924,
-          "complexity": 1
-        },
-        {
-          "name": "generate_report",
-          "lineno": 9927,
-          "complexity": 1
-        },
-        {
-          "name": "build_html_report",
-          "lineno": 9930,
-          "complexity": 1
-        },
-        {
-          "name": "resolve_original",
-          "lineno": 9932,
-          "complexity": 4
-        },
-        {
-          "name": "go_back",
-          "lineno": 9938,
-          "complexity": 1
-        },
-        {
-          "name": "draw_page_subtree",
-          "lineno": 9941,
-          "complexity": 1
-        },
-        {
-          "name": "draw_page_grid",
-          "lineno": 9944,
-          "complexity": 1
-        },
-        {
-          "name": "draw_page_connections_subtree",
-          "lineno": 9947,
-          "complexity": 1
-        },
-        {
-          "name": "draw_page_nodes_subtree",
-          "lineno": 9950,
-          "complexity": 1
-        },
-        {
-          "name": "draw_node_on_page_canvas",
-          "lineno": 9953,
-          "complexity": 1
-        },
-        {
-          "name": "on_ctrl_mousewheel_page",
-          "lineno": 9956,
-          "complexity": 1
-        },
-        {
-          "name": "close_page_diagram",
-          "lineno": 9959,
-          "complexity": 5
-        },
-        {
-          "name": "start_peer_review",
-          "lineno": 10006,
-          "complexity": 1
-        },
-        {
-          "name": "start_joint_review",
-          "lineno": 10009,
-          "complexity": 1
-        },
-        {
-          "name": "open_review_document",
-          "lineno": 10012,
-          "complexity": 1
-        },
-        {
-          "name": "open_review_toolbox",
-          "lineno": 10015,
-          "complexity": 1
-        },
-        {
-          "name": "send_review_email",
-          "lineno": 10018,
-          "complexity": 1
-        },
-        {
-          "name": "review_is_closed",
-          "lineno": 10021,
-          "complexity": 1
-        },
-        {
-          "name": "review_is_closed_for",
-          "lineno": 10024,
-          "complexity": 1
-        },
-        {
-          "name": "capture_diff_diagram",
-          "lineno": 10027,
-          "complexity": 1
-        },
-        {
-          "name": "compute_requirement_asil",
-          "lineno": 10032,
-          "complexity": 3
-        },
-        {
-          "name": "find_safety_goal_node",
-          "lineno": 10042,
-          "complexity": 3
-        },
-        {
-          "name": "compute_validation_criteria",
-          "lineno": 10048,
-          "complexity": 1
-        },
-        {
-          "name": "update_validation_criteria",
-          "lineno": 10051,
-          "complexity": 1
-        },
-        {
-          "name": "update_requirement_asil",
-          "lineno": 10054,
-          "complexity": 2
-        },
-        {
-          "name": "update_all_validation_criteria",
-          "lineno": 10060,
-          "complexity": 1
-        },
-        {
-          "name": "update_all_requirement_asil",
-          "lineno": 10063,
-          "complexity": 3
-        },
-        {
-          "name": "update_base_event_requirement_asil",
-          "lineno": 10069,
-          "complexity": 6
-        },
-        {
-          "name": "ensure_asil_consistency",
-          "lineno": 10083,
-          "complexity": 1
-        },
-        {
-          "name": "invalidate_reviews_for_hara",
-          "lineno": 10091,
-          "complexity": 1
-        },
-        {
-          "name": "invalidate_reviews_for_requirement",
-          "lineno": 10094,
-          "complexity": 1
-        },
-        {
-          "name": "add_version",
-          "lineno": 10097,
-          "complexity": 1
-        },
-        {
-          "name": "compare_versions",
-          "lineno": 10101,
-          "complexity": 1
-        },
-        {
-          "name": "merge_review_comments",
-          "lineno": 10105,
-          "complexity": 1
-        },
-        {
-          "name": "calculate_diff_nodes",
-          "lineno": 10109,
-          "complexity": 1
-        },
-        {
-          "name": "calculate_diff_between",
-          "lineno": 10113,
-          "complexity": 1
-        },
-        {
-          "name": "node_map_from_data",
-          "lineno": 10117,
-          "complexity": 1
-        },
-        {
-          "name": "set_current_user",
-          "lineno": 10121,
-          "complexity": 1
-        },
-        {
-          "name": "get_current_user_role",
-          "lineno": 10124,
-          "complexity": 1
-        },
-        {
-          "name": "focus_on_node",
-          "lineno": 10127,
-          "complexity": 1
-        },
-        {
-          "name": "get_review_targets",
-          "lineno": 10130,
-          "complexity": 1
-        },
-        {
-          "name": "_color",
-          "lineno": 718,
-          "complexity": 2
-        },
-        {
-          "name": "_wrapped_select",
-          "lineno": 1480,
-          "complexity": 2
-        },
-        {
-          "name": "save_props",
-          "lineno": 2090,
-          "complexity": 9
-        },
-        {
-          "name": "_refresh_children",
-          "lineno": 2459,
-          "complexity": 3
-        },
-        {
-          "name": "rec",
-          "lineno": 2535,
-          "complexity": 3
-        },
-        {
-          "name": "layout",
-          "lineno": 2613,
-          "complexity": 3
-        },
-        {
-          "name": "iter_analysis_events",
-          "lineno": 3346,
-          "complexity": 7
-        },
-        {
-          "name": "alloc_from_data",
-          "lineno": 4073,
-          "complexity": 12
-        },
-        {
-          "name": "goals_from_data",
-          "lineno": 4091,
-          "complexity": 21
-        },
-        {
-          "name": "insert_diff",
-          "lineno": 4125,
-          "complexity": 6
-        },
-        {
-          "name": "insert_list_diff",
-          "lineno": 4138,
-          "complexity": 9
-        },
-        {
-          "name": "refresh",
-          "lineno": 4191,
-          "complexity": 2
-        },
-        {
-          "name": "add_tc",
-          "lineno": 4198,
-          "complexity": 2
-        },
-        {
-          "name": "edit_tc",
-          "lineno": 4204,
-          "complexity": 4
-        },
-        {
-          "name": "del_tc",
-          "lineno": 4215,
-          "complexity": 3
-        },
-        {
-          "name": "export_csv",
-          "lineno": 4224,
-          "complexity": 4
-        },
-        {
-          "name": "add_tc",
-          "lineno": 4234,
-          "complexity": 2
-        },
-        {
-          "name": "edit_tc",
-          "lineno": 4240,
-          "complexity": 4
-        },
-        {
-          "name": "del_tc",
-          "lineno": 4250,
-          "complexity": 3
-        },
-        {
-          "name": "refresh",
-          "lineno": 4280,
-          "complexity": 2
-        },
-        {
-          "name": "add",
-          "lineno": 4285,
-          "complexity": 2
-        },
-        {
-          "name": "rename",
-          "lineno": 4291,
-          "complexity": 5
-        },
-        {
-          "name": "delete",
-          "lineno": 4305,
-          "complexity": 3
-        },
-        {
-          "name": "refresh",
-          "lineno": 4335,
-          "complexity": 2
-        },
-        {
-          "name": "add",
-          "lineno": 4340,
-          "complexity": 2
-        },
-        {
-          "name": "rename",
-          "lineno": 4346,
-          "complexity": 3
-        },
-        {
-          "name": "delete",
-          "lineno": 4357,
-          "complexity": 3
-        },
-        {
-          "name": "refresh",
-          "lineno": 4386,
-          "complexity": 2
-        },
-        {
-          "name": "add",
-          "lineno": 4391,
-          "complexity": 2
-        },
-        {
-          "name": "rename",
-          "lineno": 4397,
-          "complexity": 3
-        },
-        {
-          "name": "delete",
-          "lineno": 4408,
-          "complexity": 3
-        },
-        {
-          "name": "refresh",
-          "lineno": 4450,
-          "complexity": 2
-        },
-        {
-          "name": "export_csv",
-          "lineno": 4457,
-          "complexity": 4
-        },
-        {
-          "name": "add_fi",
-          "lineno": 4467,
-          "complexity": 2
-        },
-        {
-          "name": "edit_fi",
-          "lineno": 4473,
-          "complexity": 4
-        },
-        {
-          "name": "del_fi",
-          "lineno": 4483,
-          "complexity": 3
-        },
-        {
-          "name": "add_mal",
-          "lineno": 4512,
-          "complexity": 5
-        },
-        {
-          "name": "edit_mal",
-          "lineno": 4525,
-          "complexity": 6
-        },
-        {
-          "name": "del_mal",
-          "lineno": 4546,
-          "complexity": 3
-        },
-        {
-          "name": "__init__",
-          "lineno": 4566,
-          "complexity": 2
-        },
-        {
-          "name": "body",
-          "lineno": 4576,
-          "complexity": 63
-        },
-        {
-          "name": "apply",
-          "lineno": 4880,
-          "complexity": 33
-        },
-        {
-          "name": "add_existing_requirement",
-          "lineno": 4965,
-          "complexity": 8
-        },
-        {
-          "name": "comment_requirement",
-          "lineno": 4983,
-          "complexity": 2
-        },
-        {
-          "name": "comment_fmea",
-          "lineno": 4994,
-          "complexity": 1
-        },
-        {
-          "name": "add_fault",
-          "lineno": 4999,
-          "complexity": 6
-        },
-        {
-          "name": "add_safety_requirement",
-          "lineno": 5014,
-          "complexity": 8
-        },
-        {
-          "name": "edit_safety_requirement",
-          "lineno": 5047,
-          "complexity": 7
-        },
-        {
-          "name": "delete_safety_requirement",
-          "lineno": 5071,
-          "complexity": 2
-        },
-        {
-          "name": "__init__",
-          "lineno": 5081,
-          "complexity": 1
-        },
-        {
-          "name": "body",
-          "lineno": 5087,
-          "complexity": 4
-        },
-        {
-          "name": "apply",
-          "lineno": 5101,
-          "complexity": 4
-        },
-        {
-          "name": "__init__",
-          "lineno": 5111,
-          "complexity": 1
-        },
-        {
-          "name": "body",
-          "lineno": 5117,
-          "complexity": 2
-        },
-        {
-          "name": "apply",
-          "lineno": 5125,
-          "complexity": 2
-        },
-        {
-          "name": "__init__",
-          "lineno": 5131,
-          "complexity": 1
-        },
-        {
-          "name": "body",
-          "lineno": 5137,
-          "complexity": 3
-        },
-        {
-          "name": "apply",
-          "lineno": 5146,
-          "complexity": 4
-        },
-        {
-          "name": "__init__",
-          "lineno": 5156,
-          "complexity": 2
-        },
-        {
-          "name": "body",
-          "lineno": 5162,
-          "complexity": 4
-        },
-        {
-          "name": "apply",
-          "lineno": 5172,
-          "complexity": 2
-        },
-        {
-          "name": "refresh_tree",
-          "lineno": 5437,
-          "complexity": 39
-        },
-        {
-          "name": "on_double",
-          "lineno": 5578,
-          "complexity": 5
-        },
-        {
-          "name": "add_failure_mode",
-          "lineno": 5592,
-          "complexity": 19
-        },
-        {
-          "name": "remove_from_fmea",
-          "lineno": 5639,
-          "complexity": 5
-        },
-        {
-          "name": "delete_failure_mode",
-          "lineno": 5654,
-          "complexity": 6
-        },
-        {
-          "name": "comment_fmea_entry",
-          "lineno": 5671,
-          "complexity": 3
-        },
-        {
-          "name": "on_close",
-          "lineno": 5685,
-          "complexity": 4
-        },
-        {
-          "name": "refresh_tree",
-          "lineno": 5944,
-          "complexity": 5
-        },
-        {
-          "name": "add_sg",
-          "lineno": 6045,
-          "complexity": 4
-        },
-        {
-          "name": "edit_sg",
-          "lineno": 6063,
-          "complexity": 5
-        },
-        {
-          "name": "del_sg",
-          "lineno": 6085,
-          "complexity": 5
-        },
-        {
-          "name": "edit_selected",
-          "lineno": 6154,
-          "complexity": 5
-        },
-        {
-          "name": "on_double_click",
-          "lineno": 6352,
-          "complexity": 16
-        },
-        {
-          "name": "edit_selected",
-          "lineno": 6408,
-          "complexity": 5
-        },
-        {
-          "name": "export_csv",
-          "lineno": 6428,
-          "complexity": 4
-        },
-        {
-          "name": "on_right_click",
-          "lineno": 6451,
-          "complexity": 2
-        },
-        {
-          "name": "export_csv",
-          "lineno": 6534,
-          "complexity": 4
-        },
-        {
-          "name": "refresh",
-          "lineno": 6573,
-          "complexity": 17
-        },
-        {
-          "name": "export_csv",
-          "lineno": 6599,
-          "complexity": 4
-        },
-        {
-          "name": "to_canvas",
-          "lineno": 6656,
-          "complexity": 1
-        },
-        {
-          "name": "draw_row",
-          "lineno": 6765,
-          "complexity": 3
-        },
-        {
-          "name": "on_select",
-          "lineno": 6841,
-          "complexity": 3
-        },
-        {
-          "name": "export_csv",
-          "lineno": 6861,
-          "complexity": 4
-        },
-        {
-          "name": "export_csv",
-          "lineno": 6905,
-          "complexity": 4
-        },
-        {
-          "name": "refresh",
-          "lineno": 6944,
-          "complexity": 17
-        },
-        {
-          "name": "export_csv",
-          "lineno": 6970,
-          "complexity": 4
-        },
-        {
-          "name": "export_csv",
-          "lineno": 7017,
-          "complexity": 4
-        },
-        {
-          "name": "refresh",
-          "lineno": 7056,
-          "complexity": 17
-        },
-        {
-          "name": "export_csv",
-          "lineno": 7082,
-          "complexity": 4
-        },
-        {
-          "name": "export_csv",
-          "lineno": 7129,
-          "complexity": 4
-        },
-        {
-          "name": "refresh",
-          "lineno": 7168,
-          "complexity": 17
-        },
-        {
-          "name": "export_csv",
-          "lineno": 7194,
-          "complexity": 4
-        },
-        {
-          "name": "refresh",
-          "lineno": 7222,
-          "complexity": 3
-        },
-        {
-          "name": "add_profile",
-          "lineno": 7317,
-          "complexity": 4
-        },
-        {
-          "name": "edit_profile",
-          "lineno": 7325,
-          "complexity": 5
-        },
-        {
-          "name": "delete_profile",
-          "lineno": 7336,
-          "complexity": 4
-        },
-        {
-          "name": "refresh_libs",
-          "lineno": 7390,
-          "complexity": 2
-        },
-        {
-          "name": "refresh_scenarios",
-          "lineno": 7396,
-          "complexity": 4
-        },
-        {
-          "name": "add_lib",
-          "lineno": 7651,
-          "complexity": 2
-        },
-        {
-          "name": "edit_lib",
-          "lineno": 7657,
-          "complexity": 2
-        },
-        {
-          "name": "delete_lib",
-          "lineno": 7666,
-          "complexity": 2
-        },
-        {
-          "name": "add_scen",
-          "lineno": 7673,
-          "complexity": 3
-        },
-        {
-          "name": "edit_scen",
-          "lineno": 7683,
-          "complexity": 3
-        },
-        {
-          "name": "del_scen",
-          "lineno": 7695,
-          "complexity": 3
-        },
-        {
-          "name": "refresh_libs",
-          "lineno": 7739,
-          "complexity": 2
-        },
-        {
-          "name": "refresh_elems",
-          "lineno": 7745,
-          "complexity": 7
-        },
-        {
-          "name": "add_lib",
-          "lineno": 7983,
-          "complexity": 12
-        },
-        {
-          "name": "edit_lib",
-          "lineno": 8010,
-          "complexity": 3
-        },
-        {
-          "name": "delete_lib",
-          "lineno": 8020,
-          "complexity": 2
-        },
-        {
-          "name": "add_elem",
-          "lineno": 8028,
-          "complexity": 2
-        },
-        {
-          "name": "edit_elem",
-          "lineno": 8038,
-          "complexity": 3
-        },
-        {
-          "name": "del_elem",
-          "lineno": 8051,
-          "complexity": 3
-        },
-        {
-          "name": "_search_modules",
-          "lineno": 8870,
-          "complexity": 5
-        },
-        {
-          "name": "scrub",
-          "lineno": 8972,
-          "complexity": 6
-        },
-        {
-          "name": "_visible",
-          "lineno": 2940,
-          "complexity": 1
-        },
-        {
-          "name": "_in_any_module",
-          "lineno": 2948,
-          "complexity": 4
-        },
-        {
-          "name": "_add_module",
-          "lineno": 2954,
-          "complexity": 4
-        },
-        {
-          "name": "_collect_gsn_diagrams",
-          "lineno": 2991,
-          "complexity": 2
-        },
-        {
-          "name": "add_gsn_module",
-          "lineno": 3011,
-          "complexity": 4
-        },
-        {
-          "name": "add_gsn_diagram",
-          "lineno": 3029,
-          "complexity": 2
-        },
-        {
-          "name": "add_pkg",
-          "lineno": 3083,
-          "complexity": 14
-        },
-        {
-          "name": "_ensure_haz_root",
-          "lineno": 3157,
-          "complexity": 2
-        },
-        {
-          "name": "_ensure_risk_root",
-          "lineno": 3199,
-          "complexity": 2
-        },
-        {
-          "name": "_ensure_safety_root",
-          "lineno": 3216,
-          "complexity": 2
-        },
-        {
-          "name": "traverse",
-          "lineno": 4077,
-          "complexity": 5
-        },
-        {
-          "name": "gather",
-          "lineno": 4095,
-          "complexity": 2
-        },
-        {
-          "name": "collect_goal_names",
-          "lineno": 4102,
-          "complexity": 7
-        },
-        {
-          "name": "auto_fault",
-          "lineno": 4635,
-          "complexity": 5
-        },
-        {
-          "name": "mode_sel",
-          "lineno": 4649,
-          "complexity": 6
-        },
-        {
-          "name": "update_sg",
-          "lineno": 4693,
-          "complexity": 9
-        },
-        {
-          "name": "comp_sel",
-          "lineno": 4827,
-          "complexity": 3
-        },
-        {
-          "name": "calculate_fmeda",
-          "lineno": 5250,
-          "complexity": 5
-        },
-        {
-          "name": "add_component",
-          "lineno": 5286,
-          "complexity": 5
-        },
-        {
-          "name": "choose_libs",
-          "lineno": 5355,
-          "complexity": 4
-        },
-        {
-          "name": "load_bom",
-          "lineno": 5377,
-          "complexity": 4
-        },
-        {
-          "name": "__init__",
-          "lineno": 5971,
-          "complexity": 1
-        },
-        {
-          "name": "body",
-          "lineno": 5976,
-          "complexity": 2
-        },
-        {
-          "name": "apply",
-          "lineno": 6032,
-          "complexity": 2
-        },
-        {
-          "name": "map_nodes",
-          "lineno": 6518,
-          "complexity": 2
-        },
-        {
-          "name": "to_canvas",
-          "lineno": 6793,
-          "complexity": 1
-        },
-        {
-          "name": "map_nodes",
-          "lineno": 6889,
-          "complexity": 2
-        },
-        {
-          "name": "map_nodes",
-          "lineno": 7001,
-          "complexity": 2
-        },
-        {
-          "name": "map_nodes",
-          "lineno": 7113,
-          "complexity": 2
-        },
-        {
-          "name": "__init__",
-          "lineno": 7234,
-          "complexity": 1
-        },
-        {
-          "name": "body",
-          "lineno": 7238,
-          "complexity": 8
-        },
-        {
-          "name": "apply",
-          "lineno": 7280,
-          "complexity": 20
-        },
-        {
-          "name": "__init__",
-          "lineno": 7424,
-          "complexity": 2
-        },
-        {
-          "name": "body",
-          "lineno": 7429,
-          "complexity": 6
-        },
-        {
-          "name": "apply",
-          "lineno": 7450,
-          "complexity": 3
-        },
-        {
-          "name": "__init__",
-          "lineno": 7458,
-          "complexity": 2
-        },
-        {
-          "name": "body",
-          "lineno": 7475,
-          "complexity": 23
-        },
-        {
-          "name": "update_description",
-          "lineno": 7579,
-          "complexity": 4
-        },
-        {
-          "name": "load_desc_links",
-          "lineno": 7611,
-          "complexity": 2
-        },
-        {
-          "name": "show_elem",
-          "lineno": 7624,
-          "complexity": 9
-        },
-        {
-          "name": "apply",
-          "lineno": 7636,
-          "complexity": 3
-        },
-        {
-          "name": "__init__",
-          "lineno": 7763,
-          "complexity": 2
-        },
-        {
-          "name": "add_attr_row",
-          "lineno": 7768,
-          "complexity": 2
-        },
-        {
-          "name": "body",
-          "lineno": 7803,
-          "complexity": 19
-        },
-        {
-          "name": "apply",
-          "lineno": 7957,
-          "complexity": 3
-        },
-        {
-          "name": "load_comp",
-          "lineno": 9411,
-          "complexity": 3
-        },
-        {
-          "name": "mech_sel",
-          "lineno": 4772,
-          "complexity": 9
-        },
-        {
-          "name": "refresh_attr_fields",
-          "lineno": 5314,
-          "complexity": 4
-        },
-        {
-          "name": "ok",
-          "lineno": 5332,
-          "complexity": 2
-        },
-        {
-          "name": "ok",
-          "lineno": 5364,
-          "complexity": 3
-        },
-        {
-          "name": "update_dc",
-          "lineno": 7266,
-          "complexity": 5
-        },
-        {
-          "name": "remove_row",
-          "lineno": 7779,
-          "complexity": 2
-        },
-        {
-          "name": "update_metrics",
-          "lineno": 7872,
-          "complexity": 1
-        },
-        {
-          "name": "on_vt_select",
-          "lineno": 7913,
-          "complexity": 5
-        },
-        {
-          "name": "refresh_vt",
-          "lineno": 7933,
-          "complexity": 4
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/pages_and_paa.py",
-      "loc": 206,
-      "functions": [
-        {
-          "name": "__init__",
-          "lineno": 19,
-          "complexity": 1
-        },
-        {
-          "name": "__getattr__",
-          "lineno": 22,
-          "complexity": 1
-        },
-        {
-          "name": "enable_paa_actions",
-          "lineno": 28,
-          "complexity": 4
-        },
-        {
-          "name": "_create_paa_tab",
           "lineno": 35,
           "complexity": 1
         },
         {
-          "name": "create_paa_diagram",
-          "lineno": 39,
-          "complexity": 1
+          "name": "edit_description",
+          "lineno": 41,
+          "complexity": 3
         },
         {
-          "name": "open_page_diagram",
-          "lineno": 46,
-          "complexity": 1
-        },
-        {
-          "name": "draw_page_subtree",
-          "lineno": 50,
-          "complexity": 2
-        },
-        {
-          "name": "draw_page_grid",
-          "lineno": 60,
+          "name": "edit_gate_type",
+          "lineno": 57,
           "complexity": 5
         },
         {
-          "name": "draw_page_connections_subtree",
-          "lineno": 69,
+          "name": "edit_page_flag",
+          "lineno": 74,
           "complexity": 4
         },
         {
-          "name": "draw_page_nodes_subtree",
-          "lineno": 92,
-          "complexity": 2
+          "name": "edit_rationale",
+          "lineno": 99,
+          "complexity": 3
         },
         {
-          "name": "draw_node_on_page_canvas",
-          "lineno": 97,
+          "name": "edit_selected",
+          "lineno": 114,
           "complexity": 8
         },
         {
-          "name": "_draw_non_page_node",
-          "lineno": 148,
-          "complexity": 4
-        },
-        {
-          "name": "_draw_review_marker",
-          "lineno": 193,
-          "complexity": 4
-        },
-        {
-          "name": "capture_page_diagram",
-          "lineno": 207,
-          "complexity": 4
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/data_access_queries.py",
-      "loc": 335,
-      "functions": [
-        {
-          "name": "__init__",
-          "lineno": 19,
+          "name": "edit_user_name",
+          "lineno": 140,
           "complexity": 1
         },
         {
-          "name": "get_top_level_nodes",
-          "lineno": 25,
+          "name": "edit_value",
+          "lineno": 143,
+          "complexity": 6
+        },
+        {
+          "name": "rename_failure",
+          "lineno": 168,
           "complexity": 1
         },
         {
-          "name": "get_all_nodes_no_filter",
-          "lineno": 28,
+          "name": "rename_fault",
+          "lineno": 171,
           "complexity": 1
         },
         {
-          "name": "get_all_nodes_table",
-          "lineno": 31,
+          "name": "rename_functional_insufficiency",
+          "lineno": 174,
           "complexity": 1
         },
         {
-          "name": "get_all_nodes_in_model",
-          "lineno": 34,
+          "name": "rename_hazard",
+          "lineno": 177,
           "complexity": 1
         },
         {
-          "name": "get_all_basic_events",
-          "lineno": 37,
+          "name": "rename_malfunction",
+          "lineno": 180,
           "complexity": 1
         },
         {
-          "name": "get_all_gates",
-          "lineno": 40,
+          "name": "rename_selected_tree_item",
+          "lineno": 183,
           "complexity": 1
         },
         {
-          "name": "get_extra_recommendations_list",
-          "lineno": 43,
+          "name": "rename_triggering_condition",
+          "lineno": 186,
           "complexity": 1
         },
         {
-          "name": "get_extra_recommendations_from_level",
-          "lineno": 48,
+          "name": "apply_style",
+          "lineno": 189,
           "complexity": 1
-        },
-        {
-          "name": "get_recommendation_from_description",
-          "lineno": 53,
-          "complexity": 1
-        },
-        {
-          "name": "get_top_event_safety_goals",
-          "lineno": 58,
-          "complexity": 1
-        },
-        {
-          "name": "get_cyber_goal_cal",
-          "lineno": 61,
-          "complexity": 1
-        },
-        {
-          "name": "get_page_nodes",
-          "lineno": 67,
-          "complexity": 4
-        },
-        {
-          "name": "get_all_triggering_conditions",
-          "lineno": 75,
-          "complexity": 3
-        },
-        {
-          "name": "get_all_functional_insufficiencies",
-          "lineno": 85,
-          "complexity": 5
-        },
-        {
-          "name": "get_all_scenario_names",
-          "lineno": 97,
-          "complexity": 5
-        },
-        {
-          "name": "get_scenario_exposure",
-          "lineno": 109,
-          "complexity": 9
-        },
-        {
-          "name": "get_all_scenery_names",
-          "lineno": 125,
-          "complexity": 7
-        },
-        {
-          "name": "get_all_function_names",
-          "lineno": 137,
-          "complexity": 4
-        },
-        {
-          "name": "get_all_action_names",
-          "lineno": 145,
-          "complexity": 1
-        },
-        {
-          "name": "get_all_action_labels",
-          "lineno": 149,
-          "complexity": 31
-        },
-        {
-          "name": "get_use_case_for_function",
-          "lineno": 200,
-          "complexity": 12
-        },
-        {
-          "name": "get_all_component_names",
-          "lineno": 221,
-          "complexity": 15
-        },
-        {
-          "name": "get_all_part_names",
-          "lineno": 249,
-          "complexity": 9
-        },
-        {
-          "name": "get_all_malfunction_names",
-          "lineno": 267,
-          "complexity": 3
-        },
-        {
-          "name": "get_entry_field",
-          "lineno": 275,
-          "complexity": 2
-        },
-        {
-          "name": "get_all_failure_modes",
-          "lineno": 280,
-          "complexity": 5
-        },
-        {
-          "name": "get_all_fmea_entries",
-          "lineno": 293,
-          "complexity": 3
-        },
-        {
-          "name": "get_non_basic_failure_modes",
-          "lineno": 301,
-          "complexity": 13
-        },
-        {
-          "name": "get_failure_mode_node",
-          "lineno": 328,
-          "complexity": 3
-        },
-        {
-          "name": "get_component_name_for_node",
-          "lineno": 336,
-          "complexity": 5
         },
         {
           "name": "format_failure_mode_label",
-          "lineno": 346,
+          "lineno": 194,
           "complexity": 4
         },
         {
-          "name": "get_failure_modes_for_malfunction",
-          "lineno": 355,
+          "name": "_resize_prop_columns",
+          "lineno": 203,
+          "complexity": 3
+        },
+        {
+          "name": "_spi_label",
+          "lineno": 224,
           "complexity": 4
         },
         {
-          "name": "get_all_nodes",
-          "lineno": 367,
-          "complexity": 8
+          "name": "_product_goal_name",
+          "lineno": 233,
+          "complexity": 2
         },
         {
-          "name": "get_current_user_role",
-          "lineno": 389,
+          "name": "_create_icon",
+          "lineno": 237,
           "complexity": 1
-        },
-        {
-          "name": "rec",
-          "lineno": 376,
-          "complexity": 6
         }
       ]
     },
@@ -4932,168 +26457,6 @@
       ]
     },
     {
-      "file": "mainappsrc/core/navigation_selection_input.py",
-      "loc": 201,
-      "functions": [
-        {
-          "name": "__init__",
-          "lineno": 17,
-          "complexity": 1
-        },
-        {
-          "name": "go_back",
-          "lineno": 23,
-          "complexity": 2
-        },
-        {
-          "name": "back_all_pages",
-          "lineno": 29,
-          "complexity": 1
-        },
-        {
-          "name": "focus_on_node",
-          "lineno": 32,
-          "complexity": 6
-        },
-        {
-          "name": "on_canvas_click",
-          "lineno": 48,
-          "complexity": 5
-        },
-        {
-          "name": "on_canvas_double_click",
-          "lineno": 68,
-          "complexity": 7
-        },
-        {
-          "name": "on_canvas_drag",
-          "lineno": 88,
-          "complexity": 3
-        },
-        {
-          "name": "on_canvas_release",
-          "lineno": 103,
-          "complexity": 2
-        },
-        {
-          "name": "on_treeview_click",
-          "lineno": 116,
-          "complexity": 1
-        },
-        {
-          "name": "on_analysis_tree_double_click",
-          "lineno": 119,
-          "complexity": 1
-        },
-        {
-          "name": "on_analysis_tree_right_click",
-          "lineno": 122,
-          "complexity": 1
-        },
-        {
-          "name": "on_analysis_tree_select",
-          "lineno": 125,
-          "complexity": 1
-        },
-        {
-          "name": "on_tool_list_double_click",
-          "lineno": 128,
-          "complexity": 10
-        },
-        {
-          "name": "on_ctrl_mousewheel",
-          "lineno": 156,
-          "complexity": 2
-        },
-        {
-          "name": "on_ctrl_mousewheel_page",
-          "lineno": 163,
-          "complexity": 2
-        },
-        {
-          "name": "on_right_mouse_press",
-          "lineno": 170,
-          "complexity": 1
-        },
-        {
-          "name": "on_right_mouse_drag",
-          "lineno": 175,
-          "complexity": 1
-        },
-        {
-          "name": "on_right_mouse_release",
-          "lineno": 180,
-          "complexity": 2
-        },
-        {
-          "name": "show_context_menu",
-          "lineno": 186,
-          "complexity": 7
-        },
-        {
-          "name": "open_search_toolbox",
-          "lineno": 234,
-          "complexity": 3
-        }
-      ]
-    },
-    {
-      "file": "mainappsrc/core/ui_setup.py",
-      "loc": 82,
-      "functions": [
-        {
-          "name": "enable_fta_actions",
-          "lineno": 19,
-          "complexity": 4
-        },
-        {
-          "name": "enable_paa_actions",
-          "lineno": 32,
-          "complexity": 4
-        },
-        {
-          "name": "_update_analysis_menus",
-          "lineno": 39,
-          "complexity": 2
-        },
-        {
-          "name": "_create_paa_tab",
-          "lineno": 47,
-          "complexity": 1
-        },
-        {
-          "name": "create_paa_diagram",
-          "lineno": 51,
-          "complexity": 1
-        },
-        {
-          "name": "paa_manager",
-          "lineno": 56,
-          "complexity": 2
-        },
-        {
-          "name": "_reset_fta_state",
-          "lineno": 62,
-          "complexity": 1
-        },
-        {
-          "name": "ensure_fta_tab",
-          "lineno": 71,
-          "complexity": 3
-        },
-        {
-          "name": "_format_diag_title",
-          "lineno": 83,
-          "complexity": 2
-        },
-        {
-          "name": "_create_icon",
-          "lineno": 95,
-          "complexity": 1
-        }
-      ]
-    },
-    {
       "file": "mainappsrc/core/persistence_wrappers.py",
       "loc": 10,
       "functions": [
@@ -5110,6 +26473,8331 @@
         {
           "name": "load_model",
           "lineno": 15,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/models/gsn/__init__.py",
+      "loc": 5,
+      "functions": []
+    },
+    {
+      "file": "mainappsrc/models/gsn/diagram.py",
+      "loc": 383,
+      "functions": [
+        {
+          "name": "__post_init__",
+          "lineno": 29,
+          "complexity": 2
+        },
+        {
+          "name": "ensure_unique_name",
+          "lineno": 34,
+          "complexity": 5
+        },
+        {
+          "name": "add_node",
+          "lineno": 46,
+          "complexity": 4
+        },
+        {
+          "name": "to_dict",
+          "lineno": 54,
+          "complexity": 2
+        },
+        {
+          "name": "from_dict",
+          "lineno": 64,
+          "complexity": 2
+        },
+        {
+          "name": "_traverse",
+          "lineno": 77,
+          "complexity": 1
+        },
+        {
+          "name": "draw",
+          "lineno": 84,
+          "complexity": 15
+        },
+        {
+          "name": "_parse_spi_target",
+          "lineno": 183,
+          "complexity": 3
+        },
+        {
+          "name": "_lookup_spi_probability",
+          "lineno": 191,
+          "complexity": 6
+        },
+        {
+          "name": "_lookup_validation_target",
+          "lineno": 205,
+          "complexity": 6
+        },
+        {
+          "name": "_find_module_name_strategy1",
+          "lineno": 222,
+          "complexity": 3
+        },
+        {
+          "name": "_find_module_name_strategy2",
+          "lineno": 228,
+          "complexity": 3
+        },
+        {
+          "name": "_find_module_name_strategy3",
+          "lineno": 234,
+          "complexity": 4
+        },
+        {
+          "name": "_find_module_name_strategy4",
+          "lineno": 244,
+          "complexity": 3
+        },
+        {
+          "name": "_find_module_name",
+          "lineno": 254,
+          "complexity": 4
+        },
+        {
+          "name": "_draw_node",
+          "lineno": 270,
+          "complexity": 16
+        },
+        {
+          "name": "_context_draw_func",
+          "lineno": 382,
+          "complexity": 2
+        },
+        {
+          "name": "_format_text",
+          "lineno": 395,
+          "complexity": 13
+        },
+        {
+          "name": "_wrap_text",
+          "lineno": 428,
+          "complexity": 7
+        },
+        {
+          "name": "_call",
+          "lineno": 289,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/models/gsn/module.py",
+      "loc": 25,
+      "functions": [
+        {
+          "name": "to_dict",
+          "lineno": 20,
+          "complexity": 3
+        },
+        {
+          "name": "from_dict",
+          "lineno": 30,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/models/gsn/nodes.py",
+      "loc": 209,
+      "functions": [
+        {
+          "name": "__post_init__",
+          "lineno": 53,
+          "complexity": 2
+        },
+        {
+          "name": "add_child",
+          "lineno": 59,
+          "complexity": 12
+        },
+        {
+          "name": "clone",
+          "lineno": 113,
+          "complexity": 4
+        },
+        {
+          "name": "to_dict",
+          "lineno": 153,
+          "complexity": 4
+        },
+        {
+          "name": "from_dict",
+          "lineno": 175,
+          "complexity": 2
+        },
+        {
+          "name": "resolve_references",
+          "lineno": 207,
+          "complexity": 14
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/models/gov/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "mainappsrc/models/gov/governance.py",
+      "loc": 16,
+      "functions": [
+        {
+          "name": "can_view_gsn_argumentation",
+          "lineno": 15,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/models/sysml/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "mainappsrc/models/sysml/sysml_spec.py",
+      "loc": 71,
+      "functions": [
+        {
+          "name": "load_sysml_properties",
+          "lineno": 6,
+          "complexity": 6
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/models/sysml/sysml_repository.py",
+      "loc": 967,
+      "functions": [
+        {
+          "name": "_diagram_type_abbreviation",
+          "lineno": 13,
+          "complexity": 3
+        },
+        {
+          "name": "display_name",
+          "lineno": 39,
+          "complexity": 2
+        },
+        {
+          "name": "display_name",
+          "lineno": 83,
+          "complexity": 5
+        },
+        {
+          "name": "__init__",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "touch_element",
+          "lineno": 116,
+          "complexity": 2
+        },
+        {
+          "name": "touch_diagram",
+          "lineno": 123,
+          "complexity": 2
+        },
+        {
+          "name": "touch_relationship",
+          "lineno": 130,
+          "complexity": 3
+        },
+        {
+          "name": "get_instance",
+          "lineno": 138,
+          "complexity": 2
+        },
+        {
+          "name": "reset_instance",
+          "lineno": 144,
+          "complexity": 1
+        },
+        {
+          "name": "export_state",
+          "lineno": 152,
+          "complexity": 4
+        },
+        {
+          "name": "_strip_object_positions",
+          "lineno": 169,
+          "complexity": 6
+        },
+        {
+          "name": "push_undo_state",
+          "lineno": 192,
+          "complexity": 6
+        },
+        {
+          "name": "_push_undo_state_v1",
+          "lineno": 230,
+          "complexity": 6
+        },
+        {
+          "name": "_push_undo_state_v2",
+          "lineno": 251,
+          "complexity": 6
+        },
+        {
+          "name": "_push_undo_state_v3",
+          "lineno": 265,
+          "complexity": 6
+        },
+        {
+          "name": "_push_undo_state_v4",
+          "lineno": 279,
+          "complexity": 5
+        },
+        {
+          "name": "undo",
+          "lineno": 290,
+          "complexity": 1
+        },
+        {
+          "name": "redo",
+          "lineno": 295,
+          "complexity": 1
+        },
+        {
+          "name": "_undo_v1",
+          "lineno": 301,
+          "complexity": 6
+        },
+        {
+          "name": "_undo_v2",
+          "lineno": 316,
+          "complexity": 6
+        },
+        {
+          "name": "_undo_v3",
+          "lineno": 331,
+          "complexity": 6
+        },
+        {
+          "name": "_undo_v4",
+          "lineno": 346,
+          "complexity": 6
+        },
+        {
+          "name": "_redo_v1",
+          "lineno": 361,
+          "complexity": 3
+        },
+        {
+          "name": "_redo_v2",
+          "lineno": 372,
+          "complexity": 3
+        },
+        {
+          "name": "_redo_v3",
+          "lineno": 383,
+          "complexity": 3
+        },
+        {
+          "name": "_redo_v4",
+          "lineno": 394,
+          "complexity": 3
+        },
+        {
+          "name": "ensure_unique_element_name",
+          "lineno": 405,
+          "complexity": 5
+        },
+        {
+          "name": "_default_name",
+          "lineno": 421,
+          "complexity": 5
+        },
+        {
+          "name": "create_element",
+          "lineno": 436,
+          "complexity": 6
+        },
+        {
+          "name": "create_package",
+          "lineno": 467,
+          "complexity": 2
+        },
+        {
+          "name": "create_diagram",
+          "lineno": 473,
+          "complexity": 27
+        },
+        {
+          "name": "add_element_to_diagram",
+          "lineno": 555,
+          "complexity": 9
+        },
+        {
+          "name": "add_relationship_to_diagram",
+          "lineno": 578,
+          "complexity": 4
+        },
+        {
+          "name": "delete_element",
+          "lineno": 586,
+          "complexity": 5
+        },
+        {
+          "name": "delete_package",
+          "lineno": 595,
+          "complexity": 9
+        },
+        {
+          "name": "delete_diagram",
+          "lineno": 610,
+          "complexity": 5
+        },
+        {
+          "name": "rename_phase",
+          "lineno": 621,
+          "complexity": 15
+        },
+        {
+          "name": "get_element",
+          "lineno": 653,
+          "complexity": 1
+        },
+        {
+          "name": "get_qualified_name",
+          "lineno": 656,
+          "complexity": 4
+        },
+        {
+          "name": "save",
+          "lineno": 666,
+          "complexity": 2
+        },
+        {
+          "name": "load",
+          "lineno": 670,
+          "complexity": 10
+        },
+        {
+          "name": "create_relationship",
+          "lineno": 696,
+          "complexity": 4
+        },
+        {
+          "name": "element_visible",
+          "lineno": 727,
+          "complexity": 9
+        },
+        {
+          "name": "diagram_visible",
+          "lineno": 745,
+          "complexity": 7
+        },
+        {
+          "name": "element_read_only",
+          "lineno": 760,
+          "complexity": 10
+        },
+        {
+          "name": "diagram_read_only",
+          "lineno": 776,
+          "complexity": 8
+        },
+        {
+          "name": "freeze_diagram",
+          "lineno": 790,
+          "complexity": 2
+        },
+        {
+          "name": "unfreeze_diagram",
+          "lineno": 798,
+          "complexity": 2
+        },
+        {
+          "name": "set_diagram_phase",
+          "lineno": 806,
+          "complexity": 14
+        },
+        {
+          "name": "rename_phase",
+          "lineno": 832,
+          "complexity": 14
+        },
+        {
+          "name": "element_read_only",
+          "lineno": 857,
+          "complexity": 9
+        },
+        {
+          "name": "visible_elements",
+          "lineno": 873,
+          "complexity": 2
+        },
+        {
+          "name": "visible_diagrams",
+          "lineno": 877,
+          "complexity": 2
+        },
+        {
+          "name": "object_visible",
+          "lineno": 881,
+          "complexity": 10
+        },
+        {
+          "name": "connection_visible",
+          "lineno": 895,
+          "complexity": 9
+        },
+        {
+          "name": "visible_objects",
+          "lineno": 908,
+          "complexity": 3
+        },
+        {
+          "name": "visible_connections",
+          "lineno": 915,
+          "complexity": 3
+        },
+        {
+          "name": "link_diagram",
+          "lineno": 925,
+          "complexity": 3
+        },
+        {
+          "name": "get_linked_diagram",
+          "lineno": 934,
+          "complexity": 1
+        },
+        {
+          "name": "serialize",
+          "lineno": 937,
+          "complexity": 4
+        },
+        {
+          "name": "to_dict",
+          "lineno": 946,
+          "complexity": 1
+        },
+        {
+          "name": "from_dict",
+          "lineno": 950,
+          "complexity": 8
+        },
+        {
+          "name": "_resolve_part_definition_ids",
+          "lineno": 975,
+          "complexity": 14
+        },
+        {
+          "name": "find_requirements",
+          "lineno": 1000,
+          "complexity": 6
+        },
+        {
+          "name": "get_activity_actions",
+          "lineno": 1012,
+          "complexity": 15
+        },
+        {
+          "name": "generate_requirements",
+          "lineno": 1037,
+          "complexity": 16
+        },
+        {
+          "name": "scrub",
+          "lineno": 179,
+          "complexity": 6
+        }
+      ]
+    },
+    {
+      "file": "mainappsrc/models/fta/__init__.py",
+      "loc": 3,
+      "functions": []
+    },
+    {
+      "file": "mainappsrc/models/fta/fault_tree_node.py",
+      "loc": 268,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 7
+        },
+        {
+          "name": "update_validation_target",
+          "lineno": 106,
+          "complexity": 1
+        },
+        {
+          "name": "name",
+          "lineno": 120,
+          "complexity": 4
+        },
+        {
+          "name": "to_dict",
+          "lineno": 129,
+          "complexity": 6
+        },
+        {
+          "name": "from_dict",
+          "lineno": 199,
+          "complexity": 10
+        },
+        {
+          "name": "clone",
+          "lineno": 281,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "reportlab/platypus/__init__.py",
+      "loc": 56,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 2,
+          "complexity": 1
+        },
+        {
+          "name": "setStyle",
+          "lineno": 5,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 23,
+          "complexity": 1
+        },
+        {
+          "name": "build",
+          "lineno": 33,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 60,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 65,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 70,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 75,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "reportlab/lib/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "reportlab/lib/colors.py",
+      "loc": 45,
+      "functions": [
+        {
+          "name": "__new__",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "red",
+          "lineno": 33,
+          "complexity": 1
+        },
+        {
+          "name": "green",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "blue",
+          "lineno": 41,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "reportlab/lib/units.py",
+      "loc": 2,
+      "functions": []
+    },
+    {
+      "file": "reportlab/lib/styles.py",
+      "loc": 56,
+      "functions": [
+        {
+          "name": "getSampleStyleSheet",
+          "lineno": 25,
+          "complexity": 1
+        },
+        {
+          "name": "add",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 54,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "reportlab/lib/pagesizes.py",
+      "loc": 15,
+      "functions": [
+        {
+          "name": "landscape",
+          "lineno": 13,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "matplotlib/backends/__init__.py",
+      "loc": 8,
+      "functions": []
+    },
+    {
+      "file": "matplotlib/backends/backend_tkagg.py",
+      "loc": 26,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 18,
+          "complexity": 3
+        },
+        {
+          "name": "get_tk_widget",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "draw_idle",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "pack",
+          "lineno": 24,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/styles/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "gui/styles/style_manager.py",
+      "loc": 75,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 25,
+          "complexity": 2
+        },
+        {
+          "name": "get_instance",
+          "lineno": 41,
+          "complexity": 2
+        },
+        {
+          "name": "load_style",
+          "lineno": 46,
+          "complexity": 7
+        },
+        {
+          "name": "save_style",
+          "lineno": 67,
+          "complexity": 2
+        },
+        {
+          "name": "get_color",
+          "lineno": 75,
+          "complexity": 1
+        },
+        {
+          "name": "get_canvas_color",
+          "lineno": 78,
+          "complexity": 1
+        },
+        {
+          "name": "get_outline_color",
+          "lineno": 81,
+          "complexity": 1
+        },
+        {
+          "name": "_is_dark",
+          "lineno": 86,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "gui/styles/style_editor.py",
+      "loc": 57,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 9,
+          "complexity": 2
+        },
+        {
+          "name": "choose_color",
+          "lineno": 31,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 38,
+          "complexity": 4
+        },
+        {
+          "name": "save",
+          "lineno": 46,
+          "complexity": 2
+        },
+        {
+          "name": "load",
+          "lineno": 53,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "gui/utils/__init__.py",
+      "loc": 14,
+      "functions": [
+        {
+          "name": "add_treeview_scrollbars",
+          "lineno": 20,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/utils/closable_notebook.py",
+      "loc": 305,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 21,
+          "complexity": 3
+        },
+        {
+          "name": "_on_tab_press",
+          "lineno": 127,
+          "complexity": 1
+        },
+        {
+          "name": "_on_tab_release",
+          "lineno": 130,
+          "complexity": 1
+        },
+        {
+          "name": "_on_tab_motion",
+          "lineno": 133,
+          "complexity": 1
+        },
+        {
+          "name": "_on_tab_changed",
+          "lineno": 140,
+          "complexity": 1
+        },
+        {
+          "name": "_on_focus_in",
+          "lineno": 143,
+          "complexity": 1
+        },
+        {
+          "name": "_handle_tab_focus",
+          "lineno": 146,
+          "complexity": 5
+        },
+        {
+          "name": "_get_widget",
+          "lineno": 177,
+          "complexity": 2
+        },
+        {
+          "name": "_call_method",
+          "lineno": 183,
+          "complexity": 3
+        },
+        {
+          "name": "_strategy_load_only",
+          "lineno": 190,
+          "complexity": 1
+        },
+        {
+          "name": "_strategy_swap_load_unload",
+          "lineno": 195,
+          "complexity": 3
+        },
+        {
+          "name": "_strategy_event_based",
+          "lineno": 204,
+          "complexity": 4
+        },
+        {
+          "name": "_strategy_swap_event_based",
+          "lineno": 214,
+          "complexity": 4
+        },
+        {
+          "name": "_create_close_image",
+          "lineno": 226,
+          "complexity": 2
+        },
+        {
+          "name": "_on_press",
+          "lineno": 234,
+          "complexity": 5
+        },
+        {
+          "name": "_on_motion",
+          "lineno": 263,
+          "complexity": 4
+        },
+        {
+          "name": "_on_release",
+          "lineno": 271,
+          "complexity": 18
+        },
+        {
+          "name": "_move_tab",
+          "lineno": 317,
+          "complexity": 6
+        },
+        {
+          "name": "_detach_tab",
+          "lineno": 374,
+          "complexity": 4
+        },
+        {
+          "name": "_reset_drag",
+          "lineno": 390,
+          "complexity": 6
+        }
+      ]
+    },
+    {
+      "file": "gui/utils/icon_factory.py",
+      "loc": 942,
+      "functions": [
+        {
+          "name": "create_icon",
+          "lineno": 6,
+          "complexity": 334
+        },
+        {
+          "name": "_grad",
+          "lineno": 44,
+          "complexity": 1
+        },
+        {
+          "name": "_wpt",
+          "lineno": 429,
+          "complexity": 1
+        },
+        {
+          "name": "_rot",
+          "lineno": 455,
+          "complexity": 1
+        },
+        {
+          "name": "draw_node",
+          "lineno": 794,
+          "complexity": 4
+        },
+        {
+          "name": "draw_line",
+          "lineno": 800,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "gui/utils/safety_case_table.py",
+      "loc": 210,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 19,
+          "complexity": 6
+        },
+        {
+          "name": "_parse_spi_target",
+          "lineno": 85,
+          "complexity": 4
+        },
+        {
+          "name": "_product_goal_name",
+          "lineno": 94,
+          "complexity": 3
+        },
+        {
+          "name": "populate",
+          "lineno": 100,
+          "complexity": 16
+        },
+        {
+          "name": "_adjust_text",
+          "lineno": 166,
+          "complexity": 2
+        },
+        {
+          "name": "_on_double_click",
+          "lineno": 170,
+          "complexity": 26
+        }
+      ]
+    },
+    {
+      "file": "gui/utils/tooltip.py",
+      "loc": 89,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 2
+        },
+        {
+          "name": "_schedule",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "_show",
+          "lineno": 28,
+          "complexity": 12
+        },
+        {
+          "name": "show",
+          "lineno": 95,
+          "complexity": 1
+        },
+        {
+          "name": "hide",
+          "lineno": 100,
+          "complexity": 1
+        },
+        {
+          "name": "_hide",
+          "lineno": 104,
+          "complexity": 2
+        },
+        {
+          "name": "_unschedule",
+          "lineno": 110,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "gui/utils/logger.py",
+      "loc": 199,
+      "functions": [
+        {
+          "name": "init_log_window",
+          "lineno": 27,
+          "complexity": 2
+        },
+        {
+          "name": "set_toggle_button",
+          "lineno": 107,
+          "complexity": 1
+        },
+        {
+          "name": "show_log",
+          "lineno": 113,
+          "complexity": 7
+        },
+        {
+          "name": "_animate_hide",
+          "lineno": 139,
+          "complexity": 3
+        },
+        {
+          "name": "hide_log",
+          "lineno": 151,
+          "complexity": 6
+        },
+        {
+          "name": "toggle_log",
+          "lineno": 169,
+          "complexity": 3
+        },
+        {
+          "name": "show_temporarily",
+          "lineno": 177,
+          "complexity": 4
+        },
+        {
+          "name": "_raise_widget",
+          "lineno": 205,
+          "complexity": 2
+        },
+        {
+          "name": "_update_line_numbers",
+          "lineno": 213,
+          "complexity": 4
+        },
+        {
+          "name": "log_message",
+          "lineno": 225,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "gui/utils/table_controller.py",
+      "loc": 98,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 23,
+          "complexity": 6
+        },
+        {
+          "name": "clear",
+          "lineno": 61,
+          "complexity": 1
+        },
+        {
+          "name": "insert_row",
+          "lineno": 66,
+          "complexity": 2
+        },
+        {
+          "name": "_adjust_text",
+          "lineno": 76,
+          "complexity": 8
+        },
+        {
+          "name": "adjust_text",
+          "lineno": 103,
+          "complexity": 1
+        },
+        {
+          "name": "move_up",
+          "lineno": 108,
+          "complexity": 1
+        },
+        {
+          "name": "move_down",
+          "lineno": 112,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/utils/drawing_helper.py",
+      "loc": 2410,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "clear_cache",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "_resolve_outline",
+          "lineno": 46,
+          "complexity": 2
+        },
+        {
+          "name": "_interpolate_color",
+          "lineno": 52,
+          "complexity": 3
+        },
+        {
+          "name": "_fill_gradient_polygon",
+          "lineno": 73,
+          "complexity": 12
+        },
+        {
+          "name": "_fill_gradient_circle",
+          "lineno": 101,
+          "complexity": 4
+        },
+        {
+          "name": "_fill_gradient_oval",
+          "lineno": 127,
+          "complexity": 6
+        },
+        {
+          "name": "_fill_gradient_rect",
+          "lineno": 154,
+          "complexity": 4
+        },
+        {
+          "name": "get_text_size",
+          "lineno": 165,
+          "complexity": 2
+        },
+        {
+          "name": "draw_page_clone_shape",
+          "lineno": 172,
+          "complexity": 1
+        },
+        {
+          "name": "draw_shared_marker",
+          "lineno": 214,
+          "complexity": 1
+        },
+        {
+          "name": "_segment_intersection",
+          "lineno": 226,
+          "complexity": 4
+        },
+        {
+          "name": "point_on_shape",
+          "lineno": 243,
+          "complexity": 22
+        },
+        {
+          "name": "draw_90_connection",
+          "lineno": 302,
+          "complexity": 4
+        },
+        {
+          "name": "compute_rotated_and_gate_vertices",
+          "lineno": 342,
+          "complexity": 5
+        },
+        {
+          "name": "draw_rotated_and_gate_shape",
+          "lineno": 358,
+          "complexity": 8
+        },
+        {
+          "name": "draw_rotated_or_gate_shape",
+          "lineno": 457,
+          "complexity": 15
+        },
+        {
+          "name": "draw_rotated_and_gate_clone_shape",
+          "lineno": 565,
+          "complexity": 1
+        },
+        {
+          "name": "draw_rotated_or_gate_clone_shape",
+          "lineno": 606,
+          "complexity": 1
+        },
+        {
+          "name": "draw_triangle_shape",
+          "lineno": 647,
+          "complexity": 4
+        },
+        {
+          "name": "draw_circle_event_shape",
+          "lineno": 736,
+          "complexity": 2
+        },
+        {
+          "name": "draw_circle_event_clone_shape",
+          "lineno": 830,
+          "complexity": 1
+        },
+        {
+          "name": "draw_triangle_clone_shape",
+          "lineno": 869,
+          "complexity": 2
+        },
+        {
+          "name": "_scaled_font",
+          "lineno": 919,
+          "complexity": 1
+        },
+        {
+          "name": "draw_goal_shape",
+          "lineno": 924,
+          "complexity": 2
+        },
+        {
+          "name": "draw_module_shape",
+          "lineno": 969,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_arrow",
+          "lineno": 1028,
+          "complexity": 4
+        },
+        {
+          "name": "draw_solved_by_connection",
+          "lineno": 1073,
+          "complexity": 4
+        },
+        {
+          "name": "draw_in_context_connection",
+          "lineno": 1150,
+          "complexity": 4
+        },
+        {
+          "name": "draw_strategy_shape",
+          "lineno": 1233,
+          "complexity": 2
+        },
+        {
+          "name": "draw_solution_shape",
+          "lineno": 1272,
+          "complexity": 2
+        },
+        {
+          "name": "draw_assumption_shape",
+          "lineno": 1314,
+          "complexity": 2
+        },
+        {
+          "name": "draw_justification_shape",
+          "lineno": 1369,
+          "complexity": 2
+        },
+        {
+          "name": "draw_context_shape",
+          "lineno": 1424,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_module_reference_box",
+          "lineno": 1527,
+          "complexity": 2
+        },
+        {
+          "name": "draw_away_goal_shape",
+          "lineno": 1610,
+          "complexity": 2
+        },
+        {
+          "name": "draw_away_solution_shape",
+          "lineno": 1683,
+          "complexity": 2
+        },
+        {
+          "name": "draw_away_context_shape",
+          "lineno": 1756,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_away_assumption_or_justification",
+          "lineno": 1848,
+          "complexity": 2
+        },
+        {
+          "name": "draw_away_assumption_shape",
+          "lineno": 1950,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_justification_shape",
+          "lineno": 1980,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_module_shape",
+          "lineno": 2010,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_context_shape",
+          "lineno": 2020,
+          "complexity": 3
+        },
+        {
+          "name": "_draw_away_assumption_or_justification",
+          "lineno": 2116,
+          "complexity": 2
+        },
+        {
+          "name": "draw_away_assumption_shape",
+          "lineno": 2190,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_justification_shape",
+          "lineno": 2220,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_module_shape",
+          "lineno": 2250,
+          "complexity": 1
+        },
+        {
+          "name": "_scaled_font",
+          "lineno": 2261,
+          "complexity": 1
+        },
+        {
+          "name": "draw_goal_shape",
+          "lineno": 2267,
+          "complexity": 2
+        },
+        {
+          "name": "draw_module_shape",
+          "lineno": 2281,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_module_reference_box",
+          "lineno": 2304,
+          "complexity": 2
+        },
+        {
+          "name": "draw_away_goal_shape",
+          "lineno": 2369,
+          "complexity": 2
+        },
+        {
+          "name": "draw_away_solution_shape",
+          "lineno": 2398,
+          "complexity": 2
+        },
+        {
+          "name": "draw_away_context_shape",
+          "lineno": 2457,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_away_assumption_or_justification",
+          "lineno": 2533,
+          "complexity": 2
+        },
+        {
+          "name": "draw_away_assumption_shape",
+          "lineno": 2607,
+          "complexity": 1
+        },
+        {
+          "name": "draw_away_justification_shape",
+          "lineno": 2613,
+          "complexity": 1
+        },
+        {
+          "name": "rotate_point",
+          "lineno": 350,
+          "complexity": 1
+        },
+        {
+          "name": "cubic_bezier",
+          "lineno": 475,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/utils/name_utils.py",
+      "loc": 108,
+      "functions": [
+        {
+          "name": "_collect_gsn_diagrams",
+          "lineno": 16,
+          "complexity": 4
+        },
+        {
+          "name": "collect_work_product_names_v1",
+          "lineno": 26,
+          "complexity": 6
+        },
+        {
+          "name": "collect_work_product_names_v2",
+          "lineno": 39,
+          "complexity": 8
+        },
+        {
+          "name": "collect_work_product_names_v3",
+          "lineno": 56,
+          "complexity": 6
+        },
+        {
+          "name": "collect_work_product_names_v4",
+          "lineno": 66,
+          "complexity": 8
+        },
+        {
+          "name": "unique_name_v1",
+          "lineno": 82,
+          "complexity": 3
+        },
+        {
+          "name": "unique_name_v2",
+          "lineno": 94,
+          "complexity": 3
+        },
+        {
+          "name": "unique_name_v3",
+          "lineno": 106,
+          "complexity": 3
+        },
+        {
+          "name": "unique_name_v4",
+          "lineno": 118,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "gui/toolboxes/__init__.py",
+      "loc": 4127,
+      "functions": [
+        {
+          "name": "allowed_action_labels",
+          "lineno": 53,
+          "complexity": 4
+        },
+        {
+          "name": "find_requirement_traces",
+          "lineno": 66,
+          "complexity": 9
+        },
+        {
+          "name": "configure_table_style",
+          "lineno": 86,
+          "complexity": 2
+        },
+        {
+          "name": "stripe_rows",
+          "lineno": 218,
+          "complexity": 3
+        },
+        {
+          "name": "enable_treeview_reorder",
+          "lineno": 226,
+          "complexity": 13
+        },
+        {
+          "name": "_total_fit_from_boms",
+          "lineno": 300,
+          "complexity": 2
+        },
+        {
+          "name": "_wrap_val",
+          "lineno": 314,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 129,
+          "complexity": 4
+        },
+        {
+          "name": "_begin_edit",
+          "lineno": 149,
+          "complexity": 14
+        },
+        {
+          "name": "_refresh",
+          "lineno": 248,
+          "complexity": 7
+        },
+        {
+          "name": "_on_start",
+          "lineno": 265,
+          "complexity": 1
+        },
+        {
+          "name": "_on_drop",
+          "lineno": 268,
+          "complexity": 4
+        },
+        {
+          "name": "_move",
+          "lineno": 280,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 324,
+          "complexity": 5
+        },
+        {
+          "name": "body",
+          "lineno": 335,
+          "complexity": 1
+        },
+        {
+          "name": "apply",
+          "lineno": 399,
+          "complexity": 3
+        },
+        {
+          "name": "_toggle_fields",
+          "lineno": 423,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 448,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 454,
+          "complexity": 8
+        },
+        {
+          "name": "apply",
+          "lineno": 467,
+          "complexity": 7
+        },
+        {
+          "name": "__init__",
+          "lineno": 485,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 490,
+          "complexity": 11
+        },
+        {
+          "name": "apply",
+          "lineno": 514,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 521,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 526,
+          "complexity": 11
+        },
+        {
+          "name": "_populate",
+          "lineno": 559,
+          "complexity": 8
+        },
+        {
+          "name": "apply",
+          "lineno": 579,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 588,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 593,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 600,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 607,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 611,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 618,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 625,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 629,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 636,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 643,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 647,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 654,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 659,
+          "complexity": 10
+        },
+        {
+          "name": "add_component",
+          "lineno": 863,
+          "complexity": 5
+        },
+        {
+          "name": "show_formula",
+          "lineno": 946,
+          "complexity": 4
+        },
+        {
+          "name": "refresh_tree",
+          "lineno": 962,
+          "complexity": 3
+        },
+        {
+          "name": "on_cell_edit",
+          "lineno": 980,
+          "complexity": 7
+        },
+        {
+          "name": "load_csv",
+          "lineno": 997,
+          "complexity": 13
+        },
+        {
+          "name": "ask_mapping",
+          "lineno": 1031,
+          "complexity": 6
+        },
+        {
+          "name": "configure_component",
+          "lineno": 1070,
+          "complexity": 8
+        },
+        {
+          "name": "delete_component",
+          "lineno": 1147,
+          "complexity": 3
+        },
+        {
+          "name": "calculate_fit",
+          "lineno": 1156,
+          "complexity": 19
+        },
+        {
+          "name": "save_analysis",
+          "lineno": 1228,
+          "complexity": 6
+        },
+        {
+          "name": "load_analysis",
+          "lineno": 1263,
+          "complexity": 4
+        },
+        {
+          "name": "load_selected_analysis",
+          "lineno": 1287,
+          "complexity": 3
+        },
+        {
+          "name": "delete_analysis",
+          "lineno": 1294,
+          "complexity": 4
+        },
+        {
+          "name": "refresh_analysis_list",
+          "lineno": 1310,
+          "complexity": 4
+        },
+        {
+          "name": "_populate_from_analysis",
+          "lineno": 1317,
+          "complexity": 1
+        },
+        {
+          "name": "_create_icon",
+          "lineno": 1331,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 1357,
+          "complexity": 6
+        },
+        {
+          "name": "refresh",
+          "lineno": 1423,
+          "complexity": 4
+        },
+        {
+          "name": "add_row",
+          "lineno": 1844,
+          "complexity": 2
+        },
+        {
+          "name": "edit_row",
+          "lineno": 1850,
+          "complexity": 3
+        },
+        {
+          "name": "del_row",
+          "lineno": 1860,
+          "complexity": 3
+        },
+        {
+          "name": "on_cell_edit",
+          "lineno": 1868,
+          "complexity": 2
+        },
+        {
+          "name": "export_csv",
+          "lineno": 1873,
+          "complexity": 5
+        },
+        {
+          "name": "refresh_docs",
+          "lineno": 1886,
+          "complexity": 8
+        },
+        {
+          "name": "select_doc",
+          "lineno": 1911,
+          "complexity": 4
+        },
+        {
+          "name": "new_doc",
+          "lineno": 1923,
+          "complexity": 3
+        },
+        {
+          "name": "rename_doc",
+          "lineno": 1937,
+          "complexity": 4
+        },
+        {
+          "name": "delete_doc",
+          "lineno": 1952,
+          "complexity": 6
+        },
+        {
+          "name": "__init__",
+          "lineno": 1974,
+          "complexity": 6
+        },
+        {
+          "name": "refresh_docs",
+          "lineno": 2053,
+          "complexity": 8
+        },
+        {
+          "name": "select_doc",
+          "lineno": 2078,
+          "complexity": 4
+        },
+        {
+          "name": "new_doc",
+          "lineno": 2090,
+          "complexity": 2
+        },
+        {
+          "name": "rename_doc",
+          "lineno": 2104,
+          "complexity": 3
+        },
+        {
+          "name": "delete_doc",
+          "lineno": 2116,
+          "complexity": 5
+        },
+        {
+          "name": "refresh",
+          "lineno": 2135,
+          "complexity": 6
+        },
+        {
+          "name": "add_row",
+          "lineno": 2353,
+          "complexity": 3
+        },
+        {
+          "name": "edit_row",
+          "lineno": 2362,
+          "complexity": 2
+        },
+        {
+          "name": "del_row",
+          "lineno": 2371,
+          "complexity": 3
+        },
+        {
+          "name": "on_cell_edit",
+          "lineno": 2379,
+          "complexity": 4
+        },
+        {
+          "name": "load_analysis",
+          "lineno": 2399,
+          "complexity": 4
+        },
+        {
+          "name": "save_analysis",
+          "lineno": 2432,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 2468,
+          "complexity": 6
+        },
+        {
+          "name": "refresh_docs",
+          "lineno": 2556,
+          "complexity": 12
+        },
+        {
+          "name": "select_doc",
+          "lineno": 2604,
+          "complexity": 6
+        },
+        {
+          "name": "new_doc",
+          "lineno": 2735,
+          "complexity": 2
+        },
+        {
+          "name": "edit_doc",
+          "lineno": 2760,
+          "complexity": 4
+        },
+        {
+          "name": "rename_doc",
+          "lineno": 2777,
+          "complexity": 3
+        },
+        {
+          "name": "delete_doc",
+          "lineno": 2789,
+          "complexity": 5
+        },
+        {
+          "name": "refresh",
+          "lineno": 2811,
+          "complexity": 3
+        },
+        {
+          "name": "add_row",
+          "lineno": 3332,
+          "complexity": 3
+        },
+        {
+          "name": "edit_row",
+          "lineno": 3345,
+          "complexity": 3
+        },
+        {
+          "name": "del_row",
+          "lineno": 3358,
+          "complexity": 4
+        },
+        {
+          "name": "on_cell_edit",
+          "lineno": 3371,
+          "complexity": 8
+        },
+        {
+          "name": "approve_doc",
+          "lineno": 3396,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 3429,
+          "complexity": 6
+        },
+        {
+          "name": "refresh",
+          "lineno": 3496,
+          "complexity": 4
+        },
+        {
+          "name": "add_row",
+          "lineno": 3956,
+          "complexity": 2
+        },
+        {
+          "name": "edit_row",
+          "lineno": 3962,
+          "complexity": 3
+        },
+        {
+          "name": "del_row",
+          "lineno": 3972,
+          "complexity": 3
+        },
+        {
+          "name": "on_cell_edit",
+          "lineno": 3980,
+          "complexity": 2
+        },
+        {
+          "name": "export_csv",
+          "lineno": 3986,
+          "complexity": 5
+        },
+        {
+          "name": "refresh_docs",
+          "lineno": 3999,
+          "complexity": 8
+        },
+        {
+          "name": "select_doc",
+          "lineno": 4024,
+          "complexity": 4
+        },
+        {
+          "name": "new_doc",
+          "lineno": 4036,
+          "complexity": 3
+        },
+        {
+          "name": "rename_doc",
+          "lineno": 4050,
+          "complexity": 4
+        },
+        {
+          "name": "delete_doc",
+          "lineno": 4065,
+          "complexity": 6
+        },
+        {
+          "name": "__init__",
+          "lineno": 4089,
+          "complexity": 6
+        },
+        {
+          "name": "refresh",
+          "lineno": 4126,
+          "complexity": 3
+        },
+        {
+          "name": "export_csv",
+          "lineno": 4145,
+          "complexity": 4
+        },
+        {
+          "name": "on_cell_edit",
+          "lineno": 4158,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 4172,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 4187,
+          "complexity": 9
+        },
+        {
+          "name": "apply",
+          "lineno": 4208,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 4218,
+          "complexity": 7
+        },
+        {
+          "name": "refresh",
+          "lineno": 4309,
+          "complexity": 16
+        },
+        {
+          "name": "export_csv",
+          "lineno": 4349,
+          "complexity": 4
+        },
+        {
+          "name": "on_cell_edit",
+          "lineno": 4360,
+          "complexity": 10
+        },
+        {
+          "name": "add_requirement",
+          "lineno": 4385,
+          "complexity": 2
+        },
+        {
+          "name": "edit_requirement",
+          "lineno": 4392,
+          "complexity": 3
+        },
+        {
+          "name": "delete_requirement",
+          "lineno": 4406,
+          "complexity": 2
+        },
+        {
+          "name": "_get_requirement_allocations",
+          "lineno": 4412,
+          "complexity": 6
+        },
+        {
+          "name": "__init__",
+          "lineno": 4428,
+          "complexity": 2
+        },
+        {
+          "name": "refresh_docs",
+          "lineno": 4447,
+          "complexity": 4
+        },
+        {
+          "name": "select_doc",
+          "lineno": 4460,
+          "complexity": 3
+        },
+        {
+          "name": "new_doc",
+          "lineno": 4468,
+          "complexity": 4
+        },
+        {
+          "name": "rename_doc",
+          "lineno": 4483,
+          "complexity": 7
+        },
+        {
+          "name": "delete_doc",
+          "lineno": 4501,
+          "complexity": 5
+        },
+        {
+          "name": "refresh_attr_fields",
+          "lineno": 901,
+          "complexity": 4
+        },
+        {
+          "name": "ok",
+          "lineno": 925,
+          "complexity": 2
+        },
+        {
+          "name": "ok",
+          "lineno": 1051,
+          "complexity": 2
+        },
+        {
+          "name": "cancel",
+          "lineno": 1056,
+          "complexity": 1
+        },
+        {
+          "name": "do_load",
+          "lineno": 1275,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 1432,
+          "complexity": 3
+        },
+        {
+          "name": "body",
+          "lineno": 1440,
+          "complexity": 39
+        },
+        {
+          "name": "apply",
+          "lineno": 1650,
+          "complexity": 14
+        },
+        {
+          "name": "add_dm_new",
+          "lineno": 1677,
+          "complexity": 2
+        },
+        {
+          "name": "add_dm_existing",
+          "lineno": 1689,
+          "complexity": 4
+        },
+        {
+          "name": "edit_dm",
+          "lineno": 1696,
+          "complexity": 3
+        },
+        {
+          "name": "del_dm",
+          "lineno": 1716,
+          "complexity": 2
+        },
+        {
+          "name": "add_tc_existing",
+          "lineno": 1721,
+          "complexity": 4
+        },
+        {
+          "name": "add_tc",
+          "lineno": 1728,
+          "complexity": 3
+        },
+        {
+          "name": "edit_tc",
+          "lineno": 1734,
+          "complexity": 4
+        },
+        {
+          "name": "del_tc",
+          "lineno": 1745,
+          "complexity": 2
+        },
+        {
+          "name": "add_mit_new",
+          "lineno": 1750,
+          "complexity": 2
+        },
+        {
+          "name": "add_mit_existing",
+          "lineno": 1762,
+          "complexity": 4
+        },
+        {
+          "name": "add_fi_new",
+          "lineno": 1769,
+          "complexity": 3
+        },
+        {
+          "name": "add_fi_existing",
+          "lineno": 1776,
+          "complexity": 4
+        },
+        {
+          "name": "edit_fi",
+          "lineno": 1784,
+          "complexity": 4
+        },
+        {
+          "name": "del_fi",
+          "lineno": 1796,
+          "complexity": 2
+        },
+        {
+          "name": "edit_mit",
+          "lineno": 1802,
+          "complexity": 3
+        },
+        {
+          "name": "del_mit",
+          "lineno": 1822,
+          "complexity": 2
+        },
+        {
+          "name": "update_known_use_case",
+          "lineno": 1828,
+          "complexity": 6
+        },
+        {
+          "name": "__init__",
+          "lineno": 2157,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 2173,
+          "complexity": 9
+        },
+        {
+          "name": "new_hazard",
+          "lineno": 2319,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 2327,
+          "complexity": 5
+        },
+        {
+          "name": "do_load",
+          "lineno": 2410,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 2624,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 2628,
+          "complexity": 12
+        },
+        {
+          "name": "apply",
+          "lineno": 2669,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 2682,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 2687,
+          "complexity": 13
+        },
+        {
+          "name": "apply",
+          "lineno": 2726,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 2833,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 2838,
+          "complexity": 72
+        },
+        {
+          "name": "apply",
+          "lineno": 3275,
+          "complexity": 12
+        },
+        {
+          "name": "__init__",
+          "lineno": 3505,
+          "complexity": 3
+        },
+        {
+          "name": "body",
+          "lineno": 3512,
+          "complexity": 40
+        },
+        {
+          "name": "apply",
+          "lineno": 3720,
+          "complexity": 13
+        },
+        {
+          "name": "add_dm_new",
+          "lineno": 3747,
+          "complexity": 2
+        },
+        {
+          "name": "add_dm_existing",
+          "lineno": 3759,
+          "complexity": 4
+        },
+        {
+          "name": "edit_dm",
+          "lineno": 3766,
+          "complexity": 3
+        },
+        {
+          "name": "del_dm",
+          "lineno": 3786,
+          "complexity": 2
+        },
+        {
+          "name": "add_tc_existing",
+          "lineno": 3791,
+          "complexity": 4
+        },
+        {
+          "name": "add_tc",
+          "lineno": 3798,
+          "complexity": 3
+        },
+        {
+          "name": "edit_tc",
+          "lineno": 3804,
+          "complexity": 4
+        },
+        {
+          "name": "del_tc",
+          "lineno": 3815,
+          "complexity": 2
+        },
+        {
+          "name": "add_mit_new",
+          "lineno": 3820,
+          "complexity": 2
+        },
+        {
+          "name": "add_mit_existing",
+          "lineno": 3832,
+          "complexity": 4
+        },
+        {
+          "name": "add_fi_new",
+          "lineno": 3838,
+          "complexity": 3
+        },
+        {
+          "name": "add_fi_existing",
+          "lineno": 3845,
+          "complexity": 4
+        },
+        {
+          "name": "edit_fi",
+          "lineno": 3853,
+          "complexity": 4
+        },
+        {
+          "name": "del_fi",
+          "lineno": 3865,
+          "complexity": 2
+        },
+        {
+          "name": "edit_mit",
+          "lineno": 3871,
+          "complexity": 3
+        },
+        {
+          "name": "del_mit",
+          "lineno": 3891,
+          "complexity": 2
+        },
+        {
+          "name": "add_func_existing",
+          "lineno": 3896,
+          "complexity": 4
+        },
+        {
+          "name": "del_func",
+          "lineno": 3904,
+          "complexity": 2
+        },
+        {
+          "name": "add_haz_new",
+          "lineno": 3910,
+          "complexity": 4
+        },
+        {
+          "name": "add_haz_existing",
+          "lineno": 3920,
+          "complexity": 4
+        },
+        {
+          "name": "edit_haz",
+          "lineno": 3927,
+          "complexity": 4
+        },
+        {
+          "name": "del_haz",
+          "lineno": 3938,
+          "complexity": 2
+        },
+        {
+          "name": "update_known_use_case",
+          "lineno": 3943,
+          "complexity": 7
+        },
+        {
+          "name": "save",
+          "lineno": 184,
+          "complexity": 2
+        },
+        {
+          "name": "save",
+          "lineno": 207,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 1083,
+          "complexity": 3
+        },
+        {
+          "name": "apply",
+          "lineno": 1136,
+          "complexity": 3
+        },
+        {
+          "name": "get_frame",
+          "lineno": 1493,
+          "complexity": 3
+        },
+        {
+          "name": "refresh_funcs",
+          "lineno": 1501,
+          "complexity": 6
+        },
+        {
+          "name": "recalc",
+          "lineno": 3017,
+          "complexity": 2
+        },
+        {
+          "name": "update_exposure",
+          "lineno": 3031,
+          "complexity": 2
+        },
+        {
+          "name": "update_goal_cal",
+          "lineno": 3124,
+          "complexity": 2
+        },
+        {
+          "name": "sync_from_safety",
+          "lineno": 3131,
+          "complexity": 1
+        },
+        {
+          "name": "sync_from_cyber",
+          "lineno": 3135,
+          "complexity": 1
+        },
+        {
+          "name": "update_cyber",
+          "lineno": 3153,
+          "complexity": 12
+        },
+        {
+          "name": "build_attack_widgets",
+          "lineno": 3195,
+          "complexity": 7
+        },
+        {
+          "name": "auto_hazard",
+          "lineno": 3235,
+          "complexity": 8
+        },
+        {
+          "name": "on_threat_selected",
+          "lineno": 3260,
+          "complexity": 2
+        },
+        {
+          "name": "get_frame",
+          "lineno": 3567,
+          "complexity": 3
+        },
+        {
+          "name": "refresh_funcs",
+          "lineno": 3575,
+          "complexity": 5
+        },
+        {
+          "name": "new_hazard",
+          "lineno": 1601,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "gui/toolboxes/report_template_manager.py",
+      "loc": 130,
+      "functions": [
+        {
+          "name": "_default_templates_dir",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "_user_templates_dir",
+          "lineno": 26,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 33,
+          "complexity": 2
+        },
+        {
+          "name": "_template_files",
+          "lineno": 63,
+          "complexity": 7
+        },
+        {
+          "name": "_refresh_list",
+          "lineno": 77,
+          "complexity": 2
+        },
+        {
+          "name": "_add_template",
+          "lineno": 85,
+          "complexity": 4
+        },
+        {
+          "name": "_selected_path",
+          "lineno": 99,
+          "complexity": 2
+        },
+        {
+          "name": "_edit_template",
+          "lineno": 106,
+          "complexity": 3
+        },
+        {
+          "name": "_delete_template",
+          "lineno": 119,
+          "complexity": 5
+        },
+        {
+          "name": "_load_template",
+          "lineno": 135,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "gui/toolboxes/metrics_tab.py",
+      "loc": 71,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 8,
+          "complexity": 3
+        },
+        {
+          "name": "_draw_line_chart",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_line_chart_v1",
+          "lineno": 24,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_line_chart_v2",
+          "lineno": 28,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_line_chart_v3",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_line_chart_v4",
+          "lineno": 36,
+          "complexity": 1
+        },
+        {
+          "name": "_line_chart_core",
+          "lineno": 40,
+          "complexity": 6
+        },
+        {
+          "name": "_draw_bar_chart",
+          "lineno": 55,
+          "complexity": 3
+        },
+        {
+          "name": "update_plots",
+          "lineno": 71,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "gui/toolboxes/diagram_rules_toolbox.py",
+      "loc": 263,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 13,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 19,
+          "complexity": 3
+        },
+        {
+          "name": "apply",
+          "lineno": 48,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 56,
+          "complexity": 3
+        },
+        {
+          "name": "_populate_tree",
+          "lineno": 108,
+          "complexity": 11
+        },
+        {
+          "name": "_on_select",
+          "lineno": 156,
+          "complexity": 3
+        },
+        {
+          "name": "_collect_node_types",
+          "lineno": 170,
+          "complexity": 5
+        },
+        {
+          "name": "_diagram_node_types",
+          "lineno": 189,
+          "complexity": 4
+        },
+        {
+          "name": "_edit_item",
+          "lineno": 199,
+          "complexity": 13
+        },
+        {
+          "name": "_draw_rule",
+          "lineno": 269,
+          "complexity": 5
+        },
+        {
+          "name": "save",
+          "lineno": 291,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "gui/toolboxes/report_template_toolbox.py",
+      "loc": 332,
+      "functions": [
+        {
+          "name": "layout_report_template",
+          "lineno": 14,
+          "complexity": 11
+        },
+        {
+          "name": "_tokenize",
+          "lineno": 30,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 101,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 105,
+          "complexity": 1
+        },
+        {
+          "name": "apply",
+          "lineno": 115,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 125,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 129,
+          "complexity": 1
+        },
+        {
+          "name": "_populate",
+          "lineno": 149,
+          "complexity": 2
+        },
+        {
+          "name": "_add",
+          "lineno": 154,
+          "complexity": 2
+        },
+        {
+          "name": "_edit",
+          "lineno": 160,
+          "complexity": 4
+        },
+        {
+          "name": "_delete",
+          "lineno": 173,
+          "complexity": 3
+        },
+        {
+          "name": "apply",
+          "lineno": 179,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 186,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 190,
+          "complexity": 1
+        },
+        {
+          "name": "apply",
+          "lineno": 210,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 220,
+          "complexity": 3
+        },
+        {
+          "name": "_populate_tree",
+          "lineno": 291,
+          "complexity": 2
+        },
+        {
+          "name": "_on_select",
+          "lineno": 297,
+          "complexity": 1
+        },
+        {
+          "name": "_edit_section",
+          "lineno": 300,
+          "complexity": 3
+        },
+        {
+          "name": "_add_section",
+          "lineno": 312,
+          "complexity": 3
+        },
+        {
+          "name": "_delete_section",
+          "lineno": 326,
+          "complexity": 3
+        },
+        {
+          "name": "_edit_elements",
+          "lineno": 335,
+          "complexity": 2
+        },
+        {
+          "name": "save",
+          "lineno": 341,
+          "complexity": 2
+        },
+        {
+          "name": "_render_preview",
+          "lineno": 350,
+          "complexity": 7
+        }
+      ]
+    },
+    {
+      "file": "gui/toolboxes/search_toolbox.py",
+      "loc": 453,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 50,
+          "complexity": 1
+        },
+        {
+          "name": "_node_path",
+          "lineno": 110,
+          "complexity": 7
+        },
+        {
+          "name": "_obj_label",
+          "lineno": 122,
+          "complexity": 4
+        },
+        {
+          "name": "_obj_text",
+          "lineno": 129,
+          "complexity": 6
+        },
+        {
+          "name": "_init_handlers",
+          "lineno": 143,
+          "complexity": 5
+        },
+        {
+          "name": "_make_extra_handler",
+          "lineno": 166,
+          "complexity": 5
+        },
+        {
+          "name": "_add_result",
+          "lineno": 187,
+          "complexity": 1
+        },
+        {
+          "name": "_search_nodes",
+          "lineno": 192,
+          "complexity": 3
+        },
+        {
+          "name": "_search_connections",
+          "lineno": 207,
+          "complexity": 4
+        },
+        {
+          "name": "_search_failures",
+          "lineno": 223,
+          "complexity": 43
+        },
+        {
+          "name": "_search_hazards",
+          "lineno": 399,
+          "complexity": 3
+        },
+        {
+          "name": "_search_faults",
+          "lineno": 409,
+          "complexity": 3
+        },
+        {
+          "name": "_search_malfunctions",
+          "lineno": 419,
+          "complexity": 3
+        },
+        {
+          "name": "_search_failure_list",
+          "lineno": 431,
+          "complexity": 3
+        },
+        {
+          "name": "_search_triggers",
+          "lineno": 443,
+          "complexity": 3
+        },
+        {
+          "name": "_search_funcins",
+          "lineno": 455,
+          "complexity": 3
+        },
+        {
+          "name": "_run_search",
+          "lineno": 467,
+          "complexity": 11
+        },
+        {
+          "name": "_open_index",
+          "lineno": 505,
+          "complexity": 3
+        },
+        {
+          "name": "_find_next",
+          "lineno": 519,
+          "complexity": 2
+        },
+        {
+          "name": "_find_prev",
+          "lineno": 527,
+          "complexity": 2
+        },
+        {
+          "name": "_open_selected",
+          "lineno": 535,
+          "complexity": 2
+        },
+        {
+          "name": "handler",
+          "lineno": 167,
+          "complexity": 5
+        },
+        {
+          "name": "_open",
+          "lineno": 252,
+          "complexity": 11
+        },
+        {
+          "name": "_open",
+          "lineno": 175,
+          "complexity": 2
+        },
+        {
+          "name": "_open",
+          "lineno": 269,
+          "complexity": 5
+        },
+        {
+          "name": "_open",
+          "lineno": 389,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "gui/toolboxes/safety_management_toolbox.py",
+      "loc": 816,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 33,
+          "complexity": 4
+        },
+        {
+          "name": "refresh_diagrams",
+          "lineno": 146,
+          "complexity": 6
+        },
+        {
+          "name": "refresh_phases",
+          "lineno": 170,
+          "complexity": 2
+        },
+        {
+          "name": "select_phase",
+          "lineno": 179,
+          "complexity": 13
+        },
+        {
+          "name": "new_diagram",
+          "lineno": 213,
+          "complexity": 1
+        },
+        {
+          "name": "delete_diagram",
+          "lineno": 219,
+          "complexity": 2
+        },
+        {
+          "name": "rename_diagram",
+          "lineno": 226,
+          "complexity": 4
+        },
+        {
+          "name": "select_diagram",
+          "lineno": 238,
+          "complexity": 1
+        },
+        {
+          "name": "open_diagram",
+          "lineno": 242,
+          "complexity": 4
+        },
+        {
+          "name": "toggle_freeze",
+          "lineno": 255,
+          "complexity": 2
+        },
+        {
+          "name": "update_freeze_button",
+          "lineno": 263,
+          "complexity": 3
+        },
+        {
+          "name": "_add_requirement",
+          "lineno": 273,
+          "complexity": 6
+        },
+        {
+          "name": "_display_requirements",
+          "lineno": 316,
+          "complexity": 36
+        },
+        {
+          "name": "_current_requirement_pairs",
+          "lineno": 512,
+          "complexity": 5
+        },
+        {
+          "name": "generate_requirements",
+          "lineno": 532,
+          "complexity": 22
+        },
+        {
+          "name": "_refresh_phase_menu",
+          "lineno": 620,
+          "complexity": 3
+        },
+        {
+          "name": "generate_phase_requirements",
+          "lineno": 641,
+          "complexity": 29
+        },
+        {
+          "name": "generate_lifecycle_requirements",
+          "lineno": 750,
+          "complexity": 29
+        },
+        {
+          "name": "delete_obsolete_requirements",
+          "lineno": 859,
+          "complexity": 4
+        },
+        {
+          "name": "_collect_requirements",
+          "lineno": 872,
+          "complexity": 4
+        },
+        {
+          "name": "_fit_columns",
+          "lineno": 334,
+          "complexity": 8
+        },
+        {
+          "name": "populate",
+          "lineno": 354,
+          "complexity": 3
+        },
+        {
+          "name": "_selected_rid",
+          "lineno": 376,
+          "complexity": 3
+        },
+        {
+          "name": "_add",
+          "lineno": 385,
+          "complexity": 3
+        },
+        {
+          "name": "_edit",
+          "lineno": 399,
+          "complexity": 4
+        },
+        {
+          "name": "_remove",
+          "lineno": 417,
+          "complexity": 4
+        },
+        {
+          "name": "_save_csv",
+          "lineno": 430,
+          "complexity": 6
+        },
+        {
+          "name": "_popup",
+          "lineno": 468,
+          "complexity": 3
+        },
+        {
+          "name": "_on_double_click",
+          "lineno": 478,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "gui/toolboxes/review_toolbox.py",
+      "loc": 2649,
+      "functions": [
+        {
+          "name": "reload_config",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 101,
+          "complexity": 3
+        },
+        {
+          "name": "body",
+          "lineno": 109,
+          "complexity": 6
+        },
+        {
+          "name": "add_mod_row",
+          "lineno": 143,
+          "complexity": 2
+        },
+        {
+          "name": "add_part_row",
+          "lineno": 155,
+          "complexity": 4
+        },
+        {
+          "name": "apply",
+          "lineno": 175,
+          "complexity": 12
+        },
+        {
+          "name": "__init__",
+          "lineno": 218,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 222,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 255,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 271,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 275,
+          "complexity": 11
+        },
+        {
+          "name": "apply",
+          "lineno": 357,
+          "complexity": 9
+        },
+        {
+          "name": "__init__",
+          "lineno": 381,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 386,
+          "complexity": 5
+        },
+        {
+          "name": "on_select",
+          "lineno": 405,
+          "complexity": 4
+        },
+        {
+          "name": "apply",
+          "lineno": 416,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 420,
+          "complexity": 2
+        },
+        {
+          "name": "on_close",
+          "lineno": 499,
+          "complexity": 1
+        },
+        {
+          "name": "refresh_reviews",
+          "lineno": 503,
+          "complexity": 6
+        },
+        {
+          "name": "on_review_change",
+          "lineno": 526,
+          "complexity": 11
+        },
+        {
+          "name": "refresh_comments",
+          "lineno": 560,
+          "complexity": 13
+        },
+        {
+          "name": "start_participant_timer",
+          "lineno": 583,
+          "complexity": 5
+        },
+        {
+          "name": "on_select",
+          "lineno": 592,
+          "complexity": 4
+        },
+        {
+          "name": "add_comment",
+          "lineno": 603,
+          "complexity": 19
+        },
+        {
+          "name": "resolve_comment",
+          "lineno": 657,
+          "complexity": 6
+        },
+        {
+          "name": "mark_done",
+          "lineno": 676,
+          "complexity": 5
+        },
+        {
+          "name": "approve",
+          "lineno": 690,
+          "complexity": 10
+        },
+        {
+          "name": "reject",
+          "lineno": 712,
+          "complexity": 6
+        },
+        {
+          "name": "edit_review",
+          "lineno": 729,
+          "complexity": 8
+        },
+        {
+          "name": "open_document",
+          "lineno": 763,
+          "complexity": 2
+        },
+        {
+          "name": "open_comment",
+          "lineno": 769,
+          "complexity": 2
+        },
+        {
+          "name": "on_user_change",
+          "lineno": 776,
+          "complexity": 1
+        },
+        {
+          "name": "show_comment",
+          "lineno": 781,
+          "complexity": 2
+        },
+        {
+          "name": "update_buttons",
+          "lineno": 790,
+          "complexity": 12
+        },
+        {
+          "name": "check_completion",
+          "lineno": 817,
+          "complexity": 21
+        },
+        {
+          "name": "refresh_targets",
+          "lineno": 852,
+          "complexity": 2
+        },
+        {
+          "name": "on_target_change",
+          "lineno": 858,
+          "complexity": 6
+        },
+        {
+          "name": "__init__",
+          "lineno": 876,
+          "complexity": 3
+        },
+        {
+          "name": "draw_tree",
+          "lineno": 914,
+          "complexity": 26
+        },
+        {
+          "name": "diff_segments",
+          "lineno": 1008,
+          "complexity": 6
+        },
+        {
+          "name": "insert_diff_text",
+          "lineno": 1023,
+          "complexity": 6
+        },
+        {
+          "name": "draw_segment_text",
+          "lineno": 1036,
+          "complexity": 8
+        },
+        {
+          "name": "draw_diff_tree",
+          "lineno": 1057,
+          "complexity": 48
+        },
+        {
+          "name": "populate",
+          "lineno": 1218,
+          "complexity": 149
+        },
+        {
+          "name": "__init__",
+          "lineno": 1709,
+          "complexity": 18
+        },
+        {
+          "name": "insert_diff",
+          "lineno": 2042,
+          "complexity": 6
+        },
+        {
+          "name": "_on_log_text_modified",
+          "lineno": 2056,
+          "complexity": 1
+        },
+        {
+          "name": "_update_log_line_numbers",
+          "lineno": 2061,
+          "complexity": 2
+        },
+        {
+          "name": "diff_segments",
+          "lineno": 2070,
+          "complexity": 6
+        },
+        {
+          "name": "draw_segment_text",
+          "lineno": 2086,
+          "complexity": 8
+        },
+        {
+          "name": "draw_small_tree",
+          "lineno": 2117,
+          "complexity": 7
+        },
+        {
+          "name": "compare",
+          "lineno": 2187,
+          "complexity": 201
+        },
+        {
+          "name": "on_close",
+          "lineno": 2886,
+          "complexity": 4
+        },
+        {
+          "name": "draw_connections",
+          "lineno": 915,
+          "complexity": 5
+        },
+        {
+          "name": "draw_node_simple",
+          "lineno": 932,
+          "complexity": 21
+        },
+        {
+          "name": "draw_all",
+          "lineno": 998,
+          "complexity": 2
+        },
+        {
+          "name": "draw_connections",
+          "lineno": 1058,
+          "complexity": 10
+        },
+        {
+          "name": "draw_node",
+          "lineno": 1085,
+          "complexity": 28
+        },
+        {
+          "name": "filter_data",
+          "lineno": 1227,
+          "complexity": 9
+        },
+        {
+          "name": "build_conn_set",
+          "lineno": 1277,
+          "complexity": 3
+        },
+        {
+          "name": "collect_ids",
+          "lineno": 1324,
+          "complexity": 2
+        },
+        {
+          "name": "collect_nodes",
+          "lineno": 1334,
+          "complexity": 3
+        },
+        {
+          "name": "collect_reqs",
+          "lineno": 1366,
+          "complexity": 5
+        },
+        {
+          "name": "draw_connections",
+          "lineno": 2118,
+          "complexity": 3
+        },
+        {
+          "name": "draw_node_simple",
+          "lineno": 2133,
+          "complexity": 4
+        },
+        {
+          "name": "draw_all",
+          "lineno": 2177,
+          "complexity": 2
+        },
+        {
+          "name": "build_conn_set",
+          "lineno": 2205,
+          "complexity": 3
+        },
+        {
+          "name": "collect_nodes",
+          "lineno": 2255,
+          "complexity": 3
+        },
+        {
+          "name": "draw_connections",
+          "lineno": 2266,
+          "complexity": 7
+        },
+        {
+          "name": "draw_node",
+          "lineno": 2293,
+          "complexity": 23
+        },
+        {
+          "name": "collect_reqs",
+          "lineno": 2464,
+          "complexity": 5
+        },
+        {
+          "name": "fmt",
+          "lineno": 2501,
+          "complexity": 1
+        },
+        {
+          "name": "req_lines",
+          "lineno": 1103,
+          "complexity": 2
+        },
+        {
+          "name": "visit",
+          "lineno": 1279,
+          "complexity": 2
+        },
+        {
+          "name": "fmt",
+          "lineno": 1668,
+          "complexity": 1
+        },
+        {
+          "name": "visit",
+          "lineno": 2207,
+          "complexity": 2
+        },
+        {
+          "name": "req_lines",
+          "lineno": 2309,
+          "complexity": 2
+        },
+        {
+          "name": "req_lines",
+          "lineno": 2586,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "gui/toolboxes/requirement_patterns_toolbox.py",
+      "loc": 877,
+      "functions": [
+        {
+          "name": "_extract_action",
+          "lineno": 25,
+          "complexity": 7
+        },
+        {
+          "name": "highlight_placeholders",
+          "lineno": 47,
+          "complexity": 6
+        },
+        {
+          "name": "_render_template",
+          "lineno": 81,
+          "complexity": 3
+        },
+        {
+          "name": "position_template_widgets",
+          "lineno": 93,
+          "complexity": 8
+        },
+        {
+          "name": "__init__",
+          "lineno": 144,
+          "complexity": 1
+        },
+        {
+          "name": "_on_ok",
+          "lineno": 218,
+          "complexity": 2
+        },
+        {
+          "name": "_highlight_template",
+          "lineno": 230,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 238,
+          "complexity": 2
+        },
+        {
+          "name": "_on_ok",
+          "lineno": 327,
+          "complexity": 9
+        },
+        {
+          "name": "__init__",
+          "lineno": 355,
+          "complexity": 2
+        },
+        {
+          "name": "_on_ok",
+          "lineno": 435,
+          "complexity": 9
+        },
+        {
+          "name": "__init__",
+          "lineno": 460,
+          "complexity": 8
+        },
+        {
+          "name": "_populate_pattern_tree",
+          "lineno": 711,
+          "complexity": 5
+        },
+        {
+          "name": "_position_pattern_templates",
+          "lineno": 740,
+          "complexity": 1
+        },
+        {
+          "name": "_edit_item",
+          "lineno": 743,
+          "complexity": 3
+        },
+        {
+          "name": "add_pattern",
+          "lineno": 756,
+          "complexity": 1
+        },
+        {
+          "name": "delete_pattern",
+          "lineno": 762,
+          "complexity": 2
+        },
+        {
+          "name": "save_patterns",
+          "lineno": 770,
+          "complexity": 4
+        },
+        {
+          "name": "_populate_rule_tree",
+          "lineno": 794,
+          "complexity": 6
+        },
+        {
+          "name": "_position_rule_templates",
+          "lineno": 834,
+          "complexity": 1
+        },
+        {
+          "name": "_edit_rule",
+          "lineno": 837,
+          "complexity": 5
+        },
+        {
+          "name": "add_rule",
+          "lineno": 857,
+          "complexity": 3
+        },
+        {
+          "name": "delete_rule",
+          "lineno": 869,
+          "complexity": 3
+        },
+        {
+          "name": "save_rules",
+          "lineno": 878,
+          "complexity": 5
+        },
+        {
+          "name": "_ensure_role_subject_variants",
+          "lineno": 911,
+          "complexity": 5
+        },
+        {
+          "name": "_populate_seq_tree",
+          "lineno": 924,
+          "complexity": 6
+        },
+        {
+          "name": "_position_seq_templates",
+          "lineno": 966,
+          "complexity": 1
+        },
+        {
+          "name": "_edit_sequence",
+          "lineno": 969,
+          "complexity": 5
+        },
+        {
+          "name": "add_sequence",
+          "lineno": 991,
+          "complexity": 3
+        },
+        {
+          "name": "delete_sequence",
+          "lineno": 1005,
+          "complexity": 4
+        },
+        {
+          "name": "_pat_yscroll",
+          "lineno": 527,
+          "complexity": 1
+        },
+        {
+          "name": "_pat_xscroll",
+          "lineno": 531,
+          "complexity": 1
+        },
+        {
+          "name": "_rule_yscroll",
+          "lineno": 596,
+          "complexity": 1
+        },
+        {
+          "name": "_rule_xscroll",
+          "lineno": 600,
+          "complexity": 1
+        },
+        {
+          "name": "_seq_yscroll",
+          "lineno": 673,
+          "complexity": 1
+        },
+        {
+          "name": "_seq_xscroll",
+          "lineno": 677,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/__init__.py",
+      "loc": 20,
+      "functions": [
+        {
+          "name": "__getattr__",
+          "lineno": 11,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/threat_dialog.py",
+      "loc": 518,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 23,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 29,
+          "complexity": 4
+        },
+        {
+          "name": "_get_assets",
+          "lineno": 260,
+          "complexity": 18
+        },
+        {
+          "name": "_get_functions",
+          "lineno": 301,
+          "complexity": 1
+        },
+        {
+          "name": "_selected_func_idx",
+          "lineno": 307,
+          "complexity": 2
+        },
+        {
+          "name": "add_function",
+          "lineno": 311,
+          "complexity": 4
+        },
+        {
+          "name": "remove_function",
+          "lineno": 322,
+          "complexity": 2
+        },
+        {
+          "name": "on_func_select",
+          "lineno": 330,
+          "complexity": 1
+        },
+        {
+          "name": "on_ds_select",
+          "lineno": 334,
+          "complexity": 3
+        },
+        {
+          "name": "on_threat_select",
+          "lineno": 347,
+          "complexity": 4
+        },
+        {
+          "name": "on_path_select",
+          "lineno": 362,
+          "complexity": 5
+        },
+        {
+          "name": "refresh_ds",
+          "lineno": 376,
+          "complexity": 3
+        },
+        {
+          "name": "refresh_threats",
+          "lineno": 387,
+          "complexity": 4
+        },
+        {
+          "name": "refresh_paths",
+          "lineno": 400,
+          "complexity": 5
+        },
+        {
+          "name": "add_damage_scenario",
+          "lineno": 417,
+          "complexity": 3
+        },
+        {
+          "name": "update_damage_scenario",
+          "lineno": 433,
+          "complexity": 3
+        },
+        {
+          "name": "del_damage_scenario",
+          "lineno": 446,
+          "complexity": 3
+        },
+        {
+          "name": "add_threat_scenario",
+          "lineno": 461,
+          "complexity": 5
+        },
+        {
+          "name": "update_threat_scenario",
+          "lineno": 479,
+          "complexity": 4
+        },
+        {
+          "name": "del_threat_scenario",
+          "lineno": 493,
+          "complexity": 4
+        },
+        {
+          "name": "add_attack_path",
+          "lineno": 509,
+          "complexity": 5
+        },
+        {
+          "name": "update_attack_path",
+          "lineno": 527,
+          "complexity": 5
+        },
+        {
+          "name": "del_attack_path",
+          "lineno": 542,
+          "complexity": 5
+        },
+        {
+          "name": "apply",
+          "lineno": 557,
+          "complexity": 1
+        },
+        {
+          "name": "buttonbox",
+          "lineno": 562,
+          "complexity": 2
+        },
+        {
+          "name": "_set_initial_size",
+          "lineno": 597,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/req_dialog.py",
+      "loc": 123,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 25,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "apply",
+          "lineno": 91,
+          "complexity": 3
+        },
+        {
+          "name": "validate",
+          "lineno": 113,
+          "complexity": 4
+        },
+        {
+          "name": "_toggle_fields",
+          "lineno": 120,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/dialog_utils.py",
+      "loc": 21,
+      "functions": [
+        {
+          "name": "askstring_fixed",
+          "lineno": 7,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 20,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/gsn_connection_config.py",
+      "loc": 62,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 5
+        },
+        {
+          "name": "_node_for_label",
+          "lineno": 55,
+          "complexity": 1
+        },
+        {
+          "name": "_remove_connection",
+          "lineno": 58,
+          "complexity": 4
+        },
+        {
+          "name": "_ok",
+          "lineno": 66,
+          "complexity": 2
+        },
+        {
+          "name": "_delete",
+          "lineno": 75,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/decomposition_dialog.py",
+      "loc": 34,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 20,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 24,
+          "complexity": 4
+        },
+        {
+          "name": "apply",
+          "lineno": 37,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/user_info_dialog.py",
+      "loc": 46,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 10,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 15,
+          "complexity": 1
+        },
+        {
+          "name": "apply",
+          "lineno": 29,
+          "complexity": 1
+        },
+        {
+          "name": "buttonbox",
+          "lineno": 35,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/edit_node_dialog.py",
+      "loc": 1038,
+      "functions": [
+        {
+          "name": "format_requirement",
+          "lineno": 25,
+          "complexity": 6
+        },
+        {
+          "name": "__init__",
+          "lineno": 42,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 47,
+          "complexity": 24
+        },
+        {
+          "name": "add_existing_requirement",
+          "lineno": 495,
+          "complexity": 9
+        },
+        {
+          "name": "add_new_requirement",
+          "lineno": 524,
+          "complexity": 3
+        },
+        {
+          "name": "list_all_requirements",
+          "lineno": 555,
+          "complexity": 2
+        },
+        {
+          "name": "get_requirement_allocation_names",
+          "lineno": 563,
+          "complexity": 24
+        },
+        {
+          "name": "_collect_goal_names",
+          "lineno": 591,
+          "complexity": 5
+        },
+        {
+          "name": "get_requirement_goal_names",
+          "lineno": 597,
+          "complexity": 19
+        },
+        {
+          "name": "format_requirement_with_trace",
+          "lineno": 621,
+          "complexity": 1
+        },
+        {
+          "name": "infer_requirement_asil_from_node",
+          "lineno": 629,
+          "complexity": 3
+        },
+        {
+          "name": "refresh_model",
+          "lineno": 640,
+          "complexity": 2
+        },
+        {
+          "name": "invalidate_reviews_for_hara",
+          "lineno": 648,
+          "complexity": 4
+        },
+        {
+          "name": "invalidate_reviews_for_fta",
+          "lineno": 661,
+          "complexity": 4
+        },
+        {
+          "name": "invalidate_reviews_for_requirement",
+          "lineno": 673,
+          "complexity": 4
+        },
+        {
+          "name": "invalidate_reviews_for_hara",
+          "lineno": 685,
+          "complexity": 4
+        },
+        {
+          "name": "invalidate_reviews_for_requirement",
+          "lineno": 698,
+          "complexity": 4
+        },
+        {
+          "name": "add_safety_requirement",
+          "lineno": 718,
+          "complexity": 14
+        },
+        {
+          "name": "edit_safety_requirement",
+          "lineno": 804,
+          "complexity": 10
+        },
+        {
+          "name": "delete_safety_requirement",
+          "lineno": 864,
+          "complexity": 3
+        },
+        {
+          "name": "decompose_safety_requirement",
+          "lineno": 876,
+          "complexity": 6
+        },
+        {
+          "name": "update_decomposition_scheme",
+          "lineno": 938,
+          "complexity": 8
+        },
+        {
+          "name": "buttonbox",
+          "lineno": 975,
+          "complexity": 1
+        },
+        {
+          "name": "on_enter_pressed",
+          "lineno": 996,
+          "complexity": 1
+        },
+        {
+          "name": "validate_float",
+          "lineno": 1000,
+          "complexity": 7
+        },
+        {
+          "name": "update_probability",
+          "lineno": 1030,
+          "complexity": 6
+        },
+        {
+          "name": "validate",
+          "lineno": 1045,
+          "complexity": 1
+        },
+        {
+          "name": "apply",
+          "lineno": 1048,
+          "complexity": 35
+        },
+        {
+          "name": "__init__",
+          "lineno": 1155,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 1159,
+          "complexity": 4
+        },
+        {
+          "name": "apply",
+          "lineno": 1170,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 323,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 328,
+          "complexity": 3
+        },
+        {
+          "name": "apply",
+          "lineno": 389,
+          "complexity": 2
+        },
+        {
+          "name": "validate",
+          "lineno": 412,
+          "complexity": 4
+        },
+        {
+          "name": "_toggle_fields",
+          "lineno": 428,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 454,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 459,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 491,
+          "complexity": 2
+        },
+        {
+          "name": "mal_sel",
+          "lineno": 239,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/fmea_row_dialog.py",
+      "loc": 484,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 17,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 27,
+          "complexity": 63
+        },
+        {
+          "name": "apply",
+          "lineno": 331,
+          "complexity": 33
+        },
+        {
+          "name": "add_existing_requirement",
+          "lineno": 416,
+          "complexity": 8
+        },
+        {
+          "name": "comment_requirement",
+          "lineno": 434,
+          "complexity": 2
+        },
+        {
+          "name": "comment_fmea",
+          "lineno": 445,
+          "complexity": 1
+        },
+        {
+          "name": "add_fault",
+          "lineno": 450,
+          "complexity": 6
+        },
+        {
+          "name": "add_safety_requirement",
+          "lineno": 465,
+          "complexity": 8
+        },
+        {
+          "name": "edit_safety_requirement",
+          "lineno": 498,
+          "complexity": 7
+        },
+        {
+          "name": "delete_safety_requirement",
+          "lineno": 522,
+          "complexity": 2
+        },
+        {
+          "name": "auto_fault",
+          "lineno": 86,
+          "complexity": 5
+        },
+        {
+          "name": "mode_sel",
+          "lineno": 100,
+          "complexity": 6
+        },
+        {
+          "name": "update_sg",
+          "lineno": 144,
+          "complexity": 9
+        },
+        {
+          "name": "comp_sel",
+          "lineno": 278,
+          "complexity": 3
+        },
+        {
+          "name": "mech_sel",
+          "lineno": 223,
+          "complexity": 9
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/user_select_dialog.py",
+      "loc": 62,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 19,
+          "complexity": 2
+        },
+        {
+          "name": "_on_select",
+          "lineno": 40,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "buttonbox",
+          "lineno": 52,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/dialogs/select_base_event_dialog.py",
+      "loc": 36,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 16,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 22,
+          "complexity": 4
+        },
+        {
+          "name": "apply",
+          "lineno": 36,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "gui/explorers/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "gui/explorers/safety_case_explorer.py",
+      "loc": 221,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 12,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 18,
+          "complexity": 3
+        },
+        {
+          "name": "apply",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 46,
+          "complexity": 5
+        },
+        {
+          "name": "populate",
+          "lineno": 95,
+          "complexity": 3
+        },
+        {
+          "name": "refresh",
+          "lineno": 118,
+          "complexity": 1
+        },
+        {
+          "name": "_available_diagrams",
+          "lineno": 123,
+          "complexity": 7
+        },
+        {
+          "name": "_collect_module_diagrams",
+          "lineno": 154,
+          "complexity": 2
+        },
+        {
+          "name": "new_case",
+          "lineno": 161,
+          "complexity": 7
+        },
+        {
+          "name": "edit_case",
+          "lineno": 185,
+          "complexity": 8
+        },
+        {
+          "name": "delete_case",
+          "lineno": 219,
+          "complexity": 4
+        },
+        {
+          "name": "open_item",
+          "lineno": 231,
+          "complexity": 10
+        },
+        {
+          "name": "_on_double_click",
+          "lineno": 258,
+          "complexity": 1
+        },
+        {
+          "name": "_create_icon",
+          "lineno": 262,
+          "complexity": 1
+        },
+        {
+          "name": "_color",
+          "lineno": 81,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "gui/explorers/gsn_explorer.py",
+      "loc": 452,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 17,
+          "complexity": 4
+        },
+        {
+          "name": "populate",
+          "lineno": 80,
+          "complexity": 4
+        },
+        {
+          "name": "refresh",
+          "lineno": 119,
+          "complexity": 1
+        },
+        {
+          "name": "_bind_shortcuts",
+          "lineno": 124,
+          "complexity": 2
+        },
+        {
+          "name": "_add_module_children",
+          "lineno": 131,
+          "complexity": 3
+        },
+        {
+          "name": "_add_diagram_children",
+          "lineno": 152,
+          "complexity": 4
+        },
+        {
+          "name": "new_diagram",
+          "lineno": 191,
+          "complexity": 8
+        },
+        {
+          "name": "_diagram_name_exists",
+          "lineno": 216,
+          "complexity": 8
+        },
+        {
+          "name": "new_module",
+          "lineno": 236,
+          "complexity": 6
+        },
+        {
+          "name": "rename_item",
+          "lineno": 257,
+          "complexity": 11
+        },
+        {
+          "name": "delete_item",
+          "lineno": 290,
+          "complexity": 25
+        },
+        {
+          "name": "_all_diagram_names",
+          "lineno": 342,
+          "complexity": 1
+        },
+        {
+          "name": "_unique_diagram_name",
+          "lineno": 346,
+          "complexity": 1
+        },
+        {
+          "name": "_collect_diagrams",
+          "lineno": 351,
+          "complexity": 3
+        },
+        {
+          "name": "_find_parent_module",
+          "lineno": 358,
+          "complexity": 3
+        },
+        {
+          "name": "_find_parent_diagram",
+          "lineno": 368,
+          "complexity": 3
+        },
+        {
+          "name": "_on_right_click",
+          "lineno": 378,
+          "complexity": 5
+        },
+        {
+          "name": "_on_drag_start",
+          "lineno": 404,
+          "complexity": 1
+        },
+        {
+          "name": "_on_drag_end",
+          "lineno": 409,
+          "complexity": 13
+        },
+        {
+          "name": "_remove_diagram_from_all_modules",
+          "lineno": 446,
+          "complexity": 5
+        },
+        {
+          "name": "_remove_module_from_parent",
+          "lineno": 457,
+          "complexity": 5
+        },
+        {
+          "name": "_move_diagram_to_module",
+          "lineno": 468,
+          "complexity": 2
+        },
+        {
+          "name": "_move_diagram_to_root",
+          "lineno": 476,
+          "complexity": 2
+        },
+        {
+          "name": "_move_module_to_module",
+          "lineno": 482,
+          "complexity": 2
+        },
+        {
+          "name": "_move_module_to_root",
+          "lineno": 490,
+          "complexity": 2
+        },
+        {
+          "name": "_is_descendant_module",
+          "lineno": 496,
+          "complexity": 4
+        },
+        {
+          "name": "_on_double_click",
+          "lineno": 505,
+          "complexity": 1
+        },
+        {
+          "name": "open_item",
+          "lineno": 509,
+          "complexity": 6
+        },
+        {
+          "name": "_create_icon",
+          "lineno": 533,
+          "complexity": 1
+        },
+        {
+          "name": "_color",
+          "lineno": 44,
+          "complexity": 2
+        },
+        {
+          "name": "_add_node",
+          "lineno": 163,
+          "complexity": 2
+        },
+        {
+          "name": "_collect",
+          "lineno": 221,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "gui/explorers/safety_management_explorer.py",
+      "loc": 274,
+      "functions": [
+        {
+          "name": "_strip_phase_suffix",
+          "lineno": 18,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 28,
+          "complexity": 5
+        },
+        {
+          "name": "populate",
+          "lineno": 79,
+          "complexity": 6
+        },
+        {
+          "name": "refresh",
+          "lineno": 123,
+          "complexity": 1
+        },
+        {
+          "name": "_refresh_diagram_list",
+          "lineno": 128,
+          "complexity": 4
+        },
+        {
+          "name": "new_folder",
+          "lineno": 138,
+          "complexity": 5
+        },
+        {
+          "name": "new_diagram",
+          "lineno": 154,
+          "complexity": 6
+        },
+        {
+          "name": "rename_item",
+          "lineno": 179,
+          "complexity": 8
+        },
+        {
+          "name": "delete_item",
+          "lineno": 205,
+          "complexity": 8
+        },
+        {
+          "name": "open_item",
+          "lineno": 227,
+          "complexity": 5
+        },
+        {
+          "name": "_on_double_click",
+          "lineno": 239,
+          "complexity": 1
+        },
+        {
+          "name": "_on_drag_start",
+          "lineno": 243,
+          "complexity": 2
+        },
+        {
+          "name": "_on_drop",
+          "lineno": 249,
+          "complexity": 12
+        },
+        {
+          "name": "_is_descendant",
+          "lineno": 291,
+          "complexity": 3
+        },
+        {
+          "name": "_in_any_module",
+          "lineno": 300,
+          "complexity": 5
+        },
+        {
+          "name": "_replace_name_in_modules",
+          "lineno": 307,
+          "complexity": 4
+        },
+        {
+          "name": "_remove_name",
+          "lineno": 314,
+          "complexity": 3
+        },
+        {
+          "name": "_remove_module",
+          "lineno": 320,
+          "complexity": 4
+        },
+        {
+          "name": "_create_icon",
+          "lineno": 330,
+          "complexity": 1
+        },
+        {
+          "name": "_color",
+          "lineno": 64,
+          "complexity": 2
+        },
+        {
+          "name": "_add_module",
+          "lineno": 91,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "gui/controls/__init__.py",
+      "loc": 22,
+      "functions": [
+        {
+          "name": "__getattr__",
+          "lineno": 20,
+          "complexity": 2
+        }
+      ]
+    },
+    {
+      "file": "gui/controls/messagebox.py",
+      "loc": 100,
+      "functions": [
+        {
+          "name": "_log_and_return",
+          "lineno": 17,
+          "complexity": 1
+        },
+        {
+          "name": "showinfo",
+          "lineno": 35,
+          "complexity": 1
+        },
+        {
+          "name": "showwarning",
+          "lineno": 39,
+          "complexity": 1
+        },
+        {
+          "name": "showerror",
+          "lineno": 43,
+          "complexity": 1
+        },
+        {
+          "name": "_create_dialog",
+          "lineno": 47,
+          "complexity": 7
+        },
+        {
+          "name": "askyesno",
+          "lineno": 105,
+          "complexity": 2
+        },
+        {
+          "name": "askyesnocancel",
+          "lineno": 114,
+          "complexity": 2
+        },
+        {
+          "name": "askokcancel",
+          "lineno": 125,
+          "complexity": 2
+        },
+        {
+          "name": "_set",
+          "lineno": 88,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/controls/capsule_button.py",
+      "loc": 618,
+      "functions": [
+        {
+          "name": "_hex_to_rgb",
+          "lineno": 8,
+          "complexity": 2
+        },
+        {
+          "name": "_rgb_to_hex",
+          "lineno": 14,
+          "complexity": 1
+        },
+        {
+          "name": "_lighten",
+          "lineno": 18,
+          "complexity": 1
+        },
+        {
+          "name": "_darken",
+          "lineno": 37,
+          "complexity": 1
+        },
+        {
+          "name": "_interpolate_color",
+          "lineno": 45,
+          "complexity": 1
+        },
+        {
+          "name": "_glow_color",
+          "lineno": 54,
+          "complexity": 1
+        },
+        {
+          "name": "_glow_image",
+          "lineno": 65,
+          "complexity": 6
+        },
+        {
+          "name": "__init__",
+          "lineno": 117,
+          "complexity": 8
+        },
+        {
+          "name": "_content_width",
+          "lineno": 212,
+          "complexity": 5
+        },
+        {
+          "name": "_draw_button",
+          "lineno": 221,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_gradient",
+          "lineno": 258,
+          "complexity": 8
+        },
+        {
+          "name": "_set_gradient",
+          "lineno": 277,
+          "complexity": 7
+        },
+        {
+          "name": "_draw_highlight",
+          "lineno": 302,
+          "complexity": 3
+        },
+        {
+          "name": "_draw_shade",
+          "lineno": 333,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_content",
+          "lineno": 360,
+          "complexity": 9
+        },
+        {
+          "name": "_draw_border",
+          "lineno": 417,
+          "complexity": 1
+        },
+        {
+          "name": "_set_color",
+          "lineno": 464,
+          "complexity": 2
+        },
+        {
+          "name": "_apply_border_color",
+          "lineno": 478,
+          "complexity": 4
+        },
+        {
+          "name": "_get_glow_image",
+          "lineno": 498,
+          "complexity": 3
+        },
+        {
+          "name": "_add_glow",
+          "lineno": 506,
+          "complexity": 4
+        },
+        {
+          "name": "_remove_glow",
+          "lineno": 541,
+          "complexity": 2
+        },
+        {
+          "name": "_toggle_shine",
+          "lineno": 546,
+          "complexity": 3
+        },
+        {
+          "name": "_on_motion",
+          "lineno": 551,
+          "complexity": 12
+        },
+        {
+          "name": "_on_enter",
+          "lineno": 575,
+          "complexity": 5
+        },
+        {
+          "name": "_on_leave",
+          "lineno": 586,
+          "complexity": 4
+        },
+        {
+          "name": "_on_press",
+          "lineno": 595,
+          "complexity": 2
+        },
+        {
+          "name": "_on_release",
+          "lineno": 602,
+          "complexity": 5
+        },
+        {
+          "name": "_apply_state",
+          "lineno": 620,
+          "complexity": 2
+        },
+        {
+          "name": "configure",
+          "lineno": 631,
+          "complexity": 3
+        },
+        {
+          "name": "_update_command",
+          "lineno": 659,
+          "complexity": 2
+        },
+        {
+          "name": "_update_text",
+          "lineno": 663,
+          "complexity": 3
+        },
+        {
+          "name": "_update_colors",
+          "lineno": 669,
+          "complexity": 4
+        },
+        {
+          "name": "_update_image",
+          "lineno": 678,
+          "complexity": 3
+        },
+        {
+          "name": "_update_geometry",
+          "lineno": 692,
+          "complexity": 7
+        },
+        {
+          "name": "_update_state",
+          "lineno": 705,
+          "complexity": 3
+        },
+        {
+          "name": "state",
+          "lineno": 713,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "gui/controls/button_utils.py",
+      "loc": 222,
+      "functions": [
+        {
+          "name": "set_uniform_button_width",
+          "lineno": 11,
+          "complexity": 7
+        },
+        {
+          "name": "_lighten_color",
+          "lineno": 41,
+          "complexity": 1
+        },
+        {
+          "name": "_blend_with",
+          "lineno": 62,
+          "complexity": 1
+        },
+        {
+          "name": "_blend_with",
+          "lineno": 73,
+          "complexity": 1
+        },
+        {
+          "name": "_blend_with",
+          "lineno": 84,
+          "complexity": 1
+        },
+        {
+          "name": "_lighten_image",
+          "lineno": 95,
+          "complexity": 11
+        },
+        {
+          "name": "add_hover_highlight",
+          "lineno": 144,
+          "complexity": 1
+        },
+        {
+          "name": "enable_listbox_hover_highlight",
+          "lineno": 164,
+          "complexity": 33
+        },
+        {
+          "name": "_collect",
+          "lineno": 23,
+          "complexity": 3
+        },
+        {
+          "name": "_lb_on_motion",
+          "lineno": 173,
+          "complexity": 15
+        },
+        {
+          "name": "_lb_on_leave",
+          "lineno": 206,
+          "complexity": 5
+        },
+        {
+          "name": "_tv_on_motion",
+          "lineno": 221,
+          "complexity": 11
+        },
+        {
+          "name": "_tv_on_leave",
+          "lineno": 249,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "gui/controls/mac_button_style.py",
+      "loc": 92,
+      "functions": [
+        {
+          "name": "apply_mac_button_style",
+          "lineno": 7,
+          "complexity": 2
+        },
+        {
+          "name": "apply_purplish_button_style",
+          "lineno": 32,
+          "complexity": 3
+        },
+        {
+          "name": "apply_translucid_button_style",
+          "lineno": 56,
+          "complexity": 3
+        },
+        {
+          "name": "_purplish_buttonbox",
+          "lineno": 80,
+          "complexity": 1
+        },
+        {
+          "name": "enable_purplish_dialog_buttons",
+          "lineno": 104,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/windows/__init__.py",
+      "loc": 0,
+      "functions": []
+    },
+    {
+      "file": "gui/windows/causal_bayesian_network_window.py",
+      "loc": 1268,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 29,
+          "complexity": 3
+        },
+        {
+          "name": "refresh_docs",
+          "lineno": 139,
+          "complexity": 4
+        },
+        {
+          "name": "redraw",
+          "lineno": 153,
+          "complexity": 1
+        },
+        {
+          "name": "select_doc",
+          "lineno": 158,
+          "complexity": 3
+        },
+        {
+          "name": "_update_toolbox_visibility",
+          "lineno": 170,
+          "complexity": 3
+        },
+        {
+          "name": "_on_focus_in",
+          "lineno": 177,
+          "complexity": 2
+        },
+        {
+          "name": "_fit_toolbox",
+          "lineno": 182,
+          "complexity": 6
+        },
+        {
+          "name": "new_doc",
+          "lineno": 211,
+          "complexity": 6
+        },
+        {
+          "name": "_doc_name_exists",
+          "lineno": 228,
+          "complexity": 6
+        },
+        {
+          "name": "rename_doc",
+          "lineno": 239,
+          "complexity": 7
+        },
+        {
+          "name": "delete_doc",
+          "lineno": 259,
+          "complexity": 5
+        },
+        {
+          "name": "select_tool",
+          "lineno": 274,
+          "complexity": 5
+        },
+        {
+          "name": "on_click",
+          "lineno": 299,
+          "complexity": 37
+        },
+        {
+          "name": "on_drag",
+          "lineno": 416,
+          "complexity": 13
+        },
+        {
+          "name": "on_release",
+          "lineno": 460,
+          "complexity": 14
+        },
+        {
+          "name": "_animate_temp_edge",
+          "lineno": 504,
+          "complexity": 2
+        },
+        {
+          "name": "_highlight_node",
+          "lineno": 513,
+          "complexity": 4
+        },
+        {
+          "name": "on_double_click",
+          "lineno": 531,
+          "complexity": 10
+        },
+        {
+          "name": "_fill_tag_strategy1",
+          "lineno": 574,
+          "complexity": 1
+        },
+        {
+          "name": "_fill_tag_strategy2",
+          "lineno": 579,
+          "complexity": 1
+        },
+        {
+          "name": "_fill_tag_strategy3",
+          "lineno": 584,
+          "complexity": 1
+        },
+        {
+          "name": "_fill_tag_strategy4",
+          "lineno": 589,
+          "complexity": 1
+        },
+        {
+          "name": "_generate_fill_tag",
+          "lineno": 594,
+          "complexity": 3
+        },
+        {
+          "name": "_draw_node",
+          "lineno": 607,
+          "complexity": 10
+        },
+        {
+          "name": "_draw_edge",
+          "lineno": 656,
+          "complexity": 3
+        },
+        {
+          "name": "_place_table",
+          "lineno": 674,
+          "complexity": 11
+        },
+        {
+          "name": "_table_lookup_strategy1",
+          "lineno": 730,
+          "complexity": 2
+        },
+        {
+          "name": "_table_lookup_strategy2",
+          "lineno": 736,
+          "complexity": 3
+        },
+        {
+          "name": "_table_lookup_strategy3",
+          "lineno": 742,
+          "complexity": 3
+        },
+        {
+          "name": "_table_lookup_strategy4",
+          "lineno": 748,
+          "complexity": 2
+        },
+        {
+          "name": "_get_table",
+          "lineno": 752,
+          "complexity": 3
+        },
+        {
+          "name": "_update_table",
+          "lineno": 765,
+          "complexity": 7
+        },
+        {
+          "name": "_position_table",
+          "lineno": 790,
+          "complexity": 2
+        },
+        {
+          "name": "_drag_table_strategy1",
+          "lineno": 802,
+          "complexity": 1
+        },
+        {
+          "name": "_drag_table_strategy2",
+          "lineno": 805,
+          "complexity": 2
+        },
+        {
+          "name": "_drag_table_strategy3",
+          "lineno": 809,
+          "complexity": 2
+        },
+        {
+          "name": "_drag_table_strategy4",
+          "lineno": 814,
+          "complexity": 2
+        },
+        {
+          "name": "_drag_table",
+          "lineno": 820,
+          "complexity": 3
+        },
+        {
+          "name": "_update_all_tables",
+          "lineno": 834,
+          "complexity": 5
+        },
+        {
+          "name": "_rebuild_table",
+          "lineno": 844,
+          "complexity": 5
+        },
+        {
+          "name": "add_cpd_row",
+          "lineno": 855,
+          "complexity": 9
+        },
+        {
+          "name": "edit_cpd_row",
+          "lineno": 889,
+          "complexity": 10
+        },
+        {
+          "name": "_select_triggering_conditions",
+          "lineno": 957,
+          "complexity": 3
+        },
+        {
+          "name": "_select_functional_insufficiencies",
+          "lineno": 973,
+          "complexity": 3
+        },
+        {
+          "name": "_select_malfunctions",
+          "lineno": 989,
+          "complexity": 4
+        },
+        {
+          "name": "_find_node_strategy1",
+          "lineno": 1006,
+          "complexity": 3
+        },
+        {
+          "name": "_find_node_strategy2",
+          "lineno": 1018,
+          "complexity": 3
+        },
+        {
+          "name": "_find_node_strategy3",
+          "lineno": 1030,
+          "complexity": 5
+        },
+        {
+          "name": "_find_node_strategy4",
+          "lineno": 1042,
+          "complexity": 5
+        },
+        {
+          "name": "_find_node",
+          "lineno": 1057,
+          "complexity": 3
+        },
+        {
+          "name": "load_doc",
+          "lineno": 1071,
+          "complexity": 11
+        },
+        {
+          "name": "refresh_from_repository",
+          "lineno": 1096,
+          "complexity": 1
+        },
+        {
+          "name": "_update_scroll_region",
+          "lineno": 1101,
+          "complexity": 4
+        },
+        {
+          "name": "_bind_shortcuts",
+          "lineno": 1109,
+          "complexity": 2
+        },
+        {
+          "name": "zoom",
+          "lineno": 1118,
+          "complexity": 5
+        },
+        {
+          "name": "on_right_click",
+          "lineno": 1131,
+          "complexity": 5
+        },
+        {
+          "name": "_prompt_rename_node",
+          "lineno": 1151,
+          "complexity": 6
+        },
+        {
+          "name": "_delete_node",
+          "lineno": 1168,
+          "complexity": 19
+        },
+        {
+          "name": "_rename_node",
+          "lineno": 1220,
+          "complexity": 24
+        },
+        {
+          "name": "_clone_node_strategy1",
+          "lineno": 1275,
+          "complexity": 3
+        },
+        {
+          "name": "_clone_node_strategy2",
+          "lineno": 1284,
+          "complexity": 2
+        },
+        {
+          "name": "_clone_node_strategy3",
+          "lineno": 1290,
+          "complexity": 2
+        },
+        {
+          "name": "_clone_node_strategy4",
+          "lineno": 1296,
+          "complexity": 1
+        },
+        {
+          "name": "_clone_node",
+          "lineno": 1299,
+          "complexity": 3
+        },
+        {
+          "name": "_add_position_strategy1",
+          "lineno": 1310,
+          "complexity": 1
+        },
+        {
+          "name": "_add_position_strategy2",
+          "lineno": 1314,
+          "complexity": 1
+        },
+        {
+          "name": "_add_position_strategy3",
+          "lineno": 1319,
+          "complexity": 2
+        },
+        {
+          "name": "_add_position_strategy4",
+          "lineno": 1327,
+          "complexity": 1
+        },
+        {
+          "name": "_add_position",
+          "lineno": 1330,
+          "complexity": 3
+        },
+        {
+          "name": "_reconstruct_node_strategy1",
+          "lineno": 1344,
+          "complexity": 6
+        },
+        {
+          "name": "_reconstruct_node_strategy2",
+          "lineno": 1364,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_node_strategy3",
+          "lineno": 1367,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_node_strategy4",
+          "lineno": 1370,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_node",
+          "lineno": 1373,
+          "complexity": 3
+        },
+        {
+          "name": "copy_selected",
+          "lineno": 1386,
+          "complexity": 4
+        },
+        {
+          "name": "cut_selected",
+          "lineno": 1394,
+          "complexity": 3
+        },
+        {
+          "name": "paste_selected",
+          "lineno": 1401,
+          "complexity": 9
+        },
+        {
+          "name": "max_button_width",
+          "lineno": 187,
+          "complexity": 3
+        },
+        {
+          "name": "_set_uniform",
+          "lineno": 198,
+          "complexity": 4
+        },
+        {
+          "name": "__init__",
+          "lineno": 927,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 932,
+          "complexity": 1
+        },
+        {
+          "name": "_add",
+          "lineno": 944,
+          "complexity": 3
+        },
+        {
+          "name": "apply",
+          "lineno": 950,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "gui/windows/splash_screen.py",
+      "loc": 370,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 8,
+          "complexity": 3
+        },
+        {
+          "name": "close",
+          "lineno": 96,
+          "complexity": 2
+        },
+        {
+          "name": "_fade_in",
+          "lineno": 103,
+          "complexity": 7
+        },
+        {
+          "name": "_fade_out",
+          "lineno": 121,
+          "complexity": 5
+        },
+        {
+          "name": "_center",
+          "lineno": 137,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_gradient",
+          "lineno": 148,
+          "complexity": 4
+        },
+        {
+          "name": "_draw_cloud",
+          "lineno": 173,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_title",
+          "lineno": 196,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_floor",
+          "lineno": 230,
+          "complexity": 2
+        },
+        {
+          "name": "_project",
+          "lineno": 257,
+          "complexity": 1
+        },
+        {
+          "name": "_shade_color",
+          "lineno": 265,
+          "complexity": 1
+        },
+        {
+          "name": "_face_data",
+          "lineno": 273,
+          "complexity": 5
+        },
+        {
+          "name": "_draw_cube",
+          "lineno": 303,
+          "complexity": 6
+        },
+        {
+          "name": "_draw_gear",
+          "lineno": 376,
+          "complexity": 4
+        },
+        {
+          "name": "_animate",
+          "lineno": 399,
+          "complexity": 1
+        },
+        {
+          "name": "_close",
+          "lineno": 405,
+          "complexity": 3
+        }
+      ]
+    },
+    {
+      "file": "gui/windows/fault_prioritization.py",
+      "loc": 421,
+      "functions": [
+        {
+          "name": "requirement_ids",
+          "lineno": 94,
+          "complexity": 2
+        },
+        {
+          "name": "compute_metrics",
+          "lineno": 98,
+          "complexity": 11
+        },
+        {
+          "name": "default_rows",
+          "lineno": 144,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 22,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 27,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 34,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 214,
+          "complexity": 8
+        },
+        {
+          "name": "next_fault_id",
+          "lineno": 317,
+          "complexity": 3
+        },
+        {
+          "name": "refresh_tree",
+          "lineno": 324,
+          "complexity": 3
+        },
+        {
+          "name": "recompute_all",
+          "lineno": 331,
+          "complexity": 2
+        },
+        {
+          "name": "on_cell_edit",
+          "lineno": 344,
+          "complexity": 13
+        },
+        {
+          "name": "add_row",
+          "lineno": 379,
+          "complexity": 2
+        },
+        {
+          "name": "add_existing_fault",
+          "lineno": 396,
+          "complexity": 6
+        },
+        {
+          "name": "remove_fault",
+          "lineno": 421,
+          "complexity": 9
+        },
+        {
+          "name": "delete_selected",
+          "lineno": 439,
+          "complexity": 9
+        },
+        {
+          "name": "export_csv",
+          "lineno": 458,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "gui/windows/stpa_window.py",
+      "loc": 512,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 37,
+          "complexity": 6
+        },
+        {
+          "name": "refresh_docs",
+          "lineno": 101,
+          "complexity": 8
+        },
+        {
+          "name": "select_doc",
+          "lineno": 132,
+          "complexity": 4
+        },
+        {
+          "name": "new_doc",
+          "lineno": 236,
+          "complexity": 3
+        },
+        {
+          "name": "rename_doc",
+          "lineno": 254,
+          "complexity": 4
+        },
+        {
+          "name": "edit_doc",
+          "lineno": 269,
+          "complexity": 3
+        },
+        {
+          "name": "delete_doc",
+          "lineno": 284,
+          "complexity": 6
+        },
+        {
+          "name": "refresh",
+          "lineno": 309,
+          "complexity": 4
+        },
+        {
+          "name": "_get_control_actions",
+          "lineno": 327,
+          "complexity": 24
+        },
+        {
+          "name": "add_row",
+          "lineno": 541,
+          "complexity": 3
+        },
+        {
+          "name": "edit_row",
+          "lineno": 550,
+          "complexity": 2
+        },
+        {
+          "name": "del_row",
+          "lineno": 558,
+          "complexity": 3
+        },
+        {
+          "name": "_on_double_click",
+          "lineno": 566,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 148,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 152,
+          "complexity": 7
+        },
+        {
+          "name": "apply",
+          "lineno": 187,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 192,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 196,
+          "complexity": 10
+        },
+        {
+          "name": "apply",
+          "lineno": 233,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 390,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 396,
+          "complexity": 4
+        },
+        {
+          "name": "add_sc_new",
+          "lineno": 473,
+          "complexity": 2
+        },
+        {
+          "name": "add_sc_existing",
+          "lineno": 491,
+          "complexity": 4
+        },
+        {
+          "name": "edit_sc",
+          "lineno": 498,
+          "complexity": 3
+        },
+        {
+          "name": "del_sc",
+          "lineno": 527,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 531,
+          "complexity": 2
+        },
+        {
+          "name": "_update_tooltip",
+          "lineno": 415,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/windows/threat_window.py",
+      "loc": 362,
+      "functions": [
+        {
+          "name": "_join_damage_scenarios",
+          "lineno": 16,
+          "complexity": 3
+        },
+        {
+          "name": "_join_damage_types",
+          "lineno": 23,
+          "complexity": 3
+        },
+        {
+          "name": "_join_threats",
+          "lineno": 30,
+          "complexity": 4
+        },
+        {
+          "name": "_join_attack_paths",
+          "lineno": 40,
+          "complexity": 5
+        },
+        {
+          "name": "__init__",
+          "lineno": 54,
+          "complexity": 5
+        },
+        {
+          "name": "refresh_docs",
+          "lineno": 121,
+          "complexity": 6
+        },
+        {
+          "name": "select_doc",
+          "lineno": 146,
+          "complexity": 4
+        },
+        {
+          "name": "new_doc",
+          "lineno": 283,
+          "complexity": 3
+        },
+        {
+          "name": "rename_doc",
+          "lineno": 301,
+          "complexity": 4
+        },
+        {
+          "name": "edit_doc",
+          "lineno": 318,
+          "complexity": 3
+        },
+        {
+          "name": "delete_doc",
+          "lineno": 333,
+          "complexity": 5
+        },
+        {
+          "name": "refresh",
+          "lineno": 357,
+          "complexity": 3
+        },
+        {
+          "name": "on_double_click",
+          "lineno": 381,
+          "complexity": 1
+        },
+        {
+          "name": "add_row",
+          "lineno": 384,
+          "complexity": 2
+        },
+        {
+          "name": "edit_row",
+          "lineno": 390,
+          "complexity": 3
+        },
+        {
+          "name": "del_row",
+          "lineno": 401,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 162,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 166,
+          "complexity": 7
+        },
+        {
+          "name": "apply",
+          "lineno": 201,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 207,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 211,
+          "complexity": 10
+        },
+        {
+          "name": "buttonbox",
+          "lineno": 249,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 280,
+          "complexity": 1
+        }
+      ]
+    },
+    {
+      "file": "gui/windows/architecture.py",
+      "loc": 12723,
+      "functions": [
+        {
+          "name": "_labelframe",
+          "lineno": 47,
+          "complexity": 2
+        },
+        {
+          "name": "_load_requirement_relations",
+          "lineno": 75,
+          "complexity": 3
+        },
+        {
+          "name": "_normalize_plan_types",
+          "lineno": 122,
+          "complexity": 4
+        },
+        {
+          "name": "_work_products_for_area",
+          "lineno": 178,
+          "complexity": 2
+        },
+        {
+          "name": "_repo_phase",
+          "lineno": 182,
+          "complexity": 1
+        },
+        {
+          "name": "_make_gov_element_classes",
+          "lineno": 194,
+          "complexity": 13
+        },
+        {
+          "name": "_connection_rule_allows",
+          "lineno": 293,
+          "complexity": 5
+        },
+        {
+          "name": "_relations_for",
+          "lineno": 309,
+          "complexity": 9
+        },
+        {
+          "name": "_external_relations_for",
+          "lineno": 338,
+          "complexity": 20
+        },
+        {
+          "name": "_dedup_category",
+          "lineno": 384,
+          "complexity": 9
+        },
+        {
+          "name": "_toolbox_defs",
+          "lineno": 410,
+          "complexity": 5
+        },
+        {
+          "name": "_gov_connection_text",
+          "lineno": 442,
+          "complexity": 14
+        },
+        {
+          "name": "_all_connection_tools",
+          "lineno": 701,
+          "complexity": 3
+        },
+        {
+          "name": "_arrow_forward_types",
+          "lineno": 710,
+          "complexity": 1
+        },
+        {
+          "name": "_enforce_connection_rules",
+          "lineno": 715,
+          "complexity": 24
+        },
+        {
+          "name": "reload_config",
+          "lineno": 760,
+          "complexity": 14
+        },
+        {
+          "name": "_work_product_name",
+          "lineno": 819,
+          "complexity": 2
+        },
+        {
+          "name": "_diag_matches_wp",
+          "lineno": 824,
+          "complexity": 2
+        },
+        {
+          "name": "stpa_tool_enabled",
+          "lineno": 831,
+          "complexity": 3
+        },
+        {
+          "name": "_get_next_id",
+          "lineno": 857,
+          "complexity": 1
+        },
+        {
+          "name": "_format_label",
+          "lineno": 864,
+          "complexity": 11
+        },
+        {
+          "name": "_parse_float",
+          "lineno": 894,
+          "complexity": 2
+        },
+        {
+          "name": "_part_prop_key",
+          "lineno": 902,
+          "complexity": 2
+        },
+        {
+          "name": "_part_elem_keys",
+          "lineno": 911,
+          "complexity": 9
+        },
+        {
+          "name": "_part_elem_key",
+          "lineno": 928,
+          "complexity": 1
+        },
+        {
+          "name": "parse_part_property",
+          "lineno": 934,
+          "complexity": 3
+        },
+        {
+          "name": "_find_parent_blocks",
+          "lineno": 946,
+          "complexity": 17
+        },
+        {
+          "name": "_collect_parent_parts",
+          "lineno": 981,
+          "complexity": 8
+        },
+        {
+          "name": "extend_block_parts_with_parents",
+          "lineno": 1007,
+          "complexity": 8
+        },
+        {
+          "name": "_find_blocks_with_part",
+          "lineno": 1030,
+          "complexity": 6
+        },
+        {
+          "name": "_find_blocks_with_aggregation",
+          "lineno": 1046,
+          "complexity": 4
+        },
+        {
+          "name": "_aggregation_exists",
+          "lineno": 1058,
+          "complexity": 12
+        },
+        {
+          "name": "_reverse_aggregation_exists",
+          "lineno": 1091,
+          "complexity": 5
+        },
+        {
+          "name": "_parse_multiplicity_range",
+          "lineno": 1107,
+          "complexity": 8
+        },
+        {
+          "name": "_is_default_part_name",
+          "lineno": 1127,
+          "complexity": 3
+        },
+        {
+          "name": "_multiplicity_limit_exceeded",
+          "lineno": 1137,
+          "complexity": 27
+        },
+        {
+          "name": "_part_name_exists",
+          "lineno": 1212,
+          "complexity": 15
+        },
+        {
+          "name": "_find_generalization_children",
+          "lineno": 1250,
+          "complexity": 4
+        },
+        {
+          "name": "_collect_generalization_parents",
+          "lineno": 1259,
+          "complexity": 6
+        },
+        {
+          "name": "_shared_generalization_parent",
+          "lineno": 1278,
+          "complexity": 6
+        },
+        {
+          "name": "rename_block",
+          "lineno": 1298,
+          "complexity": 37
+        },
+        {
+          "name": "add_aggregation_part",
+          "lineno": 1376,
+          "complexity": 28
+        },
+        {
+          "name": "add_composite_aggregation_part",
+          "lineno": 1458,
+          "complexity": 25
+        },
+        {
+          "name": "add_multiplicity_parts",
+          "lineno": 1553,
+          "complexity": 37
+        },
+        {
+          "name": "_enforce_ibd_multiplicity",
+          "lineno": 1684,
+          "complexity": 5
+        },
+        {
+          "name": "_sync_ibd_composite_parts",
+          "lineno": 1706,
+          "complexity": 14
+        },
+        {
+          "name": "_sync_ibd_aggregation_parts",
+          "lineno": 1771,
+          "complexity": 14
+        },
+        {
+          "name": "_sync_ibd_partproperty_parts",
+          "lineno": 1834,
+          "complexity": 46
+        },
+        {
+          "name": "_propagate_boundary_parts",
+          "lineno": 1987,
+          "complexity": 12
+        },
+        {
+          "name": "_sync_block_parts_from_ibd",
+          "lineno": 2030,
+          "complexity": 20
+        },
+        {
+          "name": "_ensure_ibd_boundary",
+          "lineno": 2069,
+          "complexity": 16
+        },
+        {
+          "name": "_remove_ibd_boundary",
+          "lineno": 2138,
+          "complexity": 5
+        },
+        {
+          "name": "set_ibd_father",
+          "lineno": 2150,
+          "complexity": 7
+        },
+        {
+          "name": "link_block_to_ibd",
+          "lineno": 2175,
+          "complexity": 4
+        },
+        {
+          "name": "update_block_parts_from_ibd",
+          "lineno": 2188,
+          "complexity": 33
+        },
+        {
+          "name": "remove_aggregation_part",
+          "lineno": 2245,
+          "complexity": 38
+        },
+        {
+          "name": "_propagate_part_removal",
+          "lineno": 2343,
+          "complexity": 1
+        },
+        {
+          "name": "_remove_parts_from_ibd",
+          "lineno": 2367,
+          "complexity": 11
+        },
+        {
+          "name": "_propagate_ibd_part_removal",
+          "lineno": 2401,
+          "complexity": 2
+        },
+        {
+          "name": "remove_partproperty_entry",
+          "lineno": 2411,
+          "complexity": 12
+        },
+        {
+          "name": "inherit_block_properties",
+          "lineno": 2458,
+          "complexity": 18
+        },
+        {
+          "name": "remove_inherited_block_properties",
+          "lineno": 2497,
+          "complexity": 26
+        },
+        {
+          "name": "inherit_father_parts",
+          "lineno": 2574,
+          "complexity": 29
+        },
+        {
+          "name": "calculate_allocated_asil",
+          "lineno": 2720,
+          "complexity": 4
+        },
+        {
+          "name": "link_requirement_to_object",
+          "lineno": 2730,
+          "complexity": 21
+        },
+        {
+          "name": "unlink_requirement_from_object",
+          "lineno": 2775,
+          "complexity": 21
+        },
+        {
+          "name": "link_trace_between_objects",
+          "lineno": 2816,
+          "complexity": 11
+        },
+        {
+          "name": "link_requirements",
+          "lineno": 2856,
+          "complexity": 10
+        },
+        {
+          "name": "unlink_requirements",
+          "lineno": 2885,
+          "complexity": 10
+        },
+        {
+          "name": "remove_orphan_ports",
+          "lineno": 2904,
+          "complexity": 6
+        },
+        {
+          "name": "rename_port",
+          "lineno": 2917,
+          "complexity": 15
+        },
+        {
+          "name": "remove_port",
+          "lineno": 2951,
+          "complexity": 10
+        },
+        {
+          "name": "snap_port_to_parent_obj",
+          "lineno": 2974,
+          "complexity": 4
+        },
+        {
+          "name": "update_ports_for_part",
+          "lineno": 3005,
+          "complexity": 4
+        },
+        {
+          "name": "update_ports_for_boundary",
+          "lineno": 3012,
+          "complexity": 4
+        },
+        {
+          "name": "_boundary_min_size",
+          "lineno": 3019,
+          "complexity": 8
+        },
+        {
+          "name": "ensure_boundary_contains_parts",
+          "lineno": 3034,
+          "complexity": 10
+        },
+        {
+          "name": "_add_ports_for_part",
+          "lineno": 3054,
+          "complexity": 11
+        },
+        {
+          "name": "_add_ports_for_boundary",
+          "lineno": 3122,
+          "complexity": 8
+        },
+        {
+          "name": "_sync_ports_for_part",
+          "lineno": 3176,
+          "complexity": 13
+        },
+        {
+          "name": "_sync_ports_for_boundary",
+          "lineno": 3237,
+          "complexity": 10
+        },
+        {
+          "name": "propagate_block_port_changes",
+          "lineno": 3286,
+          "complexity": 19
+        },
+        {
+          "name": "propagate_block_part_changes",
+          "lineno": 3325,
+          "complexity": 8
+        },
+        {
+          "name": "_propagate_block_requirement_changes",
+          "lineno": 3344,
+          "complexity": 6
+        },
+        {
+          "name": "_collect_block_requirements",
+          "lineno": 3360,
+          "complexity": 7
+        },
+        {
+          "name": "_propagate_requirements",
+          "lineno": 3379,
+          "complexity": 9
+        },
+        {
+          "name": "propagate_block_changes",
+          "lineno": 3399,
+          "complexity": 4
+        },
+        {
+          "name": "parse_operations",
+          "lineno": 3416,
+          "complexity": 7
+        },
+        {
+          "name": "format_operation",
+          "lineno": 3431,
+          "complexity": 4
+        },
+        {
+          "name": "operations_to_json",
+          "lineno": 3438,
+          "complexity": 2
+        },
+        {
+          "name": "parse_behaviors",
+          "lineno": 3450,
+          "complexity": 4
+        },
+        {
+          "name": "behaviors_to_json",
+          "lineno": 3461,
+          "complexity": 2
+        },
+        {
+          "name": "get_block_behavior_elements",
+          "lineno": 3465,
+          "complexity": 17
+        },
+        {
+          "name": "format_control_flow_label",
+          "lineno": 3531,
+          "complexity": 21
+        },
+        {
+          "name": "diagram_type_abbreviation",
+          "lineno": 3569,
+          "complexity": 3
+        },
+        {
+          "name": "format_diagram_name",
+          "lineno": 3581,
+          "complexity": 5
+        },
+        {
+          "name": "add",
+          "lineno": 349,
+          "complexity": 1
+        },
+        {
+          "name": "_parent_parts",
+          "lineno": 1014,
+          "complexity": 1
+        },
+        {
+          "name": "display_name",
+          "lineno": 2696,
+          "complexity": 3
+        },
+        {
+          "name": "__post_init__",
+          "lineno": 3520,
+          "complexity": 5
+        },
+        {
+          "name": "__init__",
+          "lineno": 3601,
+          "complexity": 28
+        },
+        {
+          "name": "_on_focus_in",
+          "lineno": 3858,
+          "complexity": 2
+        },
+        {
+          "name": "_on_focus_out",
+          "lineno": 3864,
+          "complexity": 1
+        },
+        {
+          "name": "_fit_toolbox",
+          "lineno": 3867,
+          "complexity": 6
+        },
+        {
+          "name": "_fit_governance_toolbox",
+          "lineno": 3910,
+          "complexity": 3
+        },
+        {
+          "name": "_resize_prop_columns",
+          "lineno": 3932,
+          "complexity": 3
+        },
+        {
+          "name": "update_property_view",
+          "lineno": 3953,
+          "complexity": 10
+        },
+        {
+          "name": "select_tool",
+          "lineno": 3980,
+          "complexity": 5
+        },
+        {
+          "name": "_icon_for",
+          "lineno": 3998,
+          "complexity": 9
+        },
+        {
+          "name": "_shape_for_tool",
+          "lineno": 4024,
+          "complexity": 8
+        },
+        {
+          "name": "validate_connection",
+          "lineno": 4140,
+          "complexity": 74
+        },
+        {
+          "name": "_constrain_horizontal_movement",
+          "lineno": 4319,
+          "complexity": 12
+        },
+        {
+          "name": "_constrain_control_flow_x",
+          "lineno": 4342,
+          "complexity": 9
+        },
+        {
+          "name": "on_left_press",
+          "lineno": 4361,
+          "complexity": 138
+        },
+        {
+          "name": "on_left_drag",
+          "lineno": 4881,
+          "complexity": 93
+        },
+        {
+          "name": "_connection_targets",
+          "lineno": 5155,
+          "complexity": 5
+        },
+        {
+          "name": "_create_element_at",
+          "lineno": 5166,
+          "complexity": 7
+        },
+        {
+          "name": "_connect_objects",
+          "lineno": 5200,
+          "complexity": 29
+        },
+        {
+          "name": "_create_obj_and_conn",
+          "lineno": 5281,
+          "complexity": 10
+        },
+        {
+          "name": "on_left_release",
+          "lineno": 5313,
+          "complexity": 59
+        },
+        {
+          "name": "on_mouse_move",
+          "lineno": 5543,
+          "complexity": 3
+        },
+        {
+          "name": "on_mouse_move",
+          "lineno": 5571,
+          "complexity": 11
+        },
+        {
+          "name": "on_double_click",
+          "lineno": 5622,
+          "complexity": 6
+        },
+        {
+          "name": "on_rc_press",
+          "lineno": 5646,
+          "complexity": 1
+        },
+        {
+          "name": "on_rc_drag",
+          "lineno": 5650,
+          "complexity": 1
+        },
+        {
+          "name": "on_rc_release",
+          "lineno": 5654,
+          "complexity": 4
+        },
+        {
+          "name": "show_context_menu",
+          "lineno": 5667,
+          "complexity": 15
+        },
+        {
+          "name": "bring_to_front",
+          "lineno": 5727,
+          "complexity": 2
+        },
+        {
+          "name": "send_to_back",
+          "lineno": 5734,
+          "complexity": 2
+        },
+        {
+          "name": "move_forward",
+          "lineno": 5741,
+          "complexity": 3
+        },
+        {
+          "name": "move_backward",
+          "lineno": 5749,
+          "complexity": 3
+        },
+        {
+          "name": "_edit_object",
+          "lineno": 5757,
+          "complexity": 3
+        },
+        {
+          "name": "_open_linked_diagram",
+          "lineno": 5768,
+          "complexity": 19
+        },
+        {
+          "name": "_set_diagram_father",
+          "lineno": 5811,
+          "complexity": 5
+        },
+        {
+          "name": "go_back",
+          "lineno": 5823,
+          "complexity": 8
+        },
+        {
+          "name": "on_ctrl_mousewheel",
+          "lineno": 5853,
+          "complexity": 2
+        },
+        {
+          "name": "_find_object_strategy1",
+          "lineno": 5862,
+          "complexity": 11
+        },
+        {
+          "name": "_find_object_strategy2",
+          "lineno": 5889,
+          "complexity": 9
+        },
+        {
+          "name": "_find_object_strategy3",
+          "lineno": 5912,
+          "complexity": 5
+        },
+        {
+          "name": "_find_object_strategy4",
+          "lineno": 5929,
+          "complexity": 4
+        },
+        {
+          "name": "find_object",
+          "lineno": 5942,
+          "complexity": 3
+        },
+        {
+          "name": "hit_resize_handle",
+          "lineno": 5954,
+          "complexity": 14
+        },
+        {
+          "name": "hit_compartment_toggle",
+          "lineno": 5988,
+          "complexity": 5
+        },
+        {
+          "name": "_dist_to_segment",
+          "lineno": 5995,
+          "complexity": 3
+        },
+        {
+          "name": "_segment_intersection",
+          "lineno": 6007,
+          "complexity": 4
+        },
+        {
+          "name": "_nearest_diamond_corner",
+          "lineno": 6024,
+          "complexity": 1
+        },
+        {
+          "name": "_corner_index",
+          "lineno": 6038,
+          "complexity": 4
+        },
+        {
+          "name": "_decision_used_corners",
+          "lineno": 6045,
+          "complexity": 7
+        },
+        {
+          "name": "_choose_decision_corner",
+          "lineno": 6058,
+          "complexity": 3
+        },
+        {
+          "name": "_assign_decision_corner",
+          "lineno": 6078,
+          "complexity": 21
+        },
+        {
+          "name": "_assign_decision_corners",
+          "lineno": 6148,
+          "complexity": 25
+        },
+        {
+          "name": "find_connection",
+          "lineno": 6191,
+          "complexity": 17
+        },
+        {
+          "name": "snap_port_to_parent",
+          "lineno": 6275,
+          "complexity": 1
+        },
+        {
+          "name": "edge_point",
+          "lineno": 6278,
+          "complexity": 38
+        },
+        {
+          "name": "_line_rect_intersection",
+          "lineno": 6402,
+          "complexity": 12
+        },
+        {
+          "name": "sync_ports",
+          "lineno": 6444,
+          "complexity": 13
+        },
+        {
+          "name": "sync_boundary_ports",
+          "lineno": 6489,
+          "complexity": 12
+        },
+        {
+          "name": "zoom_in",
+          "lineno": 6533,
+          "complexity": 1
+        },
+        {
+          "name": "zoom_out",
+          "lineno": 6538,
+          "complexity": 1
+        },
+        {
+          "name": "_block_compartments",
+          "lineno": 6543,
+          "complexity": 6
+        },
+        {
+          "name": "_min_block_size",
+          "lineno": 6575,
+          "complexity": 5
+        },
+        {
+          "name": "_resize_block_to_content",
+          "lineno": 6605,
+          "complexity": 2
+        },
+        {
+          "name": "_min_action_size",
+          "lineno": 6612,
+          "complexity": 3
+        },
+        {
+          "name": "_min_data_acquisition_size",
+          "lineno": 6623,
+          "complexity": 6
+        },
+        {
+          "name": "_wrap_text_to_width",
+          "lineno": 6637,
+          "complexity": 16
+        },
+        {
+          "name": "_object_label_lines",
+          "lineno": 6685,
+          "complexity": 67
+        },
+        {
+          "name": "ensure_text_fits",
+          "lineno": 6829,
+          "complexity": 13
+        },
+        {
+          "name": "sort_objects",
+          "lineno": 6882,
+          "complexity": 9
+        },
+        {
+          "name": "redraw",
+          "lineno": 6903,
+          "complexity": 32
+        },
+        {
+          "name": "_animate_temp_connection",
+          "lineno": 7013,
+          "complexity": 5
+        },
+        {
+          "name": "_create_round_rect",
+          "lineno": 7031,
+          "complexity": 1
+        },
+        {
+          "name": "_create_gradient_image",
+          "lineno": 7062,
+          "complexity": 4
+        },
+        {
+          "name": "_draw_gradient_rect",
+          "lineno": 7081,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_cylinder",
+          "lineno": 7089,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_open_arrow",
+          "lineno": 7122,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_line_arrow",
+          "lineno": 7165,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_line_arrow",
+          "lineno": 7216,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_filled_arrow",
+          "lineno": 7266,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_open_diamond",
+          "lineno": 7301,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_filled_diamond",
+          "lineno": 7344,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_center_triangle",
+          "lineno": 7387,
+          "complexity": 2
+        },
+        {
+          "name": "_draw_subdiagram_marker",
+          "lineno": 7430,
+          "complexity": 1
+        },
+        {
+          "name": "_draw_car",
+          "lineno": 7457,
+          "complexity": 3
+        },
+        {
+          "name": "_draw_icon_shape",
+          "lineno": 7507,
+          "complexity": 3
+        },
+        {
+          "name": "_draw_gear",
+          "lineno": 7527,
+          "complexity": 5
+        },
+        {
+          "name": "_draw_wrench",
+          "lineno": 7553,
+          "complexity": 11
+        },
+        {
+          "name": "draw_object",
+          "lineno": 7639,
+          "complexity": 147
+        },
+        {
+          "name": "_label_offset",
+          "lineno": 8975,
+          "complexity": 6
+        },
+        {
+          "name": "draw_connection",
+          "lineno": 8995,
+          "complexity": 84
+        },
+        {
+          "name": "get_object",
+          "lineno": 9343,
+          "complexity": 3
+        },
+        {
+          "name": "get_ibd_boundary",
+          "lineno": 9349,
+          "complexity": 3
+        },
+        {
+          "name": "_object_within",
+          "lineno": 9356,
+          "complexity": 2
+        },
+        {
+          "name": "find_boundary_for_obj",
+          "lineno": 9365,
+          "complexity": 4
+        },
+        {
+          "name": "find_boundary_at",
+          "lineno": 9371,
+          "complexity": 5
+        },
+        {
+          "name": "_update_drag_selection",
+          "lineno": 9387,
+          "complexity": 8
+        },
+        {
+          "name": "_clone_object_strategy1",
+          "lineno": 9409,
+          "complexity": 1
+        },
+        {
+          "name": "_clone_object_strategy2",
+          "lineno": 9412,
+          "complexity": 2
+        },
+        {
+          "name": "_clone_object_strategy3",
+          "lineno": 9418,
+          "complexity": 2
+        },
+        {
+          "name": "_clone_object_strategy4",
+          "lineno": 9424,
+          "complexity": 1
+        },
+        {
+          "name": "_clone_object",
+          "lineno": 9441,
+          "complexity": 3
+        },
+        {
+          "name": "_reconstruct_object_strategy1",
+          "lineno": 9453,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_object_strategy2",
+          "lineno": 9461,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_object_strategy3",
+          "lineno": 9469,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_object_strategy4",
+          "lineno": 9486,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_object",
+          "lineno": 9499,
+          "complexity": 3
+        },
+        {
+          "name": "_task_parent_name_strategy1",
+          "lineno": 9513,
+          "complexity": 4
+        },
+        {
+          "name": "_task_parent_name_strategy2",
+          "lineno": 9521,
+          "complexity": 1
+        },
+        {
+          "name": "_task_parent_name_strategy3",
+          "lineno": 9524,
+          "complexity": 1
+        },
+        {
+          "name": "_task_parent_name_strategy4",
+          "lineno": 9527,
+          "complexity": 1
+        },
+        {
+          "name": "_task_parent_name",
+          "lineno": 9530,
+          "complexity": 3
+        },
+        {
+          "name": "_find_or_place_boundary_strategy1",
+          "lineno": 9542,
+          "complexity": 4
+        },
+        {
+          "name": "_find_or_place_boundary_strategy2",
+          "lineno": 9551,
+          "complexity": 4
+        },
+        {
+          "name": "_find_or_place_boundary_strategy3",
+          "lineno": 9557,
+          "complexity": 4
+        },
+        {
+          "name": "_find_or_place_boundary_strategy4",
+          "lineno": 9566,
+          "complexity": 1
+        },
+        {
+          "name": "_find_or_place_boundary",
+          "lineno": 9569,
+          "complexity": 3
+        },
+        {
+          "name": "copy_selected",
+          "lineno": 9580,
+          "complexity": 9
+        },
+        {
+          "name": "cut_selected",
+          "lineno": 9608,
+          "complexity": 11
+        },
+        {
+          "name": "paste_selected",
+          "lineno": 9646,
+          "complexity": 26
+        },
+        {
+          "name": "_remove_wp_and_disable",
+          "lineno": 9720,
+          "complexity": 11
+        },
+        {
+          "name": "delete_selected",
+          "lineno": 9739,
+          "complexity": 46
+        },
+        {
+          "name": "remove_object",
+          "lineno": 9871,
+          "complexity": 26
+        },
+        {
+          "name": "remove_part_diagram",
+          "lineno": 9920,
+          "complexity": 2
+        },
+        {
+          "name": "remove_part_model",
+          "lineno": 9930,
+          "complexity": 26
+        },
+        {
+          "name": "remove_element_model",
+          "lineno": 9981,
+          "complexity": 21
+        },
+        {
+          "name": "_sync_to_repository",
+          "lineno": 10030,
+          "complexity": 16
+        },
+        {
+          "name": "refresh_from_repository",
+          "lineno": 10076,
+          "complexity": 15
+        },
+        {
+          "name": "on_close",
+          "lineno": 10116,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 10124,
+          "complexity": 2
+        },
+        {
+          "name": "body",
+          "lineno": 10323,
+          "complexity": 130
+        },
+        {
+          "name": "add_port",
+          "lineno": 10817,
+          "complexity": 2
+        },
+        {
+          "name": "remove_port",
+          "lineno": 10822,
+          "complexity": 2
+        },
+        {
+          "name": "edit_port",
+          "lineno": 10827,
+          "complexity": 3
+        },
+        {
+          "name": "add_list_item",
+          "lineno": 10839,
+          "complexity": 2
+        },
+        {
+          "name": "remove_list_item",
+          "lineno": 10844,
+          "complexity": 2
+        },
+        {
+          "name": "edit_list_item",
+          "lineno": 10850,
+          "complexity": 3
+        },
+        {
+          "name": "add_trace",
+          "lineno": 10862,
+          "complexity": 3
+        },
+        {
+          "name": "remove_trace",
+          "lineno": 10876,
+          "complexity": 2
+        },
+        {
+          "name": "_format_trace_label",
+          "lineno": 10882,
+          "complexity": 7
+        },
+        {
+          "name": "add_operation",
+          "lineno": 10967,
+          "complexity": 2
+        },
+        {
+          "name": "edit_operation",
+          "lineno": 10973,
+          "complexity": 3
+        },
+        {
+          "name": "remove_operation",
+          "lineno": 10986,
+          "complexity": 2
+        },
+        {
+          "name": "add_behavior",
+          "lineno": 10993,
+          "complexity": 7
+        },
+        {
+          "name": "edit_behavior",
+          "lineno": 11009,
+          "complexity": 8
+        },
+        {
+          "name": "remove_behavior",
+          "lineno": 11031,
+          "complexity": 2
+        },
+        {
+          "name": "add_requirement",
+          "lineno": 11038,
+          "complexity": 18
+        },
+        {
+          "name": "remove_requirement",
+          "lineno": 11075,
+          "complexity": 3
+        },
+        {
+          "name": "_update_asil",
+          "lineno": 11088,
+          "complexity": 5
+        },
+        {
+          "name": "_get_failure_modes",
+          "lineno": 11100,
+          "complexity": 10
+        },
+        {
+          "name": "_on_def_selected",
+          "lineno": 11116,
+          "complexity": 10
+        },
+        {
+          "name": "apply",
+          "lineno": 11154,
+          "complexity": 166
+        },
+        {
+          "name": "__init__",
+          "lineno": 11568,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 11572,
+          "complexity": 15
+        },
+        {
+          "name": "add_point",
+          "lineno": 11709,
+          "complexity": 3
+        },
+        {
+          "name": "remove_point",
+          "lineno": 11715,
+          "complexity": 2
+        },
+        {
+          "name": "add_guard",
+          "lineno": 11720,
+          "complexity": 2
+        },
+        {
+          "name": "remove_guard",
+          "lineno": 11725,
+          "complexity": 2
+        },
+        {
+          "name": "add_guard_op",
+          "lineno": 11730,
+          "complexity": 1
+        },
+        {
+          "name": "remove_guard_op",
+          "lineno": 11734,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 11739,
+          "complexity": 18
+        },
+        {
+          "name": "__init__",
+          "lineno": 11800,
+          "complexity": 5
+        },
+        {
+          "name": "__init__",
+          "lineno": 11838,
+          "complexity": 5
+        },
+        {
+          "name": "add_block_operations",
+          "lineno": 11908,
+          "complexity": 13
+        },
+        {
+          "name": "__init__",
+          "lineno": 11958,
+          "complexity": 15
+        },
+        {
+          "name": "_activate_parent_phase",
+          "lineno": 12057,
+          "complexity": 6
+        },
+        {
+          "name": "_rebuild_toolboxes",
+          "lineno": 12082,
+          "complexity": 40
+        },
+        {
+          "name": "_switch_toolbox",
+          "lineno": 12253,
+          "complexity": 9
+        },
+        {
+          "name": "add_work_product",
+          "lineno": 12293,
+          "complexity": 11
+        },
+        {
+          "name": "_select_process_area",
+          "lineno": 12327,
+          "complexity": 1
+        },
+        {
+          "name": "_select_work_product_for_area",
+          "lineno": 12331,
+          "complexity": 1
+        },
+        {
+          "name": "add_generic_work_product",
+          "lineno": 12336,
+          "complexity": 7
+        },
+        {
+          "name": "_place_work_product",
+          "lineno": 12360,
+          "complexity": 10
+        },
+        {
+          "name": "_place_process_area",
+          "lineno": 12405,
+          "complexity": 2
+        },
+        {
+          "name": "_constrain_to_parent",
+          "lineno": 12424,
+          "complexity": 6
+        },
+        {
+          "name": "on_left_press",
+          "lineno": 12446,
+          "complexity": 17
+        },
+        {
+          "name": "add_lifecycle_phase",
+          "lineno": 12568,
+          "complexity": 7
+        },
+        {
+          "name": "__init__",
+          "lineno": 12606,
+          "complexity": 5
+        },
+        {
+          "name": "_add_block_relationships",
+          "lineno": 12643,
+          "complexity": 14
+        },
+        {
+          "name": "add_blocks",
+          "lineno": 12687,
+          "complexity": 22
+        },
+        {
+          "name": "__init__",
+          "lineno": 12750,
+          "complexity": 5
+        },
+        {
+          "name": "_get_failure_modes",
+          "lineno": 12782,
+          "complexity": 10
+        },
+        {
+          "name": "_get_part_name",
+          "lineno": 12799,
+          "complexity": 39
+        },
+        {
+          "name": "_get_part_key",
+          "lineno": 12876,
+          "complexity": 7
+        },
+        {
+          "name": "add_contained_parts",
+          "lineno": 12889,
+          "complexity": 83
+        },
+        {
+          "name": "__init__",
+          "lineno": 13091,
+          "complexity": 6
+        },
+        {
+          "name": "select_tool",
+          "lineno": 13120,
+          "complexity": 7
+        },
+        {
+          "name": "__init__",
+          "lineno": 13144,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 13149,
+          "complexity": 1
+        },
+        {
+          "name": "apply",
+          "lineno": 13167,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13175,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 13180,
+          "complexity": 8
+        },
+        {
+          "name": "apply",
+          "lineno": 13216,
+          "complexity": 5
+        },
+        {
+          "name": "__init__",
+          "lineno": 13237,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 13241,
+          "complexity": 1
+        },
+        {
+          "name": "apply",
+          "lineno": 13247,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 13254,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 13258,
+          "complexity": 3
+        },
+        {
+          "name": "apply",
+          "lineno": 13277,
+          "complexity": 3
+        },
+        {
+          "name": "__init__",
+          "lineno": 13291,
+          "complexity": 4
+        },
+        {
+          "name": "populate",
+          "lineno": 13391,
+          "complexity": 35
+        },
+        {
+          "name": "on_tree_select",
+          "lineno": 13530,
+          "complexity": 7
+        },
+        {
+          "name": "selected",
+          "lineno": 13565,
+          "complexity": 3
+        },
+        {
+          "name": "open",
+          "lineno": 13572,
+          "complexity": 7
+        },
+        {
+          "name": "on_double",
+          "lineno": 13588,
+          "complexity": 4
+        },
+        {
+          "name": "open_diagram",
+          "lineno": 13597,
+          "complexity": 15
+        },
+        {
+          "name": "new_package",
+          "lineno": 13629,
+          "complexity": 4
+        },
+        {
+          "name": "new_diagram",
+          "lineno": 13638,
+          "complexity": 4
+        },
+        {
+          "name": "delete",
+          "lineno": 13647,
+          "complexity": 7
+        },
+        {
+          "name": "properties",
+          "lineno": 13665,
+          "complexity": 12
+        },
+        {
+          "name": "on_right_click",
+          "lineno": 13698,
+          "complexity": 2
+        },
+        {
+          "name": "rename_item",
+          "lineno": 13707,
+          "complexity": 12
+        },
+        {
+          "name": "cut",
+          "lineno": 13737,
+          "complexity": 2
+        },
+        {
+          "name": "paste",
+          "lineno": 13742,
+          "complexity": 4
+        },
+        {
+          "name": "on_drag_start",
+          "lineno": 13752,
+          "complexity": 2
+        },
+        {
+          "name": "on_drag_motion",
+          "lineno": 13757,
+          "complexity": 1
+        },
+        {
+          "name": "on_drag_release",
+          "lineno": 13760,
+          "complexity": 8
+        },
+        {
+          "name": "_move_item",
+          "lineno": 13794,
+          "complexity": 6
+        },
+        {
+          "name": "_drop_on_diagram",
+          "lineno": 13807,
+          "complexity": 19
+        },
+        {
+          "name": "_create_icon",
+          "lineno": 13887,
+          "complexity": 1
+        },
+        {
+          "name": "max_button_width",
+          "lineno": 3871,
+          "complexity": 3
+        },
+        {
+          "name": "_set_uniform_width",
+          "lineno": 3889,
+          "complexity": 4
+        },
+        {
+          "name": "_intersect",
+          "lineno": 6289,
+          "complexity": 18
+        },
+        {
+          "name": "key",
+          "lineno": 6885,
+          "complexity": 9
+        },
+        {
+          "name": "_pt",
+          "lineno": 7597,
+          "complexity": 1
+        },
+        {
+          "name": "_rot",
+          "lineno": 7623,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 10131,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 10135,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 10158,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 10164,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 10169,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 10191,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 10197,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 10212,
+          "complexity": 9
+        },
+        {
+          "name": "apply",
+          "lineno": 10230,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 10237,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 10242,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 10264,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 10270,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 10275,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 10283,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 10291,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 10298,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 10320,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 10904,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 10908,
+          "complexity": 3
+        },
+        {
+          "name": "apply",
+          "lineno": 10924,
+          "complexity": 5
+        },
+        {
+          "name": "__init__",
+          "lineno": 10943,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 10949,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 10962,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 11882,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 11887,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 11905,
+          "complexity": 2
+        },
+        {
+          "name": "build_frame",
+          "lineno": 12148,
+          "complexity": 12
+        },
+        {
+          "name": "__init__",
+          "lineno": 12273,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 12278,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 12290,
+          "complexity": 1
+        },
+        {
+          "name": "_collect",
+          "lineno": 12573,
+          "complexity": 3
+        },
+        {
+          "name": "_color",
+          "lineno": 13319,
+          "complexity": 2
+        },
+        {
+          "name": "add_elem",
+          "lineno": 13417,
+          "complexity": 7
+        },
+        {
+          "name": "add_pkg",
+          "lineno": 13452,
+          "complexity": 22
+        },
+        {
+          "name": "__init__",
+          "lineno": 12021,
+          "complexity": 1
+        },
+        {
+          "name": "get",
+          "lineno": 12024,
+          "complexity": 1
+        },
+        {
+          "name": "set",
+          "lineno": 12027,
+          "complexity": 1
+        },
+        {
+          "name": "flow_dir",
+          "lineno": 4185,
+          "complexity": 8
+        },
+        {
+          "name": "sync_analysis",
+          "lineno": 10522,
+          "complexity": 6
+        },
+        {
+          "name": "sync_component",
+          "lineno": 10562,
+          "complexity": 5
+        }
+      ]
+    },
+    {
+      "file": "gui/windows/gsn_config_window.py",
+      "loc": 254,
+      "functions": [
+        {
+          "name": "_collect_work_products",
+          "lineno": 10,
+          "complexity": 24
+        },
+        {
+          "name": "_collect_spi_targets",
+          "lineno": 74,
+          "complexity": 9
+        },
+        {
+          "name": "__init__",
+          "lineno": 110,
+          "complexity": 6
+        },
+        {
+          "name": "_sync_clones_strategy1",
+          "lineno": 191,
+          "complexity": 6
+        },
+        {
+          "name": "_sync_clones_strategy2",
+          "lineno": 203,
+          "complexity": 7
+        },
+        {
+          "name": "_sync_clones_strategy3",
+          "lineno": 216,
+          "complexity": 6
+        },
+        {
+          "name": "_sync_clones_strategy4",
+          "lineno": 231,
+          "complexity": 7
+        },
+        {
+          "name": "_sync_clones",
+          "lineno": 246,
+          "complexity": 3
+        },
+        {
+          "name": "_on_ok",
+          "lineno": 259,
+          "complexity": 15
+        }
+      ]
+    },
+    {
+      "file": "gui/windows/gsn_diagram_window.py",
+      "loc": 932,
+      "functions": [
+        {
+          "name": "__init__",
+          "lineno": 32,
+          "complexity": 1
+        },
+        {
+          "name": "body",
+          "lineno": 37,
+          "complexity": 2
+        },
+        {
+          "name": "apply",
+          "lineno": 49,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 71,
+          "complexity": 7
+        },
+        {
+          "name": "_on_focus_in",
+          "lineno": 248,
+          "complexity": 2
+        },
+        {
+          "name": "_fit_toolbox",
+          "lineno": 252,
+          "complexity": 6
+        },
+        {
+          "name": "_sync_from_originals",
+          "lineno": 284,
+          "complexity": 4
+        },
+        {
+          "name": "refresh_from_repository",
+          "lineno": 294,
+          "complexity": 1
+        },
+        {
+          "name": "refresh",
+          "lineno": 300,
+          "complexity": 10
+        },
+        {
+          "name": "redraw",
+          "lineno": 329,
+          "complexity": 1
+        },
+        {
+          "name": "_bind_shortcuts",
+          "lineno": 334,
+          "complexity": 2
+        },
+        {
+          "name": "_add_node",
+          "lineno": 342,
+          "complexity": 2
+        },
+        {
+          "name": "add_goal",
+          "lineno": 349,
+          "complexity": 1
+        },
+        {
+          "name": "add_strategy",
+          "lineno": 352,
+          "complexity": 1
+        },
+        {
+          "name": "add_solution",
+          "lineno": 355,
+          "complexity": 1
+        },
+        {
+          "name": "add_assumption",
+          "lineno": 358,
+          "complexity": 1
+        },
+        {
+          "name": "add_justification",
+          "lineno": 361,
+          "complexity": 1
+        },
+        {
+          "name": "add_context",
+          "lineno": 364,
+          "complexity": 1
+        },
+        {
+          "name": "add_module",
+          "lineno": 367,
+          "complexity": 6
+        },
+        {
+          "name": "connect_solved_by",
+          "lineno": 387,
+          "complexity": 2
+        },
+        {
+          "name": "connect_in_context",
+          "lineno": 395,
+          "complexity": 2
+        },
+        {
+          "name": "_on_click",
+          "lineno": 402,
+          "complexity": 17
+        },
+        {
+          "name": "_move_subtree",
+          "lineno": 472,
+          "complexity": 4
+        },
+        {
+          "name": "_on_drag",
+          "lineno": 489,
+          "complexity": 5
+        },
+        {
+          "name": "_on_release_strategy1",
+          "lineno": 528,
+          "complexity": 1
+        },
+        {
+          "name": "_on_release_strategy2",
+          "lineno": 531,
+          "complexity": 1
+        },
+        {
+          "name": "_on_release_strategy3",
+          "lineno": 536,
+          "complexity": 2
+        },
+        {
+          "name": "_on_release_strategy4",
+          "lineno": 542,
+          "complexity": 1
+        },
+        {
+          "name": "_on_release",
+          "lineno": 549,
+          "complexity": 12
+        },
+        {
+          "name": "_animate_temp_connection",
+          "lineno": 587,
+          "complexity": 4
+        },
+        {
+          "name": "_open_work_product",
+          "lineno": 603,
+          "complexity": 9
+        },
+        {
+          "name": "_on_double_click",
+          "lineno": 644,
+          "complexity": 13
+        },
+        {
+          "name": "_on_right_click",
+          "lineno": 697,
+          "complexity": 7
+        },
+        {
+          "name": "_edit_node",
+          "lineno": 732,
+          "complexity": 2
+        },
+        {
+          "name": "_delete_node",
+          "lineno": 740,
+          "complexity": 9
+        },
+        {
+          "name": "_edit_connection",
+          "lineno": 759,
+          "complexity": 2
+        },
+        {
+          "name": "_delete_connection",
+          "lineno": 767,
+          "complexity": 5
+        },
+        {
+          "name": "_node_at_strategy1",
+          "lineno": 780,
+          "complexity": 4
+        },
+        {
+          "name": "_node_at_strategy2",
+          "lineno": 792,
+          "complexity": 6
+        },
+        {
+          "name": "_node_from_canvas_item",
+          "lineno": 816,
+          "complexity": 3
+        },
+        {
+          "name": "_node_at_strategy3",
+          "lineno": 824,
+          "complexity": 5
+        },
+        {
+          "name": "_node_at_strategy4",
+          "lineno": 837,
+          "complexity": 4
+        },
+        {
+          "name": "_node_at",
+          "lineno": 849,
+          "complexity": 3
+        },
+        {
+          "name": "_rel_id",
+          "lineno": 861,
+          "complexity": 1
+        },
+        {
+          "name": "_connection_at",
+          "lineno": 865,
+          "complexity": 4
+        },
+        {
+          "name": "_move_connection",
+          "lineno": 875,
+          "complexity": 7
+        },
+        {
+          "name": "_on_delete",
+          "lineno": 902,
+          "complexity": 6
+        },
+        {
+          "name": "_clone_node_strategy1",
+          "lineno": 918,
+          "complexity": 1
+        },
+        {
+          "name": "_clone_node_strategy2",
+          "lineno": 921,
+          "complexity": 2
+        },
+        {
+          "name": "_clone_node_strategy3",
+          "lineno": 924,
+          "complexity": 2
+        },
+        {
+          "name": "_clone_node_strategy4",
+          "lineno": 927,
+          "complexity": 1
+        },
+        {
+          "name": "_clone_node",
+          "lineno": 930,
+          "complexity": 3
+        },
+        {
+          "name": "_reconstruct_node_strategy1",
+          "lineno": 942,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_node_strategy2",
+          "lineno": 948,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_node_strategy3",
+          "lineno": 951,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_node_strategy4",
+          "lineno": 954,
+          "complexity": 1
+        },
+        {
+          "name": "_reconstruct_node",
+          "lineno": 957,
+          "complexity": 3
+        },
+        {
+          "name": "copy_selected",
+          "lineno": 970,
+          "complexity": 6
+        },
+        {
+          "name": "cut_selected",
+          "lineno": 988,
+          "complexity": 6
+        },
+        {
+          "name": "paste_selected",
+          "lineno": 1000,
+          "complexity": 7
+        },
+        {
+          "name": "_on_mousewheel",
+          "lineno": 1018,
+          "complexity": 3
+        },
+        {
+          "name": "zoom_in",
+          "lineno": 1026,
+          "complexity": 1
+        },
+        {
+          "name": "zoom_out",
+          "lineno": 1030,
+          "complexity": 1
+        },
+        {
+          "name": "export_csv",
+          "lineno": 1034,
+          "complexity": 6
+        },
+        {
+          "name": "_color",
+          "lineno": 100,
+          "complexity": 2
+        },
+        {
+          "name": "max_button_width",
+          "lineno": 256,
+          "complexity": 3
+        },
+        {
+          "name": "_set_uniform_width",
+          "lineno": 271,
+          "complexity": 4
+        }
+      ]
+    },
+    {
+      "file": "gui/windows/faults_gui.py",
+      "loc": 949,
+      "functions": [
+        {
+          "name": "requirement_ids",
+          "lineno": 148,
+          "complexity": 2
+        },
+        {
+          "name": "compute_metrics",
+          "lineno": 178,
+          "complexity": 11
+        },
+        {
+          "name": "apply_fusion_palette",
+          "lineno": 1116,
+          "complexity": 2
+        },
+        {
+          "name": "main",
+          "lineno": 1147,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 157,
+          "complexity": 4
+        },
+        {
+          "name": "selected_items",
+          "lineno": 174,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 252,
+          "complexity": 1
+        },
+        {
+          "name": "createEditor",
+          "lineno": 256,
+          "complexity": 1
+        },
+        {
+          "name": "setEditorData",
+          "lineno": 262,
+          "complexity": 4
+        },
+        {
+          "name": "setModelData",
+          "lineno": 271,
+          "complexity": 1
+        },
+        {
+          "name": "__init__",
+          "lineno": 277,
+          "complexity": 1
+        },
+        {
+          "name": "rowCount",
+          "lineno": 290,
+          "complexity": 1
+        },
+        {
+          "name": "columnCount",
+          "lineno": 293,
+          "complexity": 1
+        },
+        {
+          "name": "data",
+          "lineno": 296,
+          "complexity": 34
+        },
+        {
+          "name": "setData",
+          "lineno": 387,
+          "complexity": 9
+        },
+        {
+          "name": "flags",
+          "lineno": 428,
+          "complexity": 4
+        },
+        {
+          "name": "headerData",
+          "lineno": 439,
+          "complexity": 5
+        },
+        {
+          "name": "set_dataframe",
+          "lineno": 453,
+          "complexity": 1
+        },
+        {
+          "name": "column_index",
+          "lineno": 458,
+          "complexity": 1
+        },
+        {
+          "name": "sort",
+          "lineno": 461,
+          "complexity": 2
+        },
+        {
+          "name": "__init__",
+          "lineno": 474,
+          "complexity": 1
+        },
+        {
+          "name": "build_menu_toolbar",
+          "lineno": 553,
+          "complexity": 1
+        },
+        {
+          "name": "build_help_menu",
+          "lineno": 661,
+          "complexity": 1
+        },
+        {
+          "name": "install_delegates",
+          "lineno": 670,
+          "complexity": 1
+        },
+        {
+          "name": "on_table_double_clicked",
+          "lineno": 679,
+          "complexity": 8
+        },
+        {
+          "name": "model_from_df",
+          "lineno": 722,
+          "complexity": 1
+        },
+        {
+          "name": "is_output_column",
+          "lineno": 734,
+          "complexity": 1
+        },
+        {
+          "name": "recompute_row",
+          "lineno": 737,
+          "complexity": 5
+        },
+        {
+          "name": "row_tooltip_text",
+          "lineno": 760,
+          "complexity": 12
+        },
+        {
+          "name": "new_table",
+          "lineno": 829,
+          "complexity": 2
+        },
+        {
+          "name": "open_csv",
+          "lineno": 836,
+          "complexity": 9
+        },
+        {
+          "name": "save_csv",
+          "lineno": 881,
+          "complexity": 3
+        },
+        {
+          "name": "save_xlsx",
+          "lineno": 891,
+          "complexity": 4
+        },
+        {
+          "name": "add_row",
+          "lineno": 905,
+          "complexity": 1
+        },
+        {
+          "name": "delete_selected",
+          "lineno": 929,
+          "complexity": 4
+        },
+        {
+          "name": "on_table_double_clicked",
+          "lineno": 939,
+          "complexity": 5
+        },
+        {
+          "name": "on_thresholds_changed",
+          "lineno": 961,
+          "complexity": 2
+        },
+        {
+          "name": "show_formulas_dialog",
+          "lineno": 969,
+          "complexity": 2
+        },
+        {
+          "name": "confirm_discard",
+          "lineno": 1018,
+          "complexity": 1
+        },
+        {
+          "name": "default_df",
+          "lineno": 1028,
+          "complexity": 5
+        },
+        {
+          "name": "col_index",
+          "lineno": 671,
           "complexity": 1
         }
       ]

--- a/tests/test_dialog_instantiation.py
+++ b/tests/test_dialog_instantiation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import types
+import tkinter.simpledialog as simpledialog
+
+from gui.dialogs.req_dialog import ReqDialog
+from gui.dialogs.fmea_row_dialog import FMEARowDialog
+from gui.dialogs.select_base_event_dialog import SelectBaseEventDialog
+
+
+def _stub_init(self, *args, **kwargs):
+    """Stubbed initializer to avoid creating real GUI windows."""
+    pass
+
+
+def test_req_dialog_instantiation(monkeypatch):
+    monkeypatch.setattr(simpledialog.Dialog, "__init__", _stub_init)
+    dlg = ReqDialog(None, "Add")
+    assert isinstance(dlg, ReqDialog)
+
+
+def test_fmea_row_dialog_instantiation(monkeypatch):
+    monkeypatch.setattr(simpledialog.Dialog, "__init__", _stub_init)
+    node = types.SimpleNamespace()
+    app = types.SimpleNamespace(selected_node=None)
+    dlg = FMEARowDialog(None, node, app, [])
+    assert isinstance(dlg, FMEARowDialog)
+
+
+def test_select_base_event_dialog_instantiation(monkeypatch):
+    monkeypatch.setattr(simpledialog.Dialog, "__init__", _stub_init)
+    events = [types.SimpleNamespace(description="A"), types.SimpleNamespace(description="B")]
+    dlg = SelectBaseEventDialog(None, events)
+    assert isinstance(dlg, SelectBaseEventDialog)


### PR DESCRIPTION
## Summary
- extract SelectBaseEventDialog into gui/dialogs module
- load ReqDialog and SelectBaseEventDialog from their own modules
- test dialog instantiation without launching GUI

## Testing
- `python tools/metrics_generator.py`
- `pytest -q` *(fails: FileNotFoundError and missing PyQt6 libraries)*

------
https://chatgpt.com/codex/tasks/task_b_68abeac2b4508327bf3409c1d101da2c