### PR TITLE
refactor: centralize configuration service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.106
+version: 0.2.107
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1712,6 +1712,7 @@ and run the build again if you hit this issue.
 - 0.2.40 - Import Syncing_And_IDs during core initialization to prevent startup NameError.
 - 0.2.39 - Import SafetyAnalysis_FTA_FMEA during core initialization to prevent startup NameError.
 - 0.2.38 - Import ProjectEditorSubApp, RiskAssessmentSubApp and ReliabilitySubApp to prevent startup NameError.
+- 0.2.107 - Introduced ConfigService to centralise configuration helpers.
 - 0.2.38 - Extract node cloning into dedicated service and delegate from core.
 - 0.2.37 - Import TreeSubApp in core to prevent startup NameError.
 - 0.2.36 - Delegate add/get/show/link/refresh/collect routines to safety analysis facade.

--- a/automl.py
+++ b/automl.py
@@ -16,8 +16,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Convenience wrapper exposing AutoML launcher helpers."""
 
-VERSION = "0.2.107"
+from importlib import util
+from pathlib import Path
 
-__all__ = ["VERSION"]
+_spec = util.spec_from_file_location("automl_launcher", Path(__file__).with_name("AutoML.py"))
+_launcher = util.module_from_spec(_spec)
+assert _spec and _spec.loader  # for type checkers
+_spec.loader.exec_module(_launcher)
+
+ensure_ghostscript = _launcher.ensure_ghostscript
+GS_PATH = _launcher.GS_PATH
+os = _launcher.os
+subprocess = _launcher.subprocess
+main = _launcher.main
+
+__all__ = [
+    "ensure_ghostscript",
+    "GS_PATH",
+    "os",
+    "subprocess",
+    "main",
+]
+
+if __name__ == "__main__":
+    main()

--- a/gui/utils/config_utils.py
+++ b/gui/utils/config_utils.py
@@ -16,62 +16,37 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
 from __future__ import annotations
 
-"""Configuration helpers and global state for AutoML."""
+"""Compatibility layer exposing :mod:`ConfigService` globals."""
 
-from pathlib import Path
-from typing import Any
+from mainappsrc.services.config import config_service
 
-from config import load_diagram_rules
-from analysis.requirement_rule_generator import regenerate_requirement_patterns
-from analysis.risk_assessment import AutoMLHelper
 
 # ---------------------------------------------------------------------------
 # Paths and loaded configuration
 # ---------------------------------------------------------------------------
-_CONFIG_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "config"
-    / "rules"
-    / "diagram_rules.json"
-)
-_CONFIG: dict[str, Any] = load_diagram_rules(_CONFIG_PATH)
-GATE_NODE_TYPES: set[str] = set(_CONFIG.get("gate_node_types", []))
-
-_PATTERN_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "config"
-    / "patterns"
-    / "requirement_patterns.json"
-)
-_REPORT_TEMPLATE_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "config"
-    / "templates"
-    / "product_report_template.json"
-)
+_CONFIG_PATH = config_service.config_path
+_PATTERN_PATH = config_service.pattern_path
+_REPORT_TEMPLATE_PATH = config_service.report_template_path
+GATE_NODE_TYPES = config_service.gate_node_types
 
 # Generate requirement patterns on import so consumers have up-to-date data.
-regenerate_requirement_patterns()
+# Already handled by ConfigService initialisation.
 
 
 # ---------------------------------------------------------------------------
 # Public helpers
 # ---------------------------------------------------------------------------
+
 def _reload_local_config() -> None:
     """Reload gate node types from the external configuration file."""
-    global _CONFIG
-    _CONFIG = load_diagram_rules(_CONFIG_PATH)
-    GATE_NODE_TYPES.clear()
-    GATE_NODE_TYPES.update(_CONFIG.get("gate_node_types", []))
-    regenerate_requirement_patterns()
+    config_service.reload_local_config()
 
 
 # Global Unique ID counter and helper instance
-unique_node_id_counter = 1
-AutoML_Helper = AutoMLHelper()
+unique_node_id_counter = config_service.unique_node_id_counter
+AutoML_Helper = config_service.automl_helper
 
 __all__ = [
     "_reload_local_config",
@@ -82,4 +57,3 @@ __all__ = [
     "_PATTERN_PATH",
     "_REPORT_TEMPLATE_PATH",
 ]
-

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -261,16 +261,20 @@ from gui.toolboxes import (
 from pathlib import Path
 from gui.dialogs.user_info_dialog import UserInfoDialog
 
-import gui.utils.config_utils as config_utils
-from gui.utils.config_utils import _reload_local_config
+from mainappsrc.services.config import config_service
+
+
+def _reload_local_config() -> None:
+    config_service.reload_local_config()
+
 
 # Expose configuration helpers and global state
-_CONFIG_PATH = config_utils._CONFIG_PATH
-GATE_NODE_TYPES = config_utils.GATE_NODE_TYPES
-_PATTERN_PATH = config_utils._PATTERN_PATH
-_REPORT_TEMPLATE_PATH = config_utils._REPORT_TEMPLATE_PATH
-unique_node_id_counter = config_utils.unique_node_id_counter
-AutoML_Helper = config_utils.AutoML_Helper
+_CONFIG_PATH = config_service.config_path
+GATE_NODE_TYPES = config_service.gate_node_types
+_PATTERN_PATH = config_service.pattern_path
+_REPORT_TEMPLATE_PATH = config_service.report_template_path
+unique_node_id_counter = config_service.unique_node_id_counter
+AutoML_Helper = config_service.automl_helper
 import uuid
 
 ##########################################
@@ -2831,8 +2835,8 @@ class AutoMLApp(
 
         global AutoML_Helper, unique_node_id_counter
         SysMLRepository.reset_instance()
-        AutoML_Helper = config_utils.AutoML_Helper = AutoMLHelper()
-        unique_node_id_counter = config_utils.unique_node_id_counter = 1
+        AutoML_Helper = config_service.automl_helper = AutoMLHelper()
+        unique_node_id_counter = config_service.unique_node_id_counter = 1
 
         self.top_events = []
         self.cta_events = []
@@ -3064,7 +3068,7 @@ def _launch_app() -> None:
             save_user_config(name, email)
     set_current_user(name, email)
     global AutoML_Helper
-    AutoML_Helper = config_utils.AutoML_Helper = AutoMLHelper()
+    AutoML_Helper = config_service.automl_helper = AutoMLHelper()
     root.deiconify()
     try:
         root.state("zoomed")

--- a/mainappsrc/managers/project_manager.py
+++ b/mainappsrc/managers/project_manager.py
@@ -50,7 +50,7 @@ from analysis.safety_management import SafetyManagementToolbox
 from mainappsrc.models.gsn import GSNModule, GSNDiagram
 from mainappsrc.models.fta.fault_tree_node import FaultTreeNode
 from mainappsrc.models.sysml.sysml_repository import SysMLRepository
-import gui.utils.config_utils as config_utils
+from mainappsrc.services.config import config_service
 
 
 class ProjectManager:
@@ -122,9 +122,11 @@ class ProjectManager:
         automl_mod = importlib.import_module("AutoML")
         helper_cls = getattr(automl_mod, "AutoMLHelper", _AutoMLHelper)
         global AutoML_Helper, unique_node_id_counter
-        AutoML_Helper = config_utils.AutoML_Helper = automl_mod.AutoML_Helper = helper_cls()
+        AutoML_Helper = (
+            config_service.automl_helper
+        ) = automl_mod.AutoML_Helper = helper_cls()
         unique_node_id_counter = (
-            config_utils.unique_node_id_counter
+            config_service.unique_node_id_counter
         ) = automl_mod.unique_node_id_counter = 1
         SysMLRepository.reset_instance()
         app.zoom = 1.0
@@ -188,9 +190,11 @@ class ProjectManager:
         automl_mod = importlib.import_module("AutoML")
         helper_cls = getattr(automl_mod, "AutoMLHelper", _AutoMLHelper)
         global AutoML_Helper, unique_node_id_counter
-        AutoML_Helper = config_utils.AutoML_Helper = automl_mod.AutoML_Helper = helper_cls()
+        AutoML_Helper = (
+            config_service.automl_helper
+        ) = automl_mod.AutoML_Helper = helper_cls()
         unique_node_id_counter = (
-            config_utils.unique_node_id_counter
+            config_service.unique_node_id_counter
         ) = automl_mod.unique_node_id_counter = 1
         SysMLRepository.reset_instance()
         app.top_events = []

--- a/mainappsrc/services/config/__init__.py
+++ b/mainappsrc/services/config/__init__.py
@@ -15,9 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Configuration services package."""
 
