### PR TITLE
Fix undo manager service import and add lowercase launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.107
+version: 0.2.108
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,6 +1644,7 @@ and run the build again if you hit this issue.
 
 
 ## Version History
+- 0.2.108 - Import UndoRedoService during service setup to fix NameError when launching the application.
 - 0.2.107 - Allow importing top-level modules when rewriting legacy mainappsrc paths.
 - 0.2.106 - Move clipboard, project properties and undo managers into managers package.
 - 0.2.105 - Fix missing mechanism library references in analysis utilities and prevent thread monitor shutdown error.

--- a/automl.py
+++ b/automl.py
@@ -15,29 +15,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""Service wrapper for :mod:`mainappsrc.managers.undo_manager`."""
+"""Lowercase compatibility wrapper for :mod:`AutoML`.
 
-from __future__ import annotations
+This thin module re-exports the public interface of the main
+:mod:`AutoML` launcher using a lowercase name so imports remain
+consistent on case-sensitive systems.
+"""
 
-from typing import Any
+from AutoML import *  # noqa: F401,F403
 
-from mainappsrc.managers.undo_manager import UndoRedoManager
-
-
-class UndoRedoService:
-    """Expose :class:`UndoRedoManager` as a service.
-
-    This thin wrapper enables dependency injection of the undo/redo
-    functionality and provides a stable service façade for the
-    application. Attribute access is delegated to the underlying manager
-    so existing calls continue to work unchanged.
-    """
-
-    def __init__(self, app: Any) -> None:  # pragma: no cover - simple container
-        self._manager = UndoRedoManager(app)
-
-    def __getattr__(self, name: str):  # pragma: no cover - delegation
-        return getattr(self._manager, name)
-
-
-__all__ = ["UndoRedoService"]
+__all__ = [name for name in globals() if not name.startswith("_")]

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -27,7 +27,7 @@ from mainappsrc.subapps.risk_assessment_subapp import RiskAssessmentSubApp
 from mainappsrc.subapps.reliability_subapp import ReliabilitySubApp
 
 from .syncing_and_ids import Syncing_And_IDs
-from ..managers.undo_manager import UndoRedoManager
+from mainappsrc.services.undo import UndoRedoService
 from mainappsrc.services.navigation import NavigationInputService
 from mainappsrc.services.syncing import SyncingAndIdsService
 

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.107"
+VERSION = "0.2.108"
 
 __all__ = ["VERSION"]

--- a/tests/test_undo_redo_service.py
+++ b/tests/test_undo_redo_service.py
@@ -29,12 +29,12 @@ def _load_service(monkeypatch):
     """Load the service module with a stubbed ``mainappsrc`` package."""
 
     dummy_pkg = types.SimpleNamespace()
-    core_pkg = types.SimpleNamespace()
+    managers_pkg = types.SimpleNamespace()
     undo_pkg = types.SimpleNamespace(UndoRedoManager=object)
     monkeypatch.setitem(sys.modules, "mainappsrc", dummy_pkg)  # type: ignore[arg-type]
-    monkeypatch.setitem(sys.modules, "mainappsrc.core", core_pkg)  # type: ignore[arg-type]
+    monkeypatch.setitem(sys.modules, "mainappsrc.managers", managers_pkg)  # type: ignore[arg-type]
     monkeypatch.setitem(
-        sys.modules, "mainappsrc.core.undo_manager", undo_pkg
+        sys.modules, "mainappsrc.managers.undo_manager", undo_pkg
     )  # type: ignore[arg-type]
 
     path = Path("mainappsrc/services/undo/undo_redo_service.py")


### PR DESCRIPTION
## Summary
- Import `UndoRedoService` in service initialization and adjust service to use managers package
- Provide lowercase `automl` module wrapper for case-sensitive imports
- Bump project version to 0.2.108 and document in README

## Testing
- `radon cc -j mainappsrc/core/service_init_mixin.py mainappsrc/services/undo/undo_redo_service.py automl.py`
- `pytest --ignore=__init__.py` *(fails: 209 failed, 992 passed, 60 skipped)*


------
https://chatgpt.com/codex/tasks/task_b_68ad411aacdc83278e297dca47c21fcd