### PR TITLE
Fix Syncing_And_IDs import NameError

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.36
+version: 0.2.40
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,10 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.40 - Import Syncing_And_IDs during core initialization to prevent startup NameError.
+- 0.2.39 - Import SafetyAnalysis_FTA_FMEA during core initialization to prevent startup NameError.
+- 0.2.38 - Import ProjectEditorSubApp, RiskAssessmentSubApp and ReliabilitySubApp to prevent startup NameError.
+- 0.2.37 - Import TreeSubApp in core to prevent startup NameError.
 - 0.2.36 - Delegate add/get/show/link/refresh/collect routines to safety analysis facade.
 - 0.2.35 - Wrap update routines within safety analysis facade.
 - 0.2.34 - Centralise safety analysis helpers into facade and delegate from core.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -248,6 +248,12 @@ from functools import partial
 # Governance helper class
 from mainappsrc.managers.governance_manager import GovernanceManager
 from mainappsrc.managers.paa_manager import PrototypeAssuranceManager
+from mainappsrc.subapps.tree_subapp import TreeSubApp
+from mainappsrc.subapps.project_editor_subapp import ProjectEditorSubApp
+from mainappsrc.subapps.risk_assessment_subapp import RiskAssessmentSubApp
+from mainappsrc.subapps.reliability_subapp import ReliabilitySubApp
+from .safety_analysis import SafetyAnalysis_FTA_FMEA
+from .syncing_and_ids import Syncing_And_IDs
 from gui.toolboxes.safety_management_toolbox import SafetyManagementToolbox
 from gui.explorers.safety_management_explorer import SafetyManagementExplorer
 from gui.explorers.safety_case_explorer import SafetyCaseExplorer

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -1,5 +1,5 @@
 """Project version information."""
 
-VERSION = "0.2.36"
+VERSION = "0.2.40"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- import Syncing_And_IDs during core initialization to construct ID synchronization helper without NameErrors
- bump project version to 0.2.40 and document in README

## Testing
- `pytest -q` *(fails: missing mainappsrc/automl_core.py, page_diagram.py, PyQt6, etc.; 7 errors during collection)*
- `pytest tests/test_version_sync.py -q`
- `radon cc -j mainappsrc/core/automl_core.py | jq '.["mainappsrc/core/automl_core.py"][] | select(.name=="apply_model_data")'`


------
https://chatgpt.com/codex/tasks/task_b_68abf963951c83279b185bbe67690ec9