### PR TITLE
Fix FTA node addition and expose core modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.57 - Fix fault tree node addition and expose core modules for unit tests.
 - 0.2.55 - Delegate ODD library management to dedicated manager and remove legacy scenario code.
 - 0.2.54 - Initialize undo manager during service setup to prevent project load errors.
 - 0.2.52 - Move product goal UIs into RequirementsManager and add wrapper methods.

--- a/automl.py
+++ b/automl.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Lower-case launcher wrapper for :mod:`AutoML`."""
 
-VERSION = "0.2.57"
-
-__all__ = ["VERSION"]
+from AutoML import *  # noqa: F401,F403

--- a/mainappsrc/automl_core.py
+++ b/mainappsrc/automl_core.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper exporting the core AutoML application classes."""
 
-VERSION = "0.2.57"
-
-__all__ = ["VERSION"]
+from mainappsrc.core.automl_core import *  # noqa: F401,F403

--- a/mainappsrc/page_diagram.py
+++ b/mainappsrc/page_diagram.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper for the ``PageDiagram`` utilities."""
 
-VERSION = "0.2.57"
+from mainappsrc.core.page_diagram import PageDiagram, fta_drawing_helper
 
-__all__ = ["VERSION"]
+__all__ = ["PageDiagram", "fta_drawing_helper"]

--- a/tests/test_add_fault_tree_nodes.py
+++ b/tests/test_add_fault_tree_nodes.py
@@ -1,0 +1,57 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Ensure fault-tree nodes are created when invoking add_node_of_type."""
+
+import sys
+import pathlib
+import types
+
+repo_root = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
+
+import AutoML
+
+AutoMLApp = AutoML.AutoMLApp
+FaultTreeNode = AutoML.FaultTreeNode
+
+
+def _make_app(root):
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.root_node = root
+    app.top_events = [root]
+    app.selected_node = root
+    app.analysis_tree = types.SimpleNamespace(selection=lambda: ())
+    app.update_views = lambda: None
+    app.find_node_by_id_all = lambda uid: root if uid == root.unique_id else None
+    app.push_undo_state = lambda: None
+    app.diagram_mode = "FTA"
+    return app
+
+
+def test_add_gate_and_basic_event():
+    root = FaultTreeNode("Root", "TOP EVENT")
+    app = _make_app(root)
+
+    app.add_node_of_type("Gate")
+    assert len(root.children) == 1
+    assert root.children[0].node_type.upper() == "GATE"
+
+    app.add_node_of_type("Basic Event")
+    assert len(root.children) == 2
+    assert root.children[1].node_type.upper() == "BASIC EVENT"


### PR DESCRIPTION
## Summary
- ensure adding gates and basic events creates new FaultTreeNodes
- expose core modules via compatibility wrappers and lowercase launcher
- bump project version and document changes
- add regression test for gate and basic event creation

## Testing
- `radon cc -s -j mainappsrc/models/fta/fault_tree_node.py`
- `pytest tests/test_add_fault_tree_nodes.py -q`
- `pytest tests/test_diagram_mode_enforcement.py tests/test_fta_clone_paste.py -q` *(fails: RuntimeError: Too early to use font; AttributeError: 'AutoMLApp' object has no attribute 'undo_manager'; AttributeError: property 'window_controllers' has no setter)*


------
https://chatgpt.com/codex/tasks/task_b_68aca80883f88327bcbdd3a28107eac8