### PR TITLE
Centralize configuration reload logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.49
+version: 0.2.50
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.50 - Consolidate configuration reload logic in config_utils and drop local helper.
 - 0.2.49 - Move ``from __future__`` annotations imports to top-level of modules.
 - 0.2.48 - Provide wrapper for 90° connections and serialize SysML diagrams for export.
 - 0.2.47 - Delegate basic event probability updates to probability service to avoid missing risk module method.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -79,7 +79,6 @@ from analysis.mechanisms import (
     ANNEX_D_MECHANISMS,
     PAS_8800_MECHANISMS,
 )
-from config import load_report_template, load_diagram_rules
 from pathlib import Path
 from collections.abc import Mapping
 import csv
@@ -283,45 +282,14 @@ def format_requirement(req, include_id=True):
 from pathlib import Path
 from gui.dialogs.user_info_dialog import UserInfoDialog
 
-# Node types treated as gates when rendering and editing
-_CONFIG_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "config"
-    / "rules"
-    / "diagram_rules.json"
-)
-_CONFIG = load_diagram_rules(_CONFIG_PATH)
-GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
-_PATTERN_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "config"
-    / "patterns"
-    / "requirement_patterns.json"
-)
-_REPORT_TEMPLATE_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "config"
-    / "templates"
-    / "product_report_template.json"
-)
-
-
-def _reload_local_config() -> None:
-    """Reload gate node types from the external configuration file."""
-    global _CONFIG, GATE_NODE_TYPES
-    _CONFIG = load_diagram_rules(_CONFIG_PATH)
-    GATE_NODE_TYPES = set(_CONFIG.get("gate_node_types", []))
-    # Regenerate requirement patterns whenever diagram rules change
-    regenerate_requirement_patterns()
-
 from . import config_utils
+from .config_utils import _reload_local_config
 
 # Expose configuration helpers and global state
 _CONFIG_PATH = config_utils._CONFIG_PATH
 GATE_NODE_TYPES = config_utils.GATE_NODE_TYPES
 _PATTERN_PATH = config_utils._PATTERN_PATH
 _REPORT_TEMPLATE_PATH = config_utils._REPORT_TEMPLATE_PATH
-_reload_local_config = config_utils._reload_local_config
 unique_node_id_counter = config_utils.unique_node_id_counter
 AutoML_Helper = config_utils.AutoML_Helper
 import uuid

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.49"
+VERSION = "0.2.50"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- remove local `_reload_local_config` and rely on `config_utils`
- bump version to 0.2.50 and document in README

## Testing
- `pytest` *(fails: libGL.so.1 not found, missing Qt dependencies)*
- `radon cc -s -a -j mainappsrc/core/automl_core.py mainappsrc/core/config_utils.py`

------
https://chatgpt.com/codex/tasks/task_b_68ac8e5b3d388327bd86ecc22eefc43f