### PR TITLE
Emit light green horizon glow to splash screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.88
+version: 0.2.92
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,10 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.92 - Thicken white horizon, add violet-blue sky gradient, and whiten title text.
+- 0.2.91 - Emit light green glow from white horizon into void.
+- 0.2.90 - Add light green and white gradient shading to the void.
+- 0.2.89 - Render splash screen as a black void with a white horizon.
 - 0.2.88 - Add translucent night sky gradient to splash screen.
 - 0.2.87 - Use absolute imports for config constants to support bundled executables.
 - 0.2.86 - Explicitly include tools package in PyInstaller builds to prevent runtime import errors.

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -86,15 +86,16 @@ class SplashScreen(tk.Toplevel):
             self._shadow_alpha_target = None
 
         self.canvas_size = 300
-        # Black background so colors pop
+        # Deep dark background similar to log area for void effect
         self.canvas = tk.Canvas(
             self,
             width=self.canvas_size,
             height=self.canvas_size,
             highlightthickness=0,
-            bg="black",
+            bg="#1e1e1e",
         )
         self.canvas.pack()
+        self._draw_top_gradient()
         self._draw_gradient()
         self._draw_stars()
         self._draw_floor()
@@ -193,42 +194,55 @@ class SplashScreen(tk.Toplevel):
         self.geometry(f"{w}x{h}+{x}+{y}")
         self.shadow.lower(self)
 
-    def _draw_gradient(self):
-        """Draw a multi-colour gradient with a translucent night overlay."""
-        # Color stops: violet sky -> magenta -> light green horizon -> dark ground
-        stops = [
-            (0.0, (138, 43, 226)),   # violet
-            (0.3, (255, 0, 255)),    # magenta
-            (0.55, (144, 238, 144)), # light green
-            (1.0, (0, 100, 0)),      # dark green ground
-        ]
-        steps = self.canvas_size
-        night_height = int(self.canvas_size * 0.3)
-        for i in range(steps):
-            ratio = i / steps
-            # Find two surrounding color stops
-            for idx in range(len(stops) - 1):
-                if stops[idx][0] <= ratio <= stops[idx + 1][0]:
-                    left_pos, left_col = stops[idx]
-                    right_pos, right_col = stops[idx + 1]
-                    break
-            # Normalize ratio between the two stops
-            local = (ratio - left_pos) / (right_pos - left_pos)
-            r = int(left_col[0] + (right_col[0] - left_col[0]) * local)
-            g = int(left_col[1] + (right_col[1] - left_col[1]) * local)
-            b = int(left_col[2] + (right_col[2] - left_col[2]) * local)
-            if i < night_height:
-                # Apply 50% black at the top, fading to 0% at night_height
-                overlay = 0.5 * (1 - i / night_height)
-                r = int(r * (1 - overlay))
-                g = int(g * (1 - overlay))
-                b = int(b * (1 - overlay))
+    def _draw_top_gradient(self) -> None:
+        """Add a small violet-to-blue gradient at the top."""
+        gradient_height = int(self.canvas_size * 0.1)
+        half = gradient_height // 2
+        violet = (0x9B, 0x59, 0xB6)
+        blue = (0x56, 0x9C, 0xD6)
+        dark = (0x1E, 0x1E, 0x1E)
+        for y in range(gradient_height):
+            if y < half:
+                ratio = y / max(1, half - 1)
+                r = int(violet[0] + (blue[0] - violet[0]) * ratio)
+                g = int(violet[1] + (blue[1] - violet[1]) * ratio)
+                b = int(violet[2] + (blue[2] - violet[2]) * ratio)
+            else:
+                ratio = (y - half) / max(1, gradient_height - half - 1)
+                r = int(blue[0] + (dark[0] - blue[0]) * ratio)
+                g = int(blue[1] + (dark[1] - blue[1]) * ratio)
+                b = int(blue[2] + (dark[2] - blue[2]) * ratio)
             color = f"#{r:02x}{g:02x}{b:02x}"
