### PR TITLE
Allow gates in PAA diagrams

### DIFF
--- a/automl.py
+++ b/automl.py
@@ -1,0 +1,21 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Lowercase launcher wrapper for compatibility with test imports."""
+
+from AutoML import *  # noqa: F401,F403

--- a/mainappsrc/automl_core.py
+++ b/mainappsrc/automl_core.py
@@ -1,0 +1,21 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Compatibility shim re-exporting the core AutoML application module."""
+
+from mainappsrc.core.automl_core import *  # noqa: F401,F403

--- a/mainappsrc/models/fta/fault_tree_node.py
+++ b/mainappsrc/models/fta/fault_tree_node.py
@@ -538,12 +538,15 @@ def add_node_of_type(app, event_type):
     allowed = {
         "FTA": {"GATE", "BASIC EVENT"},
         "CTA": {"TRIGGERING CONDITION", "FUNCTIONAL INSUFFICIENCY"},
-        "PAA": {"CONFIDENCE LEVEL", "ROBUSTNESS SCORE"},
+        "PAA": {"GATE", "CONFIDENCE LEVEL", "ROBUSTNESS SCORE"},
     }
 
     if event_upper not in allowed.get(diag_mode, set()):
+        allowed_nodes = ", ".join(
+            sorted(name.title() for name in allowed.get(diag_mode, []))
+        )
         msg = (
-            "Only Confidence and Robustness nodes are allowed in Prototype Assurance Analysis."
+            f"Only {allowed_nodes} nodes are allowed in Prototype Assurance Analysis."
             if diag_mode == "PAA"
             else f"Node type '{event_type}' is not allowed in {diag_mode} diagrams."
         )

--- a/mainappsrc/page_diagram.py
+++ b/mainappsrc/page_diagram.py
@@ -1,0 +1,23 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Compatibility shim exposing the page diagram utilities."""
+
+from mainappsrc.core.page_diagram import PageDiagram, fta_drawing_helper
+
+__all__ = ["PageDiagram", "fta_drawing_helper"]

--- a/tests/test_add_paa_gate.py
+++ b/tests/test_add_paa_gate.py
@@ -1,0 +1,60 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Verify that gates can be added in Prototype Assurance Analysis diagrams."""
+
+import sys
+import pathlib
+import types
+
+repo_root = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
+
+import AutoML
+
+AutoMLApp = AutoML.AutoMLApp
+FaultTreeNode = AutoML.FaultTreeNode
+
+
+def _make_app(root):
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.root_node = root
+    app.top_events = [root]
+    app.selected_node = root
+    app.analysis_tree = types.SimpleNamespace(selection=lambda: ())
+    app.update_views = lambda: None
+    app.find_node_by_id_all = lambda uid: root if uid == root.unique_id else None
+    app.push_undo_state = lambda: None
+    app.diagram_mode = "PAA"
+    return app
+
+
+def test_add_gate_in_paa(monkeypatch):
+    root = FaultTreeNode("Root", "TOP EVENT")
+    app = _make_app(root)
+
+    warnings = []
+    monkeypatch.setattr(
+        AutoML.messagebox, "showwarning", lambda *a, **k: warnings.append(a)
+    )
+
+    app.add_node_of_type("Gate")
+
+    assert not warnings
+    assert len(root.children) == 1
+    assert root.children[0].node_type.upper() == "GATE"


### PR DESCRIPTION
## Summary
- permit gate nodes in Prototype Assurance Analysis diagrams
- add regression test for PAA gate support
- provide compatibility shims for legacy imports

## Testing
- `radon cc -j mainappsrc/models/fta/fault_tree_node.py tests/test_add_paa_gate.py automl.py mainappsrc/automl_core.py mainappsrc/page_diagram.py`
- `pytest -q` *(fails: 211 failed, 963 passed, 52 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68acb4dcf00c83278d5711d760bcc861