### PR TITLE
feat(paa): add gate option to PAA menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.58
+version: 0.2.59
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.59 - Add Gate creation option to PAA context and menu.
 - 0.2.58 - Fix empty Safety tab when editing nodes in FTA, CTA and PAA diagrams.
 - 0.2.57 - Map Task toolbox selection to Action elements so governance diagrams support adding tasks.
 - 0.2.56 - Synchronize README version header with source.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -631,6 +631,12 @@ class AutoMLApp(
             accelerator="Ctrl+Shift+R",
         )
         self._paa_menu_indices["add_robustness"] = paa_menu.index("end")
+        paa_menu.add_command(
+            label="Add Gate",
+            command=lambda: self.add_node_of_type("GATE"),
+            accelerator="Ctrl+Shift+G",
+        )
+        self._paa_menu_indices["add_gate"] = paa_menu.index("end")
         qualitative_menu.add_cascade(
             label="Prototype Assurance Analysis",
             menu=paa_menu,

--- a/mainappsrc/core/navigation_selection_input.py
+++ b/mainappsrc/core/navigation_selection_input.py
@@ -235,6 +235,7 @@ class Navigation_Selection_Input:
         menu.add_separator()
         diag_mode = getattr(app.canvas, "diagram_mode", "FTA")
         if diag_mode == "PAA":
+            menu.add_command(label="Add Gate", command=lambda: app.add_node_of_type("GATE"))
             menu.add_command(label="Add Confidence", command=lambda: app.add_node_of_type("Confidence Level"))
             menu.add_command(label="Add Robustness", command=lambda: app.add_node_of_type("Robustness Score"))
         elif diag_mode == "CTA":

--- a/mainappsrc/core/page_diagram.py
+++ b/mainappsrc/core/page_diagram.py
@@ -154,6 +154,7 @@ class PageDiagram:
             menu.add_command(label="Edit Page Flag", command=lambda: self.context_edit_page_flag(node))
         menu.add_separator()
         if self.diagram_mode == "PAA":
+            menu.add_command(label="Add Gate", command=lambda: self.context_add("GATE"))
             menu.add_command(label="Add Confidence", command=lambda: self.context_add("Confidence Level"))
             menu.add_command(label="Add Robustness", command=lambda: self.context_add("Robustness Score"))
         elif self.diagram_mode == "CTA":

--- a/mainappsrc/core/pages_and_paa.py
+++ b/mainappsrc/core/pages_and_paa.py
@@ -48,7 +48,7 @@ class Pages_and_PAA:
         """Enable or disable PAA-related menu actions."""
         if hasattr(self, "paa_menu"):
             state = tk.NORMAL if enabled else tk.DISABLED
-            for key in ("add_confidence", "add_robustness"):
+            for key in ("add_confidence", "add_robustness", "add_gate"):
                 self.paa_menu.entryconfig(self._paa_menu_indices[key], state=state)
 
     def _create_paa_tab(self) -> None:

--- a/mainappsrc/core/ui_setup.py
+++ b/mainappsrc/core/ui_setup.py
@@ -61,7 +61,7 @@ class UISetupMixin:
         """Enable or disable PAA-related menu actions."""
         if hasattr(self, "paa_menu"):
             state = tk.NORMAL if enabled else tk.DISABLED
-            for key in ("add_confidence", "add_robustness"):
+            for key in ("add_confidence", "add_robustness", "add_gate"):
                 self.paa_menu.entryconfig(self._paa_menu_indices[key], state=state)
 
     def _update_analysis_menus(self, mode: str | None = None) -> None:

--- a/mainappsrc/managers/paa_manager.py
+++ b/mainappsrc/managers/paa_manager.py
@@ -239,7 +239,7 @@ class PrototypeAssuranceManager:
         """Enable or disable PAA-related menu actions."""
         if hasattr(self.app, "paa_menu"):
             state = tk.NORMAL if enabled else tk.DISABLED
-            for key in ("add_confidence", "add_robustness"):
+            for key in ("add_confidence", "add_robustness", "add_gate"):
                 self.app.paa_menu.entryconfig(
                     self.app._paa_menu_indices[key], state=state
                 )

--- a/tests/test_paa_context_menu_gate.py
+++ b/tests/test_paa_context_menu_gate.py
@@ -1,0 +1,91 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mainappsrc.core.navigation_selection_input import Navigation_Selection_Input
+
+
+def test_paa_context_menu_add_gate(monkeypatch):
+    labels = []
+
+    class DummyMenu:
+        def __init__(self, root, tearoff=0):
+            pass
+
+        def add_command(self, label, command=None, accelerator=None):
+            labels.append(label)
+
+        def add_separator(self):
+            pass
+
+        def tk_popup(self, x, y):  # pragma: no cover - no GUI
+            pass
+
+    monkeypatch.setattr(
+        "mainappsrc.core.navigation_selection_input.tk.Menu", DummyMenu
+    )
+
+    class Node:
+        node_type = "Basic Event"
+        x = 0
+        y = 0
+        children = []
+        unique_id = 1
+
+    node = Node()
+
+    class Canvas:
+        diagram_mode = "PAA"
+
+        def canvasx(self, x):
+            return x
+
+        def canvasy(self, y):
+            return y
+
+    class App:
+        root = None
+        canvas = Canvas()
+        zoom = 1
+        root_node = node
+        selected_node = None
+
+        def get_all_nodes(self, root_node):
+            return [node]
+
+        # Placeholder callbacks referenced by context menu
+        edit_selected = remove_connection = delete_node_and_subtree = (
+            remove_node
+        ) = copy_node = cut_node = paste_node = edit_description = edit_rationale = (
+            edit_value
+        ) = edit_gate_type = edit_severity = edit_controllability = (
+            edit_page_flag
+        ) = add_node_of_type = lambda *a, **k: None
+        user_manager = types.SimpleNamespace(edit_user_name=lambda: None)
+
+    nsi = Navigation_Selection_Input.__new__(Navigation_Selection_Input)
+    nsi.app = App()
+    event = types.SimpleNamespace(x=0, y=0, x_root=0, y_root=0)
+    nsi.show_context_menu(event)
+
+    assert "Add Gate" in labels

--- a/tests/test_paa_menu_gate_enable.py
+++ b/tests/test_paa_menu_gate_enable.py
@@ -16,8 +16,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+import sys
+from pathlib import Path
 
-VERSION = "0.2.59"
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-__all__ = ["VERSION"]
+from mainappsrc.core.ui_setup import UISetupMixin
+
+
+def test_enable_paa_actions_includes_gate():
+    called = []
+
+    class DummyMenu:
+        def entryconfig(self, index, state):
+            called.append(index)
+
+    obj = type("O", (UISetupMixin,), {})()
+    obj.paa_menu = DummyMenu()
+    obj._paa_menu_indices = {"add_confidence": 0, "add_robustness": 1, "add_gate": 2}
+    obj.enable_paa_actions(True)
+
+    assert 2 in called


### PR DESCRIPTION
## Summary
- allow adding Gate nodes via right-click in PAA diagrams
- expose Gate creation in Prototype Assurance Analysis menu
- cover PAA gate actions with unit tests

## Testing
- `radon cc -j mainappsrc/core/page_diagram.py mainappsrc/core/navigation_selection_input.py mainappsrc/core/automl_core.py mainappsrc/core/ui_setup.py mainappsrc/managers/paa_manager.py mainappsrc/core/pages_and_paa.py`
- `pytest` *(fails: FileNotFoundError for automl_core, page_diagram, ModuleNotFoundError: automl, ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_b_68acb0aa53488327af5748ae893693d2