### PR TITLE
feat: enrich splash screen lighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.84
+version: 0.2.85
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.85 - Add sun and horizon lighting effects to splash screen.
 - 0.2.84 - Run TrashEater resource monitor via thread manager during startup.
 - 0.2.83 - Fix PyInstaller data path for core module and update documentation.
 - 0.2.82 - Preserve governance folder structure when saving and loading projects.

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -67,7 +67,10 @@ class SplashScreen(tk.Toplevel):
         )
         self.canvas.pack()
         self._draw_gradient()
+        self._draw_horizon_glow()
+        self._draw_sun()
         self._draw_floor()
+        self._draw_floor_light()
         self._center()
         # Initialize cube geometry
         self.angle = 0.0
@@ -164,13 +167,13 @@ class SplashScreen(tk.Toplevel):
         self.shadow.lower(self)
 
     def _draw_gradient(self):
-        """Draw a multi-color background gradient."""
-        # Color stops: violet sky -> magenta -> light green horizon -> dark ground
+        """Draw a sky-to-ground gradient with warm horizon."""
+        # Color stops: deep blue sky -> light blue -> warm horizon -> dark ground
         stops = [
-            (0.0, (138, 43, 226)),   # violet
-            (0.3, (255, 0, 255)),    # magenta
-            (0.55, (144, 238, 144)), # light green
-            (1.0, (0, 100, 0)),      # dark green ground
+            (0.0, (10, 10, 80)),      # deep blue
+            (0.4, (70, 130, 180)),    # sky blue
+            (0.55, (255, 214, 170)),  # warm horizon
+            (1.0, (0, 100, 0)),       # ground
         ]
         steps = self.canvas_size
         for i in range(steps):
@@ -187,7 +190,40 @@ class SplashScreen(tk.Toplevel):
             g = int(left_col[1] + (right_col[1] - left_col[1]) * local)
             b = int(left_col[2] + (right_col[2] - left_col[2]) * local)
             color = f"#{r:02x}{g:02x}{b:02x}"
-            self.canvas.create_line(0, i, self.canvas_size, i, fill=color)
+            self.canvas.create_line(0, i, self.canvas_size, i, fill=color, tags="sky")
+
+    def _draw_horizon_glow(self) -> None:
+        """Render a soft band of light across the horizon."""
+        horizon = int(self.canvas_size * 0.55)
+        band = 30
+        for i in range(band):
+            ratio = i / band
+            r = 255
+            g = int(233 - 80 * ratio)
+            b = int(200 - 120 * ratio)
+            color = f"#{r:02x}{g:02x}{b:02x}"
+            y = horizon - band // 2 + i
+            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="horizon_glow")
+
+    def _draw_sun(self) -> None:
+        """Draw a glowing sun centered on the horizon."""
+        cx = self.canvas_size / 2
+        cy = int(self.canvas_size * 0.55)
+        for radius, colour, stipple in [
+            (50, "#fffacd", "gray25"),
+            (35, "#ffe066", "gray25"),
+            (20, "#ffd700", ""),
+        ]:
+            self.canvas.create_oval(
+                cx - radius,
+                cy - radius,
+                cx + radius,
+                cy + radius,
+                fill=colour,
+                outline="",
+                stipple=stipple,
+                tags="sun",
+            )
     def _draw_cloud(self):
         """Draw a small turquoise-magenta-white cloud on the sky."""
         cx, cy = 80, 80
@@ -271,6 +307,22 @@ class SplashScreen(tk.Toplevel):
             color = f"#{r:02x}{g:02x}{b:02x}"
             y = horizon + i
             self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="floor")
+
+    def _draw_floor_light(self) -> None:
+        """Add a soft highlight to the ground."""
+        cx = self.canvas_size / 2
+        cy = int(self.canvas_size * 0.55) + 40
+        for radius, stipple in [(120, "gray75"), (80, "gray50")]:
+            self.canvas.create_oval(
+                cx - radius,
+                cy - radius / 2,
+                cx + radius,
+                cy + radius / 2,
+                fill="#ffffe0",
+                outline="",
+                stipple=stipple,
+                tags="floor_light",
+            )
 
     def _project(self, x, y, z):
         """Project 3D point onto 2D canvas."""

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.84"
+VERSION = "0.2.85"
 
 __all__ = ["VERSION"]

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -58,6 +58,14 @@ class SplashScreenTests(unittest.TestCase):
         for t in text_items:
             self.assertEqual(self.splash.canvas.itemcget(t, "fill"), "white")
 
+    def test_environment_features_present(self):
+        sun_items = self.splash.canvas.find_withtag("sun")
+        glow_items = self.splash.canvas.find_withtag("horizon_glow")
+        light_items = self.splash.canvas.find_withtag("floor_light")
+        self.assertGreater(len(sun_items), 0)
+        self.assertGreater(len(glow_items), 0)
+        self.assertGreater(len(light_items), 0)
+
     def test_close_fades_to_invisible(self):
         if not getattr(self.splash, "_alpha_supported", False):
             self.skipTest("alpha not supported")


### PR DESCRIPTION
## Summary
- add sun, horizon glow, and ground highlight to splash screen
- test presence of new lighting elements
- bump version to 0.2.85 and update docs

## Testing
- `PYTHONPATH=. pytest tests/test_splash_screen.py tests/test_splash_launcher.py tests/test_version_sync.py`
- `python tools/metrics_generator.py --path gui/windows --output /tmp/metrics.json` (filtered for splash_screen)
- `pytest` *(fails: AttributeError: 'AutoMLApp' object has no attribute 'lifecycle_phase', FileNotFoundError, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68ad0944e54483278d1e494a1aeb0d08