### PR TITLE
Fix duplicate tool tabs when switching phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.67
+version: 0.2.68
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.68 - Prevent tool tab duplication when switching lifecycle phases.
 - 0.2.67 - Activate risk assessment tools only when risk assessment work products exist.
 - 0.2.66 - Recognize copied work products in active phase governance diagrams.
 - 0.2.65 - Always paste to the focused governance diagram and show focused tab details in the status bar.

--- a/mainappsrc/core/app_lifecycle_ui.py
+++ b/mainappsrc/core/app_lifecycle_ui.py
@@ -119,6 +119,13 @@ class AppLifecycleUI:
                         self.status_meta_vars[k].set(v)
 
     def _add_tool_category(self, cat: str, names: list[str]) -> None:
+        existing = self.tool_listboxes.get(cat)
+        if existing is not None:
+            current = set(existing.get(0, tk.END))
+            for n in names:
+                if n not in current:
+                    existing.insert(tk.END, n)
+            return
         frame = ttk.Frame(self.tools_nb)
         display = cat
         if len(display) > self.MAX_TOOL_TAB_TEXT_LENGTH:

--- a/mainappsrc/core/validation_consistency.py
+++ b/mainappsrc/core/validation_consistency.py
@@ -97,6 +97,15 @@ class Validation_Consistency:
             app.tool_categories[area] = []
             app.lifecycle_ui._add_tool_category(area, [])
 
+    def _update_tool_mapping(self, mapping, tool_name, name) -> None:
+        existing = mapping.get(tool_name)
+        if isinstance(existing, set):
+            existing.add(name)
+        elif existing:
+            mapping[tool_name] = {existing, name}
+        else:
+            mapping.setdefault(tool_name, set()).add(name)
+
     def enable_work_product(self, name: str, *, refresh: bool = True) -> None:
         app = self.app
         info = app.WORK_PRODUCT_INFO.get(name)
@@ -109,16 +118,10 @@ class Validation_Consistency:
                 if action:
                     app.tool_actions[tool_name] = action
                     lb = app.tool_listboxes.get(area)
-                    if lb:
+                    if lb and tool_name not in lb.get(0, tk.END):
                         lb.insert(tk.END, tool_name)
             mapping = getattr(app, "tool_to_work_product", {})
-            existing = mapping.get(tool_name)
-            if isinstance(existing, set):
-                existing.add(name)
-            elif existing:
-                mapping[tool_name] = {existing, name}
-            else:
-                mapping.setdefault(tool_name, set()).add(name)
+            self._update_tool_mapping(mapping, tool_name, name)
         for menu, idx in app.work_product_menus.get(name, []):
             try:
                 menu.entryconfig(idx, state=tk.NORMAL)

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.67"
+VERSION = "0.2.68"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- avoid re-adding existing tool categories and tool names when phases change
- prevent duplicate tool entries by checking existing list items
- bump version to 0.2.68 and document change

## Testing
- `pytest`
- `radon cc -j mainappsrc/core/validation_consistency.py mainappsrc/core/app_lifecycle_ui.py > /tmp/cc.json`


------
https://chatgpt.com/codex/tasks/task_b_68acd33abcec832780598af9fdcbf783