### PR TITLE
Add radial gradient to splash gear

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 # Version History
 
+- 0.2.110 - Add radial green highlight to gear on splash screen.
 - 0.2.109 - Move version history to dedicated HISTORY.md file.
 - 0.2.108 - Import UndoRedoService during service setup to fix NameError when launching the application.
 - 0.2.107 - Allow importing top-level modules when rewriting legacy mainappsrc paths.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.109
+version: 0.2.110
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -417,17 +417,56 @@ class SplashScreen(tk.Toplevel):
     def _draw_gear(self):
         self.canvas.delete("gear")
         self.canvas.delete("gear_glow")
+        self.canvas.delete("gear_fill")
         teeth = 8
         inner = 20
         outer = 30
-        pts = []
         angle = math.radians(self.angle * 2)
+
+        # Radial gradient fill from white at the centre to light green at the teeth
+        steps = 25
+        start = (255, 255, 255)
+        end = (204, 255, 204)  # low green
+        for step in range(steps, 0, -1):
+            ratio = step / steps
+            r_inner = inner * ratio
+            r_outer = outer * ratio
+            pts = []
+            for i in range(teeth * 2):
+                r = r_outer if i % 2 == 0 else r_inner
+                theta = angle + i * math.pi / teeth
+                x = self.canvas_size / 2 + r * math.cos(theta)
+                y = self.canvas_size / 2 + r * math.sin(theta)
+                pts.append((x, y))
+            cr = int(start[0] * (1 - ratio) + end[0] * ratio)
+            cg = int(start[1] * (1 - ratio) + end[1] * ratio)
+            cb = int(start[2] * (1 - ratio) + end[2] * ratio)
+            colour = f"#{cr:02x}{cg:02x}{cb:02x}"
+            self.canvas.create_polygon(
+                pts, outline="", fill=colour, tags="gear_fill"
+            )
+
+        # Ensure a bright spot at the very centre for a shiny appearance
+        cx = cy = self.canvas_size / 2
+        self.canvas.create_oval(
+            cx - 1,
+            cy - 1,
+            cx + 1,
+            cy + 1,
+            fill="#ffffff",
+            outline="",
+            tags="gear_fill",
+        )
+
+        # Points for gear outline and glow
+        pts = []
         for i in range(teeth * 2):
             r = outer if i % 2 == 0 else inner
             theta = angle + i * math.pi / teeth
             x = self.canvas_size / 2 + r * math.cos(theta)
             y = self.canvas_size / 2 + r * math.sin(theta)
             pts.append((x, y))
+
         # Draw expanding outlines for a simple glow effect
         for width, colour in [(6, "#00ffff"), (4, "#66ffff")]:
             self.canvas.create_polygon(

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -49,6 +49,15 @@ class SplashScreenTests(unittest.TestCase):
         gear_items = self.splash.canvas.find_withtag("gear")
         self.assertEqual(len(gear_items), 1)
 
+    def test_gear_gradient(self):
+        self.splash._draw_gear()
+        fill_items = self.splash.canvas.find_withtag("gear_fill")
+        self.assertGreater(len(fill_items), 1)
+        outer_color = self.splash.canvas.itemcget(fill_items[0], "fill")
+        inner_color = self.splash.canvas.itemcget(fill_items[-1], "fill")
+        self.assertEqual(outer_color, "#ccffcc")
+        self.assertEqual(inner_color, "#ffffff")
+
     def test_title_shadow(self):
         shadow_items = self.splash.canvas.find_withtag("title_shadow")
         text_items = self.splash.canvas.find_withtag("title_text")


### PR DESCRIPTION
## Summary
- Render a white-to-light-green radial gradient on the splash screen gear for a shinier effect
- Test the new gear gradient logic
- Record the enhancement in the version history and bump README version

## Testing
- `radon cc -s -j gui/windows/splash_screen.py`
- `pytest` *(fails: AttributeError, AssertionError, etc.)*
- `PYTHONPATH=. pytest tests/test_splash_screen.py tests/test_splash_launcher.py`

------
https://chatgpt.com/codex/tasks/task_b_68addd9039f88327bd9bc455f39cdf27