### PR TITLE
Restrict safety case inputs to active-phase governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.78
+version: 0.2.80
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.80 - Enforce active-phase governance relations for safety case inputs.
 - 0.2.79 - Ensure tools package is available for bundled executable by injecting project root into ``sys.path``.
 - 0.2.78 - Open Requirements Matrix in workspace tab and enforce fixed-size dialogs.
 - 0.2.77 - Coerce PDF export path to string to support Windows paths.

--- a/gui/explorers/safety_case_explorer.py
+++ b/gui/explorers/safety_case_explorer.py
@@ -154,12 +154,10 @@ class SafetyCaseExplorer(tk.Frame):
         if toolbox:
             reviewed = getattr(getattr(self.app, "current_review", None), "reviewed", False)
             approved = getattr(getattr(self.app, "current_review", None), "approved", False)
-            if toolbox.can_use_as_input(
-                "GSN Argumentation",
-                "Safety & Security Case",
-                reviewed=reviewed,
-                approved=approved,
-            ):
+            inputs = toolbox.analysis_inputs(
+                "Safety & Security Case", reviewed=reviewed, approved=approved
+            )
+            if "GSN Argumentation" in inputs:
                 diagrams = [
                     d
                     for d in diagrams

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.79"
+VERSION = "0.2.80"
 
 __all__ = ["VERSION"]

--- a/tests/test_safety_case_gsn_visibility.py
+++ b/tests/test_safety_case_gsn_visibility.py
@@ -21,7 +21,11 @@ import types
 from mainappsrc.models.gsn import GSNNode, GSNDiagram
 from gui.safety_case_explorer import SafetyCaseExplorer
 from gui.architecture import SysMLObject
-from analysis.safety_management import SafetyManagementToolbox, SafetyWorkProduct
+from analysis.safety_management import (
+    GovernanceModule,
+    SafetyManagementToolbox,
+    SafetyWorkProduct,
+)
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
 
 
@@ -81,3 +85,47 @@ def test_gsn_diagram_visibility_for_safety_case():
     assert explorer._available_diagrams() == []
     app.current_review.approved = True
     assert explorer._available_diagrams()
+
+
+def test_gsn_diagram_visibility_respects_active_phase():
+    """GSN diagrams are hidden when their relation resides in another phase."""
+    SysMLRepository._instance = None
+    repo = SysMLRepository.get_instance()
+    gov1 = repo.create_diagram("Governance Diagram", name="Gov1")
+    gov2 = repo.create_diagram("Governance Diagram", name="Gov2")
+
+    toolbox = SafetyManagementToolbox()
+    toolbox.diagrams = {"Gov1": gov1.diag_id, "Gov2": gov2.diag_id}
+    toolbox.modules = [
+        GovernanceModule(name="P1", diagrams=["Gov1"]),
+        GovernanceModule(name="P2", diagrams=["Gov2"]),
+    ]
+
+    e1 = repo.create_element("Block", name="E1")
+    e2 = repo.create_element("Block", name="E2")
+    repo.add_element_to_diagram(gov2.diag_id, e1.elem_id)
+    repo.add_element_to_diagram(gov2.diag_id, e2.elem_id)
+    o1 = SysMLObject(1, "Work Product", 0, 0, element_id=e1.elem_id, properties={"name": "GSN Argumentation"})
+    o2 = SysMLObject(2, "Work Product", 0, 100, element_id=e2.elem_id, properties={"name": "Safety & Security Case"})
+    gov2.objects = [o1.__dict__, o2.__dict__]
+    gov2.connections = [{"src": 1, "dst": 2, "conn_type": "Used By"}]
+
+    toolbox.work_products = [
+        SafetyWorkProduct("Gov2", "GSN Argumentation", ""),
+        SafetyWorkProduct("Gov2", "Safety & Security Case", ""),
+    ]
+    toolbox.doc_phases = {"GSN Argumentation": {"Diag": "P1"}}
+    toolbox.active_module = "P1"
+
+    root = GSNNode("Diag", "Goal")
+    gdiag = GSNDiagram(root)
+    explorer = SafetyCaseExplorer.__new__(SafetyCaseExplorer)
+    explorer.app = types.SimpleNamespace(
+        safety_mgmt_toolbox=toolbox,
+        current_review=types.SimpleNamespace(reviewed=False, approved=False),
+        gsn_diagrams=[gdiag],
+        gsn_modules=[],
+        all_gsn_diagrams=[],
+    )
+
+    assert explorer._available_diagrams() == []


### PR DESCRIPTION
## Summary
- gate GSN diagram availability on `analysis_inputs` so only relations in the active lifecycle phase provide Safety & Security Case inputs
- verify that cross-phase relations do not expose GSN diagrams
- bump version to 0.2.80

## Testing
- `radon cc -j gui/explorers/safety_case_explorer.py tests/test_safety_case_gsn_visibility.py | python -m json.tool | head -n 80`
- `pytest` *(fails: FileNotFoundError: mainappsrc/page_diagram.py)*

------
https://chatgpt.com/codex/tasks/task_b_68acfaa449308327b2e9f8f5e473929d