### PR TITLE
feat: centralize app initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.96
+version: 0.2.97
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -68,7 +68,7 @@ from .icon_setup_mixin import IconSetupMixin
 from .style_setup_mixin import StyleSetupMixin
 from .page_diagram import PageDiagram
 from .node_utils import resolve_original as resolve_node_original
-from .app_initializer import AppInitializer
+from mainappsrc.services.app_init import AppInitializationService
 from analysis.mechanisms import (
     DiagnosticMechanism,
     MechanismLibrary,
@@ -271,7 +271,6 @@ from gui.dialogs.user_info_dialog import UserInfoDialog
 
 from . import config_utils
 from .config_utils import _reload_local_config
-from .project_properties_manager import ProjectPropertiesManager
 
 # Expose configuration helpers and global state
 _CONFIG_PATH = config_utils._CONFIG_PATH
@@ -416,7 +415,10 @@ class AutoMLApp(
         self.lifecycle_ui._init_nav_button_style()
         self.setup_services()
         self.setup_icons()
-        AppInitializer(self).initialize()
+        self.init_service = AppInitializationService(self)
+        self.init_service.initialize()
+        self.project_properties_manager = self.init_service.project_properties_manager
+        self.diagram_clipboard = self.init_service.diagram_clipboard_manager
 
         menubar = tk.Menu(root)
         file_menu = tk.Menu(menubar, tearoff=0)

--- a/mainappsrc/services/__init__.py
+++ b/mainappsrc/services/__init__.py
@@ -15,9 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Service layer for application modules."""
 
-"""Project version information."""
-
-VERSION = "0.2.97"
-
-__all__ = ["VERSION"]
+__all__ = []

--- a/mainappsrc/services/app_init/__init__.py
+++ b/mainappsrc/services/app_init/__init__.py
@@ -15,9 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Application initialisation services."""
 
-"""Project version information."""
+from .app_initialization_service import AppInitializationService
 
-VERSION = "0.2.97"
-
-__all__ = ["VERSION"]
+__all__ = ["AppInitializationService"]

--- a/mainappsrc/services/app_init/app_initialization_service.py
+++ b/mainappsrc/services/app_init/app_initialization_service.py
@@ -1,0 +1,48 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Service orchestrating application state initialisation."""
+
+from __future__ import annotations
+
+from ...core.app_initializer import AppInitializer
+from ...core.project_properties_manager import ProjectPropertiesManager
+from ...core.diagram_clipboard_manager import DiagramClipboardManager
+
+
+class AppInitializationService:
+    """Facade coordinating core initialisation helpers."""
+
+    def __init__(self, app: object) -> None:
+        self.app = app
+        self._initializer = AppInitializer(app)
+        self.project_properties_manager: ProjectPropertiesManager | None = None
+        self.diagram_clipboard_manager: DiagramClipboardManager | None = None
+
+    def initialize(self) -> None:
+        """Run initialisation and expose created managers."""
+        self._initializer.initialize()
+        if not hasattr(self.app, "project_properties_manager"):
+            self.app.project_properties_manager = ProjectPropertiesManager(
+                self.app.project_properties
+            )
+        if not hasattr(self.app, "diagram_clipboard"):
+            self.app.diagram_clipboard = DiagramClipboardManager(self.app)
+        self.project_properties_manager = self.app.project_properties_manager
+        self.diagram_clipboard_manager = self.app.diagram_clipboard
+
+__all__ = ["AppInitializationService"]

--- a/tests/test_app_initialization_service.py
+++ b/tests/test_app_initialization_service.py
@@ -1,0 +1,96 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for :mod:`AppInitializationService`."""
+
+import types
+import tkinter as tk
+import pytest
+
+from mainappsrc.services.app_init import AppInitializationService
+
+
+def test_service_initialises_managers(monkeypatch):
+    """Service should create project properties and clipboard managers."""
+
+    class DummyPPM:
+        pass
+
+    class DummyDCM:
+        pass
+
+    class DummyInitializer:
+        def __init__(self, app):
+            self.app = app
+
+        def initialize(self):
+            self.app.project_properties = {}
+
+    monkeypatch.setattr(
+        "mainappsrc.services.app_init.app_initialization_service.AppInitializer",
+        DummyInitializer,
+    )
+    monkeypatch.setattr(
+        "mainappsrc.services.app_init.app_initialization_service.ProjectPropertiesManager",
+        lambda props: DummyPPM(),
+    )
+    monkeypatch.setattr(
+        "mainappsrc.services.app_init.app_initialization_service.DiagramClipboardManager",
+        lambda app: DummyDCM(),
+    )
+
+    app = types.SimpleNamespace()
+    service = AppInitializationService(app)
+    service.initialize()
+
+    assert isinstance(service.project_properties_manager, DummyPPM)
+    assert isinstance(service.diagram_clipboard_manager, DummyDCM)
+
+
+def test_automl_app_uses_service(monkeypatch):
+    """AutoMLApp should rely on the initialisation service."""
+
+    from AutoML import AutoMLApp
+    from mainappsrc.core import automl_core as automl_module
+
+    calls = []
+
+    class DummyService:
+        def __init__(self, app):
+            calls.append("init")
+            self.app = app
+            self.project_properties_manager = object()
+            self.diagram_clipboard_manager = object()
+
+        def initialize(self):
+            calls.append("initialize")
+            self.app.project_properties_manager = self.project_properties_manager
+            self.app.diagram_clipboard = self.diagram_clipboard_manager
+
+    monkeypatch.setattr(automl_module, "AppInitializationService", DummyService)
+
+    try:
+        root = tk.Tk()
+        root.withdraw()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    app = AutoMLApp(root)
+    assert calls == ["init", "initialize"]
+    assert hasattr(app, "project_properties_manager")
+    assert hasattr(app, "diagram_clipboard")
+    root.destroy()


### PR DESCRIPTION
## Summary
- add AppInitializationService to coordinate app init helpers
- switch AutoMLApp to use the new initialization service
- document version bump and expose initialisation tests

## Testing
- `pytest` *(fails: AttributeError, FileNotFoundError and others)*
- `radon cc -j mainappsrc`

------
https://chatgpt.com/codex/tasks/task_b_68ad27f6aaec8327899301148e3ef953