### PR TITLE
Refactor fault dialog and gate retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.59
+version: 0.2.60
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.60 - Import SelectFaultDialog directly and delegate gate retrieval to FTA subapp to fix context menu errors.
 - 0.2.59 - Reactivate lifecycle phase when focusing governance diagrams to allow editing after opening other analyses.
 - 0.2.58 - Fix empty Safety tab when editing nodes in FTA, CTA and PAA diagrams.
 - 0.2.57 - Map Task toolbox selection to Action elements so governance diagrams support adding tasks.

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.59"
+VERSION = "0.2.60"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- import `SelectFaultDialog` directly to avoid missing attribute errors
- delegate gate retrieval to `FTASubApp` and simplify fault event workflow
- bump version to 0.2.60 and document changes

## Testing
- `pytest` *(fails: No module named 'automl'; libGL.so.1 missing)*
- `radon cc mainappsrc/core/safety_analysis.py -j` (add_fault_event: complexity 10, _determine_parent_node: complexity 5, _prompt_fault_selection: complexity 4, get_all_gates: complexity 2)
- `radon cc mainappsrc/core/data_access_queries.py -j` (get_all_gates: complexity 1)


------
https://chatgpt.com/codex/tasks/task_b_68acb48b5e088327a12e876df14abbfc