### PR TITLE
Add navigation input service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.102
+version: 0.2.103
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1722,6 +1722,7 @@ and run the build again if you hit this issue.
 - 0.2.29 - Instantiate validation consistency helper during application start-up.
 - 0.2.28 - Avoid circular import by using application helper in probability calculations.
 - 0.2.27 - Import Probability_Reliability in fallback path to avoid initialization error.
+- 0.2.103 - Introduced NavigationInputService to unify navigation and window helpers.
 - 0.2.26 - Import Syncing_And_IDs in fallback path to avoid initialization error.
 - 0.2.25 - Extract page and PAA helpers into dedicated module and delegate from core.
 - 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -1172,7 +1172,7 @@ class AutoMLApp(
         return self.lifecycle_ui.open_metrics_tab(*args, **kwargs)
 
     def open_management_window(self, *args, **kwargs):
-        return self.open_windows_features.open_management_window(*args, **kwargs)
+        return self.nav_input.open_management_window(*args, **kwargs)
 
     def _register_close(self, *args, **kwargs):
         return self.lifecycle_ui._register_close(*args, **kwargs)
@@ -1684,7 +1684,7 @@ class AutoMLApp(
 
         for idx, diag in enumerate(self.management_diagrams):
             if getattr(diag, "name", "") == name or getattr(diag, "diag_id", "") == name:
-                self.open_windows_features.open_management_window(idx)
+                self.nav_input.open_management_window(idx)
                 return
 
         for diag in getattr(self, "all_gsn_diagrams", []):
@@ -2109,7 +2109,7 @@ class AutoMLApp(
         return self.mission_profile_manager.manage_mission_profiles()
 
     def manage_mechanism_libraries(self):
-        return self.open_windows_features.manage_mechanism_libraries()
+        return self.nav_input.manage_mechanism_libraries()
 
     def manage_scenario_libraries(self):
         return self.scenario_library_manager.manage_scenario_libraries()
@@ -2118,34 +2118,34 @@ class AutoMLApp(
         return self.odd_library_manager.manage_odd_libraries()
 
     def open_reliability_window(self):
-        return self.open_windows_features.open_reliability_window()
+        return self.nav_input.open_reliability_window()
 
     def open_fmeda_window(self):
-        return self.open_windows_features.open_fmeda_window()
+        return self.nav_input.open_fmeda_window()
 
     def open_hazop_window(self):
-        return self.open_windows_features.open_hazop_window()
+        return self.nav_input.open_hazop_window()
 
     def open_risk_assessment_window(self):
-        return self.open_windows_features.open_risk_assessment_window()
+        return self.nav_input.open_risk_assessment_window()
 
     def open_stpa_window(self):
-        return self.open_windows_features.open_stpa_window()
+        return self.nav_input.open_stpa_window()
 
     def open_threat_window(self):
-        return self.open_windows_features.open_threat_window()
+        return self.nav_input.open_threat_window()
 
     def open_fi2tc_window(self):
-        return self.open_windows_features.open_fi2tc_window()
+        return self.nav_input.open_fi2tc_window()
 
     def open_tc2fi_window(self):
-        return self.open_windows_features.open_tc2fi_window()
+        return self.nav_input.open_tc2fi_window()
 
     def open_fault_prioritization_window(self):
-        return self.open_windows_features.open_fault_prioritization_window()
+        return self.nav_input.open_fault_prioritization_window()
 
     def open_safety_management_toolbox(self, show_diagrams: bool = True):
-        return self.open_windows_features.open_safety_management_toolbox(show_diagrams)
+        return self.nav_input.open_safety_management_toolbox(show_diagrams)
 
     def open_diagram_rules_toolbox(self):
         """Open editor for diagram rule configuration."""
@@ -2409,13 +2409,13 @@ class AutoMLApp(
         self.window_controllers.open_page_diagram(node, push_history)
 
     def manage_architecture(self):
-        return self.open_windows_features.manage_architecture()
+        return self.nav_input.manage_architecture()
 
     def manage_gsn(self):
         self.gsn_manager.manage_gsn()
 
     def manage_safety_management(self):
-        return self.open_windows_features.manage_safety_management()
+        return self.nav_input.manage_safety_management()
 
     def manage_safety_cases(self):
         return self.safety_case_manager.manage_safety_cases()

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -26,11 +26,10 @@ from mainappsrc.subapps.project_editor_subapp import ProjectEditorSubApp
 from mainappsrc.subapps.risk_assessment_subapp import RiskAssessmentSubApp
 from mainappsrc.subapps.reliability_subapp import ReliabilitySubApp
 
-from .open_windows_features import Open_Windows_Features
 from .syncing_and_ids import Syncing_And_IDs
 from .diagram_renderer import DiagramRenderer
-from .navigation_selection_input import Navigation_Selection_Input
 from .undo_manager import UndoRedoManager
+from mainappsrc.services.navigation import NavigationInputService
 
 from mainappsrc.managers.user_manager import UserManager
 from mainappsrc.managers.project_manager import ProjectManager
@@ -70,7 +69,6 @@ class ServiceInitMixin:
         self.project_editor_app = ProjectEditorSubApp()
         self.risk_app = RiskAssessmentSubApp()
         self.reliability_app = ReliabilitySubApp()
-        self.open_windows_features = Open_Windows_Features(self)
         self.safety_analysis = SafetyAnalysisService(self)
         self.fta_app = self.safety_analysis
         self.fmea_service = self.safety_analysis
@@ -79,7 +77,7 @@ class ServiceInitMixin:
         self.helper = AutoML_Helper
         self.syncing_and_ids = Syncing_And_IDs(self)
         self.diagram_renderer = DiagramRenderer(self)
-        self.nav_input = Navigation_Selection_Input(self)
+        self.nav_input = NavigationInputService(self)
         for _name in (
             "go_back",
             "back_all_pages",

--- a/mainappsrc/services/navigation/__init__.py
+++ b/mainappsrc/services/navigation/__init__.py
@@ -15,9 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Navigation related services."""
 
-"""Project version information."""
+from .navigation_input_service import NavigationInputService
 
-VERSION = "0.2.103"
-
-__all__ = ["VERSION"]
+__all__ = ["NavigationInputService"]

--- a/mainappsrc/services/navigation/navigation_input_service.py
+++ b/mainappsrc/services/navigation/navigation_input_service.py
@@ -1,0 +1,48 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Navigation and window management service.
+
+This service wraps :class:`~mainappsrc.core.navigation_selection_input.Navigation_Selection_Input`
+for canvas and tree interactions together with
+:class:`~mainappsrc.core.open_windows_features.Open_Windows_Features` for
+window management helpers.  It exposes the combined interface so callers
+can access both sets of functionality through a single object.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from mainappsrc.core.navigation_selection_input import Navigation_Selection_Input
+from mainappsrc.core.open_windows_features import Open_Windows_Features
+
+
+class NavigationInputService:
+    """Delegate navigation and window operations for :class:`AutoMLApp`."""
+
+    def __init__(self, app: Any) -> None:  # pragma: no cover - simple container
+        self._navigation = Navigation_Selection_Input(app)
+        self._windows = Open_Windows_Features(app)
+
+    def __getattr__(self, name: str):
+        """Delegate attribute lookups to wrapped helpers."""
+        if hasattr(self._navigation, name):
+            return getattr(self._navigation, name)
+        return getattr(self._windows, name)
+
+
+__all__ = ["NavigationInputService"]

--- a/tests/test_navigation_input_service.py
+++ b/tests/test_navigation_input_service.py
@@ -1,0 +1,53 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mainappsrc.services.navigation import NavigationInputService
+from mainappsrc.core.open_windows_features import Open_Windows_Features
+from mainappsrc.core.navigation_selection_input import Navigation_Selection_Input
+
+
+def test_service_delegates_to_open_windows(monkeypatch):
+    called = {}
+
+    def fake_open(self):
+        called["flag"] = True
+
+    monkeypatch.setattr(Open_Windows_Features, "open_reliability_window", fake_open)
+
+    svc = NavigationInputService(types.SimpleNamespace())
+    svc.open_reliability_window()
+    assert called["flag"] is True
+
+
+def test_service_delegates_to_navigation(monkeypatch):
+    called = {}
+
+    def fake_back(self):
+        called["flag"] = True
+
+    monkeypatch.setattr(Navigation_Selection_Input, "go_back", fake_back)
+
+    svc = NavigationInputService(types.SimpleNamespace())
+    svc.go_back()
+    assert called["flag"] is True


### PR DESCRIPTION
## Summary
- wrap navigation and window helpers in new NavigationInputService
- replace direct open_windows_features usage with NavigationInputService
- bump version to 0.2.103 and document in README
- add unit test for NavigationInputService

## Testing
- `radon cc -j mainappsrc > /tmp/radon.json`
- `pytest` *(fails: FileNotFoundError, AttributeError, etc.)*
- `pytest tests/test_navigation_input_service.py tests/test_paa_context_menu_gate.py`
- `pytest tests/test_version_sync.py::test_readme_matches_version`


------
https://chatgpt.com/codex/tasks/task_b_68ad344ec4208327bf66b08e85066c32