### PR TITLE
feat: centralize undo/redo management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.50
+version: 0.2.51
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.51 - Introduced UndoRedoManager to centralize undo/redo logic.
 - 0.2.50 - Extract shared product goal updates into ProductGoalManager.
 - 0.2.49 - Move ``from __future__`` annotations imports to top-level of modules.
 - 0.2.48 - Provide wrapper for 90° connections and serialize SysML diagrams for export.

--- a/mainappsrc/core/undo_manager.py
+++ b/mainappsrc/core/undo_manager.py
@@ -1,0 +1,303 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Centralised undo/redo state management."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+
+
+class UndoRedoManager:
+    """Manage undo/redo stacks for :class:`AutoMLApp`."""
+
+    def __init__(self, app: Any):
+        self.app = app
+        self._undo_stack: list[dict] = []
+        self._redo_stack: list[dict] = []
+        self._last_move_base: dict | None = None
+        self._move_run_length = 0
+
+    # ------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------
+    def _strip_object_positions(self, data: dict) -> dict:
+        """Return a copy of *data* without concrete object positions."""
+
+        cleaned = json.loads(json.dumps(data))
+
+        def scrub(obj: Any) -> None:
+            if isinstance(obj, dict):
+                for field in ("x", "y", "modified", "modified_by", "modified_by_email"):
+                    obj.pop(field, None)
+                for value in obj.values():
+                    scrub(value)
+            elif isinstance(obj, list):
+                for item in obj:
+                    scrub(item)
+
+        scrub(cleaned)
+        return cleaned
+
+    # ------------------------------------------------------------
+    # State recording
+    # ------------------------------------------------------------
+    def push_undo_state(self, strategy: str = "v4", sync_repo: bool = True) -> None:
+        """Save the current model state for undo operations."""
+
+        repo = SysMLRepository.get_instance()
+        if sync_repo:
+            repo.push_undo_state(strategy=strategy, sync_app=False)
+        try:
+            state = self.app.export_model_data(include_versions=False)
+            stripped = self._strip_object_positions(state)
+        except AttributeError:
+            state = {}
+            stripped = {}
+
+        handler = getattr(self, f"_push_undo_state_{strategy}", self._push_undo_state_v1)
+        changed = handler(state, stripped)
+
+        if changed and len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        if changed:
+            self._redo_stack.clear()
+
+    def _push_undo_state_v1(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack:
+            last = self._undo_stack[-1]
+            if last == state:
+                return False
+            if self._strip_object_positions(last) == stripped:
+                if (
+                    len(self._undo_stack) >= 2
+                    and self._strip_object_positions(self._undo_stack[-2]) == stripped
+                ):
+                    self._undo_stack[-1] = state
+                    return True
+                self._undo_stack.append(state)
+                return True
+        else:
+            self._undo_stack.append(state)
+            return True
+
+        self._undo_stack.append(state)
+        return True
+
+    def _push_undo_state_v2(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        if self._undo_stack and self._strip_object_positions(self._undo_stack[-1]) == stripped:
+            if self._last_move_base == stripped:
+                self._undo_stack[-1] = state
+            else:
+                self._undo_stack.append(state)
+                self._last_move_base = stripped
+            return True
+        self._last_move_base = None
+        self._undo_stack.append(state)
+        return True
+
+    def _push_undo_state_v3(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        if self._undo_stack and self._strip_object_positions(self._undo_stack[-1]) == stripped:
+            if self._move_run_length:
+                self._undo_stack[-1] = state
+            else:
+                self._undo_stack.append(state)
+            self._move_run_length += 1
+            return True
+        self._move_run_length = 0
+        self._undo_stack.append(state)
+        return True
+
+    def _push_undo_state_v4(self, state: dict, stripped: dict) -> bool:
+        if self._undo_stack and self._undo_stack[-1] == state:
+            return False
+        self._undo_stack.append(state)
+        if len(self._undo_stack) >= 3:
+            s1 = self._strip_object_positions(self._undo_stack[-3])
+            s2 = self._strip_object_positions(self._undo_stack[-2])
+            if s1 == s2 == stripped:
+                self._undo_stack.pop(-2)
+        return True
+
+    # ------------------------------------------------------------
+    # Undo/Redo public interface
+    # ------------------------------------------------------------
+    def undo(self, strategy: str = "v4") -> None:
+        """Revert the repository and model data to the previous state."""
+
+        repo = SysMLRepository.get_instance()
+        handler = getattr(self, f"_undo_{strategy}", self._undo_v1)
+        changed = handler(repo)
+        if not changed:
+            return
+        for tab in getattr(self.app, "diagram_tabs", {}).values():
+            for child in tab.winfo_children():
+                if hasattr(child, "refresh_from_repository"):
+                    child.refresh_from_repository()
+        self.app.refresh_all()
+
+    def redo(self, strategy: str = "v4") -> None:
+        """Reapply a state previously reverted with :meth:`undo`."""
+
+        repo = SysMLRepository.get_instance()
+        handler = getattr(self, f"_redo_{strategy}", self._redo_v1)
+        changed = handler(repo)
+        if not changed:
+            return
+        for tab in getattr(self.app, "diagram_tabs", {}).values():
+            for child in tab.winfo_children():
+                if hasattr(child, "refresh_from_repository"):
+                    child.refresh_from_repository()
+        self.app.refresh_all()
+
+    def clear_history(self) -> None:
+        """Remove all undo and redo history."""
+
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+        repo = SysMLRepository.get_instance()
+        getattr(repo, "_undo_stack", []).clear()
+        getattr(repo, "_redo_stack", []).clear()
+
+    # ------------------------------------------------------------
+    # Undo variants
+    # ------------------------------------------------------------
+    def _undo_v1(self, repo: Any) -> bool:
+        if not self._undo_stack:
+            return False
+        current = self.app.export_model_data(include_versions=False)
+        repo.undo(strategy="v1")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.app.apply_model_data(state)
+        return True
+
+    def _undo_v2(self, repo: Any) -> bool:
+        if not self._undo_stack:
+            return False
+        current = self.app.export_model_data(include_versions=False)
+        repo.undo(strategy="v2")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.app.apply_model_data(state)
+        return True
+
+    def _undo_v3(self, repo: Any) -> bool:
+        if not self._undo_stack:
+            return False
+        current = self.app.export_model_data(include_versions=False)
+        repo.undo(strategy="v3")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                return False
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.app.apply_model_data(state)
+        return True
+
+    def _undo_v4(self, repo: Any) -> bool:
+        if not self._undo_stack:
+            return False
+        current = self.app.export_model_data(include_versions=False)
+        repo.undo(strategy="v4")
+        if self._undo_stack and self._undo_stack[-1] == current:
+            self._undo_stack.pop()
+            if not self._undo_stack:
+                self._redo_stack.append(current)
+                if len(self._redo_stack) > 20:
+                    self._redo_stack.pop(0)
+                return True
+        state = self._undo_stack.pop()
+        self._redo_stack.append(current)
+        if len(self._redo_stack) > 20:
+            self._redo_stack.pop(0)
+        self.app.apply_model_data(state)
+        return True
+
+    # ------------------------------------------------------------
+    # Redo variants
+    # ------------------------------------------------------------
+    def _redo_v1(self, repo: Any) -> bool:
+        if not self._redo_stack:
+            return False
+        current = self.app.export_model_data(include_versions=False)
+        repo.redo(strategy="v1")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.app.apply_model_data(state)
+        return True
+
+    def _redo_v2(self, repo: Any) -> bool:
+        if not self._redo_stack:
+            return False
+        current = self.app.export_model_data(include_versions=False)
+        repo.redo(strategy="v2")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.app.apply_model_data(state)
+        return True
+
+    def _redo_v3(self, repo: Any) -> bool:
+        if not self._redo_stack:
+            return False
+        current = self.app.export_model_data(include_versions=False)
+        repo.redo(strategy="v3")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.app.apply_model_data(state)
+        return True
+
+    def _redo_v4(self, repo: Any) -> bool:
+        if not self._redo_stack:
+            return False
+        current = self.app.export_model_data(include_versions=False)
+        repo.redo(strategy="v4")
+        state = self._redo_stack.pop()
+        self._undo_stack.append(current)
+        if len(self._undo_stack) > 20:
+            self._undo_stack.pop(0)
+        self.app.apply_model_data(state)
+        return True

--- a/mainappsrc/managers/project_manager.py
+++ b/mainappsrc/managers/project_manager.py
@@ -94,8 +94,7 @@ class ProjectManager:
             app.project_properties["severity_probabilities"],
         )
         app.apply_model_data({}, ensure_root=False)
-        app._undo_stack.clear()
-        app._redo_stack.clear()
+        app.undo_manager.clear_history()
         app.analysis_tree.delete(*app.analysis_tree.get_children())
         app.update_views()
         app.set_last_saved_state()
@@ -146,8 +145,7 @@ class ProjectManager:
         app.root_node = None
         app.selected_node = None
         app.page_history = []
-        app._undo_stack.clear()
-        app._redo_stack.clear()
+        app.undo_manager.clear_history()
         if getattr(app, "analysis_tree", None):
             app.analysis_tree.delete(*app.analysis_tree.get_children())
         app._reset_fta_state()

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.50"
+VERSION = "0.2.51"
 
 __all__ = ["VERSION"]

--- a/tests/test_app_drag_undo_redo.py
+++ b/tests/test_app_drag_undo_redo.py
@@ -19,6 +19,7 @@
 import types
 
 from AutoML import AutoMLApp
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 class DummyEvent:
@@ -43,8 +44,7 @@ def test_drag_records_only_endpoints_and_undo_redo():
     app.move_subtree = lambda n, dx, dy: None
     app.sync_nodes_by_id = lambda n: None
     app.redraw_canvas = lambda: None
-    app._undo_stack = []
-    app._redo_stack = []
+    app.undo_manager = UndoRedoManager(app)
     app.export_model_data = lambda include_versions=False: {
         "diagrams": [{"objects": [{"x": node.x, "y": node.y}]}]
     }
@@ -67,7 +67,7 @@ def test_drag_records_only_endpoints_and_undo_redo():
     app.on_canvas_release(DummyEvent(10, 10))
 
     assert node.x == 10.0 and node.y == 10.0
-    assert len(app._undo_stack) == 2
+    assert len(app.undo_manager._undo_stack) == 2
 
     app.undo()
     assert node.x == 0.0 and node.y == 0.0

--- a/tests/test_app_hotkey_task_lifecycle.py
+++ b/tests/test_app_hotkey_task_lifecycle.py
@@ -24,6 +24,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from AutoML import AutoMLApp
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 class HotkeyTaskLifecycleTests(unittest.TestCase):
@@ -32,8 +33,7 @@ class HotkeyTaskLifecycleTests(unittest.TestCase):
         repo = SysMLRepository.get_instance()
         diag = repo.create_diagram("Governance Diagram", name="Gov")
         app = AutoMLApp.__new__(AutoMLApp)
-        app._undo_stack = []
-        app._redo_stack = []
+        app.undo_manager = UndoRedoManager(app)
         app.export_model_data = lambda include_versions=False: repo.to_dict()
         app.apply_model_data = lambda data: repo.from_dict(data)
         app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)

--- a/tests/test_app_undo_move_creation.py
+++ b/tests/test_app_undo_move_creation.py
@@ -24,6 +24,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from AutoML import AutoMLApp
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 class AppUndoMoveCreationTests(unittest.TestCase):
@@ -32,8 +33,7 @@ class AppUndoMoveCreationTests(unittest.TestCase):
         repo = SysMLRepository.get_instance()
         diag = repo.create_diagram("Governance Diagram", name="Gov")
         app = AutoMLApp.__new__(AutoMLApp)
-        app._undo_stack = []
-        app._redo_stack = []
+        app.undo_manager = UndoRedoManager(app)
         app.export_model_data = lambda include_versions=False: repo.to_dict()
         app.apply_model_data = lambda data: repo.from_dict(data)
         app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)

