### PR TITLE
feat: add cosmic star field to splash screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1697,6 +1697,7 @@ and run the build again if you hit this issue.
 - 0.2.36 - Delegate add/get/show/link/refresh/collect routines to safety analysis facade.
 - 0.2.35 - Wrap update routines within safety analysis facade.
 - 0.2.34 - Centralise safety analysis helpers into facade and delegate from core.
+- 0.2.87 - Render star field on splash screen for cosmic backdrop.
 - 0.2.33 - Extract dialog classes into dedicated modules and update mixins.
 - 0.2.32 - Refactor core initialization into mixins for style, services, and icons.
 - 0.2.31 - Provide requirements editor export placeholder to prevent export error.

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -18,6 +18,35 @@
 
 import tkinter as tk
 import math
+import random
+from dataclasses import dataclass
+
+
+@dataclass
+class StarField:
+    """Render a simple star field on a Tkinter canvas."""
+
+    canvas: tk.Canvas
+    width: int
+    height: int
+    star_count: int = 50
+
+    def draw(self) -> None:
+        """Draw randomly positioned stars across the sky region."""
+        sky_limit = int(self.height * 0.55)
+        for _ in range(self.star_count):
+            x = random.randint(0, self.width)
+            y = random.randint(0, sky_limit)
+            size = random.choice((1, 2))
+            self.canvas.create_oval(
+                x,
+                y,
+                x + size,
+                y + size,
+                fill="white",
+                outline="",
+                tags="star",
+            )
 
 
 class SplashScreen(tk.Toplevel):
@@ -67,6 +96,7 @@ class SplashScreen(tk.Toplevel):
         )
         self.canvas.pack()
         self._draw_gradient()
+        self._draw_stars()
         self._draw_floor()
         self._center()
         # Initialize cube geometry
@@ -188,6 +218,10 @@ class SplashScreen(tk.Toplevel):
             b = int(left_col[2] + (right_col[2] - left_col[2]) * local)
             color = f"#{r:02x}{g:02x}{b:02x}"
             self.canvas.create_line(0, i, self.canvas_size, i, fill=color)
+
+    def _draw_stars(self) -> None:
+        """Scatter small white stars across the upper sky."""
+        StarField(self.canvas, self.canvas_size, self.canvas_size).draw()
     def _draw_cloud(self):
         """Draw a small turquoise-magenta-white cloud on the sky."""
         cx, cy = 80, 80

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.86"
+VERSION = "0.2.87"
 
 __all__ = ["VERSION"]

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -58,6 +58,10 @@ class SplashScreenTests(unittest.TestCase):
         for t in text_items:
             self.assertEqual(self.splash.canvas.itemcget(t, "fill"), "white")
 
+    def test_star_field_present(self):
+        star_items = self.splash.canvas.find_withtag("star")
+        self.assertGreater(len(star_items), 0)
+
     def test_close_fades_to_invisible(self):
         if not getattr(self.splash, "_alpha_supported", False):
             self.skipTest("alpha not supported")


### PR DESCRIPTION
## Summary
- add starry backdrop to splash screen to evoke cosmic scene
- bump version to 0.2.87
- document new version in README and test star field presence

## Testing
- `pytest` *(fails: GovernanceManager NameError, AutoMLApp AttributeError, and others)*
- `PYTHONPATH=. pytest tests/test_splash_screen.py` *(fails: circular import in architecture module)*
- `radon cc -j gui/windows/splash_screen.py`

------
https://chatgpt.com/codex/tasks/task_b_68ad0e3791b88327bcf6ebe38446c44b