### PR TITLE
Initialize undo manager during service setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.53
+version: 0.2.54
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.54 - Initialize undo manager during service setup to prevent project load errors.
 - 0.2.52 - Move product goal UIs into RequirementsManager and add wrapper methods.
 - 0.2.51 - Extract clone-chain resolution into reusable utility.
 - 0.2.50 - Extract shared product goal updates into ProductGoalManager.

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -31,6 +31,7 @@ from .safety_analysis import SafetyAnalysis_FTA_FMEA
 from .syncing_and_ids import Syncing_And_IDs
 from .diagram_renderer import DiagramRenderer
 from .navigation_selection_input import Navigation_Selection_Input
+from .undo_manager import UndoRedoManager
 
 from mainappsrc.managers.user_manager import UserManager
 from mainappsrc.managers.project_manager import ProjectManager
@@ -96,7 +97,7 @@ class ServiceInitMixin:
             "open_search_toolbox",
         ):
             setattr(self, _name, getattr(self.nav_input, _name))
-
+        self.undo_manager = UndoRedoManager(self)
         self.user_manager = UserManager(self)
         self.project_manager = ProjectManager(self)
         self.cyber_manager = CyberSecurityManager(self)

--- a/tests/test_undo_manager_initialised.py
+++ b/tests/test_undo_manager_initialised.py
@@ -15,9 +15,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Verify AutoMLApp initialises the undo manager."""
 
-"""Project version information."""
+import tkinter as tk
+import pytest
+from AutoML import AutoMLApp
 
-VERSION = "0.2.54"
 
-__all__ = ["VERSION"]
+def test_undo_manager_initialised():
+    try:
+        root = tk.Tk()
+        root.withdraw()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    app = AutoMLApp(root)
+    assert hasattr(app, "undo_manager")
+    root.destroy()


### PR DESCRIPTION
## Summary
- create `UndoRedoManager` during service initialization to ensure undo history is available for project load/reset operations
- bump version to 0.2.54 and document change in README
- add regression test covering `AutoMLApp` undo manager initialization

## Testing
- `pytest` *(fails: AttributeError, FileNotFoundError in multiple tests)*
- `python tools/metrics_generator.py --path mainappsrc/core --output /tmp/metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68ac9ecceb9483279862ebf7661f89cc