### PR TITLE
Add requirement editor helpers and CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.57
+version: 0.2.58
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.58 - Add requirement editor helpers and CSV export wrapper.
 - 0.2.57 - Map Task toolbox selection to Action elements so governance diagrams support adding tasks.
 - 0.2.56 - Synchronize README version header with source.
 - 0.2.55 - Delegate ODD library management to dedicated manager and remove legacy scenario code.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -1291,6 +1291,24 @@ class AutoMLApp(
     def format_requirement_with_trace(self, req):
         return self.requirements_manager.format_requirement_with_trace(req)
 
+    def add_requirement(self, tree, refresh_cb):
+        return self.requirements_manager.add_requirement(tree, refresh_cb)
+
+    def edit_requirement(self, tree, refresh_cb):
+        return self.requirements_manager.edit_requirement(tree, refresh_cb)
+
+    def delete_requirement(self, tree, refresh_cb):
+        return self.requirements_manager.delete_requirement(tree, refresh_cb)
+
+    def link_requirement(self, tree, refresh_cb):
+        return self.requirements_manager.link_requirement(tree, refresh_cb)
+
+    def unlink_requirement(self, tree, refresh_cb):
+        return self.requirements_manager.unlink_requirement(tree, refresh_cb)
+
+    def export_requirements_to_csv(self):
+        return self.requirements_manager.export_requirements_to_csv()
+
     def build_requirement_diff_html(self, review):
         return self.reporting_export.build_requirement_diff_html(review)
 

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.57"
+VERSION = "0.2.58"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- delegate requirement editing (add, edit, delete, link, unlink, export) to RequirementsManagerSubApp
- expose new requirement helper wrappers on AutoMLApp
- bump version to 0.2.58 and document update

## Testing
- `pytest` *(fails: No module named 'automl'; PyQt6 missing)*
- `radon cc -s -j mainappsrc/core/automl_core.py mainappsrc/managers/requirements_manager.py`


------
https://chatgpt.com/codex/tasks/task_b_68acadf90d348327815f5168ff1642cd