### PR TITLE
Initialize diagram clipboard manager and guard clipboard actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.57
+version: 0.2.58
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.58 - Initialize diagram clipboard manager by default and guard clipboard actions.
 - 0.2.57 - Map Task toolbox selection to Action elements so governance diagrams support adding tasks.
 - 0.2.56 - Synchronize README version header with source.
 - 0.2.55 - Delegate ODD library management to dedicated manager and remove legacy scenario code.

--- a/mainappsrc/core/app_initializer.py
+++ b/mainappsrc/core/app_initializer.py
@@ -42,6 +42,7 @@ from mainappsrc.core.structure_tree_operations import Structure_Tree_Operations
 from mainappsrc.core.probability_reliability import Probability_Reliability
 from gui.utils.drawing_helper import fta_drawing_helper
 from .project_properties_manager import ProjectPropertiesManager
+from .diagram_clipboard_manager import DiagramClipboardManager
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from .automl_core import AutoMLApp
@@ -75,8 +76,7 @@ class AppInitializer:
         app._loaded_model_paths = []
 
         app.clipboard_node = None
-        app.diagram_clipboard = None
-        app.diagram_clipboard_type = None
+        app.diagram_clipboard = DiagramClipboardManager(app)
         app.active_arch_window = None
         app.cut_mode = False
         app.page_history = []

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -2487,10 +2487,12 @@ class AutoMLApp(
         return False
 
     def copy_node(self):
-        self.diagram_clipboard.copy_node()
+        if self.diagram_clipboard:
+            self.diagram_clipboard.copy_node()
 
     def cut_node(self):
-        self.diagram_clipboard.cut_node()
+        if self.diagram_clipboard:
+            self.diagram_clipboard.cut_node()
 
     # ------------------------------------------------------------------
     def _reset_gsn_clone(self, node):
@@ -2580,7 +2582,8 @@ class AutoMLApp(
         return self.clipboard_node
 
     def paste_node(self):
-        self.diagram_clipboard.paste_node()
+        if self.diagram_clipboard:
+            self.diagram_clipboard.paste_node()
 
     def _get_diag_type(self, win):
         repo = getattr(win, "repo", None)

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.57"
+VERSION = "0.2.58"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- Instantiate `DiagramClipboardManager` during app initialization
- Guard copy/cut/paste operations when clipboard manager is absent
- Bump version to 0.2.58 and document in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'automl'; ImportError: libEGL.so.1: cannot open shared object file)*
- `python tools/metrics_generator.py --path mainappsrc/core --output /tmp/metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68acad72e2fc832797442c27085d0245