### PR TITLE
refactor: centralize requirement formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.49
+version: 0.2.50
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.50 - Centralise requirement formatting logic within RequirementsManager.
 - 0.2.49 - Move ``from __future__`` annotations imports to top-level of modules.
 - 0.2.48 - Provide wrapper for 90° connections and serialize SysML diagrams for export.
 - 0.2.47 - Delegate basic event probability updates to probability service to avoid missing risk module method.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -263,23 +263,6 @@ from gui.toolboxes import (
 )
 
 
-def format_requirement(req, include_id=True):
-    """Return a formatted requirement string without empty ASIL/CAL fields."""
-    parts = []
-    if include_id and req.get("id"):
-        parts.append(f"[{req['id']}]")
-    if req.get("req_type"):
-        parts.append(f"[{req['req_type']}]")
-    asil = req.get("asil")
-    if asil:
-        parts.append(f"[{asil}]")
-    cal = req.get("cal")
-    if cal:
-        parts.append(f"[{cal}]")
-    parts.append(req.get("text", ""))
-    return " ".join(parts)
-
-
 from pathlib import Path
 from gui.dialogs.user_info_dialog import UserInfoDialog
 
@@ -1442,6 +1425,10 @@ class AutoMLApp(
 
     def get_requirement_goal_names(self, req_id):
         return self.requirements_manager.get_requirement_goal_names(req_id)
+
+    def format_requirement(self, req, include_id=True):
+        """Return a formatted requirement string without empty ASIL/CAL fields."""
+        return self.requirements_manager.format_requirement(req, include_id)
 
     def format_requirement_with_trace(self, req):
         return self.requirements_manager.format_requirement_with_trace(req)

--- a/mainappsrc/managers/requirements_manager.py
+++ b/mainappsrc/managers/requirements_manager.py
@@ -112,12 +112,28 @@ class RequirementsManagerSubApp:
         return sorted(goals)
 
     # ------------------------------------------------------------------
+    def format_requirement(self, req: Dict[str, Any], include_id: bool = True) -> str:
+        """Return a formatted requirement string without empty ASIL/CAL fields."""
+        parts: list[str] = []
+        if include_id and req.get("id"):
+            parts.append(f"[{req['id']}]")
+        if req.get("req_type"):
+            parts.append(f"[{req['req_type']}]")
+        asil = req.get("asil")
+        if asil:
+            parts.append(f"[{asil}]")
+        cal = req.get("cal")
+        if cal:
+            parts.append(f"[{cal}]")
+        parts.append(req.get("text", ""))
+        return " ".join(parts)
+
+    # ------------------------------------------------------------------
     def format_requirement_with_trace(self, req: Dict[str, Any]) -> str:
-        from .AutoML import format_requirement  # local import to avoid circular
         rid = req.get("id", "")
         alloc = ", ".join(self.get_requirement_allocation_names(rid))
         goals = ", ".join(self.get_requirement_goal_names(rid))
-        base = format_requirement(req)
+        base = self.format_requirement(req)
         return f"{base} (Alloc: {alloc}; SGs: {goals})"
 
     # ------------------------------------------------------------------

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.49"
+VERSION = "0.2.50"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- centralize requirement formatting in RequirementsManager
- expose thin wrapper in AutoMLApp
- bump version to 0.2.50 and document in README

## Testing
- `radon cc mainappsrc/managers/requirements_manager.py mainappsrc/core/automl_core.py -s -j | jq '{req_mgr: .["mainappsrc/managers/requirements_manager.py"] | map(select(.name=="format_requirement")), automl_core: .["mainappsrc/core/automl_core.py"] | map(select(.name=="format_requirement"))}'`
- `pytest -q` *(fails: FileNotFoundError: mainappsrc/automl_core.py, ModuleNotFoundError: automl, ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_b_68ac8e545d8083279c52d1c65da1152c