### PR TITLE
Enhance splash screen title style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.86
+version: 0.2.87
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -246,38 +246,50 @@ class SplashScreen(tk.Toplevel):
         )
 
     def _draw_title(self) -> None:
-        """Render project title in white on a black shadow background."""
+        """Render project title with a subtle white shadow."""
         x = self.canvas_size / 2
         y = self.canvas_size - 40
         main_text = "Automotive Modeling Language"
         sub_text = "by Karel Capek Robotics"
-        title_font = ("Helvetica", 12, "bold")
-        sub_font = ("Helvetica", 10)
+        title_font = ("Helvetica", 14, "bold")
+        sub_font = ("Helvetica", 12, "bold")
+        offset = 1
 
-        text_ids = [
-            self.canvas.create_text(
-                x,
-                y,
-                text=main_text,
-                font=title_font,
-                fill="white",
-                tags="title_text",
-            ),
-            self.canvas.create_text(
-                x,
-                y + 20,
-                text=sub_text,
-                font=sub_font,
-                fill="white",
-                tags="title_text",
-            ),
-        ]
-        bbox = self.canvas.bbox(*text_ids)
-        bg_id = self.canvas.create_rectangle(
-            bbox, fill="black", outline="", tags="title_bg"
+        # White shadow drawn slightly offset behind the main text
+        self.canvas.create_text(
+            x + offset,
+            y + offset,
+            text=main_text,
+            font=title_font,
+            fill="white",
+            tags="title_shadow",
         )
-        for t_id in text_ids:
-            self.canvas.tag_raise(t_id, bg_id)
+        self.canvas.create_text(
+            x + offset,
+            y + 20 + offset,
+            text=sub_text,
+            font=sub_font,
+            fill="white",
+            tags="title_shadow",
+        )
+
+        # Foreground text in bold black
+        self.canvas.create_text(
+            x,
+            y,
+            text=main_text,
+            font=title_font,
+            fill="black",
+            tags="title_text",
+        )
+        self.canvas.create_text(
+            x,
+            y + 20,
+            text=sub_text,
+            font=sub_font,
+            fill="black",
+            tags="title_text",
+        )
 
     def _draw_floor(self):
         """Add subtle white light near horizon and darker shadow toward bottom."""

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -49,14 +49,17 @@ class SplashScreenTests(unittest.TestCase):
         gear_items = self.splash.canvas.find_withtag("gear")
         self.assertEqual(len(gear_items), 1)
 
-    def test_title_background(self):
+    def test_title_shadow(self):
         bg_items = self.splash.canvas.find_withtag("title_bg")
+        shadow_items = self.splash.canvas.find_withtag("title_shadow")
         text_items = self.splash.canvas.find_withtag("title_text")
-        self.assertEqual(len(bg_items), 1)
+        self.assertEqual(len(bg_items), 0)
+        self.assertEqual(len(shadow_items), 2)
         self.assertEqual(len(text_items), 2)
-        self.assertEqual(self.splash.canvas.itemcget(bg_items[0], "fill"), "black")
         for t in text_items:
-            self.assertEqual(self.splash.canvas.itemcget(t, "fill"), "white")
+            self.assertEqual(self.splash.canvas.itemcget(t, "fill"), "black")
+        for s in shadow_items:
+            self.assertEqual(self.splash.canvas.itemcget(s, "fill"), "white")
 
     def test_star_field_present(self):
         star_items = self.splash.canvas.find_withtag("star")


### PR DESCRIPTION
## Summary
- Remove black backdrop from splash screen title and render bold black text with subtle white shadow
- Adjust splash screen test expectations for new styling
- Sync README version with source version

## Testing
- `radon cc -s -j gui/windows/splash_screen.py`
- `PYTHONPATH=. pytest tests/test_splash_screen.py tests/test_splash_launcher.py tests/test_version_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ad10e38fe483279c024d8014692f7a