### PR TITLE
Fix analysis tree module insertion for missing parent nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.67 - Guard analysis tree module insertion when parent item missing.
 - 0.2.66 - Recognize copied work products in active phase governance diagrams.
 - 0.2.65 - Always paste to the focused governance diagram and show focused tab details in the status bar.
 - 0.2.64 - Fix paste so governance diagrams honor the currently focused tab.

--- a/automl/__init__.py
+++ b/automl/__init__.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper exporting :mod:`AutoML` as a package."""
 
-VERSION = "0.2.67"
-
-__all__ = ["VERSION"]
+from AutoML import *  # noqa: F401,F403

--- a/mainappsrc/automl_core.py
+++ b/mainappsrc/automl_core.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper for :mod:`mainappsrc.core.automl_core`."""
 
-VERSION = "0.2.67"
-
-__all__ = ["VERSION"]
+from mainappsrc.core.automl_core import *  # noqa: F401,F403

--- a/mainappsrc/core/view_updater.py
+++ b/mainappsrc/core/view_updater.py
@@ -36,6 +36,38 @@ class ViewUpdater:
     def __init__(self, app: AutoMLApp) -> None:
         self.app = app
 
+    def _insert_module(self, tree, mod, parent, index_map):
+        """Insert a module into the analysis tree if the parent exists.
+
+        The GUI can trigger refreshes while elements are being modified. If a
+        parent item was removed between refreshes, attempting to insert under
+        that missing parent would raise ``TclError``. Guard against this by
+        verifying the parent still exists before inserting.
+        """
+
+        if not tree.exists(parent):
+            return
+
+        node = tree.insert(
+            parent,
+            "end",
+            text=mod.name,
+            open=True,
+            image=getattr(self.app, "pkg_icon", None),
+        )
+        for sub in sorted(mod.modules, key=lambda m: m.name):
+            self._insert_module(tree, sub, node, index_map)
+        for name in sorted(mod.diagrams):
+            idx = index_map.get(name)
+            if idx is not None:
+                tree.insert(
+                    node,
+                    "end",
+                    text=name,
+                    tags=("gov", str(idx)),
+                    image=getattr(self.app, "gsn_diagram_icon", None),
+                )
+
     def update_views(self) -> None:
         """Refresh project views based on current model state."""
 
@@ -94,29 +126,8 @@ class ViewUpdater:
                         return True
                 return False
 
-            def _add_module(mod, parent):
-                node = tree.insert(
-                    parent,
-                    "end",
-                    text=mod.name,
-                    open=True,
-                    image=getattr(app, "pkg_icon", None),
-                )
-                for sub in sorted(mod.modules, key=lambda m: m.name):
-                    _add_module(sub, node)
-                for name in sorted(mod.diagrams):
-                    idx = index_map.get(name)
-                    if idx is not None:
-                        tree.insert(
-                            node,
-                            "end",
-                            text=name,
-                            tags=("gov", str(idx)),
-                            image=getattr(app, "gsn_diagram_icon", None),
-                        )
-
             for mod in sorted(toolbox.modules, key=lambda m: m.name):
-                _add_module(mod, gov_root)
+                self._insert_module(tree, mod, gov_root, index_map)
 
             for name in sorted(toolbox.diagrams.keys()):
                 if not _in_any_module(name, toolbox.modules):

--- a/mainappsrc/page_diagram.py
+++ b/mainappsrc/page_diagram.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper for :mod:`mainappsrc.core.page_diagram`."""
 
-VERSION = "0.2.67"
+from mainappsrc.core.page_diagram import PageDiagram, fta_drawing_helper
 
-__all__ = ["VERSION"]
+__all__ = ["PageDiagram", "fta_drawing_helper"]

--- a/tests/test_view_updater_module_insert.py
+++ b/tests/test_view_updater_module_insert.py
@@ -16,8 +16,39 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Tests for :mod:`mainappsrc.core.view_updater` module helpers."""
 
-VERSION = "0.2.67"
+from mainappsrc.core.view_updater import ViewUpdater
 
-__all__ = ["VERSION"]
+
+class _DummyTree:
+    """Minimal tree stub tracking insert calls."""
+
+    def __init__(self):
+        self.called = False
+
+    def exists(self, item):
+        return False
+
+    def insert(self, parent, index, **kwargs):
+        self.called = True
+
+
+class _DummyModule:
+    name = "mod"
+    modules = []
+    diagrams = []
+
+
+class _DummyApp:
+    pkg_icon = None
+    gsn_diagram_icon = None
+
+
+def test_insert_module_missing_parent_ignored():
+    """_insert_module returns early when parent item is absent."""
+
+    updater = ViewUpdater(_DummyApp())
+    tree = _DummyTree()
+    updater._insert_module(tree, _DummyModule(), "missing", {})
+    assert not tree.called


### PR DESCRIPTION
## Summary
- prevent `TclError` when inserting modules into analysis tree with missing parent
- add compatibility wrappers for legacy module paths
- add regression test for safe module insertion
- bump version to 0.2.67 and document in README

## Testing
- `radon cc -j mainappsrc/core/view_updater.py`
- `pytest -q` *(fails: missing application components and GUI environment, 216 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68accf522638832786706261b0307cae