### PR TITLE
Refine splash screen styling and font

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.92
+version: 0.2.94
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,8 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.94 - Add beveled blue splash background and render AutoML title in black.
+- 0.2.93 - Replace splash background with properties window color, remove top gradient, and switch title font.
 - 0.2.92 - Thicken white horizon, add violet-blue sky gradient, and whiten title text.
 - 0.2.91 - Emit light green glow from white horizon into void.
 - 0.2.90 - Add light green and white gradient shading to the void.

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -19,34 +19,7 @@
 import tkinter as tk
 import math
 import random
-from dataclasses import dataclass
-
-
-@dataclass
-class StarField:
-    """Render a simple star field on a Tkinter canvas."""
-
-    canvas: tk.Canvas
-    width: int
-    height: int
-    star_count: int = 50
-
-    def draw(self) -> None:
-        """Draw randomly positioned stars across the sky region."""
-        sky_limit = int(self.height * 0.55)
-        for _ in range(self.star_count):
-            x = random.randint(0, self.width)
-            y = random.randint(0, sky_limit)
-            size = random.choice((1, 2))
-            self.canvas.create_oval(
-                x,
-                y,
-                x + size,
-                y + size,
-                fill="white",
-                outline="",
-                tags="star",
-            )
+from PIL import Image, ImageDraw, ImageTk
 
 
 class SplashScreen(tk.Toplevel):
@@ -86,19 +59,15 @@ class SplashScreen(tk.Toplevel):
             self._shadow_alpha_target = None
 
         self.canvas_size = 300
-        # Deep dark background similar to log area for void effect
         self.canvas = tk.Canvas(
             self,
             width=self.canvas_size,
             height=self.canvas_size,
             highlightthickness=0,
-            bg="#1e1e1e",
+            bg="#002d5f",
         )
         self.canvas.pack()
-        self._draw_top_gradient()
-        self._draw_gradient()
-        self._draw_stars()
-        self._draw_floor()
+        self._draw_background()
         self._center()
         # Initialize cube geometry
         self.angle = 0.0
@@ -194,97 +163,86 @@ class SplashScreen(tk.Toplevel):
         self.geometry(f"{w}x{h}+{x}+{y}")
         self.shadow.lower(self)
 
-    def _draw_top_gradient(self) -> None:
-        """Add a small violet-to-blue gradient at the top."""
-        gradient_height = int(self.canvas_size * 0.1)
-        half = gradient_height // 2
-        violet = (0x9B, 0x59, 0xB6)
-        blue = (0x56, 0x9C, 0xD6)
-        dark = (0x1E, 0x1E, 0x1E)
-        for y in range(gradient_height):
-            if y < half:
-                ratio = y / max(1, half - 1)
-                r = int(violet[0] + (blue[0] - violet[0]) * ratio)
-                g = int(violet[1] + (blue[1] - violet[1]) * ratio)
-                b = int(violet[2] + (blue[2] - violet[2]) * ratio)
-            else:
-                ratio = (y - half) / max(1, gradient_height - half - 1)
-                r = int(blue[0] + (dark[0] - blue[0]) * ratio)
-                g = int(blue[1] + (dark[1] - blue[1]) * ratio)
-                b = int(blue[2] + (dark[2] - blue[2]) * ratio)
-            color = f"#{r:02x}{g:02x}{b:02x}"
-            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="top_gradient")
+    def _draw_background(self) -> None:
+        """Draw beveled blue background with slanted bands."""
+        W = H = self.canvas_size
+        c_top = (0, 102, 153)
+        c_bottom = (0, 45, 95)
+        band_base = (0, 75, 130)
+        band_dark = (0, 40, 90)
+        n_bands_primary = 10
+        n_bands_secondary = 18
+        margin = 0.06
+        rng = random.Random(42)
 
