### PR TITLE
fix drawing manager helper import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.36 - Correct AutoML_Helper import for drawing manager.
 - 0.2.35 - Wrap update routines within safety analysis facade.
 - 0.2.34 - Centralise safety analysis helpers into facade and delegate from core.
 - 0.2.33 - Extract dialog classes into dedicated modules and update mixins.

--- a/mainappsrc/managers/drawing_manager.py
+++ b/mainappsrc/managers/drawing_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Centralised drawing helpers for AutoML diagrams."""
 
 import tkinter as tk
-from analysis.risk_assessment import AutoML_Helper
+from ..core.config_utils import AutoML_Helper
 from analysis.fmeda_utils import GATE_NODE_TYPES
 from gui.utils.drawing_helper import fta_drawing_helper
 from gui.styles.style_manager import StyleManager

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.35"
+VERSION = "0.2.36"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- fix AutoML_Helper import in drawing manager to use central config utils
- bump version to 0.2.36 and document in README

## Testing
- `pytest`
- `python tools/metrics_generator.py --path mainappsrc/managers`

------
https://chatgpt.com/codex/tasks/task_b_68abf604068483278ed0aca671731424