### PR TITLE
Introduce safety analysis service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.101
+version: 0.2.102
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.102 - Introduce SafetyAnalysisService wrapping FTA/FMEA/FMDA helpers and metrics.
 - 0.2.101 - Introduce AnalysisUtilsService wrapping probability and analysis utilities.
 - 0.2.100 - Wrap legacy editor helpers into EditorsService and refactor core usage.
 - 0.2.99 - Introduce ViewUpdateService for centralised view refreshing.

--- a/automl.py
+++ b/automl.py
@@ -15,9 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Lowercase launcher alias for :mod:`AutoML`."""
 
-"""Project version information."""
-
-VERSION = "0.2.102"
-
-__all__ = ["VERSION"]
+from AutoML import *  # noqa: F401,F403

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -152,7 +152,6 @@ from gui.windows.architecture import (
 )
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
 from .undo_manager import UndoRedoManager
-from analysis.fmeda_utils import compute_fmeda_metrics
 from analysis.scenario_description import template_phrases
 from mainappsrc.core.app_lifecycle_ui import AppLifecycleUI
 from tools.crash_report_logger import install_best, watchdog_best
@@ -1542,7 +1541,7 @@ class AutoMLApp(
         return self.safety_analysis.calculate_fmeda_metrics(events)
 
     def compute_fmeda_metrics(self, events):
-        """Delegate detailed FMEDA metric computation to the facade."""
+        """Delegate detailed FMEDA metric computation to the safety analysis service."""
         return self.safety_analysis.compute_fmeda_metrics(events)
 
     def sync_hara_to_safety_goals(self):

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -27,7 +27,6 @@ from mainappsrc.subapps.risk_assessment_subapp import RiskAssessmentSubApp
 from mainappsrc.subapps.reliability_subapp import ReliabilitySubApp
 
 from .open_windows_features import Open_Windows_Features
-from .safety_analysis import SafetyAnalysis_FTA_FMEA
 from .syncing_and_ids import Syncing_And_IDs
 from .diagram_renderer import DiagramRenderer
 from .navigation_selection_input import Navigation_Selection_Input
@@ -57,6 +56,7 @@ from .validation_consistency import Validation_Consistency
 from .reporting_export import Reporting_Export
 from mainappsrc.services.editing.editors_service import EditorsService
 from mainappsrc.services.analysis.analysis_utils_service import AnalysisUtilsService
+from mainappsrc.services.safety_analysis import SafetyAnalysisService
 
 
 class ServiceInitMixin:
@@ -71,7 +71,7 @@ class ServiceInitMixin:
         self.risk_app = RiskAssessmentSubApp()
         self.reliability_app = ReliabilitySubApp()
         self.open_windows_features = Open_Windows_Features(self)
-        self.safety_analysis = SafetyAnalysis_FTA_FMEA(self)
+        self.safety_analysis = SafetyAnalysisService(self)
         self.fta_app = self.safety_analysis
         self.fmea_service = self.safety_analysis
         self.fmeda_manager = self.safety_analysis

--- a/mainappsrc/services/safety_analysis/__init__.py
+++ b/mainappsrc/services/safety_analysis/__init__.py
@@ -15,9 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Safety analysis services."""
 
-"""Project version information."""
+from .safety_analysis_service import SafetyAnalysisService
 
-VERSION = "0.2.102"
-
-__all__ = ["VERSION"]
+__all__ = ["SafetyAnalysisService"]

--- a/mainappsrc/services/safety_analysis/safety_analysis_service.py
+++ b/mainappsrc/services/safety_analysis/safety_analysis_service.py
@@ -1,0 +1,57 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Service facade for safety analysis helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from mainappsrc.core.safety_analysis import SafetyAnalysis_FTA_FMEA
+from mainappsrc.models.fta.fault_tree_node import FaultTreeNode
+from analysis.fmeda_utils import compute_fmeda_metrics as _compute_fmeda_metrics
+
+
+class SafetyAnalysisService:
+    """Wrap :class:`SafetyAnalysis_FTA_FMEA` and expose utility helpers."""
+
+    def __init__(self, app: object) -> None:
+        self.app = app
+        self._impl = SafetyAnalysis_FTA_FMEA(app)
+
+    def __getattr__(self, name: str):
+        return getattr(self._impl, name)
+
+    # ------------------------------------------------------------------
+    # FMEDA metric helpers
+    def compute_fmeda_metrics(self, events: Iterable[FaultTreeNode]):
+        """Compute FMEDA metrics for ``events``.
+
+        Parameters
+        ----------
+        events:
+            Iterable of :class:`FaultTreeNode` instances representing
+            failure modes to analyse.
+        """
+        return _compute_fmeda_metrics(
+            list(events),
+            getattr(self.app, "reliability_components", []),
+            self.get_safety_goal_asil,
+        )
+
+
+__all__ = ["SafetyAnalysisService"]

--- a/tests/test_safety_analysis_service.py
+++ b/tests/test_safety_analysis_service.py
@@ -1,0 +1,68 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import types
+import sys
+from pathlib import Path
+
+# Ensure project root on path and stub optional GUI modules
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault('PIL', types.ModuleType('PIL'))
+sys.modules.setdefault('PIL.Image', types.ModuleType('PIL.Image'))
+sys.modules.setdefault('PIL.ImageDraw', types.ModuleType('PIL.ImageDraw'))
+sys.modules.setdefault('PIL.ImageFont', types.ModuleType('PIL.ImageFont'))
+sys.modules.setdefault('PIL.ImageTk', types.ModuleType('PIL.ImageTk'))
+
+from mainappsrc.models.fta.fault_tree_node import FaultTreeNode
+from mainappsrc.services.safety_analysis import SafetyAnalysisService
+
+
+class SimpleComponent:
+    def __init__(self, name, fit):
+        self.name = name
+        self.fit = fit
+        self.quantity = 1
+        self.sub_boms = []
+
+
+class DummyRiskApp:
+    def get_safety_goal_asil(self, app, sg_name):
+        return "QM"
+
+
+class DummyApp:
+    def __init__(self):
+        self.reliability_components = [SimpleComponent("CompA", 100.0)]
+        self.risk_app = DummyRiskApp()
+
+
+def test_compute_fmeda_metrics_basic():
+    app = DummyApp()
+    service = SafetyAnalysisService(app)
+
+    parent = FaultTreeNode("CompA", "FUNCTION")
+    event = FaultTreeNode("BE", "BASIC EVENT", parent=parent)
+    event.fmeda_fault_fraction = 1.0
+    event.fmeda_diag_cov = 0.5
+
+    metrics = service.compute_fmeda_metrics([event])
+    assert metrics["total"] == 100.0
+    assert metrics["spfm_raw"] == 50.0
+    assert metrics["lpfm_raw"] == 0.0


### PR DESCRIPTION
## Summary
- add SafetyAnalysisService wrapping `safety_analysis` and delegating FMEDA metrics
- route core service setup through SafetyAnalysisService
- expose compute_fmeda_metrics via safety analysis service and test

## Testing
- `pytest`
- `radon cc -j . > /tmp/radon.json`


------
https://chatgpt.com/codex/tasks/task_b_68ad323f823c8327ab7d620e57cb75e5