### PR TITLE
Add gradient shading to splash screen void

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.88
+version: 0.2.90
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,8 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.90 - Add light green and white gradient shading to the void.
+- 0.2.89 - Render splash screen as a black void with a white horizon.
 - 0.2.88 - Add translucent night sky gradient to splash screen.
 - 0.2.87 - Use absolute imports for config constants to support bundled executables.
 - 0.2.86 - Explicitly include tools package in PyInstaller builds to prevent runtime import errors.

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -194,41 +194,40 @@ class SplashScreen(tk.Toplevel):
         self.shadow.lower(self)
 
     def _draw_gradient(self):
-        """Draw a multi-colour gradient with a translucent night overlay."""
-        # Color stops: violet sky -> magenta -> light green horizon -> dark ground
-        stops = [
-            (0.0, (138, 43, 226)),   # violet
-            (0.3, (255, 0, 255)),    # magenta
-            (0.55, (144, 238, 144)), # light green
-            (1.0, (0, 100, 0)),      # dark green ground
-        ]
-        steps = self.canvas_size
-        night_height = int(self.canvas_size * 0.3)
-        for i in range(steps):
-            ratio = i / steps
-            # Find two surrounding color stops
-            for idx in range(len(stops) - 1):
-                if stops[idx][0] <= ratio <= stops[idx + 1][0]:
-                    left_pos, left_col = stops[idx]
-                    right_pos, right_col = stops[idx + 1]
-                    break
-            # Normalize ratio between the two stops
-            local = (ratio - left_pos) / (right_pos - left_pos)
-            r = int(left_col[0] + (right_col[0] - left_col[0]) * local)
-            g = int(left_col[1] + (right_col[1] - left_col[1]) * local)
-            b = int(left_col[2] + (right_col[2] - left_col[2]) * local)
-            if i < night_height:
-                # Apply 50% black at the top, fading to 0% at night_height
-                overlay = 0.5 * (1 - i / night_height)
-                r = int(r * (1 - overlay))
-                g = int(g * (1 - overlay))
-                b = int(b * (1 - overlay))
+        """Fill the void with vertical gradients of light green and white."""
+        horizon = int(self.canvas_size * 0.55)
+        # Top gradient: light green to black
+        for y in range(horizon):
+            ratio = 1 - (y / max(1, horizon))
+            r = int(144 * ratio)
+            g = int(238 * ratio)
+            b = int(144 * ratio)
             color = f"#{r:02x}{g:02x}{b:02x}"
-            self.canvas.create_line(0, i, self.canvas_size, i, fill=color)
+            self.canvas.create_line(
+                0,
+                y,
+                self.canvas_size,
+                y,
+                fill=color,
+                tags="void_bg",
+            )
+        # Bottom gradient: white to black
+        for y in range(horizon, self.canvas_size):
+            ratio = (y - horizon) / max(1, self.canvas_size - horizon)
+            v = int(255 * (1 - ratio))
+            color = f"#{v:02x}{v:02x}{v:02x}"
+            self.canvas.create_line(
+                0,
+                y,
+                self.canvas_size,
+                y,
+                fill=color,
+                tags="void_bg",
+            )
 
     def _draw_stars(self) -> None:
-        """Scatter small white stars across the upper sky."""
-        StarField(self.canvas, self.canvas_size, self.canvas_size).draw()
+        """No stars in the void."""
+        return
     def _draw_cloud(self):
         """Draw a small turquoise-magenta-white cloud on the sky."""
         cx, cy = 80, 80
@@ -299,31 +298,16 @@ class SplashScreen(tk.Toplevel):
         )
 
     def _draw_floor(self):
