### PR TITLE
docs: move version history to dedicated file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,130 @@
+# Version History
+
+- 0.2.109 - Move version history to dedicated HISTORY.md file.
+- 0.2.108 - Import UndoRedoService during service setup to fix NameError when launching the application.
+- 0.2.107 - Allow importing top-level modules when rewriting legacy mainappsrc paths.
+- 0.2.106 - Move clipboard, project properties and undo managers into managers package.
+- 0.2.105 - Fix missing mechanism library references in analysis utilities and prevent thread monitor shutdown error.
+- 0.2.104 - Render orange AutoML splash title at 1.5x subtitle size.
+- 0.2.103 - Render white AutoML splash title using subtitle font at quadruple size.
+- 0.2.102 - Fix splash font name retrieval to avoid startup error.
+- 0.2.101 - Ensure AutoML splash title font matches subtitle and store ratio for testing.
+- 0.2.100 - Use subtitle font for AutoML splash title and size it at double the subtitle.
+- 0.2.99 - Double AutoML splash title size for improved visibility.
+- 0.2.98 - Render large orange AutoML title with black border.
+- 0.2.97 - Enlarge AutoML title and apply per-letter white-to-orange gradient.
+- 0.2.96 - Enlarge AutoML title with white-to-orange gradient.
+- 0.2.95 - Fix random band generation bug in splash screen.
+- 0.2.94 - Add beveled blue splash background and render AutoML title in black.
+- 0.2.93 - Replace splash background with properties window color, remove top gradient, and switch title font.
+- 0.2.92 - Thicken white horizon, add violet-blue sky gradient, and whiten title text.
+- 0.2.91 - Emit light green glow from white horizon into void.
+- 0.2.90 - Add light green and white gradient shading to the void.
+- 0.2.89 - Render splash screen as a black void with a white horizon.
+- 0.2.88 - Add translucent night sky gradient to splash screen.
+- 0.2.87 - Use absolute imports for config constants to support bundled executables.
+- 0.2.86 - Explicitly include tools package in PyInstaller builds to prevent runtime import errors.
+- 0.2.85 - Ensure PyInstaller bundles the tools package by collecting all modules.
+- 0.2.84 - Bundle tools package in executable to fix missing module at runtime.
+- 0.2.83 - Fix PyInstaller data path for core module and update documentation.
+- 0.2.82 - Preserve governance folder structure when saving and loading projects.
+- 0.2.81 - Show GSN diagrams as inputs when governance conditions are met and provide compatibility wrapper for ``page_diagram``.
+- 0.2.80 - Enforce active-phase governance relations for safety case inputs.
+- 0.2.79 - Ensure tools package is available for bundled executable by injecting project root into ``sys.path``.
+- 0.2.78 - Open Requirements Matrix in workspace tab and enforce fixed-size dialogs.
+- 0.2.77 - Coerce PDF export path to string to support Windows paths.
+- 0.2.76 - Delegate basic events access through reporting helpers for PDF report generation.
+- 0.2.75 - Delegate root node access through reporting helpers for traceability PDF generation.
+- 0.2.74 - Delegate node traversal helper through reporting export for traceability PDF elements.
+- 0.2.73 - Delegate top events access through reporting helpers for PDF exports.
+- 0.2.72 - Delegate cause-effect data builder to fix PDF report generation.
+- 0.2.71 - Expand PDF report generator with template-driven content and enforce `.pdf` extension.
+- 0.2.70 - Ensure PDF exports always use the user-selected `.pdf` extension.
+- 0.2.68 - Prevent tool tab duplication when switching lifecycle phases.
+- 0.2.67 - Activate risk assessment tools only when risk assessment work products exist.
+- 0.2.66 - Recognize copied work products in active phase governance diagrams.
+- 0.2.70 - Enforce PDF extension on export so files use the selected format.
+- 0.2.65 - Always paste to the focused governance diagram and show focused tab details in the status bar.
+- 0.2.64 - Fix paste so governance diagrams honor the currently focused tab.
+- 0.2.63 - Ensure governance diagram clipboard uses focused tab for copy, cut and paste.
+- 0.2.62 - Move PMHF calculation to FTA menu, move PAL calculation to PAA menu and remove Process menu.
+- 0.2.61 - Fix parent-node resolution and enable FTA/CTA node creation when PAA mode is active.
+- 0.2.60 - Allow adding FTA and CTA nodes regardless of active work product mode.
+- 0.2.59 - Reactivate lifecycle phase when focusing governance diagrams to allow editing after opening other analyses.
+- 0.2.58 - Fix empty Safety tab when editing nodes in FTA, CTA and PAA diagrams.
+- 0.2.57 - Map Task toolbox selection to Action elements so governance diagrams support adding tasks.
+- 0.2.56 - Synchronize README version header with source.
+- 0.2.55 - Delegate ODD library management to dedicated manager and remove legacy scenario code.
+- 0.2.54 - Initialize undo manager during service setup to prevent project load errors.
+- 0.2.52 - Move product goal UIs into RequirementsManager and add wrapper methods.
+- 0.2.51 - Extract clone-chain resolution into reusable utility.
+- 0.2.50 - Extract shared product goal updates into ProductGoalManager.
+- 0.2.49 - Move ``from __future__`` annotations imports to top-level of modules.
+- 0.2.48 - Provide wrapper for 90° connections and serialize SysML diagrams for export.
+- 0.2.47 - Delegate basic event probability updates to probability service to avoid missing risk module method.
+- 0.2.46 - Delegate basic event retrieval to FTASubApp to fix invocation mismatch.
+- 0.2.45 - Guard AutoML import in package initialisation to avoid circular reference on startup.
+- 0.2.44 - Import StyleSetupMixin to prevent startup NameError in AutoMLApp.
+- 0.2.43 - Remove duplicate service initialisation and centralise drawing manager.
+- 0.2.42 - Integrate initialization mixins to provide setup_services and icons.
+- 0.2.41 - Guard RoundedButton creation to prevent duplicate element errors.
+- 0.2.40 - Import Syncing_And_IDs during core initialization to prevent startup NameError.
+- 0.2.39 - Import SafetyAnalysis_FTA_FMEA during core initialization to prevent startup NameError.
+- 0.2.38 - Import ProjectEditorSubApp, RiskAssessmentSubApp and ReliabilitySubApp to prevent startup NameError.
+- 0.2.107 - Introduced ConfigService to centralise configuration helpers.
+- 0.2.38 - Extract node cloning into dedicated service and delegate from core.
+- 0.2.37 - Import TreeSubApp in core to prevent startup NameError.
+- 0.2.36 - Delegate add/get/show/link/refresh/collect routines to safety analysis facade.
+- 0.2.35 - Wrap update routines within safety analysis facade.
+- 0.2.34 - Centralise safety analysis helpers into facade and delegate from core.
+- 0.2.87 - Render star field on splash screen for cosmic backdrop.
+- 0.2.33 - Extract dialog classes into dedicated modules and update mixins.
+- 0.2.32 - Refactor core initialization into mixins for style, services, and icons.
+- 0.2.31 - Provide requirements editor export placeholder to prevent export error.
+- 0.2.59 - Introduced TrashEater module for proactive resource cleanup.
+- 0.2.30 - Instantiate reporting export helper during application start-up.
+- 0.2.29 - Instantiate validation consistency helper during application start-up.
+- 0.2.28 - Avoid circular import by using application helper in probability calculations.
+- 0.2.27 - Import Probability_Reliability in fallback path to avoid initialization error.
+- 0.2.103 - Introduced NavigationInputService to unify navigation and window helpers.
+- 0.2.26 - Import Syncing_And_IDs in fallback path to avoid initialization error.
+- 0.2.25 - Extract page and PAA helpers into dedicated module and delegate from core.
+- 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.
+- 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.
+- 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.
+- 0.2.25 - Extracted window opening helpers into dedicated class.
+- 0.2.21 - Expose DIALOG_BG_COLOR via gui.utils and re-export drawing helper for compatibility.
+- 0.2.20 - Re-export logger through gui package to fix DIALOG_BG_COLOR import failure.
+- 0.2.19 - Provide compatibility wrapper for splash screen import.
+- 0.2.18 - Organized GUI modules into functional subpackages and reduced threat window refresh complexity.
+- 0.2.17 - Ensure AutoMLHelper fallback if AutoML module lacks helper export.
+- 0.2.16 - Import PurpleButton lazily in custom messagebox to avoid early circular imports.
+- 0.2.15 - Lazily import messagebox module to resolve circular import.
+- 0.2.14 - Fade out splash screen symmetrically before launching application.
+- 0.2.13 - Delegate tab motion events to lifecycle UI to prevent missing handler error.
+- 0.2.18 - Organised mainappsrc into core, managers and subapps packages.
+- 0.2.12 - Fix property initialisation error in safety analysis facade.
+- 0.2.11 - Keep splash screen visible through startup and five-second post-load delay.
+- 0.2.10 - Hold splash screen for five seconds after initialisation completes.
+- 0.2.9 - Display splash screen during dependency checks and startup.
+- 0.2.8 - Renamed core module to `automl_core.py` and launcher to `automl.py`.
+- 0.2.7 - Launcher now shows the splash screen during application load.
+- 0.2.6 - Introduced WindowControllers class for centralized window management.
+- 0.2.5 - Added PDF report generation placeholder and fixed missing menu action.
+- 0.2.4 - Centralized diff capture and review tools into ReviewManager.
+- 0.2.3 - Moved capsule button into dedicated controls module.
+- 0.2.2 - Moved risk assessment helpers into dedicated sub-app.
+- 0.2.1 - Extracted review diff and version functions into ReviewManager.
+- 0.1.12 - Delegated reliability and risk-analysis windows to dedicated sub-app wrappers.
+- 0.1.11 - Split fault-tree and risk assessment logic into dedicated sub-app wrappers.
+- 0.1.10 - Centralised constants and moved requirement logic into a RequirementsManager sub-app.
+- 0.1.9 - Split diagram creation into dedicated sub-apps and centralised PNG export.
+- 0.1.8 - Moved analysis tree logic into a dedicated TreeSubApp wrapper.
+- 0.1.7 - Refactored main application into modular sub-apps and added CLI version option.
+- 0.1.6 - Fixed version display in Help → About and splash screen.
+- 0.1.5 - Added a pastel style with peach actions and steel-blue nodes.
+- 0.1.4 - Initial diagram style support documented.
+- 0.1.3 - Added context menu actions to remove parts from a diagram or from the model.
+- 0.1.2 - Clarified systems safety focus in description and About dialog.
+- 0.1.1 - Updated description and About dialog.
+- 0.1.0 - Added Help menu and version tracking.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.107
+version: 0.2.109
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 
@@ -1644,133 +1644,9 @@ and run the build again if you hit this issue.
 
 
 ## Version History
