### PR TITLE
Add TrashEater resource monitor and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.58
+version: 0.2.59
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1672,6 +1672,7 @@ and run the build again if you hit this issue.
 - 0.2.33 - Extract dialog classes into dedicated modules and update mixins.
 - 0.2.32 - Refactor core initialization into mixins for style, services, and icons.
 - 0.2.31 - Provide requirements editor export placeholder to prevent export error.
+- 0.2.59 - Introduced TrashEater module for proactive resource cleanup.
 - 0.2.30 - Instantiate reporting export helper during application start-up.
 - 0.2.29 - Instantiate validation consistency helper during application start-up.
 - 0.2.28 - Avoid circular import by using application helper in probability calculations.

--- a/automl.py
+++ b/automl.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility launcher exposing the same interface as ``AutoML.py``."""
 
-VERSION = "0.2.59"
-
-__all__ = ["VERSION"]
+from AutoML import *  # noqa: F401,F403

--- a/mainappsrc/automl_core.py
+++ b/mainappsrc/automl_core.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper for :mod:`mainappsrc.core.automl_core`."""
 
-VERSION = "0.2.59"
-
-__all__ = ["VERSION"]
+from mainappsrc.core.automl_core import *  # noqa: F401,F403

--- a/mainappsrc/page_diagram.py
+++ b/mainappsrc/page_diagram.py
@@ -16,8 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper for :mod:`mainappsrc.core.page_diagram`."""
 
-VERSION = "0.2.59"
+from mainappsrc.core.page_diagram import (
+    PageDiagram,
+    fta_drawing_helper,
+    GATE_NODE_TYPES,
+)
 
-__all__ = ["VERSION"]
+__all__ = ["PageDiagram", "fta_drawing_helper", "GATE_NODE_TYPES"]

--- a/tests/test_trash_eater.py
+++ b/tests/test_trash_eater.py
@@ -1,0 +1,57 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+"""Unit tests for the TrashEater resource monitor."""
+
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path for local imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.trash_eater import TrashEater
+
+
+class DummyManager:
+    """Minimal stand-in for the real memory manager."""
+
+    def __init__(self) -> None:
+        self.called = False
+
+    def cleanup(self) -> None:  # pragma: no cover - simple flag setter
+        self.called = True
+
+
+def test_cleanup_triggered_when_above_threshold() -> None:
+    """TrashEater should call cleanup when usage exceeds threshold."""
+
+    mgr = DummyManager()
+    eater = TrashEater(threshold=0.5, usage_provider=lambda: 0.6, manager=mgr)
+    eater.check_once()
+    assert mgr.called
+
+
+def test_no_cleanup_below_threshold() -> None:
+    """TrashEater should not clean when usage is below threshold."""
+
+    mgr = DummyManager()
+    eater = TrashEater(threshold=0.5, usage_provider=lambda: 0.4, manager=mgr)
+    eater.check_once()
+    assert not mgr.called

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -26,6 +26,7 @@ from .diagnostics_manager import (
     PassiveDiagnosticsManager,
     PollingDiagnosticsManager,
 )
+from .trash_eater import TrashEater, manager_eater
 
 __all__ = [
     "AsyncDiagnosticsManager",
@@ -34,4 +35,6 @@ __all__ = [
     "EventDiagnosticsManager",
     "PassiveDiagnosticsManager",
     "PollingDiagnosticsManager",
+    "TrashEater",
+    "manager_eater",
 ]

--- a/tools/trash_eater.py
+++ b/tools/trash_eater.py
@@ -1,0 +1,103 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+"""Background monitor that trims unused resources when memory is low."""
+
+import threading
+from typing import Callable, Optional
+
+try:  # pragma: no cover - psutil may not be installed
+    import psutil
+except Exception:  # pragma: no cover - optional dependency
+    psutil = None
+
+from .memory_manager import manager as memory_manager
+
+
+class TrashEater:
+    """Monitor memory usage and trigger cleanup of idle resources.
+
+    Parameters
+    ----------
+    threshold:
+        Fractional memory usage (0.0 - 1.0) beyond which cleanup is triggered.
+    interval:
+        Seconds to wait between checks when running in background.
+    usage_provider:
+        Optional callable returning current memory usage fraction.  Defaults to
+        :func:`psutil.virtual_memory` when available.
+    manager:
+        Memory manager instance responsible for cleanup.
+    """
+
+    def __init__(
+        self,
+        threshold: float = 0.75,
+        interval: float = 5.0,
+        usage_provider: Optional[Callable[[], float]] = None,
+        manager=memory_manager,
+    ) -> None:
+        self.threshold = threshold
+        self.interval = interval
+        self.usage_provider = usage_provider or self._get_usage
+        self.manager = manager
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    @staticmethod
+    def _get_usage() -> float:
+        """Return the current memory usage as a fraction."""
+        if psutil is None:
+            return 0.0
+        try:
+            return psutil.virtual_memory().percent / 100.0
+        except Exception:
+            return 0.0
+
+    def check_once(self) -> None:
+        """Check usage once and clean up if above threshold."""
+        usage = self.usage_provider()
+        if usage >= self.threshold:
+            self.manager.cleanup()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self.check_once()
+            self._stop.wait(self.interval)
+
+    def start(self) -> None:
+        """Start background monitoring thread."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop background monitoring thread."""
+        self._stop.set()
+        if self._thread:
+            self._thread.join()
+
+
+# Shared default instance for convenience
+manager_eater = TrashEater()
+
+__all__ = ["TrashEater", "manager_eater"]


### PR DESCRIPTION
## Summary
- introduce TrashEater background monitor to clean unused resources when memory usage is high
- expose TrashEater via tools package and maintain compatibility shims for legacy imports
- bump version to 0.2.59 and document in README

## Testing
- `pytest tests/test_trash_eater.py tests/test_version_sync.py -q`
- `pytest -q` *(fails: AutoMLApp missing many attributes)*
- `python tools/metrics_generator.py --path mainappsrc --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68acaf3432b88327ba855becab442460