### PR TITLE
Fix governance toolbox crash and ensure monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.66
+version: 0.2.67
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.67 - Prevent crash when switching governance diagram toolboxes and ensure crash, watchdog and thread monitors run.
 - 0.2.66 - Recognize copied work products in active phase governance diagrams.
 - 0.2.65 - Always paste to the focused governance diagram and show focused tab details in the status bar.
 - 0.2.64 - Fix paste so governance diagrams honor the currently focused tab.

--- a/gui/windows/architecture.py
+++ b/gui/windows/architecture.py
@@ -12304,14 +12304,20 @@ class GovernanceDiagramWindow(SysMLDiagramWindow):
             for frame in frames:
                 if frame and hasattr(frame, "pack_forget"):
                     frame.pack_forget()
-        frames = self._toolbox_frames.get(choice, [])
+        frames = self._toolbox_frames.setdefault(choice, [])
         key = f"toolbox:{choice}"
-        if choice in getattr(self, "_frame_loaders", {}):
-            loader = self._frame_loaders.pop(choice)
+        loader = getattr(self, "_frame_loaders", {}).get(choice)
+        if loader:
             frame = memory_manager.lazy_load(key, loader)
-            frames.append(frame)
+            if frame not in frames:
+                frames.append(frame)
         else:
             memory_manager.mark_active(key)
+        frames[:] = [
+            f
+            for f in frames
+            if not hasattr(f, "winfo_exists") or f.winfo_exists()
+        ]
         for frame in frames:
             if frame and hasattr(frame, "pack"):
                 frame.pack(fill=tk.X, padx=2, pady=2)

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -23,6 +23,8 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 import tkinter as tk
 import os, sys
+import threading
+import time
 base = os.path.dirname(__file__)
 if base not in sys.path:
     sys.path.append(base)
@@ -158,6 +160,8 @@ from .undo_manager import UndoRedoManager
 from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.scenario_description import template_phrases
 from mainappsrc.core.app_lifecycle_ui import AppLifecycleUI
+from tools.crash_report_logger import install_best, watchdog_best
+from tools.thread_manager import manager as thread_manager
 from mainappsrc.core.editing_labels_styling import Editing_Labels_Styling
 import copy
 import tkinter.font as tkFont
@@ -3054,13 +3058,10 @@ def load_user_data() -> tuple[dict, tuple[str, str]]:
         return users_future.result(), config_future.result()
 
 
-def main():
+def _launch_app() -> None:
     root = tk.Tk()
-    # Prevent the main window from being resized so small that
-    # widgets and toolbars become unusable.
     root.minsize(1200, 700)
     enable_listbox_hover_highlight(root)
-    # Hide the main window while prompting for user info
     root.withdraw()
     users, (last_name, last_email) = load_user_data()
     if users:
@@ -3081,11 +3082,8 @@ def main():
             name, email = dlg.result
             save_user_config(name, email)
     set_current_user(name, email)
-    # Create a fresh helper each session:
     global AutoML_Helper
     AutoML_Helper = config_utils.AutoML_Helper = AutoMLHelper()
-
-    # Show and maximize the main window after login
     root.deiconify()
     try:
         root.state("zoomed")
@@ -3094,9 +3092,29 @@ def main():
             root.attributes("-zoomed", True)
         except tk.TclError:
             pass
-
     app = AutoMLApp(root)
     root.mainloop()
+
+
+def _watchdog_feeder(wd, stop_event, interval: float = 1.0) -> None:
+    while not stop_event.is_set():
+        time.sleep(interval)
+        try:
+            wd.feed()
+        except Exception:
+            break
+
+
+def main() -> None:
+    install_best()
+    wd = watchdog_best(10.0)
+    stop_event = threading.Event()
+    thread_manager.register("watchdog", _watchdog_feeder, args=(wd, stop_event))
+    try:
+        _launch_app()
+    finally:
+        stop_event.set()
+        thread_manager.stop_all()
 
 if __name__ == "__main__":
     main()

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.66"
+VERSION = "0.2.67"
 
 __all__ = ["VERSION"]

--- a/tests/test_governance_toolbox_reload.py
+++ b/tests/test_governance_toolbox_reload.py
@@ -1,0 +1,62 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gui.architecture import GovernanceDiagramWindow
+
+
+def test_switch_rebuilds_destroyed_frames():
+    win = GovernanceDiagramWindow.__new__(GovernanceDiagramWindow)
+
+    class Frame:
+        def __init__(self):
+            self.destroyed = False
+
+        def pack(self, *a, **k):
+            if self.destroyed:
+                raise RuntimeError("Frame destroyed")
+
+        def pack_forget(self, *a, **k):
+            pass
+
+        def destroy(self):
+            self.destroyed = True
+
+        def winfo_exists(self):
+            return not self.destroyed
+
+    win._toolbox_frames = {"Entities": [], "Safety & AI Lifecycle": []}
+    win._frame_loaders = {"Entities": Frame, "Safety & AI Lifecycle": Frame}
+
+    win.toolbox_var = types.SimpleNamespace(get=lambda: "Entities")
+    win._switch_toolbox()
+
+    win.toolbox_var = types.SimpleNamespace(get=lambda: "Safety & AI Lifecycle")
+    win._switch_toolbox()
+
+    win.toolbox_var = types.SimpleNamespace(get=lambda: "Entities")
+    win._switch_toolbox()
+
+    frames = win._toolbox_frames["Entities"]
+    assert len(frames) == 1
+    assert frames[0].winfo_exists()


### PR DESCRIPTION
## Summary
- rebuild governance toolbox frames after cleanup to avoid crashes
- wrap application startup with crash logging, watchdog, and thread manager
- add regression test and bump version to 0.2.67

## Testing
- `python tools/metrics_generator.py --path mainappsrc/core --output metrics.json`
- `pytest tests/test_governance_toolbox_reload.py -q`
- `pytest -q` *(fails: FileNotFoundError: '/workspace/AutoML/mainappsrc/automl_core.py'; ModuleNotFoundError: No module named 'automl')*

------
https://chatgpt.com/codex/tasks/task_b_68accec409c48327801db9bf5ece951e