### PR TITLE
feat: add diagram renderer service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.103
+version: 0.2.104
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -8,7 +8,7 @@ Project configuration is handled by the new **ProjectPropertiesManager** module,
 
 The metamodel blends concepts from key automotive standards—ISO 26262 (functional safety), ISO 21448 (SOTIF), ISO 21434 (cybersecurity) and ISO 8800 (safety and AI)—so one project can address safety, cybersecurity and assurance requirements side by side.
 
-Diagram drawing is centralised in a dedicated :class:`DiagramRenderer`, providing a clear interface for generating and exporting diagrams.
+Diagram drawing is centralised in a dedicated :class:`DiagramRendererService`, providing a clear interface for generating and exporting diagrams.
 
 ## Getting Started
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.104 - Introduced DiagramRendererService to consolidate diagram helpers and export delegation.
 - 0.2.103 - Render white AutoML splash title using subtitle font at quadruple size.
 - 0.2.102 - Fix splash font name retrieval to avoid startup error.
 - 0.2.101 - Ensure AutoML splash title font matches subtitle and store ratio for testing.

--- a/mainappsrc/__init__.py
+++ b/mainappsrc/__init__.py
@@ -74,7 +74,7 @@ for old, new in _submodule_map.items():
 from .core.automl_core import AutoMLApp
 from .core.page_diagram import PageDiagram
 from .managers.fmeda_manager import FMEDAManager
-from .core.diagram_renderer import DiagramRenderer
+from .services.diagram import DiagramRendererService
 import importlib as _importlib
 
 # Avoid importing the main AutoML launcher during package initialisation
@@ -88,4 +88,10 @@ if AutoML is None:  # pragma: no cover - import only when needed externally
     except Exception:  # pragma: no cover - safety net for optional dependency
         AutoML = None
 
-__all__ = ["AutoMLApp", "PageDiagram", "FMEDAManager", "DiagramRenderer", "AutoML"]
+__all__ = [
+    "AutoMLApp",
+    "PageDiagram",
+    "FMEDAManager",
+    "DiagramRendererService",
+    "AutoML",
+]

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -60,8 +60,6 @@ from pathlib import Path
 from .event_handlers import EventHandlersMixin
 from .persistence_wrappers import PersistenceWrappersMixin
 from .service_init_mixin import ServiceInitMixin
