### PR TITLE
fix: persist governance folders on save/load

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.81
+version: 0.2.82
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.82 - Preserve governance folder structure when saving and loading projects.
 - 0.2.81 - Show GSN diagrams as inputs when governance conditions are met and provide compatibility wrapper for ``page_diagram``.
 - 0.2.80 - Enforce active-phase governance relations for safety case inputs.
 - 0.2.79 - Ensure tools package is available for bundled executable by injecting project root into ``sys.path``.

--- a/mainappsrc/core/reporting_export.py
+++ b/mainappsrc/core/reporting_export.py
@@ -1401,6 +1401,14 @@ class Reporting_Export:
             ],
             "gsn_modules": [m.to_dict() for m in app.gsn_modules],
             "gsn_diagrams": [d.to_dict() for d in app.gsn_diagrams],
+            "safety_mgmt_toolbox": (
+                app.safety_mgmt_toolbox.to_dict()
+                if getattr(app, "safety_mgmt_toolbox", None)
+                else {}
+            ),
+            "enabled_work_products": list(
+                getattr(app, "enabled_work_products", [])
+            ),
         }
         return data
 

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.81"
+VERSION = "0.2.82"
 
 __all__ = ["VERSION"]

--- a/tests/test_governance_folder_persistence.py
+++ b/tests/test_governance_folder_persistence.py
@@ -1,0 +1,119 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Verify governance folder structure persists through save/load."""
+
+import importlib.util
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+spec = importlib.util.spec_from_file_location(
+    "analysis.safety_management",
+    os.path.join(os.path.dirname(__file__), "..", "analysis", "safety_management.py"),
+)
+safety_management = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(safety_management)
+SafetyManagementToolbox = safety_management.SafetyManagementToolbox
+GovernanceModule = safety_management.GovernanceModule
+
+from mainappsrc.core.reporting_export import Reporting_Export
+from mainappsrc.managers.project_manager import ProjectManager
+from mainappsrc.models.sysml.sysml_repository import SysMLRepository
+
+
+class _MinimalApp:
+    """Minimal application stub for export/import tests."""
+
+    def __init__(self):
+        self.update_odd_elements = lambda: None
+        self.top_events = []
+        self.cta_events = []
+        self.paa_events = []
+        self.fmeas = []
+        self.fmedas = []
+        self.mechanism_libraries = []
+        self.mission_profiles = []
+        self.reliability_analyses = []
+        self.reliability_components = []
+        self.reliability_total_fit = 0
+        self.spfm = 0
+        self.lpfm = 0
+        self.reliability_dc = 0
+        self.item_definition = {}
+        self.safety_concept = {}
+        self.fmeda_components = []
+        self.current_user = None
+        self.hazop_docs = []
+        self.hara_docs = []
+        self.stpa_docs = []
+        self.threat_docs = []
+        self.fi2tc_docs = []
+        self.tc2fi_docs = []
+        self.review_data = types.SimpleNamespace(name=None)
+        self.reviews = []
+        self.project_properties = {}
+        self.selected_mechanism_libraries = []
+        self.scenario_libraries = []
+        self.odd_libraries = []
+        self.odd_elements = []
+        self.versions = []
+        self.fmea_service = types.SimpleNamespace(get_settings_dict=lambda: {})
+        self.requirements_manager = types.SimpleNamespace(export_state=lambda: {})
+        self.arch_diagrams = []
+        self.management_diagrams = []
+        self.gsn_modules = []
+        self.gsn_diagrams = []
+        self.safety_mgmt_toolbox = SafetyManagementToolbox()
+        self.enabled_work_products = set()
+        self.project_manager = ProjectManager.__new__(ProjectManager)
+        self.project_manager.app = self
+        self.reporting_export = Reporting_Export(self)
+        # Needed by ProjectManager.apply_model_data
+        self.governance_manager = types.SimpleNamespace(
+            attach_toolbox=lambda tb: None,
+            set_active_module=lambda name: None,
+        )
+        self._refresh_phase_requirements_menu = lambda: None
+        self.validation_consistency = types.SimpleNamespace(
+            enable_work_product=lambda name, refresh=True: self.enabled_work_products.add(name),
+            disable_work_product=lambda name: self.enabled_work_products.discard(name),
+        )
+        self._load_project_properties = lambda data: None
+        self._load_fault_tree_events = lambda data, ensure_root: None
+
+    def enable_work_product(self, name, *, refresh=True):
+        self.enabled_work_products.add(name)
+
+
+def test_folder_structure_roundtrip():
+    """Saving and loading a project preserves governance folders."""
+    app = _MinimalApp()
+    tb = app.safety_mgmt_toolbox
+    tb.create_diagram("Gov")
+    tb.modules = [GovernanceModule("Phase", diagrams=["Gov"])]
+
+    SysMLRepository._instance = types.SimpleNamespace(export_state=lambda: {})
+
+    data = app.reporting_export.export_model_data(include_versions=False)
+    assert data["safety_mgmt_toolbox"]["modules"][0]["name"] == "Phase"
+
+    loaded = SafetyManagementToolbox.from_dict(data["safety_mgmt_toolbox"])
+    assert loaded.modules[0].name == "Phase"
+    assert loaded.modules[0].diagrams == ["Gov"]

--- a/tests/test_safety_management_persistence.py
+++ b/tests/test_safety_management_persistence.py
@@ -38,6 +38,7 @@ def _minimal_app():
     """Return a barebones ``AutoMLApp`` suitable for serialisation tests."""
 
     app = AutoMLApp.__new__(AutoMLApp)
+    app.safety_analysis = types.SimpleNamespace(fmeas=[], fmedas=[])
     app.top_events = []
     app.root_node = None
     app.fmea_entries = []


### PR DESCRIPTION
## Summary
- include safety management toolbox and enabled work products when exporting project data
- update version to 0.2.82 and document in README
- add regression test ensuring governance folder hierarchy survives save/load

## Testing
- `pytest tests/test_governance_folder_persistence.py -q`
- `pytest tests/test_version_sync.py -q`
- `pytest -q` *(fails: FileNotFoundError: mainappsrc/automl_core.py)*
- `python tools/metrics_generator.py --path mainappsrc/core --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68acffe92aec8327a20231d4634c1a1c