### PR TITLE
feat: centralize lifecycle refresh logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.50
+version: 0.2.51
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -1814,40 +1814,12 @@ class AutoMLApp(
 
     def on_lifecycle_selected(self, _event=None) -> None:
         phase = self.lifecycle_var.get()
-        if hasattr(self, "active_phase_lbl"):
-            self.active_phase_lbl.config(
-                text=f"Active phase: {phase or 'None'}"
-            )
-        if not phase:
-            self.governance_manager.set_active_module(None)
-        else:
-            self.governance_manager.set_active_module(phase)
-        self.update_views()
-        if hasattr(self, "refresh_tool_enablement"):
-            try:
-                self.refresh_tool_enablement()
-            except Exception:
-                pass
-        for name in (
-            "_hazop_window",
-            "_risk_window",
-            "_stpa_window",
-            "_threat_window",
-            "_fi2tc_window",
-            "_tc2fi_window",
-        ):
-            win = getattr(self, name, None)
-            if win and getattr(win, "refresh_docs", None) and win.winfo_exists():
-                win.refresh_docs()
-
-        def _refresh_children(widget):
-            if hasattr(widget, "refresh_from_repository"):
-                widget.refresh_from_repository()
-            for ch in getattr(widget, "winfo_children", lambda: [])():
-                _refresh_children(ch)
-
-        for tab in getattr(self, "diagram_tabs", {}).values():
-            _refresh_children(tab)
+        gm = getattr(self, "governance_manager", None)
+        if gm is None:
+            gm = GovernanceManager(self)
+            self.governance_manager = gm
+            gm.attach_toolbox(getattr(self, "safety_mgmt_toolbox", None))
+        gm.on_lifecycle_selected(phase)
 
 
     def enable_process_area(self, area: str) -> None:  # pragma: no cover - delegation

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.50"
+VERSION = "0.2.51"
 
 __all__ = ["VERSION"]

--- a/tests/test_governance_manager_lifecycle.py
+++ b/tests/test_governance_manager_lifecycle.py
@@ -1,0 +1,60 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for :class:`GovernanceManager` lifecycle propagation."""
+
+from types import SimpleNamespace
+
+from AutoML import AutoMLApp
+from mainappsrc.managers.governance_manager import GovernanceManager
+
+
+def test_app_delegates_phase_to_manager():
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.lifecycle_var = SimpleNamespace(get=lambda: "PhaseA")
+    captured = {}
+
+    def fake_on_lifecycle_selected(phase):
+        captured["phase"] = phase
+
+    app.governance_manager = SimpleNamespace(on_lifecycle_selected=fake_on_lifecycle_selected)
+    AutoMLApp.on_lifecycle_selected(app)
+    assert captured["phase"] == "PhaseA"
+
+
+def test_manager_refreshes_views_and_children():
+    calls = {"update": 0, "child": 0, "refresh": 0, "phase": None}
+
+    class DummyChild:
+        def refresh_from_repository(self):
+            calls["child"] += 1
+
+        def winfo_children(self):
+            return []
+
+    app = SimpleNamespace(
+        active_phase_lbl=SimpleNamespace(config=lambda **_: None),
+        lifecycle_var=SimpleNamespace(set=lambda val: None),
+        update_views=lambda: calls.__setitem__("update", calls["update"] + 1),
+        diagram_tabs={"tab": DummyChild()},
+    )
+    gm = GovernanceManager(app)
+    gm.refresh_tool_enablement = lambda: calls.__setitem__("refresh", calls["refresh"] + 1)
+
+    gm.on_lifecycle_selected("P1")
+    assert calls == {"update": 1, "child": 1, "refresh": 1, "phase": None}


### PR DESCRIPTION
## Summary
- delegate lifecycle phase selection to GovernanceManager for consolidated refresh logic
- allow AutoMLApp to forward lifecycle changes and lazily create the manager
- add regression tests for new lifecycle delegation
- bump documented version to 0.2.51

## Testing
- `radon cc -j mainappsrc/managers/governance_manager.py` *(excerpted in logs)*
- `radon cc -j mainappsrc/core/automl_core.py | jq '."mainappsrc/core/automl_core.py" | map(select(.name=="on_lifecycle_selected"))'`
- `pytest -q` *(fails: FileNotFoundError: '/workspace/AutoML/mainappsrc/automl_core.py', ModuleNotFoundError: No module named 'automl', FileNotFoundError: '/workspace/AutoML/gui/metrics_tab.py')*

------
https://chatgpt.com/codex/tasks/task_b_68ac908f186483278c27b0de5b6fcc49