### PR TITLE
fix: enable cross-diagram governance clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.58
+version: 0.2.59
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.59 - Enable cross-diagram copy and cut between governance diagrams.
 - 0.2.58 - Fix empty Safety tab when editing nodes in FTA, CTA and PAA diagrams.
 - 0.2.57 - Map Task toolbox selection to Action elements so governance diagrams support adding tasks.
 - 0.2.56 - Synchronize README version header with source.

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.58"
+VERSION = "0.2.59"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- allow clipboard operations across governance diagrams by detecting focused diagram windows without lifecycle helpers
- bump project version to 0.2.59 and document change in README

## Testing
- `pytest tests/test_cross_diagram_clipboard.py`
- `pytest` *(fails: No module named 'automl'; libGL.so.1 missing)*
- `python tools/metrics_generator.py --path mainappsrc/core --output /tmp/metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68acb01052f08327a282c9a58490c81c