--- a/tests/test_app_undo_overflow.py
+++ b/tests/test_app_undo_overflow.py
@@ -73,6 +73,7 @@ except ModuleNotFoundError:
     from AutoML import AutoMLApp
 
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 def test_undo_does_not_unload_project_when_stack_empty():
@@ -87,8 +88,7 @@ def test_undo_does_not_unload_project_when_stack_empty():
     app.apply_model_data = lambda data: None
     app.refresh_all = lambda: None
     app.diagram_tabs = {}
-    app._undo_stack = []
-    app._redo_stack = []
+    app.undo_manager = UndoRedoManager(app)
     app.undo = AutoMLApp.undo.__get__(app)
 
     # Undoing with an empty app stack should not remove repository elements

--- a/tests/test_app_undo_task_lifecycle.py
+++ b/tests/test_app_undo_task_lifecycle.py
@@ -25,6 +25,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from AutoML import AutoMLApp
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 class AppUndoTaskLifecycleTests(unittest.TestCase):
@@ -33,8 +34,7 @@ class AppUndoTaskLifecycleTests(unittest.TestCase):
         repo = SysMLRepository.get_instance()
         diag = repo.create_diagram("Governance Diagram", name="Gov")
         app = AutoMLApp.__new__(AutoMLApp)
-        app._undo_stack = []
-        app._redo_stack = []
+        app.undo_manager = UndoRedoManager(app)
         app.export_model_data = lambda include_versions=False: repo.to_dict()
         app.apply_model_data = lambda data: repo.from_dict(data)
         app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)

