### PR TITLE
Fix missing reporting helpers and legacy module stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.71
+version: 0.2.73
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,8 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.73 - Delegate top events access through reporting helpers for PDF exports.
+- 0.2.72 - Delegate cause-effect data builder to fix PDF report generation.
 - 0.2.71 - Expand PDF report generator with template-driven content and enforce `.pdf` extension.
 - 0.2.70 - Ensure PDF exports always use the user-selected `.pdf` extension.
 - 0.2.68 - Prevent tool tab duplication when switching lifecycle phases.

--- a/mainappsrc/automl_core.py
+++ b/mainappsrc/automl_core.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper importing the core AutoML module."""
 
-VERSION = "0.2.73"
+from mainappsrc.core.automl_core import AutoMLApp, FaultTreeNode, PageDiagram
 
-__all__ = ["VERSION"]
+__all__ = ["AutoMLApp", "FaultTreeNode", "PageDiagram"]

--- a/mainappsrc/core/reporting_export.py
+++ b/mainappsrc/core/reporting_export.py
@@ -64,8 +64,34 @@ class Reporting_Export:
     def build_base_events_table_html(self):  # pragma: no cover - passthrough
         return self.app.fta_app.build_base_events_table_html(self.app)
 
+    def build_cause_effect_data(self):
+        """Return cause-effect table rows for PDF rendering."""
+        return self.app.build_cause_effect_data()
+
     def build_requirement_diff_html(self, review):
         return self.app.requirements_manager.build_requirement_diff_html(review)
+
+    def generate_recommendations_for_top_event(self, node):
+        """Return recommendations for a given top event node."""
+        return self.app.generate_recommendations_for_top_event(node)
+
+    def get_extra_recommendations_list(self, description, level):
+        """Return extra recommendations for description at a given level."""
+        return self.app.get_extra_recommendations_list(description, level)
+
+    def get_all_nodes_in_model(self):
+        """Return all nodes currently present in the model."""
+        return self.app.get_all_nodes_in_model()
+
+    @property
+    def top_events(self):
+        """Return top events currently defined in the application.
+
+        This delegates to the underlying :class:`AutoMLApp` to expose its
+        ``top_events`` list so callers can iterate over safety goals without
+        reaching into the app object directly.
+        """
+        return getattr(self.app, "top_events", [])
 
     # ------------------------------------------------------------------
     # Reporting helpers

--- a/mainappsrc/page_diagram.py
+++ b/mainappsrc/page_diagram.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper for legacy imports of page_diagram."""
 
-VERSION = "0.2.73"
+from mainappsrc.core.page_diagram import PageDiagram
+from gui.utils.drawing_helper import fta_drawing_helper
 
-__all__ = ["VERSION"]
+__all__ = ["PageDiagram", "fta_drawing_helper"]


### PR DESCRIPTION
## Summary
- delegate node traversal and recommendation helpers via Reporting_Export
- add compatibility shims for legacy module paths
- delegate cause-effect table generation to prevent PDF export errors
- expose top events through Reporting_Export for PDF report generation

## Testing
- `python tools/metrics_generator.py`
- `pytest` *(fails: AttributeError/FileNotFoundError across multiple tests)*

------
https://chatgpt.com/codex/tasks/task_b_68ace4396ec083279aada8680d37281f