-from .page_diagram import PageDiagram
-from .node_utils import resolve_original as resolve_node_original
 from mainappsrc.services.app_init import AppInitializationService
 from mainappsrc.services.ui import UISetupService
 from analysis.mechanisms import (
@@ -1562,43 +1560,43 @@ class AutoMLApp(
         ProjectPropertiesDialog(self).show()
 
     def create_diagram_image(self):  # pragma: no cover - delegation
-        return self.diagram_renderer.create_diagram_image()
+        return self.diagram_service.create_diagram_image()
 
     def get_page_nodes(self, node):
         return self.data_access_queries.get_page_nodes(node)
 
     def capture_page_diagram(self, page_node):  # pragma: no cover - delegation
-        return self.diagram_renderer.capture_page_diagram(page_node)
+        return self.diagram_service.capture_page_diagram(page_node)
 
     def capture_event_diagram(self, *args, **kwargs):  # pragma: no cover - delegation
-        return self.diagram_renderer.capture_event_diagram(*args, **kwargs)
+        return self.diagram_service.capture_event_diagram(*args, **kwargs)
 
     def capture_gsn_diagram(self, diagram):
-        return self.diagram_renderer.capture_gsn_diagram(diagram)
+        return self.diagram_service.capture_gsn_diagram(diagram)
 
     def capture_sysml_diagram(self, diagram):
-        return self.diagram_renderer.capture_sysml_diagram(diagram)
+        return self.diagram_service.capture_sysml_diagram(diagram)
 
     def capture_cbn_diagram(self, doc):
-        return self.diagram_renderer.capture_cbn_diagram(doc)
+        return self.diagram_service.capture_cbn_diagram(doc)
     
     def draw_subtree_with_filter(self, canvas, root_event, visible_nodes):
-        return self.diagram_renderer.draw_subtree_with_filter(canvas, root_event, visible_nodes)
+        return self.diagram_service.draw_subtree_with_filter(canvas, root_event, visible_nodes)
 
     def draw_subtree(self, canvas, root_event):
-        return self.diagram_renderer.draw_subtree(canvas, root_event)
+        return self.diagram_service.draw_subtree(canvas, root_event)
 
     def draw_connections_subtree(self, canvas, node, drawn_ids):
-        return self.diagram_renderer.draw_connections_subtree(canvas, node, drawn_ids)
+        return self.diagram_service.draw_connections_subtree(canvas, node, drawn_ids)
 
     def draw_node_on_canvas_pdf(self, canvas, node):
-        return self.diagram_renderer.draw_node_on_canvas_pdf(canvas, node)
+        return self.diagram_service.draw_node_on_canvas_pdf(canvas, node)
 
     def rename_selected_tree_item(self):
         self.tree_app.rename_selected_tree_item(self)
 
     def save_diagram_png(self):  # pragma: no cover - delegation
-        return self.diagram_renderer.save_diagram_png()
+        return self.diagram_service.save_diagram_png()
 
     def on_treeview_click(self, event):
         return self.nav_input.on_treeview_click(event)
@@ -1771,10 +1769,10 @@ class AutoMLApp(
         return self.structure_tree_operations.move_subtree(node, dx, dy)
 
     def zoom_in(self):  # pragma: no cover - delegation
-        return self.diagram_renderer.zoom_in()
+        return self.diagram_service.zoom_in()
 
     def zoom_out(self):  # pragma: no cover - delegation
-        return self.diagram_renderer.zoom_out()
+        return self.diagram_service.zoom_out()
 
 
     # ------------------------------------------------------------------
@@ -1956,16 +1954,16 @@ class AutoMLApp(
         return self.structure_tree_operations.insert_node_in_tree(parent_item, node)
 
     def redraw_canvas(self):
-        return self.diagram_renderer.redraw_canvas()
+        return self.diagram_service.redraw_canvas()
 
     def create_diagram_image_without_grid(self):
-        return self.diagram_renderer.create_diagram_image_without_grid()
+        return self.diagram_service.create_diagram_image_without_grid()
 
     def draw_connections(self, node, drawn_ids=set()):
-        return self.diagram_renderer.draw_connections(node, drawn_ids)
+        return self.diagram_service.draw_connections(node, drawn_ids)
 
     def draw_node(self, node):
-        return self.diagram_renderer.draw_node(node)
+        return self.diagram_service.draw_node(node)
 
     def find_node_by_id(self, node, unique_id, visited=None):
         return self.structure_tree_operations.find_node_by_id(node, unique_id, visited)
@@ -2888,31 +2886,31 @@ class AutoMLApp(
     def build_html_report(self):
         return self.reporting_export.build_html_report()
     def resolve_original(self, node):
-        return resolve_node_original(node)
+        return self.diagram_service.resolve_original(node)
 
     def go_back(self):
         return self.nav_input.go_back()
 
     def draw_page_subtree(self, page_root):
-        return self.diagram_renderer.draw_page_subtree(page_root)
+        return self.diagram_service.draw_page_subtree(page_root)
 
     def draw_page_grid(self):
-        return self.diagram_renderer.draw_page_grid()
+        return self.diagram_service.draw_page_grid()
 
     def draw_page_connections_subtree(self, node, visited_ids):
-        return self.diagram_renderer.draw_page_connections_subtree(node, visited_ids)
+        return self.diagram_service.draw_page_connections_subtree(node, visited_ids)
 
     def draw_page_nodes_subtree(self, node):
-        return self.diagram_renderer.draw_page_nodes_subtree(node)
+        return self.diagram_service.draw_page_nodes_subtree(node)
 
     def draw_node_on_page_canvas(self, *args, **kwargs):
-        return self.diagram_renderer.draw_node_on_page_canvas(*args, **kwargs)
+        return self.diagram_service.draw_node_on_page_canvas(*args, **kwargs)
 
     def on_ctrl_mousewheel_page(self, event):
         return self.nav_input.on_ctrl_mousewheel_page(event)
 
     def close_page_diagram(self):
-        return self.diagram_renderer.close_page_diagram()
+        return self.diagram_service.close_page_diagram()
 
     # --- Review Toolbox Methods ---
     def start_peer_review(self):
@@ -2937,7 +2935,7 @@ class AutoMLApp(
         return self.versioning_review.review_is_closed_for(review)
 
     def capture_diff_diagram(self, top_event):  # pragma: no cover - delegation
-        return self.diagram_renderer.capture_diff_diagram(top_event)
+        return self.diagram_service.capture_diff_diagram(top_event)
 
     # --- End Review Toolbox Methods ---
 

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -27,7 +27,6 @@ from mainappsrc.subapps.risk_assessment_subapp import RiskAssessmentSubApp
 from mainappsrc.subapps.reliability_subapp import ReliabilitySubApp
 
 from .syncing_and_ids import Syncing_And_IDs
-from .diagram_renderer import DiagramRenderer
 from .undo_manager import UndoRedoManager
 from mainappsrc.services.navigation import NavigationInputService
 
@@ -76,7 +75,9 @@ class ServiceInitMixin:
         self.fmeda = self.safety_analysis
         self.helper = AutoML_Helper
         self.syncing_and_ids = Syncing_And_IDs(self)
-        self.diagram_renderer = DiagramRenderer(self)
+        from mainappsrc.services.diagram import DiagramRendererService
+        self.diagram_service = DiagramRendererService(self)
+        self.diagram_renderer = self.diagram_service
         self.nav_input = NavigationInputService(self)
         for _name in (
             "go_back",

--- a/mainappsrc/services/diagram/__init__.py
+++ b/mainappsrc/services/diagram/__init__.py
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Diagram service package."""
 
-VERSION = "0.2.104"
+from .diagram_renderer_service import DiagramRendererService
 
-__all__ = ["VERSION"]
+__all__ = ["DiagramRendererService"]

--- a/mainappsrc/services/diagram/diagram_renderer_service.py
+++ b/mainappsrc/services/diagram/diagram_renderer_service.py
@@ -1,0 +1,78 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""High level wrapper around diagram rendering utilities.
+
+This service consolidates the legacy :mod:`diagram_renderer`,
+:mod:`page_diagram` and :mod:`node_utils` modules under a single
+interface.  Export operations are delegated to the existing
+``diagram_export_subapp`` managed by :class:`AutoMLApp`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.diagram_renderer import DiagramRenderer
+from ...core.page_diagram import PageDiagram
+from ...core.node_utils import resolve_original
+
+
+class DiagramRendererService:
+    """Facade for diagram rendering and export helpers."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+        self._renderer = DiagramRenderer(app)
+
+    # ------------------------------------------------------------------
+    # Delegation to underlying DiagramRenderer
+    # ------------------------------------------------------------------
+    def __getattr__(self, name: str):
+        return getattr(self._renderer, name)
+
+    # ------------------------------------------------------------------
+    # Page diagram helpers
+    # ------------------------------------------------------------------
+    def create_page_diagram(self, page_node, canvas):
+        """Return a :class:`PageDiagram` instance."""
+        return PageDiagram(self.app, page_node, canvas)
+
+    @staticmethod
+    def resolve_original(node):
+        """Expose :func:`resolve_original` from ``node_utils``."""
+        return resolve_original(node)
+
+    # ------------------------------------------------------------------
+    # Export helpers delegated to DiagramExportSubApp
+    # ------------------------------------------------------------------
+    def save_diagram_png(self):  # pragma: no cover - GUI export
+        return self.app.diagram_export_app.save_diagram_png()
+
+    def capture_page_diagram(self, page_node):  # pragma: no cover - GUI export
+        return self.app.diagram_export_app.capture_page_diagram(page_node)
+
+    def capture_gsn_diagram(self, diagram):  # pragma: no cover - GUI export
+        return self.app.diagram_export_app.capture_gsn_diagram(diagram)
+
+    def capture_sysml_diagram(self, diagram):  # pragma: no cover - GUI export
+        return self.app.diagram_export_app.capture_sysml_diagram(diagram)
+
+    def capture_cbn_diagram(self, doc):  # pragma: no cover - GUI export
+        return self.app.diagram_export_app.capture_cbn_diagram(doc)
+

--- a/tests/test_diagram_mode_enforcement.py
+++ b/tests/test_diagram_mode_enforcement.py
@@ -33,7 +33,8 @@ import importlib
 AutoML = importlib.import_module("mainappsrc.core.automl_core")
 AutoMLApp = AutoML.AutoMLApp
 FaultTreeNode = AutoML.FaultTreeNode
-PageDiagram = AutoML.PageDiagram
+import mainappsrc.core.page_diagram as page_module
+PageDiagram = page_module.PageDiagram
 
 import pytest
 
@@ -79,7 +80,8 @@ def _make_page_diagram(mode):
     canvas = Canvas(mode)
     root = FaultTreeNode("", "Top Event")
     root.x = root.y = 0
-    AutoML.tkFont = types.SimpleNamespace(Font=lambda *a, **k: object())
+    page_module.tkFont = types.SimpleNamespace(Font=lambda *a, **k: object())
+    page_module.fta_drawing_helper = types.SimpleNamespace()
     return PageDiagram(app, root, canvas)
 
 
@@ -136,6 +138,13 @@ def test_top_level_menu_gating():
     }
 
     app.diagram_mode = "CTA"
+    app.enable_fta_actions = lambda *a, **k: None
+    app.enable_cta_actions = lambda *a, **k: None
+    app.enable_paa_actions = lambda *a, **k: None
+    app.cta_manager = types.SimpleNamespace(enable_actions=lambda *a, **k: None)
+    app.validation_consistency = types.SimpleNamespace(
+        enable_paa_actions=lambda *a, **k: None
+    )
     app._update_analysis_menus()
     tk = AutoML.tk
     assert all(state == tk.DISABLED for state in app.fta_menu.states.values())
@@ -155,6 +164,7 @@ def test_invalid_node_addition(monkeypatch):
     app.selected_node = parent
     app.analysis_tree = types.SimpleNamespace(selection=lambda: ())
     app.update_views = lambda: None
+    app.undo_manager = types.SimpleNamespace(push_undo_state=lambda *a, **k: None)
     app.diagram_mode = "CTA"
 
     warnings = []

--- a/tests/test_diagram_renderer_service.py
+++ b/tests/test_diagram_renderer_service.py
@@ -1,0 +1,51 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for :class:`DiagramRendererService`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mainappsrc.services.diagram import DiagramRendererService
+
+
+class DummyApp:
+    def __init__(self):
+        self.diagram_export_app = MagicMock()
+
+
+class DummyNode:
+    def __init__(self, primary=None):
+        self.is_primary_instance = primary is None
+        self.original = primary or self
+
+
+def test_resolve_original_returns_primary():
+    app = DummyApp()
+    service = DiagramRendererService(app)
+    base = DummyNode()
+    clone = DummyNode(primary=base)
+    assert service.resolve_original(clone) is base
+
+
+def test_save_diagram_png_delegates():
+    app = DummyApp()
+    service = DiagramRendererService(app)
+    service.save_diagram_png()
+    assert app.diagram_export_app.save_diagram_png.called

--- a/tests/test_page_diagram_color_mode.py
+++ b/tests/test_page_diagram_color_mode.py
@@ -16,7 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from mainappsrc.automl_core import PageDiagram
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mainappsrc.services.diagram import DiagramRendererService
+import mainappsrc.core.page_diagram as page_module
 
 class DummyApp:
     def __init__(self):
@@ -67,14 +73,13 @@ class DummyFont:
 
 
 def test_page_diagram_uses_own_mode(monkeypatch):
-    from mainappsrc import AutoML as auto_module
-
-    monkeypatch.setattr(auto_module.tkFont, "Font", lambda *a, **k: DummyFont())
-    monkeypatch.setattr(auto_module, "fta_drawing_helper", StubDrawingHelper())
+    monkeypatch.setattr(page_module.tkFont, "Font", lambda *a, **k: DummyFont())
+    monkeypatch.setattr(page_module, "fta_drawing_helper", StubDrawingHelper())
 
     app = DummyApp()
     canvas = DummyCanvas()
-    pd = PageDiagram(app, DummyNode(), canvas)
+    svc = DiagramRendererService(app)
+    pd = svc.create_page_diagram(DummyNode(), canvas)
     pd.draw_node(DummyNode())
 
     assert app.modes == ["CTA"]

--- a/tests/test_render_cause_effect_diagram.py
+++ b/tests/test_render_cause_effect_diagram.py
@@ -35,8 +35,8 @@ class CauseEffectPDFTests(unittest.TestCase):
     def setUp(self):
         self.app = AutoMLApp.__new__(AutoMLApp)
         # Attach a renderer instance; __init__ is bypassed in tests.
-        from mainappsrc.diagram_renderer import DiagramRenderer
-        self.app.diagram_renderer = DiagramRenderer(self.app)
+        from mainappsrc.services.diagram import DiagramRendererService
+        self.app.diagram_service = DiagramRendererService(self.app)
 
     def test_render_cause_effect_diagram_size(self):
         row = {
@@ -49,7 +49,7 @@ class CauseEffectPDFTests(unittest.TestCase):
             "attack_paths": set(),
             "threats": {},
         }
-        img = self.app.diagram_renderer.render_cause_effect_diagram(row)
+        img = self.app.diagram_service.render_cause_effect_diagram(row)
         self.assertIsNotNone(img)
         w, h = img.size
         self.assertGreaterEqual(w, 120)


### PR DESCRIPTION
## Summary
- add DiagramRendererService to wrap rendering utilities and export helpers
- refactor AutoML core to use new service
- update documentation and tests for new diagram service

## Testing
- `pytest`
- `radon cc -j mainappsrc/services/diagram/diagram_renderer_service.py mainappsrc/core/automl_core.py`


------
https://chatgpt.com/codex/tasks/task_b_68ad36012f648327a47b3915537d05a2