### PR TITLE
Reset governance clipboard after paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.61
+version: 0.2.62
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.62 - Reset diagram clipboard after paste so governance copy/cut can be repeated between diagrams.
 - 0.2.61 - Fix parent-node resolution and enable FTA/CTA node creation when PAA mode is active.
 - 0.2.60 - Allow adding FTA and CTA nodes regardless of active work product mode.
 - 0.2.59 - Reactivate lifecycle phase when focusing governance diagrams to allow editing after opening other analyses.

--- a/mainappsrc/core/diagram_clipboard_manager.py
+++ b/mainappsrc/core/diagram_clipboard_manager.py
@@ -384,17 +384,29 @@ class DiagramClipboardManager:
             if not clip_type or clip_type == "Causal Bayesian Network":
                 if getattr(win, "paste_selected", None):
                     win.paste_selected()
+                    self.diagram_clipboard = None
+                    self.diagram_clipboard_type = None
+                    self.diagram_clipboard_parent_name = None
+                    self.cut_mode = False
                     return
         win = self.app.window_controllers._focused_gsn_window()
         if win and getattr(self, "diagram_clipboard", None):
             if not clip_type or clip_type == "GSN":
                 if getattr(win, "paste_selected", None):
                     win.paste_selected()
+                    self.diagram_clipboard = None
+                    self.diagram_clipboard_type = None
+                    self.diagram_clipboard_parent_name = None
+                    self.cut_mode = False
                     return
         win = self.app.window_controllers._focused_arch_window(clip_type)
         if win and getattr(self, "diagram_clipboard", None):
             if getattr(win, "paste_selected", None):
                 win.paste_selected()
+                self.diagram_clipboard = None
+                self.diagram_clipboard_type = None
+                self.diagram_clipboard_parent_name = None
+                self.cut_mode = False
                 return
         messagebox.showwarning("Paste", "Clipboard is empty.")
 

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.61"
+VERSION = "0.2.62"
 
 __all__ = ["VERSION"]

--- a/tests/test_governance_clipboard_repeat.py
+++ b/tests/test_governance_clipboard_repeat.py
@@ -1,0 +1,125 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Regression test for repeated clipboard operations across governance diagrams."""
+
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from mainappsrc.core.diagram_clipboard_manager import DiagramClipboardManager
+from gui.windows.architecture import SysMLObject, ARCH_WINDOWS, _get_next_id
+
+
+class MultiRepo:
+    def __init__(self, *diag_types):
+        self.diagrams = {
+            i + 1: types.SimpleNamespace(diag_type=t, elements=[])
+            for i, t in enumerate(diag_types)
+        }
+
+    def diagram_read_only(self, _id):
+        return False
+
+
+def make_window(app, repo, diagram_id):
+    from tests.test_cross_diagram_clipboard import make_window as _make_window
+
+    return _make_window(app, repo, diagram_id)
+
+
+def _boundary(name):
+    return SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="System Boundary",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"name": name},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+
+def _task(boundary):
+    return SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Task",
+        x=10,
+        y=10,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={"boundary": str(boundary.obj_id)},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+
+def test_clipboard_reuse_between_multiple_governance_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = DiagramClipboardManager(app)
+    app.diagram_clipboard.diagram_clipboard = None
+    app.diagram_clipboard.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.diagram_clipboard.clipboard_node = None
+    app.diagram_clipboard.cut_mode = False
+
+    repo = MultiRepo("Governance Diagram", "Governance Diagram", "Governance Diagram")
+
+    b1 = _boundary("Area1")
+    t1 = _task(b1)
+    win1 = make_window(app, repo, 1)
+    win1.objects = [b1, t1]
+    win1.selected_obj = t1
+
+    b2 = _boundary("Area2")
+    win2 = make_window(app, repo, 2)
+    win2.objects = [b2]
+
+    # First copy/paste
+    win1._on_focus_in()
+    app.copy_node()
+    win2._on_focus_in()
+    app.paste_node()
+    assert any(o.obj_type == "Task" for o in win2.objects)
+
+    # Second copy/paste using the new task in win2
+    task_in_win2 = next(o for o in win2.objects if o.obj_type == "Task")
+    win2.selected_obj = task_in_win2
+
+    b3 = _boundary("Area3")
+    win3 = make_window(app, repo, 3)
+    win3.objects = [b3]
+
+    win2._on_focus_in()
+    app.copy_node()
+    win3._on_focus_in()
+    app.paste_node()
+
+    assert any(o.obj_type == "Task" for o in win3.objects)

--- a/tests/test_governance_clipboard_repeat_cut.py
+++ b/tests/test_governance_clipboard_repeat_cut.py
@@ -1,0 +1,75 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Test cut then paste between multiple governance diagrams."""
+
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from mainappsrc.core.diagram_clipboard_manager import DiagramClipboardManager
+from gui.windows.architecture import SysMLObject, ARCH_WINDOWS, _get_next_id
+
+from tests.test_governance_clipboard_repeat import MultiRepo, make_window, _boundary, _task
+
+
+def test_copy_then_cut_between_governance_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = DiagramClipboardManager(app)
+    app.diagram_clipboard.diagram_clipboard = None
+    app.diagram_clipboard.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.diagram_clipboard.clipboard_node = None
+    app.diagram_clipboard.cut_mode = False
+
+    repo = MultiRepo("Governance Diagram", "Governance Diagram", "Governance Diagram")
+
+    b1 = _boundary("Area1")
+    t1 = _task(b1)
+    win1 = make_window(app, repo, 1)
+    win1.objects = [b1, t1]
+    win1.selected_obj = t1
+
+    b2 = _boundary("Area2")
+    win2 = make_window(app, repo, 2)
+    win2.objects = [b2]
+
+    win1._on_focus_in()
+    app.copy_node()
+    win2._on_focus_in()
+    app.paste_node()
+
+    # Now cut the task from win2 and paste into win3
+    task2 = next(o for o in win2.objects if o.obj_type == "Task")
+    win2.selected_obj = task2
+    win2._on_focus_in()
+    app.cut_node()
+
+    b3 = _boundary("Area3")
+    win3 = make_window(app, repo, 3)
+    win3.objects = [b3]
+
+    win3._on_focus_in()
+    app.paste_node()
+
+    assert any(o.obj_type == "Task" for o in win3.objects)
+    assert all(o.obj_type != "Task" for o in win2.objects)


### PR DESCRIPTION
## Summary
- reset diagram clipboard after pasting so subsequent governance copies/cuts work across diagrams
- add regression tests covering multiple governance copy/cut sequences
- bump version to 0.2.62 and update docs

## Testing
- `pytest tests/test_cross_diagram_clipboard.py::test_copy_paste_between_same_type_diagrams tests/test_cross_diagram_clipboard.py::test_copy_paste_task_between_governance_diagrams tests/test_cross_diagram_clipboard.py::test_cut_paste_between_governance_diagrams tests/test_governance_cut_paste.py -q`
- `pytest -q` *(fails: FileNotFoundError for mainappsrc/automl_core.py; FileNotFoundError for mainappsrc/page_diagram.py; ModuleNotFoundError for automl; ImportError: libGL.so.1 missing for PyQt6)*
- `python tools/metrics_generator.py --path mainappsrc/core/diagram_clipboard_manager.py --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68acbc4dd0b48327a2185064b8985787