--- a/tests/test_app_undo_task_multistep.py
+++ b/tests/test_app_undo_task_multistep.py
@@ -24,6 +24,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from AutoML import AutoMLApp
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 class AppUndoTaskMultistepTests(unittest.TestCase):
@@ -32,8 +33,7 @@ class AppUndoTaskMultistepTests(unittest.TestCase):
         repo = SysMLRepository.get_instance()
         diag = repo.create_diagram("Governance Diagram", name="Gov")
         app = AutoMLApp.__new__(AutoMLApp)
-        app._undo_stack = []
-        app._redo_stack = []
+        app.undo_manager = UndoRedoManager(app)
         app.export_model_data = lambda include_versions=False: repo.to_dict()
         app.apply_model_data = lambda data: repo.from_dict(data)
         app.push_undo_state = AutoMLApp.push_undo_state.__get__(app)

--- a/tests/test_cbn_undo.py
+++ b/tests/test_cbn_undo.py
@@ -29,6 +29,7 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 from AutoML import AutoMLApp
 from analysis import CausalBayesianNetwork, CausalBayesianNetworkDoc
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 def test_cbn_diagram_undo_redo_node_add_and_move():
@@ -40,6 +41,7 @@ def test_cbn_diagram_undo_redo_node_add_and_move():
 
     # Minimal application setup
     app = AutoMLApp.__new__(AutoMLApp)
