### PR TITLE
Initialize project properties manager and sync version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.55
+version: 0.2.56
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/automl.py
+++ b/automl.py
@@ -15,9 +15,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Lowercase alias for :mod:`AutoML`.
 
-"""Project version information."""
+Ensures the module is importable as ``automl`` on case-sensitive
+file systems for tests and scripts that expect this naming.
+"""
 
-VERSION = "0.2.56"
-
-__all__ = ["VERSION"]
+from AutoML import *  # re-export everything

--- a/mainappsrc/core/app_initializer.py
+++ b/mainappsrc/core/app_initializer.py
@@ -41,6 +41,7 @@ from mainappsrc.managers.gsn_manager import GSNManager
 from mainappsrc.core.structure_tree_operations import Structure_Tree_Operations
 from mainappsrc.core.probability_reliability import Probability_Reliability
 from gui.utils.drawing_helper import fta_drawing_helper
+from .project_properties_manager import ProjectPropertiesManager
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .automl_core import AutoMLApp
@@ -91,6 +92,7 @@ class AppInitializer:
             app.project_properties["controllability_probabilities"],
             app.project_properties["severity_probabilities"],
         )
+        app.project_properties_manager = ProjectPropertiesManager(app.project_properties)
         app.item_definition = {"description": "", "assumptions": ""}
         app.safety_concept = {
             "functional": "",


### PR DESCRIPTION
## Summary
- Instantiate `ProjectPropertiesManager` during app initialization so project property loading works.
- Provide lowercase `automl` alias module for case-sensitive imports.
- Bump version to 0.2.56 in sources and documentation.

## Testing
- `radon cc mainappsrc/core/app_initializer.py -j -s`
- `radon cc automl.py -j -s`
- `python AutoML.py --version`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68aca63629a483279b7bedd902637f72