### PR TITLE
Ensure tools package available in frozen executable

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -32,6 +32,14 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+
+# Ensure bundled executables can import sibling packages
+if getattr(sys, "frozen", False):
+    _ROOT = Path(sys._MEIPASS)
+else:
+    _ROOT = Path(__file__).resolve().parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
 from tools.crash_report_logger import install_best
 from tools.memory_manager import manager as memory_manager
 from tools.splash_launcher import SplashLauncher

--- a/README.md
+++ b/README.md
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.79 - Ensure tools package is available for bundled executable by injecting project root into ``sys.path``.
 - 0.2.78 - Open Requirements Matrix in workspace tab and enforce fixed-size dialogs.
 - 0.2.77 - Coerce PDF export path to string to support Windows paths.
 - 0.2.76 - Delegate basic events access through reporting helpers for PDF report generation.

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.78"
+VERSION = "0.2.79"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- add project root to `sys.path` so `tools` package resolves in bundled executables
- bump version to 0.2.79 and document change

## Testing
- `radon cc -j AutoML.py`
- `pytest -q` *(fails: NameError: name 'GovernanceManager' is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68acf33ab354832783acdd0b1712d046