### PR TITLE
Refine splash screen styling and font

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.92
+version: 0.2.93
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.93 - Replace splash background with properties window color, remove top gradient, and switch title font.
 - 0.2.92 - Thicken white horizon, add violet-blue sky gradient, and whiten title text.
 - 0.2.91 - Emit light green glow from white horizon into void.
 - 0.2.90 - Add light green and white gradient shading to the void.

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -20,6 +20,7 @@ import tkinter as tk
 import math
 import random
 from dataclasses import dataclass
+from gui.utils import DIALOG_BG_COLOR
 
 
 @dataclass
@@ -86,16 +87,18 @@ class SplashScreen(tk.Toplevel):
             self._shadow_alpha_target = None
 
         self.canvas_size = 300
-        # Deep dark background similar to log area for void effect
+        # Use properties dialog background for consistency
+        self._dark_rgb = tuple(
+            int(DIALOG_BG_COLOR.lstrip("#")[i : i + 2], 16) for i in (0, 2, 4)
+        )
         self.canvas = tk.Canvas(
             self,
             width=self.canvas_size,
             height=self.canvas_size,
             highlightthickness=0,
-            bg="#1e1e1e",
+            bg=DIALOG_BG_COLOR,
         )
         self.canvas.pack()
-        self._draw_top_gradient()
         self._draw_gradient()
         self._draw_stars()
         self._draw_floor()
@@ -194,33 +197,12 @@ class SplashScreen(tk.Toplevel):
         self.geometry(f"{w}x{h}+{x}+{y}")
         self.shadow.lower(self)
 
-    def _draw_top_gradient(self) -> None:
-        """Add a small violet-to-blue gradient at the top."""
-        gradient_height = int(self.canvas_size * 0.1)
-        half = gradient_height // 2
-        violet = (0x9B, 0x59, 0xB6)
-        blue = (0x56, 0x9C, 0xD6)
-        dark = (0x1E, 0x1E, 0x1E)
-        for y in range(gradient_height):
-            if y < half:
-                ratio = y / max(1, half - 1)
-                r = int(violet[0] + (blue[0] - violet[0]) * ratio)
-                g = int(violet[1] + (blue[1] - violet[1]) * ratio)
-                b = int(violet[2] + (blue[2] - violet[2]) * ratio)
-            else:
-                ratio = (y - half) / max(1, gradient_height - half - 1)
-                r = int(blue[0] + (dark[0] - blue[0]) * ratio)
-                g = int(blue[1] + (dark[1] - blue[1]) * ratio)
-                b = int(blue[2] + (dark[2] - blue[2]) * ratio)
-            color = f"#{r:02x}{g:02x}{b:02x}"
-            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="top_gradient")
-
     def _draw_gradient(self):
         """Emit a narrow light-green glow around the white horizon."""
         horizon = int(self.canvas_size * 0.55)
         gradient_height = int(self.canvas_size * 0.1)
         start = horizon - gradient_height
-        dark = (0x1E, 0x1E, 0x1E)
+        dark = self._dark_rgb
         glow = (0x90, 0xEE, 0x90)
         # Upward glow
         for y in range(start, horizon):
@@ -272,8 +254,8 @@ class SplashScreen(tk.Toplevel):
         y = self.canvas_size - 40
         main_text = "Automotive Modeling Language"
         sub_text = "by Karel Capek Robotics"
-        title_font = ("Helvetica", 14, "bold")
-        sub_font = ("Helvetica", 12, "bold")
+        title_font = ("ITC Stone Serif SemiBold", 14)
+        sub_font = ("ITC Stone Serif SemiBold", 12)
         offset = 1
 
         # Black shadow drawn slightly offset behind the main text

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.92"
+VERSION = "0.2.93"
 
 __all__ = ["VERSION"]

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -20,6 +20,7 @@ import unittest
 import tkinter as tk
 
 from gui.splash_screen import SplashScreen
+from gui.utils import DIALOG_BG_COLOR
 
 
 class SplashScreenTests(unittest.TestCase):
@@ -75,9 +76,9 @@ class SplashScreenTests(unittest.TestCase):
         top_color = self.splash.canvas.itemcget(bg_items[0], "fill")
         mid_color = self.splash.canvas.itemcget(bg_items[gradient_height - 1], "fill")
         bottom_color = self.splash.canvas.itemcget(bg_items[-1], "fill")
-        self.assertEqual(top_color, "#1e1e1e")
+        self.assertEqual(top_color.lower(), DIALOG_BG_COLOR.lower())
         self.assertEqual(mid_color, "#90ee90")
-        self.assertEqual(bottom_color, "#1e1e1e")
+        self.assertEqual(bottom_color.lower(), DIALOG_BG_COLOR.lower())
 
     def test_close_fades_to_invisible(self):
         if not getattr(self.splash, "_alpha_supported", False):
@@ -103,19 +104,11 @@ class SplashScreenTests(unittest.TestCase):
             )
         )
         horizon_color = self.splash.canvas.itemcget(horizon_item, "fill").lower()
-        self.assertEqual(top_color, "#9b59b6")
+        self.assertEqual(top_color, DIALOG_BG_COLOR.lower())
         self.assertEqual(horizon_color, "white")
-
-    def test_top_gradient(self):
+    def test_no_top_gradient(self):
         items = self.splash.canvas.find_withtag("top_gradient")
-        self.assertGreater(len(items), 0)
-        half = len(items) // 2
-        top_color = self.splash.canvas.itemcget(items[0], "fill")
-        mid_color = self.splash.canvas.itemcget(items[half - 1], "fill")
-        bottom_color = self.splash.canvas.itemcget(items[-1], "fill")
-        self.assertEqual(top_color, "#9b59b6")
-        self.assertEqual(mid_color, "#569cd6")
-        self.assertEqual(bottom_color, "#1e1e1e")
+        self.assertEqual(len(items), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Align splash screen background with properties dialog color
- Drop violet-to-blue top gradient and use Stone Serif title font
- Update splash screen tests and bump version to 0.2.93

## Testing
- ⚠️ `pytest` *(numerous failing tests: AttributeError, FileNotFoundError, etc.)*
- ⚠️ `PYTHONPATH=$PWD pytest tests/test_splash_screen.py tests/test_splash_launcher.py` *(1 passed, 7 skipped)*
- ✅ `python tools/metrics_generator.py --path gui/windows --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68ad1dce67d4832782df11c011e60b82