### PR TITLE
fix: bundle tools package in build

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -40,6 +40,7 @@ else:
     _ROOT = Path(__file__).resolve().parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
+import tools  # noqa: F401  # ensure package is bundled
 from tools.crash_report_logger import install_best
 from tools.memory_manager import manager as memory_manager
 from tools.splash_launcher import SplashLauncher

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.82
+version: 0.2.85
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1555,7 +1555,7 @@ If sending fails with a connection error, the dialog will prompt again so you ca
 
 AutoML relies on a few third‑party Python packages. The new
 `automl.py` script checks for these dependencies and installs any that are
-missing before handing off execution to `mainappsrc/automl_core.py`. The required packages
+missing before handing off execution to `mainappsrc/core/automl_core.py`. The required packages
 are:
 
 ```
@@ -1578,7 +1578,7 @@ dependencies with `python -m pip show` so the correct interpreter is used and
 pass `--hidden-import=PIL.ImageTk` to PyInstaller to ensure the module is
 bundled correctly.
 
-If double‑clicking `mainappsrc/automl_core.py` closes immediately, launch it from a command
+If double‑clicking `mainappsrc/core/automl_core.py` closes immediately, launch it from a command
 prompt instead so any error messages remain visible. Running `automl.py`
 performs the dependency installation automatically:
 
@@ -1644,6 +1644,9 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.85 - Ensure PyInstaller bundles the tools package by collecting all modules.
+- 0.2.84 - Bundle tools package in executable to fix missing module at runtime.
+- 0.2.83 - Fix PyInstaller data path for core module and update documentation.
 - 0.2.82 - Preserve governance folder structure when saving and loading projects.
 - 0.2.81 - Show GSN diagrams as inputs when governance conditions are met and provide compatibility wrapper for ``page_diagram``.
 - 0.2.80 - Enforce active-phase governance relations for safety case inputs.

--- a/__init__.py
+++ b/__init__.py
@@ -20,7 +20,8 @@
 import tkinter as tk
 from tkinter import ttk, simpledialog, filedialog, scrolledtext
 
-from .mainappsrc.automl_core import (
+# Import application core from the dedicated core package
+from .mainappsrc.core.automl_core import (
     AutoMLApp,
     FaultTreeNode,
     AutoML_Helper,

--- a/bin/build_exe.bat
+++ b/bin/build_exe.bat
@@ -61,9 +61,10 @@ pyinstaller --noconfirm --onefile --windowed --name AutoML ^
     --hidden-import=tkinter.simpledialog ^
     --hidden-import=tkinter.scrolledtext ^
     --hidden-import=tkinter.ttk ^
+    --collect-all tools ^
     --add-data "config/styles;config/styles" ^
-    --add-data "mainappsrc\automl_core.py;mainappsrc" ^
-    --icon "%BIN_DIR%AutoML.ico" automl.py
+    --add-data "mainappsrc\core\automl_core.py;mainappsrc\core" ^
+    --icon "%BIN_DIR%AutoML.ico" AutoML.py
 if errorlevel 1 (
     echo Failed to build executable.
     exit /b %errorlevel%

--- a/bin/build_exe.sh
+++ b/bin/build_exe.sh
@@ -62,9 +62,10 @@ pyinstaller --noconfirm --onefile --windowed \
     --hidden-import=tkinter.simpledialog \
     --hidden-import=tkinter.scrolledtext \
     --hidden-import=tkinter.ttk \
+    --collect-all tools \
     --add-data "config/styles:config/styles" \
-    --add-data "mainappsrc/automl_core.py:mainappsrc" \
-    --icon bin/AutoML.ico automl.py
+    --add-data "mainappsrc/core/automl_core.py:mainappsrc/core" \
+    --icon bin/AutoML.ico AutoML.py
 
 # Move the resulting executable to the bin directory
 mkdir -p bin

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.82"
+VERSION = "0.2.85"
 
 __all__ = ["VERSION"]

--- a/tests/test_diagram_mode_enforcement.py
+++ b/tests/test_diagram_mode_enforcement.py
@@ -28,12 +28,9 @@ sys.modules.setdefault("PIL.ImageDraw", types.ModuleType("PIL.ImageDraw"))
 sys.modules.setdefault("PIL.ImageFont", types.ModuleType("PIL.ImageFont"))
 sys.modules.setdefault("PIL.ImageTk", types.ModuleType("PIL.ImageTk"))
 
-import importlib.util
+import importlib
 
-module_path = pathlib.Path(__file__).resolve().parents[1] / "mainappsrc" / "automl_core.py"
-spec = importlib.util.spec_from_file_location("AutoML", module_path)
-AutoML = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(AutoML)
+AutoML = importlib.import_module("mainappsrc.core.automl_core")
 AutoMLApp = AutoML.AutoMLApp
 FaultTreeNode = AutoML.FaultTreeNode
 PageDiagram = AutoML.PageDiagram

--- a/tests/test_fta_clone_paste.py
+++ b/tests/test_fta_clone_paste.py
@@ -34,11 +34,7 @@ FaultTreeNode = automl.FaultTreeNode
 messagebox = automl.messagebox
 from mainappsrc.core.diagram_clipboard_manager import DiagramClipboardManager
 
-page_spec = importlib.util.spec_from_file_location(
-    "page_diagram", repo_root / "mainappsrc/page_diagram.py"
-)
-page_module = importlib.util.module_from_spec(page_spec)
-page_spec.loader.exec_module(page_module)
+page_module = importlib.import_module("mainappsrc.core.page_diagram")
 PageDiagram = page_module.PageDiagram
 fta_drawing_helper = page_module.fta_drawing_helper
 


### PR DESCRIPTION
## Summary
- ensure PyInstaller collects the entire `tools` package and reference it explicitly in the launcher
- bump project version to 0.2.85 and document new release

## Testing
- `python -m pytest` *(fails: 214 failed, 975 passed, 54 skipped)*
- `radon cc -s -j mainappsrc/core`


------
https://chatgpt.com/codex/tasks/task_b_68ad02c719508327a6dfb71520b68773