### PR TITLE
feat: add editors service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.99
+version: 0.2.100
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.100 - Wrap legacy editor helpers into EditorsService and refactor core usage.
 - 0.2.99 - Introduce ViewUpdateService for centralised view refreshing.
 - 0.2.98 - Render large orange AutoML title with black border.
 - 0.2.97 - Enlarge AutoML title and apply per-letter white-to-orange gradient.

--- a/automl.py
+++ b/automl.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Compatibility wrapper for :mod:`AutoML` launcher module."""
 
-VERSION = "0.2.100"
+from __future__ import annotations
 
-__all__ = ["VERSION"]
+# Re-export everything from the canonical launcher
+from AutoML import *  # noqa: F401,F403

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -1994,19 +1994,19 @@ class AutoMLApp(
         return self.probability_reliability.calculate_pmfh()
 
     def show_requirements_matrix(self):
-        return self.editors.show_requirements_matrix()
+        return self.editors_service.show_requirements_matrix()
 
     def show_item_definition_editor(self):
-        return self.editors.show_item_definition_editor()
+        return self.editors_service.show_item_definition_editor()
 
     def show_safety_concept_editor(self):
-        return self.editors.show_safety_concept_editor()
+        return self.editors_service.show_safety_concept_editor()
 
     def show_requirements_editor(self):
-        return self.editors.show_requirements_editor()
+        return self.editors_service.show_requirements_editor()
 
     def _show_fmea_table_impl(self, fmea=None, fmeda=False):
-        return self.editors._show_fmea_table_impl(fmea, fmeda)
+        return self.editors_service._show_fmea_table_impl(fmea, fmeda)
 
     def export_fmea_to_csv(self, fmea, path):
         return self.safety_analysis.export_fmea_to_csv(fmea, path)

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -55,7 +55,7 @@ from .versioning_review import Versioning_Review
 from .data_access_queries import DataAccess_Queries
 from .validation_consistency import Validation_Consistency
 from .reporting_export import Reporting_Export
-from .editors import Editors
+from mainappsrc.services.editing.editors_service import EditorsService
 
 
 class ServiceInitMixin:
@@ -124,4 +124,4 @@ class ServiceInitMixin:
         self.data_access_queries = DataAccess_Queries(self)
         self.validation_consistency = Validation_Consistency(self)
         self.reporting_export = Reporting_Export(self)
-        self.editors = Editors(self)
+        self.editors_service = EditorsService(self)

--- a/mainappsrc/services/editing/__init__.py
+++ b/mainappsrc/services/editing/__init__.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Editing-related services."""
 
-VERSION = "0.2.100"
-
-__all__ = ["VERSION"]
+__all__ = ["EditorsService"]

--- a/mainappsrc/services/editing/editors_service.py
+++ b/mainappsrc/services/editing/editors_service.py
@@ -16,8 +16,27 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Service wrapper for editor dialogs and tables."""
 
-VERSION = "0.2.100"
+from __future__ import annotations
 
-__all__ = ["VERSION"]
+from mainappsrc.core.editors import Editors
+
+
+class EditorsService:
+    """Facade exposing :class:`~mainappsrc.core.editors.Editors` as a service.
+
+    The legacy :class:`Editors` class contains a collection of UI-heavy helper
+    methods.  This service wraps an instance of that class and delegates attribute
+    access to preserve behaviour while enabling dependency injection and future
+    refactoring.
+    """
+
+    def __init__(self, app: object) -> None:
+        self._impl = Editors(app)
+
+    def __getattr__(self, name: str):
+        return getattr(self._impl, name)
+
+
+__all__ = ["EditorsService"]

--- a/tests/test_editors_service.py
+++ b/tests/test_editors_service.py
@@ -16,8 +16,25 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Tests for the :mod:`mainappsrc.services.editing.editors_service` module."""
 
-VERSION = "0.2.100"
+from __future__ import annotations
 
-__all__ = ["VERSION"]
+from mainappsrc.services.editing.editors_service import EditorsService
+from mainappsrc.core import editors
+
+
+def test_editors_service_delegates(monkeypatch):
+    """EditorsService forwards attribute access to underlying Editors instance."""
+
+    called = {}
+
+    def dummy(self):
+        called["hit"] = True
+        return 42
+
+    monkeypatch.setattr(editors.Editors, "dummy", dummy)
+
+    service = EditorsService(object())
+    assert service.dummy() == 42
+    assert called["hit"]


### PR DESCRIPTION
## Summary
- add EditorsService wrapper under services/editing
- refactor core to use EditorsService
- expose launcher via lowercase `automl` module and bump project version

## Testing
- `pytest`
- `radon cc -j mainappsrc`


------
https://chatgpt.com/codex/tasks/task_b_68ad2ef708388327a52a55ca1c6ef83e