### PR TITLE
refactor: centralize node clone resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.51 - Extract clone-chain resolution into reusable utility.
 - 0.2.50 - Extract shared product goal updates into ProductGoalManager.
 - 0.2.49 - Move ``from __future__`` annotations imports to top-level of modules.
 - 0.2.48 - Provide wrapper for 90° connections and serialize SysML diagrams for export.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -69,6 +69,7 @@ from .service_init_mixin import ServiceInitMixin
 from .icon_setup_mixin import IconSetupMixin
 from .style_setup_mixin import StyleSetupMixin
 from .page_diagram import PageDiagram
+from .node_utils import resolve_original as resolve_node_original
 from .editors import (
     ItemDefinitionEditorMixin,
     SafetyConceptEditorMixin,
@@ -7497,11 +7498,8 @@ class AutoMLApp(
 
     def build_html_report(self):
         return self.reporting_export.build_html_report()
-    def resolve_original(self,node):
-        # Walk the clone chain until you find a primary instance.
-        while not node.is_primary_instance and node.original is not None and node.original != node:
-            node = node.original
-        return node
+    def resolve_original(self, node):
+        return resolve_node_original(node)
 
     def go_back(self):
         return self.nav_input.go_back()

--- a/mainappsrc/core/node_utils.py
+++ b/mainappsrc/core/node_utils.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Utility helpers for node operations."""
+
+from typing import Any
+
+
+def resolve_original(node: Any) -> Any:
+    """Follow a clone chain to locate the primary instance.
+
+    Parameters
+    ----------
+    node:
+        The node whose original primary instance should be returned. The
+        object is expected to provide ``is_primary_instance`` and ``original``
+        attributes.
+
+    Returns
+    -------
+    Any
+        The primary instance at the root of the clone chain. If ``node`` is
+        already a primary instance or lacks an original reference, the same
+        object is returned.
+    """
+
+    # Walk the clone chain until we find a primary instance.
+    while (
+        getattr(node, "is_primary_instance", True) is False
+        and getattr(node, "original", None) is not None
+        and node.original is not node
+    ):
+        node = node.original
+    return node

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.50"
+VERSION = "0.2.51"
 
 __all__ = ["VERSION"]

--- a/tests/test_node_utils.py
+++ b/tests/test_node_utils.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`mainappsrc.core.node_utils`."""
+
+from mainappsrc.core.node_utils import resolve_original
+
+
+class DummyNode:
+    """Simple stand-in object for testing clone resolution."""
+
+    def __init__(self, is_primary_instance=True, original=None):
+        self.is_primary_instance = is_primary_instance
+        self.original = original if original is not None else self
+
+
+def test_resolve_primary_instance_returns_same_node():
+    primary = DummyNode(is_primary_instance=True)
+    assert resolve_original(primary) is primary
+
+
+def test_resolve_original_traverses_chain():
+    primary = DummyNode(is_primary_instance=True)
+    clone1 = DummyNode(is_primary_instance=False, original=primary)
+    clone2 = DummyNode(is_primary_instance=False, original=clone1)
+    assert resolve_original(clone2) is primary


### PR DESCRIPTION
## Summary
- factor out clone-chain resolution to `node_utils.resolve_original`
- delegate `AutoMLApp.resolve_original` to new helper
- add unit tests for node utility and bump version to 0.2.51

## Testing
- `pytest` *(fails: command not found)*
- `radon cc mainappsrc/core/node_utils.py -j` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac903cda78832798f1d3043e6faad7