-    def _draw_gradient(self):
-        """Emit a narrow light-green glow around the white horizon."""
-        horizon = int(self.canvas_size * 0.55)
-        gradient_height = int(self.canvas_size * 0.1)
-        start = horizon - gradient_height
-        dark = (0x1E, 0x1E, 0x1E)
-        glow = (0x90, 0xEE, 0x90)
-        # Upward glow
-        for y in range(start, horizon):
-            ratio = (y - start) / max(1, gradient_height - 1)
-            r = int(dark[0] + (glow[0] - dark[0]) * ratio)
-            g = int(dark[1] + (glow[1] - dark[1]) * ratio)
-            b = int(dark[2] + (glow[2] - dark[2]) * ratio)
-            color = f"#{r:02x}{g:02x}{b:02x}"
-            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="void_bg")
-        # Downward glow
-        end = horizon + gradient_height
-        for y in range(horizon + 1, end + 1):
-            ratio = (y - horizon) / max(1, gradient_height)
-            r = int(glow[0] + (dark[0] - glow[0]) * ratio)
-            g = int(glow[1] + (dark[1] - glow[1]) * ratio)
-            b = int(glow[2] + (dark[2] - glow[2]) * ratio)
-            color = f"#{r:02x}{g:02x}{b:02x}"
-            self.canvas.create_line(0, y, self.canvas_size, y, fill=color, tags="void_bg")
+        img = Image.new("RGBA", (W, H))
+        for y in range(H):
+            for x in range(W):
+                t = 0.65 * x / W + 0.35 * y / H
+                r = int(c_top[0] * (1 - t) + c_bottom[0] * t)
+                g = int(c_top[1] * (1 - t) + c_bottom[1] * t)
+                b = int(c_top[2] * (1 - t) + c_bottom[2] * t)
+                img.putpixel((x, y), (r, g, b, 255))
 
-    def _draw_stars(self) -> None:
-        """No stars in the void."""
-        return
-    def _draw_cloud(self):
-        """Draw a small turquoise-magenta-white cloud on the sky."""
-        cx, cy = 80, 80
-        ovals = [
-            (cx - 40, cy - 20, cx + 40, cy + 20),
-            (cx - 20, cy - 30, cx + 60, cy + 10),
-            (cx - 60, cy - 30, cx + 20, cy + 10),
-        ]
-        for x1, y1, x2, y2 in ovals:
-            self.canvas.create_oval(
-                x1, y1, x2, y2, fill="#40E0D0", outline="#FF00FF", width=2
-            )
-        # subtle white highlight
-        self.canvas.create_oval(
-            cx - 30,
-            cy - 20,
-            cx + 20,
-            cy + 10,
-            fill="white",
-            outline="",
-            stipple="gray50",
-        )
+        draw = ImageDraw.Draw(img, "RGBA")
+
+        def band_poly(x0, width, skew, notch, top_off, bottom_off):
+            y_top = int(margin * H + top_off)
+            y_bot = int((1 - margin) * H - bottom_off)
+            x1 = x0 + width
+            notch_y = y_top + 0.55 * (y_bot - y_top)
+            return [
+                (x0, y_top),
+                (x0 + skew, y_bot),
+                (x1 + skew, y_bot),
+                (x1 + 0.95 * skew - notch, notch_y),
+                (x1, y_top),
+            ]
+
+        for xi in sorted(rng.uniform(margin * W * 0.5, W * (0.85 - margin), n_bands_primary)):
+            width = rng.uniform(W * 0.018, W * 0.05)
+            skew = rng.uniform(W * 0.12, W * 0.22)
+            notch = rng.uniform(W * 0.01, W * 0.03)
+            top_off = rng.uniform(0, H * 0.03)
+            bot_off = rng.uniform(0, H * 0.03)
+            poly = band_poly(xi, width, skew, notch, top_off, bot_off)
+            color = band_base if rng.random() > 0.5 else band_dark
+            draw.polygon(poly, fill=color + (int(0.35 * 255),))
+
+        for xi in sorted(rng.uniform(margin * W * 0.35, W * (0.9 - margin), n_bands_secondary)):
+            width = rng.uniform(W * 0.003, W * 0.012)
+            skew = rng.uniform(W * 0.1, W * 0.24)
+            notch = rng.uniform(W * 0.004, W * 0.009)
+            top_off = rng.uniform(0, H * 0.02)
+            bot_off = rng.uniform(0, H * 0.02)
+            poly = band_poly(xi, width, skew, notch, top_off, bot_off)
+            bright = tuple(min(int(c * 1.2), 255) for c in band_base)
+            draw.polygon(poly, fill=bright + (int(0.55 * 255),))
+
+        self._bg_pil = img
+        self._bg_photo = ImageTk.PhotoImage(img)
+        self.canvas.create_image(0, 0, anchor="nw", image=self._bg_photo, tags="void_bg")
 
     def _draw_title(self) -> None:
