### PR TITLE
Fix missing reporting helpers and legacy module stubs

### DIFF
--- a/mainappsrc/automl_core.py
+++ b/mainappsrc/automl_core.py
@@ -1,0 +1,23 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Compatibility wrapper importing the core AutoML module."""
+
+from mainappsrc.core.automl_core import AutoMLApp, FaultTreeNode, PageDiagram
+
+__all__ = ["AutoMLApp", "FaultTreeNode", "PageDiagram"]

--- a/mainappsrc/core/reporting_export.py
+++ b/mainappsrc/core/reporting_export.py
@@ -67,6 +67,18 @@ class Reporting_Export:
     def build_requirement_diff_html(self, review):
         return self.app.requirements_manager.build_requirement_diff_html(review)
 
+    def generate_recommendations_for_top_event(self, node):
+        """Return recommendations for a given top event node."""
+        return self.app.generate_recommendations_for_top_event(node)
+
+    def get_extra_recommendations_list(self, description, level):
+        """Return extra recommendations for description at a given level."""
+        return self.app.get_extra_recommendations_list(description, level)
+
+    def get_all_nodes_in_model(self):
+        """Return all nodes currently present in the model."""
+        return self.app.get_all_nodes_in_model()
+
     # ------------------------------------------------------------------
     # Reporting helpers
     def _generate_pdf_report(self) -> None:

--- a/mainappsrc/page_diagram.py
+++ b/mainappsrc/page_diagram.py
@@ -1,0 +1,24 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Compatibility wrapper for legacy imports of page_diagram."""
+
+from mainappsrc.core.page_diagram import PageDiagram
+from gui.utils.drawing_helper import fta_drawing_helper
+
+__all__ = ["PageDiagram", "fta_drawing_helper"]


### PR DESCRIPTION
## Summary
- delegate node traversal and recommendation helpers via Reporting_Export
- add compatibility shims for legacy module paths

## Testing
- `pytest` *(fails: AttributeError and FileNotFoundError across multiple tests)*
- `python tools/metrics_generator.py`

------
https://chatgpt.com/codex/tasks/task_b_68ace4396ec083279aada8680d37281f