-- 0.2.108 - Import UndoRedoService during service setup to fix NameError when launching the application.
-- 0.2.107 - Allow importing top-level modules when rewriting legacy mainappsrc paths.
-- 0.2.106 - Move clipboard, project properties and undo managers into managers package.
-- 0.2.105 - Fix missing mechanism library references in analysis utilities and prevent thread monitor shutdown error.
-- 0.2.104 - Render orange AutoML splash title at 1.5x subtitle size.
-- 0.2.103 - Render white AutoML splash title using subtitle font at quadruple size.
-- 0.2.102 - Fix splash font name retrieval to avoid startup error.
-- 0.2.101 - Ensure AutoML splash title font matches subtitle and store ratio for testing.
-- 0.2.100 - Use subtitle font for AutoML splash title and size it at double the subtitle.
-- 0.2.99 - Double AutoML splash title size for improved visibility.
-- 0.2.98 - Render large orange AutoML title with black border.
-- 0.2.97 - Enlarge AutoML title and apply per-letter white-to-orange gradient.
-- 0.2.96 - Enlarge AutoML title with white-to-orange gradient.
-- 0.2.95 - Fix random band generation bug in splash screen.
-- 0.2.94 - Add beveled blue splash background and render AutoML title in black.
-- 0.2.93 - Replace splash background with properties window color, remove top gradient, and switch title font.
-- 0.2.92 - Thicken white horizon, add violet-blue sky gradient, and whiten title text.
-- 0.2.91 - Emit light green glow from white horizon into void.
-- 0.2.90 - Add light green and white gradient shading to the void.
-- 0.2.89 - Render splash screen as a black void with a white horizon.
-- 0.2.88 - Add translucent night sky gradient to splash screen.
-- 0.2.87 - Use absolute imports for config constants to support bundled executables.
-- 0.2.86 - Explicitly include tools package in PyInstaller builds to prevent runtime import errors.
-- 0.2.85 - Ensure PyInstaller bundles the tools package by collecting all modules.
-- 0.2.84 - Bundle tools package in executable to fix missing module at runtime.
-- 0.2.83 - Fix PyInstaller data path for core module and update documentation.
-- 0.2.82 - Preserve governance folder structure when saving and loading projects.
-- 0.2.81 - Show GSN diagrams as inputs when governance conditions are met and provide compatibility wrapper for ``page_diagram``.
-- 0.2.80 - Enforce active-phase governance relations for safety case inputs.
-- 0.2.79 - Ensure tools package is available for bundled executable by injecting project root into ``sys.path``.
-- 0.2.78 - Open Requirements Matrix in workspace tab and enforce fixed-size dialogs.
-- 0.2.77 - Coerce PDF export path to string to support Windows paths.
-- 0.2.76 - Delegate basic events access through reporting helpers for PDF report generation.
-- 0.2.75 - Delegate root node access through reporting helpers for traceability PDF generation.
-- 0.2.74 - Delegate node traversal helper through reporting export for traceability PDF elements.
-- 0.2.73 - Delegate top events access through reporting helpers for PDF exports.
-- 0.2.72 - Delegate cause-effect data builder to fix PDF report generation.
-- 0.2.71 - Expand PDF report generator with template-driven content and enforce `.pdf` extension.
-- 0.2.70 - Ensure PDF exports always use the user-selected `.pdf` extension.
-- 0.2.68 - Prevent tool tab duplication when switching lifecycle phases.
-- 0.2.67 - Activate risk assessment tools only when risk assessment work products exist.
-- 0.2.66 - Recognize copied work products in active phase governance diagrams.
-- 0.2.70 - Enforce PDF extension on export so files use the selected format.
-- 0.2.65 - Always paste to the focused governance diagram and show focused tab details in the status bar.
-- 0.2.64 - Fix paste so governance diagrams honor the currently focused tab.
-- 0.2.63 - Ensure governance diagram clipboard uses focused tab for copy, cut and paste.
-- 0.2.62 - Move PMHF calculation to FTA menu, move PAL calculation to PAA menu and remove Process menu.
-- 0.2.61 - Fix parent-node resolution and enable FTA/CTA node creation when PAA mode is active.
-- 0.2.60 - Allow adding FTA and CTA nodes regardless of active work product mode.
-- 0.2.59 - Reactivate lifecycle phase when focusing governance diagrams to allow editing after opening other analyses.
-- 0.2.58 - Fix empty Safety tab when editing nodes in FTA, CTA and PAA diagrams.
-- 0.2.57 - Map Task toolbox selection to Action elements so governance diagrams support adding tasks.
-- 0.2.56 - Synchronize README version header with source.
-- 0.2.55 - Delegate ODD library management to dedicated manager and remove legacy scenario code.
-- 0.2.54 - Initialize undo manager during service setup to prevent project load errors.
-- 0.2.52 - Move product goal UIs into RequirementsManager and add wrapper methods.
-- 0.2.51 - Extract clone-chain resolution into reusable utility.
-- 0.2.50 - Extract shared product goal updates into ProductGoalManager.
-- 0.2.49 - Move ``from __future__`` annotations imports to top-level of modules.
-- 0.2.48 - Provide wrapper for 90° connections and serialize SysML diagrams for export.
-- 0.2.47 - Delegate basic event probability updates to probability service to avoid missing risk module method.
-- 0.2.46 - Delegate basic event retrieval to FTASubApp to fix invocation mismatch.
-- 0.2.45 - Guard AutoML import in package initialisation to avoid circular reference on startup.
-- 0.2.44 - Import StyleSetupMixin to prevent startup NameError in AutoMLApp.
-- 0.2.43 - Remove duplicate service initialisation and centralise drawing manager.
-- 0.2.42 - Integrate initialization mixins to provide setup_services and icons.
-- 0.2.41 - Guard RoundedButton creation to prevent duplicate element errors.
-- 0.2.40 - Import Syncing_And_IDs during core initialization to prevent startup NameError.
-- 0.2.39 - Import SafetyAnalysis_FTA_FMEA during core initialization to prevent startup NameError.
-- 0.2.38 - Import ProjectEditorSubApp, RiskAssessmentSubApp and ReliabilitySubApp to prevent startup NameError.
-- 0.2.107 - Introduced ConfigService to centralise configuration helpers.
-- 0.2.38 - Extract node cloning into dedicated service and delegate from core.
-- 0.2.37 - Import TreeSubApp in core to prevent startup NameError.
-- 0.2.36 - Delegate add/get/show/link/refresh/collect routines to safety analysis facade.
-- 0.2.35 - Wrap update routines within safety analysis facade.
-- 0.2.34 - Centralise safety analysis helpers into facade and delegate from core.
-- 0.2.87 - Render star field on splash screen for cosmic backdrop.
-- 0.2.33 - Extract dialog classes into dedicated modules and update mixins.
-- 0.2.32 - Refactor core initialization into mixins for style, services, and icons.
-- 0.2.31 - Provide requirements editor export placeholder to prevent export error.
-- 0.2.59 - Introduced TrashEater module for proactive resource cleanup.
-- 0.2.30 - Instantiate reporting export helper during application start-up.
-- 0.2.29 - Instantiate validation consistency helper during application start-up.
-- 0.2.28 - Avoid circular import by using application helper in probability calculations.
-- 0.2.27 - Import Probability_Reliability in fallback path to avoid initialization error.
-- 0.2.103 - Introduced NavigationInputService to unify navigation and window helpers.
-- 0.2.26 - Import Syncing_And_IDs in fallback path to avoid initialization error.
-- 0.2.25 - Extract page and PAA helpers into dedicated module and delegate from core.
-- 0.2.24 - Move UI lifecycle helpers to dedicated class and delegate calls.
-- 0.2.23 - Correct default style path so governance diagrams and icons retain their colours.
-- 0.2.22 - Re-export add_treeview_scrollbars via gui.utils for legacy compatibility.
-- 0.2.25 - Extracted window opening helpers into dedicated class.
-- 0.2.21 - Expose DIALOG_BG_COLOR via gui.utils and re-export drawing helper for compatibility.
-- 0.2.20 - Re-export logger through gui package to fix DIALOG_BG_COLOR import failure.
-- 0.2.19 - Provide compatibility wrapper for splash screen import.
-- 0.2.18 - Organized GUI modules into functional subpackages and reduced threat window refresh complexity.
-- 0.2.17 - Ensure AutoMLHelper fallback if AutoML module lacks helper export.
-- 0.2.16 - Import PurpleButton lazily in custom messagebox to avoid early circular imports.
-- 0.2.15 - Lazily import messagebox module to resolve circular import.
-- 0.2.14 - Fade out splash screen symmetrically before launching application.
-- 0.2.13 - Delegate tab motion events to lifecycle UI to prevent missing handler error.
-- 0.2.18 - Organised mainappsrc into core, managers and subapps packages.
-- 0.2.12 - Fix property initialisation error in safety analysis facade.
-- 0.2.11 - Keep splash screen visible through startup and five-second post-load delay.
-- 0.2.10 - Hold splash screen for five seconds after initialisation completes.
-- 0.2.9 - Display splash screen during dependency checks and startup.
-- 0.2.8 - Renamed core module to `automl_core.py` and launcher to `automl.py`.
-- 0.2.7 - Launcher now shows the splash screen during application load.
-- 0.2.6 - Introduced WindowControllers class for centralized window management.
-- 0.2.5 - Added PDF report generation placeholder and fixed missing menu action.
-- 0.2.4 - Centralized diff capture and review tools into ReviewManager.
-- 0.2.3 - Moved capsule button into dedicated controls module.
-- 0.2.2 - Moved risk assessment helpers into dedicated sub-app.
-- 0.2.1 - Extracted review diff and version functions into ReviewManager.
-- 0.1.12 - Delegated reliability and risk-analysis windows to dedicated sub-app wrappers.
-- 0.1.11 - Split fault-tree and risk assessment logic into dedicated sub-app wrappers.
-- 0.1.10 - Centralised constants and moved requirement logic into a RequirementsManager sub-app.
-- 0.1.9 - Split diagram creation into dedicated sub-apps and centralised PNG export.
-- 0.1.8 - Moved analysis tree logic into a dedicated TreeSubApp wrapper.
-- 0.1.7 - Refactored main application into modular sub-apps and added CLI version option.
-- 0.1.6 - Fixed version display in Help → About and splash screen.
-- 0.1.5 - Added a pastel style with peach actions and steel-blue nodes.
-- 0.1.4 - Initial diagram style support documented.
-- 0.1.3 - Added context menu actions to remove parts from a diagram or from the model.
-- 0.1.2 - Clarified systems safety focus in description and About dialog.
-- 0.1.1 - Updated description and About dialog.
-- 0.1.0 - Added Help menu and version tracking.
+
+See [HISTORY.md](HISTORY.md) for past changes.
+
 ## Example Safety Analysis Tables
 
 The following example shows how to build a small project from scratch so you can

--- a/automl.py
+++ b/automl.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Author: Miguel Marina <karel.capek.robotics@gmail.com>
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,8 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Lowercase wrapper for the AutoML launcher."""
 
-VERSION = "0.2.109"
+from AutoML import *  # re-export launcher utilities
 
-__all__ = ["VERSION"]
+__all__ = [name for name in globals() if not name.startswith('_')]


### PR DESCRIPTION
## Summary
- move version history from README to dedicated HISTORY.md
- bump project version to 0.2.109 and expose via version.py
- add lowercase automl wrapper for launcher utilities

## Testing
- `radon cc -s -j .`
- `pytest` *(fails: FileNotFoundError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_b_68adc75845a48327a6fa60d03088c463