-"""Project version information."""
+from .config_service import ConfigService, config_service
 
-VERSION = "0.2.107"
-
-__all__ = ["VERSION"]
+__all__ = ["ConfigService", "config_service"]

--- a/mainappsrc/services/config/config_service.py
+++ b/mainappsrc/services/config/config_service.py
@@ -1,0 +1,57 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Centralised configuration helpers for AutoML."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from config import load_diagram_rules
+from analysis.requirement_rule_generator import regenerate_requirement_patterns
+from analysis.risk_assessment import AutoMLHelper
+
+
+class ConfigService:
+    """Provide access to global configuration paths and helpers."""
+
+    def __init__(self) -> None:
+        base = Path(__file__).resolve().parents[3]
+        self.config_path = base / "config" / "rules" / "diagram_rules.json"
+        self.pattern_path = base / "config" / "patterns" / "requirement_patterns.json"
+        self.report_template_path = (
+            base / "config" / "templates" / "product_report_template.json"
+        )
+        self._config: dict[str, Any] = load_diagram_rules(self.config_path)
+        self.gate_node_types: set[str] = set(self._config.get("gate_node_types", []))
+        self.automl_helper = AutoMLHelper()
+        self.unique_node_id_counter = 1
+        regenerate_requirement_patterns()
+
+    def reload_local_config(self) -> None:
+        """Reload gate node types and regenerate requirement patterns."""
+        self._config = load_diagram_rules(self.config_path)
+        self.gate_node_types.clear()
+        self.gate_node_types.update(self._config.get("gate_node_types", []))
+        regenerate_requirement_patterns()
+
+
+config_service = ConfigService()
+
+__all__ = ["ConfigService", "config_service"]

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -19,28 +19,29 @@
 import json
 from pathlib import Path
 
