### PR TITLE
fix: import product goal manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.51
+version: 0.2.52
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.52 - Import ProductGoalManager in core to prevent startup NameError.
 - 0.2.51 - Extract clone-chain resolution into reusable utility.
 - 0.2.50 - Extract shared product goal updates into ProductGoalManager.
 - 0.2.49 - Move ``from __future__`` annotations imports to top-level of modules.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -174,6 +174,7 @@ import tkinter.font as tkFont
 import builtins
 from mainappsrc.managers.user_manager import UserManager
 from mainappsrc.managers.project_manager import ProjectManager
+from mainappsrc.managers.product_goal_manager import ProductGoalManager
 from mainappsrc.ui.project_properties_dialog import ProjectPropertiesDialog
 from mainappsrc.managers.sotif_manager import SOTIFManager
 from mainappsrc.managers.cyber_manager import CyberSecurityManager

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.51"
+VERSION = "0.2.52"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- import ProductGoalManager in AutoML core to eliminate startup NameError
- document new version 0.2.52 in README and version module

## Testing
- `radon cc mainappsrc/core/automl_core.py -j >/tmp/radon.json && head -c 200 /tmp/radon.json`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log` *(fails: ModuleNotFoundError: No module named 'automl'; ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68ac94d9f0a08327b25f050ff7a3e227