+    app.undo_manager = UndoRedoManager(app)
     doc = CausalBayesianNetworkDoc("CBN")
     doc.network.add_node("A", cpd=0.5)
     doc.positions["A"] = [(0, 0)]
@@ -48,8 +50,6 @@ def test_cbn_diagram_undo_redo_node_add_and_move():
     app.cbn_docs = [doc]
     app.active_cbn = doc
     app.update_views = lambda: None
-    app._undo_stack = []
-    app._redo_stack = []
 
     def export_model_data(include_versions=False):
         return {

--- a/tests/test_fault_undo.py
+++ b/tests/test_fault_undo.py
@@ -31,6 +31,7 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from AutoML import AutoMLApp
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 class FaultUndoRedoTests(unittest.TestCase):
     def setUp(self):
@@ -67,8 +68,7 @@ class FaultUndoRedoTests(unittest.TestCase):
         self.app.versions = {}
         self.app.update_odd_elements = lambda: None
         self.app.update_views = lambda: None
-        self.app._undo_stack = []
-        self.app._redo_stack = []
+        self.app.undo_manager = UndoRedoManager(self.app)
         SysMLRepository.reset_instance()
 
     def test_undo_redo_add_fault(self):

--- a/tests/test_fta_undo.py
+++ b/tests/test_fta_undo.py
@@ -31,6 +31,7 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from AutoML import AutoMLApp, FaultTreeNode
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 class FTAUndoRedoTests(unittest.TestCase):
     def setUp(self):
@@ -42,8 +43,7 @@ class FTAUndoRedoTests(unittest.TestCase):
         # stub analysis tree and view updates
         self.app.analysis_tree = types.SimpleNamespace(selection=lambda: ())
         self.app.update_views = lambda: None
-        self.app._undo_stack = []
-        self.app._redo_stack = []
+        self.app.undo_manager = UndoRedoManager(self.app)
         # minimal persistence of state for undo/redo
         self.app.export_model_data = lambda include_versions=False: {
             "top_events": [n.to_dict() for n in self.app.top_events],

--- a/tests/test_governance_undo.py
+++ b/tests/test_governance_undo.py
@@ -33,6 +33,7 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 from AutoML import AutoMLApp
 from gui.architecture import GovernanceDiagramWindow, SysMLObject
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 def test_governance_diagram_undo_redo_work_product():
@@ -45,8 +46,7 @@ def test_governance_diagram_undo_redo_work_product():
     app.apply_model_data = lambda data: None
     app.refresh_all = lambda: None
     app.diagram_tabs = {}
-    app._undo_stack = []
-    app._redo_stack = []
+    app.undo_manager = UndoRedoManager(app)
     app.enable_work_product = lambda *a, **k: None
     app.refresh_tool_enablement_called = 0
     def refresh_tool_enablement(*args, **kwargs):

--- a/tests/test_gsn_undo.py
+++ b/tests/test_gsn_undo.py
@@ -30,6 +30,7 @@ sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 from mainappsrc.models.gsn import GSNNode, GSNDiagram
 from gui.gsn_explorer import GSNExplorer
 from AutoML import AutoMLApp
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 def test_gsn_diagram_undo_redo_rename(monkeypatch):
@@ -40,8 +41,7 @@ def test_gsn_diagram_undo_redo_rename(monkeypatch):
     app.gsn_diagrams = [diag]
     app.gsn_modules = []
     app.update_views = lambda: None
-    app._undo_stack = []
-    app._redo_stack = []
+    app.undo_manager = UndoRedoManager(app)
 
     def export_model_data(include_versions=False):
         return {
@@ -87,8 +87,7 @@ def test_gsn_explorer_refreshes_after_undo(monkeypatch):
     app.gsn_diagrams = [diag]
     app.gsn_modules = []
     app.update_views = lambda: None
-    app._undo_stack = []
-    app._redo_stack = []
+    app.undo_manager = UndoRedoManager(app)
 
     def export_model_data(include_versions=False):
         return {

--- a/tests/test_hazard_undo.py
+++ b/tests/test_hazard_undo.py
@@ -31,6 +31,7 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from AutoML import AutoMLApp
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 class HazardSeverityUndoRedoTests(unittest.TestCase):
     def setUp(self):
@@ -41,8 +42,7 @@ class HazardSeverityUndoRedoTests(unittest.TestCase):
         self.app.fi2tc_docs = []
         self.app.tc2fi_docs = []
         self.app.update_views = lambda: None
-        self.app._undo_stack = []
-        self.app._redo_stack = []
+        self.app.undo_manager = UndoRedoManager(self.app)
         self.app.export_model_data = lambda include_versions=False: {
             "hazard_severity": self.app.hazard_severity.copy()
         }

--- a/tests/test_load_model_cleanup.py
+++ b/tests/test_load_model_cleanup.py
@@ -28,6 +28,7 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 from AutoML import AutoMLApp
 import AutoML
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 class DummyNotebook:
@@ -47,6 +48,7 @@ class DummyNotebook:
 
 def _minimal_app(monkeypatch):
     app = AutoMLApp.__new__(AutoMLApp)
+    app.undo_manager = UndoRedoManager(app)
     app.doc_nb = DummyNotebook()
     app.analysis_tree = MagicMock()
     app.analysis_tree.get_children.return_value = []
@@ -57,8 +59,6 @@ def _minimal_app(monkeypatch):
     app.activity_windows = [MagicMock()]
     app.block_windows = [MagicMock()]
     app.ibd_windows = [MagicMock()]
-    app._undo_stack = []
-    app._redo_stack = []
 
     def fake_create_tab():
         app.canvas = MagicMock()

--- a/tests/test_no_empty_fta_tab.py
+++ b/tests/test_no_empty_fta_tab.py
@@ -31,6 +31,7 @@ sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
 from AutoML import AutoMLApp
 import AutoML
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 class DummyNotebook:
     def __init__(self):
@@ -50,6 +51,7 @@ class DummyNotebook:
 
 def _base_app(monkeypatch):
     app = AutoMLApp.__new__(AutoMLApp)
+    app.undo_manager = UndoRedoManager(app)
     app.doc_nb = DummyNotebook()
     app.analysis_tree = MagicMock()
     app.analysis_tree.get_children.return_value = []
@@ -60,8 +62,6 @@ def _base_app(monkeypatch):
     app.activity_windows = [MagicMock()]
     app.block_windows = [MagicMock()]
     app.ibd_windows = [MagicMock()]
-    app._undo_stack = []
-    app._redo_stack = []
     app.diagram_font = MagicMock()
     app.hara_docs = []
     app.hazop_docs = []

--- a/tests/test_project_load_undo.py
+++ b/tests/test_project_load_undo.py
@@ -22,6 +22,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from AutoML import AutoMLApp
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 def test_undo_after_project_load_keeps_project():
@@ -38,8 +39,9 @@ def test_undo_after_project_load_keeps_project():
     app.apply_model_data = lambda d: repo.from_dict(d["sysml_repository"])
     app.refresh_all = lambda: None
     app.diagram_tabs = {}
-    app._undo_stack = [{}]
-    app._redo_stack = [{}]
+    app.undo_manager = UndoRedoManager(app)
+    app.undo_manager._undo_stack = [{}]
+    app.undo_manager._redo_stack = [{}]
     app.undo = AutoMLApp.undo.__get__(app)
     app.clear_undo_history = AutoMLApp.clear_undo_history.__get__(app)
 

--- a/tests/test_safety_case.py
+++ b/tests/test_safety_case.py
@@ -35,6 +35,7 @@ from mainappsrc.models.gsn import GSNNode, GSNDiagram
 from AutoML import AutoMLApp
 from config.automl_constants import PMHF_TARGETS
 from analysis.constants import CHECK_MARK
+from mainappsrc.core.undo_manager import UndoRedoManager
 
 
 class DummyTree:
@@ -545,8 +546,7 @@ def test_safety_case_undo_redo_toggle(monkeypatch):
     app.all_gsn_diagrams = [diag]
     app.gsn_diagrams = [diag]
     app.update_views = lambda: None
-    app._undo_stack = []
-    app._redo_stack = []
+    app.undo_manager = UndoRedoManager(app)
 
     def export_model_data(include_versions=False):
         return {

--- a/tests/test_undo_redo_manager.py
+++ b/tests/test_undo_redo_manager.py
@@ -1,0 +1,74 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Unit tests for :class:`UndoRedoManager`."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import mainappsrc.core.undo_manager as um
+from mainappsrc.core.undo_manager import UndoRedoManager
+
+
+class DummyApp:
+    """Minimal stand-in for :class:`AutoMLApp`."""
+
+    def __init__(self):
+        self.value = 0
+        self.diagram_tabs = {}
+
+    def export_model_data(self, include_versions: bool = False):  # pragma: no cover - simple
+        return {"value": self.value}
+
+    def apply_model_data(self, state):  # pragma: no cover - simple
+        self.value = state["value"]
+
+    def refresh_all(self):  # pragma: no cover - simple
+        pass
+
+
+def test_push_undo_and_redo(monkeypatch):
+    app = DummyApp()
+    manager = UndoRedoManager(app)
+
+    class DummyRepo:
+        def push_undo_state(self, *a, **k):
+            pass
+
+        def undo(self, *a, **k):
+            pass
+
+        def redo(self, *a, **k):
+            pass
+
+    repo = DummyRepo()
+    monkeypatch.setattr(um.SysMLRepository, "get_instance", lambda: repo)
+
+    app.value = 1
+    manager.push_undo_state(sync_repo=False)
+    app.value = 2
+    manager.push_undo_state(sync_repo=False)
+    assert len(manager._undo_stack) == 2
+
+    manager.undo()
+    assert app.value == 1
+    manager.redo()
+    assert app.value == 2


### PR DESCRIPTION
## Summary
- introduce `UndoRedoManager` to handle application undo/redo stacks
- delegate undo/redo operations from `AutoMLApp` to the new manager
- bump version to 0.2.51 and add regression tests for `UndoRedoManager`

## Testing
- `radon cc -s mainappsrc/core/undo_manager.py --json`
- `pytest` *(fails: FileNotFoundError: No such file or directory: '/workspace/AutoML/gui/metrics_tab.py'; FileNotFoundError: No such file or directory: '/workspace/AutoML/mainappsrc/automl_core.py'; FileNotFoundError: No such file or directory: '/workspace/AutoML/mainappsrc/page_diagram.py'; ModuleNotFoundError: No module named 'automl'; ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68ac902b32c08327b4e0479e12394acf