### PR TITLE
Normalize process area names to avoid duplicate tools tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.68
+version: 0.2.69
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -1624,7 +1624,7 @@ class AutoMLApp(
         gm.on_lifecycle_selected(phase)
 
 
-    def enable_process_area(self, area: str) -> None:  # pragma: no cover - delegation
+    def enable_process_area(self, area: str) -> str:  # pragma: no cover - delegation
         return self.validation_consistency.enable_process_area(area)
 
     def enable_work_product(self, name: str, *, refresh: bool = True) -> None:  # pragma: no cover - delegation

--- a/mainappsrc/core/validation_consistency.py
+++ b/mainappsrc/core/validation_consistency.py
@@ -91,11 +91,13 @@ class Validation_Consistency:
             self.update_validation_criteria(rid)
 
     # ------------------------------------------------------------------
-    def enable_process_area(self, area: str) -> None:
+    def enable_process_area(self, area: str) -> str:
         app = self.app
+        area = " ".join(area.split())
         if area not in app.tool_listboxes:
             app.tool_categories[area] = []
             app.lifecycle_ui._add_tool_category(area, [])
+        return area
 
     def _update_tool_mapping(self, mapping, tool_name, name) -> None:
         existing = mapping.get(tool_name)
@@ -112,7 +114,7 @@ class Validation_Consistency:
         area = tool_name = method_name = None
         if info:
             area, tool_name, method_name = info
-            self.enable_process_area(area)
+            area = self.enable_process_area(area)
             if tool_name not in app.tool_actions:
                 action = getattr(app, method_name, None)
                 if action:

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.68"
+VERSION = "0.2.69"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- avoid duplicate System Design tabs by normalizing process area names
- bump project version to 0.2.69

## Testing
- `radon cc -j mainappsrc/core/validation_consistency.py`
- `radon cc -j mainappsrc/core/automl_core.py`
- `pytest` *(fails: FileNotFoundError: '/workspace/AutoML/mainappsrc/page_diagram.py')*

------
https://chatgpt.com/codex/tasks/task_b_68acd5907c288327929be6061b895132