-import gui.utils.config_utils as config_utils
+import mainappsrc.services.config.config_service as cs_module
 
 
 def test_reload_local_config_updates_gate_types(tmp_path, monkeypatch):
     cfg_path = tmp_path / "diagram_rules.json"
     cfg_path.write_text(json.dumps({"gate_node_types": ["NEW_GATE"]}))
-    monkeypatch.setattr(config_utils, "_CONFIG_PATH", cfg_path)
+    monkeypatch.setattr(cs_module.config_service, "config_path", cfg_path)
 
     called = {"val": False}
 
     def fake_regen(*args, **kwargs):
         called["val"] = True
 
-    monkeypatch.setattr(config_utils, "regenerate_requirement_patterns", fake_regen)
-    config_utils._reload_local_config()
-    assert config_utils.GATE_NODE_TYPES == {"NEW_GATE"}
+    monkeypatch.setattr(cs_module, "regenerate_requirement_patterns", fake_regen)
+    cs_module.config_service.reload_local_config()
+    assert cs_module.config_service.gate_node_types == {"NEW_GATE"}
     assert called["val"]
 
 
-def test_unique_id_generation(monkeypatch):
-    config_utils.AutoML_Helper.unique_node_id_counter = 1
-    first = config_utils.AutoML_Helper.get_next_unique_id()
-    second = config_utils.AutoML_Helper.get_next_unique_id()
+def test_unique_id_generation():
+    helper = cs_module.config_service.automl_helper
+    helper.unique_node_id_counter = 1
+    first = helper.get_next_unique_id()
+    second = helper.get_next_unique_id()
     assert (first, second) == (1, 2)
-    assert config_utils.AutoML_Helper.unique_node_id_counter == 3
+    assert helper.unique_node_id_counter == 3


### PR DESCRIPTION
## Summary
- add ConfigService to centralize configuration helpers and paths
- wrap existing config_utils around ConfigService
- adapt core and project manager to use ConfigService
- expose AutoML launcher via lowercase `automl` module

## Testing
- `pytest` *(fails: 209 failed, 994 passed, 60 skipped)*
- `radon cc -j .`

------
https://chatgpt.com/codex/tasks/task_b_68ad41bfaf4c832790e5339e0de7c45c