-        """Render project title in white with a subtle black shadow."""
+        """Render AutoML title in black and subtitle in white."""
         x = self.canvas_size / 2
         y = self.canvas_size - 40
-        main_text = "Automotive Modeling Language"
-        sub_text = "by Karel Capek Robotics"
-        title_font = ("Helvetica", 14, "bold")
-        sub_font = ("Helvetica", 12, "bold")
+        main_text = "AutoML"
+        sub_text = "Automotive Modeling Language"
+        title_font = ("ITC Stone Serif SemiBold", 14)
+        sub_font = ("ITC Stone Serif SemiBold", 12)
         offset = 1
 
-        # Black shadow drawn slightly offset behind the main text
+        # White shadow for black main text
         self.canvas.create_text(
             x + offset,
             y + offset,
             text=main_text,
             font=title_font,
-            fill="black",
+            fill="white",
             tags="title_shadow",
         )
+        # Black shadow for white subtitle
         self.canvas.create_text(
             x + offset,
             y + 20 + offset,
@@ -294,13 +252,12 @@ class SplashScreen(tk.Toplevel):
             tags="title_shadow",
         )
 
-        # Foreground text in bold white
         self.canvas.create_text(
             x,
             y,
             text=main_text,
             font=title_font,
-            fill="white",
+            fill="black",
             tags="title_text",
         )
         self.canvas.create_text(
@@ -310,19 +267,6 @@ class SplashScreen(tk.Toplevel):
             font=sub_font,
             fill="white",
             tags="title_text",
-        )
-
-    def _draw_floor(self):
-        """Draw a thick white horizon line against the void."""
-        horizon = int(self.canvas_size * 0.55)
-        self.canvas.create_line(
-            0,
-            horizon,
-            self.canvas_size,
-            horizon,
-            fill="white",
-            width=3,
-            tags="horizon",
         )
 
     def _project(self, x, y, z):

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.92"
+VERSION = "0.2.94"
 
 __all__ = ["VERSION"]

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -50,34 +50,28 @@ class SplashScreenTests(unittest.TestCase):
         self.assertEqual(len(gear_items), 1)
 
     def test_title_shadow(self):
-        bg_items = self.splash.canvas.find_withtag("title_bg")
         shadow_items = self.splash.canvas.find_withtag("title_shadow")
         text_items = self.splash.canvas.find_withtag("title_text")
-        self.assertEqual(len(bg_items), 0)
         self.assertEqual(len(shadow_items), 2)
         self.assertEqual(len(text_items), 2)
-        for t in text_items:
-            self.assertEqual(self.splash.canvas.itemcget(t, "fill"), "white")
-        for s in shadow_items:
-            self.assertEqual(self.splash.canvas.itemcget(s, "fill"), "black")
+        fills = {self.splash.canvas.itemcget(t, "fill") for t in text_items}
+        self.assertIn("black", fills)
+        self.assertIn("white", fills)
+        shadow_fills = {self.splash.canvas.itemcget(s, "fill") for s in shadow_items}
+        self.assertIn("black", shadow_fills)
+        self.assertIn("white", shadow_fills)
 
