### PR TITLE
Reset diagram clipboard between operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.61
+version: 0.2.62
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.62 - Reset diagram clipboard between operations so governance copy, cut, and paste work repeatedly.
 - 0.2.61 - Fix parent-node resolution and enable FTA/CTA node creation when PAA mode is active.
 - 0.2.60 - Allow adding FTA and CTA nodes regardless of active work product mode.
 - 0.2.59 - Reactivate lifecycle phase when focusing governance diagrams to allow editing after opening other analyses.

--- a/mainappsrc/core/diagram_clipboard_manager.py
+++ b/mainappsrc/core/diagram_clipboard_manager.py
@@ -50,6 +50,12 @@ class DiagramClipboardManager:
         self.diagram_clipboard_type: str | None = None
         self.diagram_clipboard_parent_name: str | None = None
 
+    def _clear_diagram_clipboard(self) -> None:
+        """Reset stored diagram clipboard information."""
+        self.diagram_clipboard = None
+        self.diagram_clipboard_type = None
+        self.diagram_clipboard_parent_name = None
+
     # ------------------------------------------------------------------
     # Strategies for delegating to focused diagram windows
     def _diagram_copy_strategy1(self) -> bool:
@@ -58,6 +64,7 @@ class DiagramClipboardManager:
             self.app.selected_node = None
             self.clipboard_node = None
             self.cut_mode = False
+            self._clear_diagram_clipboard()
             win.copy_selected()
             return True
         return False
@@ -68,6 +75,7 @@ class DiagramClipboardManager:
             self.app.selected_node = None
             self.clipboard_node = None
             self.cut_mode = False
+            self._clear_diagram_clipboard()
             win.copy_selected()
             return True
         return False
@@ -78,6 +86,7 @@ class DiagramClipboardManager:
             self.app.selected_node = None
             self.clipboard_node = None
             self.cut_mode = False
+            self._clear_diagram_clipboard()
             win.copy_selected()
             return True
         return False
@@ -89,6 +98,7 @@ class DiagramClipboardManager:
                 self.app.selected_node = None
                 self.clipboard_node = None
                 self.cut_mode = False
+                self._clear_diagram_clipboard()
                 win.copy_selected()
                 return True
         return False
@@ -99,6 +109,7 @@ class DiagramClipboardManager:
             self.app.selected_node = None
             self.clipboard_node = None
             self.cut_mode = False
+            self._clear_diagram_clipboard()
             win.cut_selected()
             return True
         return False
@@ -109,6 +120,7 @@ class DiagramClipboardManager:
             self.app.selected_node = None
             self.clipboard_node = None
             self.cut_mode = False
+            self._clear_diagram_clipboard()
             win.cut_selected()
             return True
         return False
@@ -119,6 +131,7 @@ class DiagramClipboardManager:
             self.app.selected_node = None
             self.clipboard_node = None
             self.cut_mode = False
+            self._clear_diagram_clipboard()
             win.cut_selected()
             return True
         return False
@@ -130,6 +143,7 @@ class DiagramClipboardManager:
                 self.app.selected_node = None
                 self.clipboard_node = None
                 self.cut_mode = False
+                self._clear_diagram_clipboard()
                 win.cut_selected()
                 return True
         return False

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.61"
+VERSION = "0.2.62"
 
 __all__ = ["VERSION"]

--- a/tests/test_governance_multi_clipboard.py
+++ b/tests/test_governance_multi_clipboard.py
@@ -1,0 +1,117 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from mainappsrc.core.diagram_clipboard_manager import DiagramClipboardManager
+from gui.architecture import SysMLDiagramWindow, _get_next_id, SysMLObject, ARCH_WINDOWS
+
+
+class DummyRepo:
+    def __init__(self):
+        self.diagrams = {
+            1: SimpleNamespace(diag_type="Governance Diagram", elements=[], name="d1"),
+            2: SimpleNamespace(diag_type="Governance Diagram", elements=[], name="d2"),
+            3: SimpleNamespace(diag_type="Governance Diagram", elements=[], name="d3"),
+        }
+
+    def diagram_read_only(self, _id):
+        return False
+
+
+def make_window(app, repo, diagram_id):
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.app = app
+    win.repo = repo
+    win.diagram_id = diagram_id
+    win.selected_obj = None
+    win.objects = []
+    win.remove_object = lambda o: win.objects.remove(o)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.sort_objects = lambda: None
+    win.refresh_from_repository = lambda e=None: None
+    win._on_focus_in = types.MethodType(SysMLDiagramWindow._on_focus_in, win)
+    win._constrain_to_parent = lambda obj, parent: None
+    return win
+
+
+def test_multiple_copy_cut_paste_governance_diagrams():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = DiagramClipboardManager(app)
+    app.diagram_clipboard.diagram_clipboard = None
+    app.diagram_clipboard.diagram_clipboard_type = None
+    app.selected_node = None
+    app.root_node = None
+    app.diagram_clipboard.clipboard_node = None
+    app.diagram_clipboard.cut_mode = False
+    repo = DummyRepo()
+
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1 = make_window(app, repo, 1)
+    win1.selected_obj = obj
+    win1.objects = [obj]
+
+    win2 = make_window(app, repo, 2)
+    win3 = make_window(app, repo, 3)
+
+    # First copy/paste from win1 to win2
+    win1._on_focus_in()
+    app.copy_node()
+    win2._on_focus_in()
+    app.paste_node()
+    assert len(win2.objects) == 1
+
+    # Second copy/paste from win2 to win3
+    win2.selected_obj = win2.objects[0]
+    win2._on_focus_in()
+    app.copy_node()
+    win3._on_focus_in()
+    app.paste_node()
+    assert len(win3.objects) == 1
+
+    # Cut/paste back to win1
+    win3.selected_obj = win3.objects[0]
+    win3._on_focus_in()
+    app.cut_node()
+    win1._on_focus_in()
+    app.paste_node()
+    assert len(win3.objects) == 0
+    assert len(win1.objects) == 2


### PR DESCRIPTION
## Summary
- Clear diagram clipboard state before copy or cut so governance copy/cut/paste can be used repeatedly
- Bump version to 0.2.62 and document change
- Add regression test covering multiple governance diagram clipboard operations

## Testing
- `radon cc -j mainappsrc/core/diagram_clipboard_manager.py`
- `pytest tests/test_governance_multi_clipboard.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'automl'; ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68acbc4dd0b48327a2185064b8985787