### PR TITLE
Delegate basic event retrieval for PDF reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.75
+version: 0.2.76
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.76 - Delegate basic events access through reporting helpers for PDF report generation.
 - 0.2.75 - Delegate root node access through reporting helpers for traceability PDF generation.
 - 0.2.74 - Delegate node traversal helper through reporting export for traceability PDF elements.
 - 0.2.73 - Delegate top events access through reporting helpers for PDF exports.

--- a/mainappsrc/core/reporting_export.py
+++ b/mainappsrc/core/reporting_export.py
@@ -92,6 +92,10 @@ class Reporting_Export:
         """
         return self.app.get_all_nodes(node)
 
+    def get_all_basic_events(self):
+        """Return all basic events currently defined in the model."""
+        return self.app.get_all_basic_events()
+
     @property
     def root_node(self):
         """Return the current root node of the application model."""

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.75"
+VERSION = "0.2.76"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- expose app basic events via Reporting_Export for PDF generation
- bump version to 0.2.76

## Testing
- `pytest`
- `python tools/metrics_generator.py --path mainappsrc/core --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68acec9e76688327b23813e87924c8fe