-        """Add subtle white light near horizon and darker shadow toward bottom."""
-        horizon_ratio = 0.55
-        horizon = int(self.canvas_size * horizon_ratio)
-        steps = self.canvas_size - horizon
-        white_strength = 0.15
-        black_strength = 0.25
-        for i in range(steps):
-            ratio = i / steps
-            # base gradient from light to dark green
-            r = int(144 + (0 - 144) * ratio)
-            g = int(238 + (100 - 238) * ratio)
-            b = int(144 + (0 - 144) * ratio)
-            # white glow near horizon
-            w = (1 - ratio) * white_strength
-            r = int(r + (255 - r) * w)
-            g = int(g + (255 - g) * w)
-            b = int(b + (255 - b) * w)
-            # black shadow near bottom
-            sh = ratio * black_strength
-            r = int(r * (1 - sh))
-            g = int(g * (1 - sh))
-            b = int(b * (1 - sh))
-            color = f"#{r:02x}{g:02x}{b:02x}"
-            y = horizon + i
-            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="floor")
+        """Draw a white horizon line against the void."""
+        horizon = int(self.canvas_size * 0.55)
+        self.canvas.create_line(
+            0,
+            horizon,
+            self.canvas_size,
+            horizon,
+            fill="white",
+            tags="horizon",
+        )
 
     def _project(self, x, y, z):
         """Project 3D point onto 2D canvas."""

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.88"
+VERSION = "0.2.90"
 
 __all__ = ["VERSION"]

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -61,9 +61,20 @@ class SplashScreenTests(unittest.TestCase):
         for s in shadow_items:
             self.assertEqual(self.splash.canvas.itemcget(s, "fill"), "white")
 
-    def test_star_field_present(self):
-        star_items = self.splash.canvas.find_withtag("star")
-        self.assertGreater(len(star_items), 0)
+    def test_horizon_line(self):
+        horizon_items = self.splash.canvas.find_withtag("horizon")
+        self.assertEqual(len(horizon_items), 1)
+        self.assertEqual(
+            self.splash.canvas.itemcget(horizon_items[0], "fill"), "white"
+        )
+
+    def test_void_gradient(self):
+        bg_items = self.splash.canvas.find_withtag("void_bg")
+        self.assertGreater(len(bg_items), 0)
+        top_color = self.splash.canvas.itemcget(bg_items[0], "fill")
+        bottom_color = self.splash.canvas.itemcget(bg_items[-1], "fill")
+        self.assertEqual(top_color, "#90ee90")
+        self.assertEqual(bottom_color, "#000000")
 
     def test_close_fades_to_invisible(self):
         if not getattr(self.splash, "_alpha_supported", False):
@@ -77,16 +88,20 @@ class SplashScreenTests(unittest.TestCase):
         self.assertAlmostEqual(float(self.splash.attributes("-alpha")), 0.0)
         self.assertTrue(self._closed)
 
-    def test_night_sky_gradient(self):
-        top_item = min(self.splash.canvas.find_overlapping(0, 0, self.splash.canvas_size, 0))
-        top_color = self.splash.canvas.itemcget(top_item, "fill").lower()
-        mid_y = int(self.splash.canvas_size * 0.3)
-        mid_item = min(
-            self.splash.canvas.find_overlapping(0, mid_y, self.splash.canvas_size, mid_y)
+    def test_void_background(self):
+        top_item = min(
+            self.splash.canvas.find_overlapping(0, 0, self.splash.canvas_size, 0)
         )
-        mid_color = self.splash.canvas.itemcget(mid_item, "fill").lower()
-        self.assertEqual(top_color, "#451571")
-        self.assertEqual(mid_color, "#ff00ff")
+        top_color = self.splash.canvas.itemcget(top_item, "fill").lower()
+        horizon_y = int(self.splash.canvas_size * 0.55)
+        horizon_item = min(
+            self.splash.canvas.find_overlapping(
+                0, horizon_y, self.splash.canvas_size, horizon_y
+            )
+        )
+        horizon_color = self.splash.canvas.itemcget(horizon_item, "fill").lower()
+        self.assertEqual(top_color, "black")
+        self.assertEqual(horizon_color, "white")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add light green and white vertical gradients to splash screen void
- Update splash screen tests for gradient background
- Bump version to 0.2.90 and record in README

## Testing
- `radon cc -s -j gui/windows/splash_screen.py tests/test_splash_screen.py mainappsrc/version.py`
- `pytest` *(fails: AttributeError in AutoMLApp and others; 214 failed, 975 passed, 57 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68ad130779d08327929203aa284279f5