### PR TITLE
Fix configuration resource lookup for packaged runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.33
+version: 0.2.34
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.34 - Resolve configuration package lookup to avoid ModuleNotFoundError.
 - 0.2.33 - Extract dialog classes into dedicated modules and update mixins.
 - 0.2.32 - Refactor core initialization into mixins for style, services, and icons.
 - 0.2.31 - Provide requirements editor export placeholder to prevent export error.

--- a/config/patterns/__init__.py
+++ b/config/patterns/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration pattern templates."""

--- a/config/rules/__init__.py
+++ b/config/rules/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration rules package."""

--- a/config/templates/__init__.py
+++ b/config/templates/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration templates package."""

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -287,7 +287,7 @@ from analysis.mechanisms import (
     ANNEX_D_MECHANISMS,
     PAS_8800_MECHANISMS,
 )
-from config import load_report_template
+from config import load_report_template, load_diagram_rules
 from pathlib import Path
 from collections.abc import Mapping
 import csv

--- a/mainappsrc/core/config_utils.py
+++ b/mainappsrc/core/config_utils.py
@@ -12,13 +12,26 @@ from analysis.risk_assessment import AutoMLHelper
 # ---------------------------------------------------------------------------
 # Paths and loaded configuration
 # ---------------------------------------------------------------------------
-_CONFIG_PATH = Path(__file__).resolve().parent / "config/diagram_rules.json"
+_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "config"
+    / "rules"
+    / "diagram_rules.json"
+)
 _CONFIG: dict[str, Any] = load_diagram_rules(_CONFIG_PATH)
 GATE_NODE_TYPES: set[str] = set(_CONFIG.get("gate_node_types", []))
 
-_PATTERN_PATH = Path(__file__).resolve().parent / "config/requirement_patterns.json"
+_PATTERN_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "config"
+    / "patterns"
+    / "requirement_patterns.json"
+)
 _REPORT_TEMPLATE_PATH = (
-    Path(__file__).resolve().parent / "config/product_report_template.json"
+    Path(__file__).resolve().parents[2]
+    / "config"
+    / "templates"
+    / "product_report_template.json"
 )
 
 # Generate requirement patterns on import so consumers have up-to-date data.

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.33"
+VERSION = "0.2.34"
 
 __all__ = ["VERSION"]

--- a/tests/test_config_loader_resource_fallback.py
+++ b/tests/test_config_loader_resource_fallback.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from config.config_loader import load_json_with_comments
+
+def test_resource_fallback(monkeypatch):
+    cfg_path = Path(__file__).resolve().parents[1] / "config" / "rules" / "diagram_rules.json"
+    original = Path.read_text
+    call_count = {"count": 0}
+
+    def mock_read_text(self, *args, **kwargs):
+        if self == cfg_path and call_count["count"] == 0:
+            call_count["count"] += 1
+            raise FileNotFoundError
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", mock_read_text)
+    data = load_json_with_comments(cfg_path)
+    assert "ai_nodes" in data


### PR DESCRIPTION
## Summary
- ensure JSON config loader resolves package names relative to config directory
- expose configuration JSON directories as importable packages
- adjust core helpers to use shared config paths
- bump version to 0.2.34 and add regression test for resource fallback

## Testing
- `pytest` *(fails: FileNotFoundError for missing metrics_tab.py and other resources)*
- `python tools/metrics_generator.py --path config --output metrics.json`
- `python tools/metrics_generator.py --path mainappsrc/core --output metrics_core.json`


------
https://chatgpt.com/codex/tasks/task_b_68abee8b3d488327b283da059551d005