-            self.canvas.create_line(0, i, self.canvas_size, i, fill=color)
+            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="top_gradient")
+
+    def _draw_gradient(self):
+        """Emit a narrow light-green glow around the white horizon."""
+        horizon = int(self.canvas_size * 0.55)
+        gradient_height = int(self.canvas_size * 0.1)
+        start = horizon - gradient_height
+        dark = (0x1E, 0x1E, 0x1E)
+        glow = (0x90, 0xEE, 0x90)
+        # Upward glow
+        for y in range(start, horizon):
+            ratio = (y - start) / max(1, gradient_height - 1)
+            r = int(dark[0] + (glow[0] - dark[0]) * ratio)
+            g = int(dark[1] + (glow[1] - dark[1]) * ratio)
+            b = int(dark[2] + (glow[2] - dark[2]) * ratio)
+            color = f"#{r:02x}{g:02x}{b:02x}"
+            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="void_bg")
+        # Downward glow
+        end = horizon + gradient_height
+        for y in range(horizon + 1, end + 1):
+            ratio = (y - horizon) / max(1, gradient_height)
+            r = int(glow[0] + (dark[0] - glow[0]) * ratio)
+            g = int(glow[1] + (dark[1] - glow[1]) * ratio)
+            b = int(glow[2] + (dark[2] - glow[2]) * ratio)
+            color = f"#{r:02x}{g:02x}{b:02x}"
+            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="void_bg")
 
     def _draw_stars(self) -> None:
-        """Scatter small white stars across the upper sky."""
-        StarField(self.canvas, self.canvas_size, self.canvas_size).draw()
+        """No stars in the void."""
+        return
     def _draw_cloud(self):
         """Draw a small turquoise-magenta-white cloud on the sky."""
         cx, cy = 80, 80
@@ -253,7 +267,7 @@ class SplashScreen(tk.Toplevel):
         )
 
     def _draw_title(self) -> None:
-        """Render project title with a subtle white shadow."""
+        """Render project title in white with a subtle black shadow."""
         x = self.canvas_size / 2
         y = self.canvas_size - 40
         main_text = "Automotive Modeling Language"
@@ -262,13 +276,13 @@ class SplashScreen(tk.Toplevel):
         sub_font = ("Helvetica", 12, "bold")
         offset = 1
 
-        # White shadow drawn slightly offset behind the main text
+        # Black shadow drawn slightly offset behind the main text
         self.canvas.create_text(
             x + offset,
             y + offset,
             text=main_text,
             font=title_font,
-            fill="white",
+            fill="black",
             tags="title_shadow",
         )
         self.canvas.create_text(
@@ -276,17 +290,17 @@ class SplashScreen(tk.Toplevel):
             y + 20 + offset,
             text=sub_text,
             font=sub_font,
-            fill="white",
+            fill="black",
             tags="title_shadow",
         )
 
-        # Foreground text in bold black
+        # Foreground text in bold white
         self.canvas.create_text(
             x,
             y,
             text=main_text,
             font=title_font,
-            fill="black",
+            fill="white",
             tags="title_text",
         )
         self.canvas.create_text(
@@ -294,36 +308,22 @@ class SplashScreen(tk.Toplevel):
             y + 20,
             text=sub_text,
             font=sub_font,
-            fill="black",
+            fill="white",
             tags="title_text",
         )
 
     def _draw_floor(self):
-        """Add subtle white light near horizon and darker shadow toward bottom."""
-        horizon_ratio = 0.55
-        horizon = int(self.canvas_size * horizon_ratio)
-        steps = self.canvas_size - horizon
-        white_strength = 0.15
-        black_strength = 0.25
-        for i in range(steps):
-            ratio = i / steps
-            # base gradient from light to dark green
-            r = int(144 + (0 - 144) * ratio)
-            g = int(238 + (100 - 238) * ratio)
-            b = int(144 + (0 - 144) * ratio)
-            # white glow near horizon
-            w = (1 - ratio) * white_strength
-            r = int(r + (255 - r) * w)
-            g = int(g + (255 - g) * w)
-            b = int(b + (255 - b) * w)
-            # black shadow near bottom
-            sh = ratio * black_strength
-            r = int(r * (1 - sh))
-            g = int(g * (1 - sh))
-            b = int(b * (1 - sh))
-            color = f"#{r:02x}{g:02x}{b:02x}"
-            y = horizon + i
-            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="floor")
+        """Draw a thick white horizon line against the void."""
+        horizon = int(self.canvas_size * 0.55)
+        self.canvas.create_line(
+            0,
+            horizon,
+            self.canvas_size,
+            horizon,
+            fill="white",
+            width=3,
+            tags="horizon",
+        )
 
     def _project(self, x, y, z):
         """Project 3D point onto 2D canvas."""

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.88"
+VERSION = "0.2.92"
 
 __all__ = ["VERSION"]

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -57,13 +57,27 @@ class SplashScreenTests(unittest.TestCase):
         self.assertEqual(len(shadow_items), 2)
         self.assertEqual(len(text_items), 2)
         for t in text_items:
