### PR TITLE
feat: ensure governance clipboard respects focused tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.62
+version: 0.2.63
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.63 - Ensure governance diagram copy, cut and paste respect the selected tab.
 - 0.2.62 - Move PMHF calculation to FTA menu, move PAL calculation to PAA menu and remove Process menu.
 - 0.2.61 - Fix parent-node resolution and enable FTA/CTA node creation when PAA mode is active.
 - 0.2.60 - Allow adding FTA and CTA nodes regardless of active work product mode.

--- a/gui/windows/architecture.py
+++ b/gui/windows/architecture.py
@@ -3633,6 +3633,8 @@ class SysMLDiagramWindow(tk.Frame):
         icon_size: int = 16,
     ):
         super().__init__(master)
+        if not isinstance(master, tk.Toplevel):
+            setattr(master, "arch_window", self)
         self.app = app
         self.diagram_history: list[str] = list(history) if history else []
         self.master.title(title) if isinstance(self.master, tk.Toplevel) else None

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.62"
+VERSION = "0.2.63"
 
 __all__ = ["VERSION"]

--- a/tests/test_governance_tab_paste.py
+++ b/tests/test_governance_tab_paste.py
@@ -1,0 +1,147 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+import types
+import weakref
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from AutoML import AutoMLApp
+from mainappsrc.core.diagram_clipboard_manager import DiagramClipboardManager
+from gui.architecture import SysMLDiagramWindow, _get_next_id, ARCH_WINDOWS, SysMLObject
+
+
+class DummyRepo:
+    def __init__(self):
+        self.diagrams = {
+            1: types.SimpleNamespace(diag_type="Governance Diagram", elements=[]),
+            2: types.SimpleNamespace(diag_type="Governance Diagram", elements=[]),
+        }
+
+    def diagram_read_only(self, _id):
+        return False
+
+
+class DummyNotebook:
+    def __init__(self):
+        self.tabs = {}
+        self._selected = None
+
+    def add(self, name, tab):
+        self.tabs[name] = tab
+        if self._selected is None:
+            self._selected = name
+
+    def select(self, name=None):
+        if name is None:
+            return self._selected
+        self._selected = name
+
+    def nametowidget(self, name):
+        return self.tabs[name]
+
+
+def _make_window(app, repo, diagram_id, tab):
+    win = SysMLDiagramWindow.__new__(SysMLDiagramWindow)
+    win.app = app
+    win.repo = repo
+    win.diagram_id = diagram_id
+    win.selected_obj = None
+    win.objects = []
+    win.remove_object = lambda o: win.objects.remove(o)
+    win._sync_to_repository = lambda: None
+    win.redraw = lambda: None
+    win.update_property_view = lambda: None
+    win.sort_objects = lambda: None
+    win._rebuild_toolboxes = lambda: None
+    win.refresh_from_repository = lambda e=None: None
+    win._on_focus_in = types.MethodType(SysMLDiagramWindow._on_focus_in, win)
+    win.master = tab
+    ARCH_WINDOWS.add(weakref.ref(win))
+    return win
+
+
+def test_paste_respects_selected_governance_tab():
+    ARCH_WINDOWS.clear()
+    app = AutoMLApp.__new__(AutoMLApp)
+    app.diagram_clipboard = DiagramClipboardManager(app)
+    app.selected_node = None
+    app.root_node = None
+    app.diagram_clipboard.clipboard_node = None
+    app.diagram_clipboard.cut_mode = False
+    repo = DummyRepo()
+    app._get_diag_type = lambda win: repo.diagrams.get(win.diagram_id).diag_type
+    nb = DummyNotebook()
+    app.doc_nb = nb
+
+    class StubControllers:
+        def __init__(self, app):
+            self.app = app
+
+        def _focused_cbn_window(self):
+            return None
+
+        def _focused_gsn_window(self):
+            return None
+
+        def _focused_arch_window(self, clip_type=None):
+            sel = nb.select()
+            tab = nb.nametowidget(sel)
+            return getattr(tab, "arch_window", None)
+
+    app._window_controllers = StubControllers(app)
+
+    tab1 = types.SimpleNamespace()
+    tab2 = types.SimpleNamespace()
+    nb.add("t1", tab1)
+    nb.add("t2", tab2)
+
+    win1 = _make_window(app, repo, 1, tab1)
+    win2 = _make_window(app, repo, 2, tab2)
+    tab1.arch_window = win1
+    tab2.arch_window = win2
+
+    obj = SysMLObject(
+        obj_id=_get_next_id(),
+        obj_type="Plan",
+        x=0,
+        y=0,
+        element_id=None,
+        width=80,
+        height=40,
+        properties={},
+        requirements=[],
+        locked=False,
+        hidden=False,
+        collapsed={},
+    )
+
+    win1.objects = [obj]
+    win1.selected_obj = obj
+    win1._on_focus_in()
+
+    win1.copy_selected()
+    assert app.diagram_clipboard.diagram_clipboard is not None
+
+    nb.select("t2")
+    assert app.window_controllers._focused_arch_window("Governance Diagram") is win2
+    app.paste_node()
+
+    assert len(win2.objects) == 1


### PR DESCRIPTION
## Summary
- register SysML diagrams with their tab so copy/cut/paste targets the selected governance diagram
- bump version to 0.2.63
- add regression test for governance tab pasting

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'automl'; ImportError: libGL.so.1)*
- `pytest tests/test_governance_tab_paste.py`
- `python tools/metrics_generator.py --path mainappsrc/core --output core_metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68acc0b4bb7c8327a75f47af5e131d9d