### PR TITLE
Fix dialog sizing and open requirements matrix in tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.77
+version: 0.2.78
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.78 - Open Requirements Matrix in workspace tab and enforce fixed-size dialogs.
 - 0.2.77 - Coerce PDF export path to string to support Windows paths.
 - 0.2.76 - Delegate basic events access through reporting helpers for PDF report generation.
 - 0.2.75 - Delegate root node access through reporting helpers for traceability PDF generation.

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -28,6 +28,9 @@ from tkinter import ttk, simpledialog
 from .utils import DIALOG_BG_COLOR, logger, drawing_helper
 from pathlib import Path
 
+# Fixed dimensions applied to all prompt dialogs to ensure consistent sizing
+DEFAULT_DIALOG_GEOMETRY = "600x400"
+
 # Allow importing modules from subpackages via ``gui.<module>``
 for _sub in ("windows", "toolboxes", "explorers", "utils", "styles", "dialogs"):
     __path__.append(str(Path(__file__).resolve().parent / _sub))
@@ -43,10 +46,12 @@ _orig_dialog_init = simpledialog.Dialog.__init__
 
 
 def _dialog_init_with_color(self, parent, title=None):
-    """Apply light blue background to every dialog window."""
+    """Apply light blue background and fixed geometry to dialog windows."""
     _orig_dialog_init(self, parent, title)
     try:
         self.configure(bg=DIALOG_BG_COLOR)
+        self.resizable(False, False)
+        self.geometry(DEFAULT_DIALOG_GEOMETRY)
         for child in self.winfo_children():
             try:
                 child.configure(bg=DIALOG_BG_COLOR)

--- a/mainappsrc/automl_core.py
+++ b/mainappsrc/automl_core.py
@@ -16,8 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper for relocated :mod:`automl_core` module."""
 
-VERSION = "0.2.78"
+try:
+    from .core.automl_core import *  # type: ignore[F401,F403]
+except Exception:  # pragma: no cover - allow direct execution
+    from mainappsrc.core.automl_core import *  # type: ignore[F401,F403]
 
-__all__ = ["VERSION"]

--- a/mainappsrc/core/editors.py
+++ b/mainappsrc/core/editors.py
@@ -249,8 +249,11 @@ class Editors:
         reqs = list(global_requirements.values())
         reqs.sort(key=lambda r: r.get("req_type", ""))
 
-        win = tk.Toplevel(app.root)
-        win.title("Requirements Matrix")
+        if hasattr(app, "_new_tab"):
+            win = app._new_tab("Requirements Matrix")
+        else:
+            win = tk.Toplevel(app.root)
+            win.title("Requirements Matrix")
 
         columns = [
             "Req ID",

--- a/mainappsrc/page_diagram.py
+++ b/mainappsrc/page_diagram.py
@@ -16,8 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper for relocated :mod:`page_diagram` module."""
 
-VERSION = "0.2.78"
+try:
+    from .core.page_diagram import PageDiagram, fta_drawing_helper
+except Exception:  # pragma: no cover - allow direct execution
+    from mainappsrc.core.page_diagram import PageDiagram, fta_drawing_helper
 
-__all__ = ["VERSION"]
+__all__ = ["PageDiagram", "fta_drawing_helper"]
+


### PR DESCRIPTION
## Summary
- enforce fixed geometry for all prompt dialogs
- open Requirements Matrix inside main working area tab
- add compatibility wrappers for relocated modules and bump version to 0.2.78

## Testing
- `radon cc -s -j mainappsrc gui`
- `pytest` *(fails: AttributeError: 'AutoMLApp' object has no attribute 'lifecycle')*

------
https://chatgpt.com/codex/tasks/task_b_68acf08fb2648327a9102423e9d22ae9