### PR TITLE
Handle governance phase group activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.56
+version: 0.2.57
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/mainappsrc/core/app_lifecycle_ui.py
+++ b/mainappsrc/core/app_lifecycle_ui.py
@@ -139,6 +139,32 @@ class AppLifecycleUI:
         for n in names:
             lb.insert(tk.END, n)
 
+    def _remove_tool_category(self, cat: str) -> None:
+        """Remove toolbox category *cat* along with its tab and widgets."""
+        lb = self.tool_listboxes.pop(cat, None)
+        if lb is None:
+            return
+        tab_id = None
+        for tid, title in self._tool_tab_titles.items():
+            if title == cat:
+                tab_id = tid
+                break
+        if tab_id:
+            try:
+                self.tools_nb.forget(tab_id)
+            except tk.TclError:
+                pass
+            self._tool_tab_titles.pop(tab_id, None)
+            if tab_id in self._tool_all_tabs:
+                self._tool_all_tabs.remove(tab_id)
+            self._tool_tab_offset = max(0, len(self._tool_all_tabs) - self.MAX_VISIBLE_TABS)
+            self._update_tool_tab_visibility()
+        parent = lb.master
+        try:
+            parent.destroy()
+        except Exception:
+            pass
+
     def _on_tool_tab_motion(self, event):
         """Show tooltip for notebook tabs when hovering over them."""
         try:

--- a/mainappsrc/core/validation_consistency.py
+++ b/mainappsrc/core/validation_consistency.py
@@ -207,6 +207,12 @@ class Validation_Consistency:
                             if lb.get(i) == tool_name:
                                 lb.delete(i)
                                 break
+                        if lb.size() == 0:
+                            app.tool_listboxes.pop(area, None)
+                            app.tool_categories.pop(area, None)
+                            lifecycle = getattr(app, "lifecycle_ui", None)
+                            if lifecycle and hasattr(lifecycle, "_remove_tool_category"):
+                                lifecycle._remove_tool_category(area)
                     app.tool_actions.pop(tool_name, None)
         parent = app.WORK_PRODUCT_PARENTS.get(name)
         if parent and parent in app.enabled_work_products:

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.56"
+VERSION = "0.2.57"
 
 __all__ = ["VERSION"]

--- a/tests/test_governance_group_activation.py
+++ b/tests/test_governance_group_activation.py
@@ -20,6 +20,7 @@ import sys
 from pathlib import Path
 import tkinter as tk
 import pytest
+import types
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -82,8 +83,9 @@ def test_work_product_groups_follow_phase(work_product, parent):
 
     app = AutoMLApp.__new__(AutoMLApp)
     lb = DummyListbox()
-    app.tool_listboxes = {AutoMLApp.WORK_PRODUCT_INFO[work_product][0]: lb}
-    app.tool_categories = {AutoMLApp.WORK_PRODUCT_INFO[work_product][0]: []}
+    area = AutoMLApp.WORK_PRODUCT_INFO[work_product][0]
+    app.tool_listboxes = {area: lb}
+    app.tool_categories = {area: []}
     app.tool_actions = {}
     wp_menu = DummyMenu()
     parent_menu = wp_menu if work_product == parent else DummyMenu()
@@ -94,6 +96,7 @@ def test_work_product_groups_follow_phase(work_product, parent):
     app.enable_process_area = lambda area: None
     app.tool_to_work_product = {info[1]: name for name, info in AutoMLApp.WORK_PRODUCT_INFO.items()}
     app.update_views = lambda: None
+    app.lifecycle_ui = types.SimpleNamespace(_remove_tool_category=lambda n: None)
     app.safety_mgmt_toolbox = toolbox
     app.refresh_tool_enablement = AutoMLApp.refresh_tool_enablement.__get__(app, AutoMLApp)
     app.enable_work_product = AutoMLApp.enable_work_product.__get__(app, AutoMLApp)
@@ -107,6 +110,7 @@ def test_work_product_groups_follow_phase(work_product, parent):
     assert parent in app.enabled_work_products
     assert wp_menu.state == tk.NORMAL
     assert parent_menu.state == tk.NORMAL
+    assert area in app.tool_listboxes
 
     toolbox.set_active_module("P2")
     app.refresh_tool_enablement()
@@ -114,6 +118,7 @@ def test_work_product_groups_follow_phase(work_product, parent):
     assert parent not in app.enabled_work_products
     assert wp_menu.state == tk.DISABLED
     assert parent_menu.state == tk.DISABLED
+    assert area not in app.tool_listboxes
     # Reset global toolbox to avoid side effects on other tests
     from analysis import safety_management as _sm
     _sm.ACTIVE_TOOLBOX = None


### PR DESCRIPTION
## Summary
- remove empty process areas when governance disables work products
- adjust unit test to confirm group removal per phase
- bump project version to 0.2.57

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'automl', ImportError: libGL.so.1: cannot open shared object file)*
- `python tools/metrics_generator.py --path mainappsrc/core --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68aca8deba9c83279f867759d481bb97