-            self.assertEqual(self.splash.canvas.itemcget(t, "fill"), "black")
+            self.assertEqual(self.splash.canvas.itemcget(t, "fill"), "white")
         for s in shadow_items:
-            self.assertEqual(self.splash.canvas.itemcget(s, "fill"), "white")
+            self.assertEqual(self.splash.canvas.itemcget(s, "fill"), "black")
 
-    def test_star_field_present(self):
-        star_items = self.splash.canvas.find_withtag("star")
-        self.assertGreater(len(star_items), 0)
+    def test_horizon_line(self):
+        horizon_items = self.splash.canvas.find_withtag("horizon")
+        self.assertEqual(len(horizon_items), 1)
+        self.assertEqual(
+            self.splash.canvas.itemcget(horizon_items[0], "fill"), "white"
+        )
+
+    def test_void_gradient(self):
+        bg_items = self.splash.canvas.find_withtag("void_bg")
+        self.assertGreater(len(bg_items), 0)
+        gradient_height = int(self.splash.canvas_size * 0.1)
+        top_color = self.splash.canvas.itemcget(bg_items[0], "fill")
+        mid_color = self.splash.canvas.itemcget(bg_items[gradient_height - 1], "fill")
+        bottom_color = self.splash.canvas.itemcget(bg_items[-1], "fill")
+        self.assertEqual(top_color, "#1e1e1e")
+        self.assertEqual(mid_color, "#90ee90")
+        self.assertEqual(bottom_color, "#1e1e1e")
 
     def test_close_fades_to_invisible(self):
         if not getattr(self.splash, "_alpha_supported", False):
@@ -77,16 +91,31 @@ class SplashScreenTests(unittest.TestCase):
         self.assertAlmostEqual(float(self.splash.attributes("-alpha")), 0.0)
         self.assertTrue(self._closed)
 
-    def test_night_sky_gradient(self):
-        top_item = min(self.splash.canvas.find_overlapping(0, 0, self.splash.canvas_size, 0))
-        top_color = self.splash.canvas.itemcget(top_item, "fill").lower()
-        mid_y = int(self.splash.canvas_size * 0.3)
-        mid_item = min(
-            self.splash.canvas.find_overlapping(0, mid_y, self.splash.canvas_size, mid_y)
+    def test_void_background(self):
+        top_item = min(
+            self.splash.canvas.find_overlapping(0, 0, self.splash.canvas_size, 0)
         )
-        mid_color = self.splash.canvas.itemcget(mid_item, "fill").lower()
-        self.assertEqual(top_color, "#451571")
-        self.assertEqual(mid_color, "#ff00ff")
+        top_color = self.splash.canvas.itemcget(top_item, "fill").lower()
+        horizon_y = int(self.splash.canvas_size * 0.55)
+        horizon_item = min(
+            self.splash.canvas.find_overlapping(
+                0, horizon_y, self.splash.canvas_size, horizon_y
+            )
+        )
+        horizon_color = self.splash.canvas.itemcget(horizon_item, "fill").lower()
+        self.assertEqual(top_color, "#9b59b6")
+        self.assertEqual(horizon_color, "white")
+
+    def test_top_gradient(self):
+        items = self.splash.canvas.find_withtag("top_gradient")
+        self.assertGreater(len(items), 0)
+        half = len(items) // 2
+        top_color = self.splash.canvas.itemcget(items[0], "fill")
+        mid_color = self.splash.canvas.itemcget(items[half - 1], "fill")
+        bottom_color = self.splash.canvas.itemcget(items[-1], "fill")
+        self.assertEqual(top_color, "#9b59b6")
+        self.assertEqual(mid_color, "#569cd6")
+        self.assertEqual(bottom_color, "#1e1e1e")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Deepen splash screen void with dark background and violet-blue sky gradient
- Emit light-green glow above and below a thicker white horizon and render white title text
- Update tests and bump version to 0.2.92 in code and README

## Testing
- `radon cc -s -j gui/windows/splash_screen.py tests/test_splash_screen.py mainappsrc/version.py | python -m json.tool | head -n 20`
- `pytest` *(fails: 214 failed, 975 passed, 58 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68ad130779d08327929203aa284279f5