-    def test_horizon_line(self):
-        horizon_items = self.splash.canvas.find_withtag("horizon")
-        self.assertEqual(len(horizon_items), 1)
-        self.assertEqual(
-            self.splash.canvas.itemcget(horizon_items[0], "fill"), "white"
-        )
-
-    def test_void_gradient(self):
+    def test_background_gradient(self):
         bg_items = self.splash.canvas.find_withtag("void_bg")
-        self.assertGreater(len(bg_items), 0)
-        gradient_height = int(self.splash.canvas_size * 0.1)
-        top_color = self.splash.canvas.itemcget(bg_items[0], "fill")
-        mid_color = self.splash.canvas.itemcget(bg_items[gradient_height - 1], "fill")
-        bottom_color = self.splash.canvas.itemcget(bg_items[-1], "fill")
-        self.assertEqual(top_color, "#1e1e1e")
-        self.assertEqual(mid_color, "#90ee90")
-        self.assertEqual(bottom_color, "#1e1e1e")
+        self.assertEqual(len(bg_items), 1)
+        top = self.splash._bg_pil.getpixel((0, 0))
+        bottom = self.splash._bg_pil.getpixel(
+            (self.splash.canvas_size - 1, self.splash.canvas_size - 1)
+        )
+        self.assertEqual(f"#{top[0]:02x}{top[1]:02x}{top[2]:02x}", "#006699")
+        self.assertEqual(
+            f"#{bottom[0]:02x}{bottom[1]:02x}{bottom[2]:02x}", "#002d5f"
+        )
 
     def test_close_fades_to_invisible(self):
         if not getattr(self.splash, "_alpha_supported", False):
@@ -91,31 +85,6 @@ class SplashScreenTests(unittest.TestCase):
         self.assertAlmostEqual(float(self.splash.attributes("-alpha")), 0.0)
         self.assertTrue(self._closed)
 
-    def test_void_background(self):
-        top_item = min(
-            self.splash.canvas.find_overlapping(0, 0, self.splash.canvas_size, 0)
-        )
-        top_color = self.splash.canvas.itemcget(top_item, "fill").lower()
-        horizon_y = int(self.splash.canvas_size * 0.55)
-        horizon_item = min(
-            self.splash.canvas.find_overlapping(
-                0, horizon_y, self.splash.canvas_size, horizon_y
-            )
-        )
-        horizon_color = self.splash.canvas.itemcget(horizon_item, "fill").lower()
-        self.assertEqual(top_color, "#9b59b6")
-        self.assertEqual(horizon_color, "white")
-
-    def test_top_gradient(self):
-        items = self.splash.canvas.find_withtag("top_gradient")
-        self.assertGreater(len(items), 0)
-        half = len(items) // 2
-        top_color = self.splash.canvas.itemcget(items[0], "fill")
-        mid_color = self.splash.canvas.itemcget(items[half - 1], "fill")
-        bottom_color = self.splash.canvas.itemcget(items[-1], "fill")
-        self.assertEqual(top_color, "#9b59b6")
-        self.assertEqual(mid_color, "#569cd6")
-        self.assertEqual(bottom_color, "#1e1e1e")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace dark splash background with beveled blue bands
- Render "AutoML" title in black with white subtitle
- Update version to 0.2.94 and adjust tests

## Testing
- ⚠️ `pytest` *(214 failed, 975 passed, 55 skipped)*
- ✅ `PYTHONPATH=$PWD pytest tests/test_splash_screen.py tests/test_splash_launcher.py tests/test_version_sync.py` *(3 passed, 4 skipped)*
- ✅ `python tools/metrics_generator.py --path gui/windows --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68ad1dce67d4832782df11c011e60b82