### PR TITLE
refactor: centralize diagram capture logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.33
+version: 0.2.34
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.34 - Move diagram capture helpers to dedicated manager.
 - 0.2.33 - Extract dialog classes into dedicated modules and update mixins.
 - 0.2.32 - Refactor core initialization into mixins for style, services, and icons.
 - 0.2.31 - Provide requirements editor export placeholder to prevent export error.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -301,6 +301,7 @@ from mainappsrc.core.window_controllers import WindowControllers
 from mainappsrc.core.navigation_selection_input import Navigation_Selection_Input
 from mainappsrc.core.top_event_workflows import Top_Event_Workflows
 from mainappsrc.managers.review_manager import ReviewManager
+from mainappsrc.managers.capture_manager import CaptureManager
 from .versioning_review import Versioning_Review
 from mainappsrc.core.diagram_renderer import DiagramRenderer
 from .validation_consistency import Validation_Consistency
@@ -827,6 +828,7 @@ class AutoMLApp(SafetyUIMixin, UISetupMixin, EventHandlersMixin, PersistenceWrap
         self.cta_manager = ControlTreeManager(self)
         self.requirements_manager = RequirementsManagerSubApp(self)
         self.review_manager = ReviewManager(self)
+        self.capture_manager = CaptureManager(self)
         self.versioning_review = Versioning_Review(self)
 
         # Centralise data lookups in a dedicated helper
@@ -2126,120 +2128,16 @@ class AutoMLApp(SafetyUIMixin, UISetupMixin, EventHandlersMixin, PersistenceWrap
         return self.data_access_queries.get_page_nodes(node)
 
     def capture_page_diagram(self, page_node):
-        return self.pages_and_paa.capture_page_diagram(page_node)
+        return self.capture_manager.capture_page_diagram(page_node)
 
     def capture_gsn_diagram(self, diagram):
-        """Return a PIL Image of the given GSN diagram."""
-        from io import BytesIO
-        from PIL import Image
-        from gui.causal_bayesian_network_window import (
-            CausalBayesianNetworkWindow,
-        )
-
-        temp = tk.Toplevel(self.root)
-        temp.withdraw()
-        canvas = tk.Canvas(temp, bg=StyleManager.get_instance().canvas_bg, width=2000, height=2000)
-        canvas.pack()
-
-        try:
-            diagram.draw(canvas)
-        except Exception:
-            temp.destroy()
-            return None
-
-        canvas.update()
-        bbox = canvas.bbox("all")
-        if not bbox:
-            temp.destroy()
-            return None
-        x, y, x2, y2 = bbox
-        width, height = x2 - x, y2 - y
-        ps = canvas.postscript(colormode="color", x=x, y=y, width=width, height=height)
-        ps_bytes = BytesIO(ps.encode("utf-8"))
-        try:
-            img = Image.open(ps_bytes)
-            img.load(scale=3)
-        except Exception:
-            img = None
-        temp.destroy()
-        return img.convert("RGB") if img else None
+        return self.capture_manager.capture_gsn_diagram(diagram)
 
     def capture_sysml_diagram(self, diagram):
-        """Return a PIL Image of the given SysML diagram."""
-        from io import BytesIO
-        from PIL import Image
-        from gui.causal_bayesian_network_window import (
-            CausalBayesianNetworkWindow,
-        )
-
-        temp = tk.Toplevel(self.root)
-        temp.withdraw()
-        if diagram.diag_type == "Use Case Diagram":
-            win = UseCaseDiagramWindow(temp, self, diagram_id=diagram.diag_id)
-        elif diagram.diag_type == "Activity Diagram":
-            win = ActivityDiagramWindow(temp, self, diagram_id=diagram.diag_id)
-        elif diagram.diag_type == "Block Diagram":
-            win = BlockDiagramWindow(temp, self, diagram_id=diagram.diag_id)
-        elif diagram.diag_type == "Internal Block Diagram":
-            win = InternalBlockDiagramWindow(temp, self, diagram_id=diagram.diag_id)
-        elif diagram.diag_type == "Control Flow Diagram":
-            win = ControlFlowDiagramWindow(temp, self, diagram_id=diagram.diag_id)
-        elif diagram.diag_type == "Governance Diagram":
-            win = GovernanceDiagramWindow(temp, self, diagram_id=diagram.diag_id)
-        else:
-            temp.destroy()
-            return None
-
-        win.redraw()
-        win.canvas.update()
-        bbox = win.canvas.bbox("all")
-        if not bbox:
-            temp.destroy()
-            return None
-
-        x, y, x2, y2 = bbox
-        width, height = x2 - x, y2 - y
-        ps = win.canvas.postscript(colormode="color", x=x, y=y, width=width, height=height)
-        ps_bytes = BytesIO(ps.encode("utf-8"))
-        try:
-            img = Image.open(ps_bytes)
-            img.load(scale=3)
-        except Exception:
-            img = None
-        temp.destroy()
-        return img.convert("RGB") if img else None
+        return self.capture_manager.capture_sysml_diagram(diagram)
 
     def capture_cbn_diagram(self, doc):
-        """Return a PIL Image of the given Causal Bayesian Network diagram."""
-        from io import BytesIO
-        from PIL import Image
-        from gui.causal_bayesian_network_window import (
-            CausalBayesianNetworkWindow,
-        )
-
-        temp = tk.Toplevel(self.root)
-        temp.withdraw()
-        try:
-            win = CausalBayesianNetworkWindow(temp, self)
-            win.doc_var.set(doc.name)
-            win.select_doc()
-            win.canvas.update()
-            bbox = win.canvas.bbox("all")
-            if not bbox:
-                temp.destroy()
-                return None
-            x, y, x2, y2 = bbox
-            width, height = x2 - x, y2 - y
-            ps = win.canvas.postscript(colormode="color", x=x, y=y, width=width, height=height)
-            ps_bytes = BytesIO(ps.encode("utf-8"))
-            try:
-                img = Image.open(ps_bytes)
-                img.load(scale=3)
-            except Exception:
-                img = None
-        finally:
-            temp.destroy()
-        return img.convert("RGB") if img else None    
+        return self.capture_manager.capture_cbn_diagram(doc)
     
     def draw_subtree_with_filter(self, canvas, root_event, visible_nodes):
         self.draw_connections_subtree(canvas, root_event, set())
@@ -9445,7 +9343,7 @@ class AutoMLApp(SafetyUIMixin, UISetupMixin, EventHandlersMixin, PersistenceWrap
         return self.versioning_review.review_is_closed_for(review)
 
     def capture_diff_diagram(self, top_event):
-        return self.review_manager.capture_diff_diagram(top_event)
+        return self.capture_manager.capture_diff_diagram(top_event)
 
     # --- End Review Toolbox Methods ---
 

--- a/mainappsrc/managers/capture_manager.py
+++ b/mainappsrc/managers/capture_manager.py
@@ -1,0 +1,148 @@
+"""Helpers for capturing various diagram types into images.
+
+This manager centralises logic that was previously scattered in
+``automl_core`` to reduce its complexity and improve modularity.
+"""
+from __future__ import annotations
+
+import tkinter as tk
+from gui.styles.style_manager import StyleManager
+
+
+class CaptureManager:
+    """Capture diagrams and return PIL images."""
+
+    def __init__(self, app):
+        self.app = app
+
+    def capture_page_diagram(self, page_node):
+        return self.app.pages_and_paa.capture_page_diagram(page_node)
+
+    def capture_gsn_diagram(self, diagram):
+        """Return a PIL Image of the given GSN diagram."""
+        from io import BytesIO
+        from PIL import Image
+
+        temp = tk.Toplevel(self.app.root)
+        temp.withdraw()
+        canvas = tk.Canvas(
+            temp,
+            bg=StyleManager.get_instance().canvas_bg,
+            width=2000,
+            height=2000,
+        )
+        canvas.pack()
+
+        try:
+            diagram.draw(canvas)
+        except Exception:
+            temp.destroy()
+            return None
+
+        canvas.update()
+        bbox = canvas.bbox("all")
+        if not bbox:
+            temp.destroy()
+            return None
+        x, y, x2, y2 = bbox
+        width, height = x2 - x, y2 - y
+        ps = canvas.postscript(
+            colormode="color", x=x, y=y, width=width, height=height
+        )
+        ps_bytes = BytesIO(ps.encode("utf-8"))
+        try:
+            img = Image.open(ps_bytes)
+            img.load(scale=3)
+        except Exception:
+            img = None
+        temp.destroy()
+        return img.convert("RGB") if img else None
+
+    def capture_sysml_diagram(self, diagram):
+        """Return a PIL Image of the given SysML diagram."""
+        from io import BytesIO
+        from PIL import Image
+        from gui.windows.architecture import (
+            UseCaseDiagramWindow,
+            ActivityDiagramWindow,
+            BlockDiagramWindow,
+            InternalBlockDiagramWindow,
+            ControlFlowDiagramWindow,
+            GovernanceDiagramWindow,
+        )
+
+        temp = tk.Toplevel(self.app.root)
+        temp.withdraw()
+        if diagram.diag_type == "Use Case Diagram":
+            win = UseCaseDiagramWindow(temp, self.app, diagram_id=diagram.diag_id)
+        elif diagram.diag_type == "Activity Diagram":
+            win = ActivityDiagramWindow(temp, self.app, diagram_id=diagram.diag_id)
+        elif diagram.diag_type == "Block Diagram":
+            win = BlockDiagramWindow(temp, self.app, diagram_id=diagram.diag_id)
+        elif diagram.diag_type == "Internal Block Diagram":
+            win = InternalBlockDiagramWindow(temp, self.app, diagram_id=diagram.diag_id)
+        elif diagram.diag_type == "Control Flow Diagram":
+            win = ControlFlowDiagramWindow(temp, self.app, diagram_id=diagram.diag_id)
+        elif diagram.diag_type == "Governance Diagram":
+            win = GovernanceDiagramWindow(temp, self.app, diagram_id=diagram.diag_id)
+        else:
+            temp.destroy()
+            return None
+
+        win.redraw()
+        win.canvas.update()
+        bbox = win.canvas.bbox("all")
+        if not bbox:
+            temp.destroy()
+            return None
+
+        x, y, x2, y2 = bbox
+        width, height = x2 - x, y2 - y
+        ps = win.canvas.postscript(
+            colormode="color", x=x, y=y, width=width, height=height
+        )
+        ps_bytes = BytesIO(ps.encode("utf-8"))
+        try:
+            img = Image.open(ps_bytes)
+            img.load(scale=3)
+        except Exception:
+            img = None
+        temp.destroy()
+        return img.convert("RGB") if img else None
+
+    def capture_cbn_diagram(self, doc):
+        """Return a PIL Image of the given Causal Bayesian Network diagram."""
+        from io import BytesIO
+        from PIL import Image
+        from gui.causal_bayesian_network_window import (
+            CausalBayesianNetworkWindow,
+        )
+
+        temp = tk.Toplevel(self.app.root)
+        temp.withdraw()
+        try:
+            win = CausalBayesianNetworkWindow(temp, self.app)
+            win.doc_var.set(doc.name)
+            win.select_doc()
+            win.canvas.update()
+            bbox = win.canvas.bbox("all")
+            if not bbox:
+                temp.destroy()
+                return None
+            x, y, x2, y2 = bbox
+            width, height = x2 - x, y2 - y
+            ps = win.canvas.postscript(
+                colormode="color", x=x, y=y, width=width, height=height
+            )
+            ps_bytes = BytesIO(ps.encode("utf-8"))
+            try:
+                img = Image.open(ps_bytes)
+                img.load(scale=3)
+            except Exception:
+                img = None
+        finally:
+            temp.destroy()
+        return img.convert("RGB") if img else None
+
+    def capture_diff_diagram(self, top_event):
+        return self.app.review_manager.capture_diff_diagram(top_event)

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.33"
+VERSION = "0.2.34"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- add `CaptureManager` to centralize diagram capture utilities
- delegate all `capture_*` calls in `AutoMLApp` to the new manager
- bump version to 0.2.34 and update documentation

## Testing
- `python tools/metrics_generator.py --path mainappsrc/managers --output /tmp/metrics_managers.json`
- `python tools/metrics_generator.py --path mainappsrc/core --output /tmp/metrics_core.json`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rules')*

------
https://chatgpt.com/codex/tasks/task_b_68abef7a0c988327b219a113e83d302d