### PR TITLE
Wrap data access queries in service

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 # Version History
 
+- 0.2.111 - Wrap data access queries in service and update core.
 - 0.2.110 - Add radial green highlight to gear on splash screen.
 - 0.2.109 - Move version history to dedicated HISTORY.md file.
 - 0.2.108 - Import UndoRedoService during service setup to fix NameError when launching the application.

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -83,6 +83,7 @@ from .validation_consistency import Validation_Consistency
 from .reporting_export import Reporting_Export
 from mainappsrc.services.node_clone import NodeCloneServiceInterface
 from mainappsrc.services.view import ViewUpdateService
+from mainappsrc.services.data_access import DataAccessQueriesService
 from analysis.user_config import (
     load_user_config,
     save_user_config,

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -50,12 +50,12 @@ from mainappsrc.managers.mission_profile_manager import MissionProfileManager
 from mainappsrc.managers.scenario_library_manager import ScenarioLibraryManager
 from mainappsrc.managers.odd_library_manager import OddLibraryManager
 from .versioning_review import Versioning_Review
-from .data_access_queries import DataAccess_Queries
 from .validation_consistency import Validation_Consistency
 from .reporting_export import Reporting_Export
 from mainappsrc.services.editing.editors_service import EditorsService
 from mainappsrc.services.analysis.analysis_utils_service import AnalysisUtilsService
 from mainappsrc.services.safety_analysis import SafetyAnalysisService
+from mainappsrc.services.data_access import DataAccessQueriesService
 
 
 class ServiceInitMixin:
@@ -122,7 +122,7 @@ class ServiceInitMixin:
         self.odd_library_manager = OddLibraryManager(self)
         self.drawing_manager = DrawingManager(self)
         self.versioning_review = Versioning_Review(self)
-        self.data_access_queries = DataAccess_Queries(self)
+        self.data_access_queries = DataAccessQueriesService(self)
         self.validation_consistency = Validation_Consistency(self)
         self.reporting_export = Reporting_Export(self)
         self.editors_service = EditorsService(self)

--- a/mainappsrc/services/data_access/__init__.py
+++ b/mainappsrc/services/data_access/__init__.py
@@ -15,17 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Data access related services."""
 
-import ast
-from pathlib import Path
+from .data_access_queries_service import DataAccessQueriesService
 
-
-def test_automl_core_imports_data_access_queries_service():
-    code = Path("mainappsrc/core/automl_core.py").read_text()
-    tree = ast.parse(code)
-    assert any(
-        isinstance(node, ast.ImportFrom)
-        and node.module == "mainappsrc.services.data_access"
-        and any(alias.name == "DataAccessQueriesService" for alias in node.names)
-        for node in ast.walk(tree)
-    ), "DataAccessQueriesService import missing in automl_core"
+__all__ = ["DataAccessQueriesService"]

--- a/mainappsrc/services/data_access/data_access_queries_service.py
+++ b/mainappsrc/services/data_access/data_access_queries_service.py
@@ -15,17 +15,22 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Wrapper around :class:`DataAccess_Queries`."""
 
-import ast
-from pathlib import Path
+from __future__ import annotations
+
+from mainappsrc.core.data_access_queries import DataAccess_Queries
 
 
-def test_automl_core_imports_data_access_queries_service():
-    code = Path("mainappsrc/core/automl_core.py").read_text()
-    tree = ast.parse(code)
-    assert any(
-        isinstance(node, ast.ImportFrom)
-        and node.module == "mainappsrc.services.data_access"
-        and any(alias.name == "DataAccessQueriesService" for alias in node.names)
-        for node in ast.walk(tree)
-    ), "DataAccessQueriesService import missing in automl_core"
+class DataAccessQueriesService:
+    """Delegate data access query helpers for :class:`AutoMLApp`."""
+
+    def __init__(self, app: object) -> None:  # pragma: no cover - simple container
+        self.app = app
+        self._impl = DataAccess_Queries(app)
+
+    def __getattr__(self, name: str):
+        return getattr(self._impl, name)
+
+
+__all__ = ["DataAccessQueriesService"]

--- a/tests/test_data_access_queries_service.py
+++ b/tests/test_data_access_queries_service.py
@@ -15,17 +15,25 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for :mod:`DataAccessQueriesService`."""
 
-import ast
+from types import SimpleNamespace
+import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-def test_automl_core_imports_data_access_queries_service():
-    code = Path("mainappsrc/core/automl_core.py").read_text()
-    tree = ast.parse(code)
-    assert any(
-        isinstance(node, ast.ImportFrom)
-        and node.module == "mainappsrc.services.data_access"
-        and any(alias.name == "DataAccessQueriesService" for alias in node.names)
-        for node in ast.walk(tree)
-    ), "DataAccessQueriesService import missing in automl_core"
+import mainappsrc.services.data_access.data_access_queries_service as svc_module
+
+
+class DummyQueries:
+    def __init__(self, app):
+        self.app = app
+    def sample(self, value):
+        return value * 2
+
+
+def test_service_delegates_attributes(monkeypatch):
+    monkeypatch.setattr(svc_module, "DataAccess_Queries", DummyQueries)
+    service = svc_module.DataAccessQueriesService(app=SimpleNamespace())
+    assert service.sample(5) == 10


### PR DESCRIPTION
## Summary
- add DataAccessQueriesService to encapsulate legacy data_access_queries helpers
- integrate data access service into core initialization and import in automl_core
- test data access service delegation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'automl')*
- `pytest tests/test_data_access_queries_import.py tests/test_data_access_queries_service.py`
- `radon cc -j mainappsrc/services/data_access/data_access_queries_service.py mainappsrc/core/service_init_mixin.py tests/test_data_access_queries_service.py tests/test_data_access_queries_import.py`


------
https://chatgpt.com/codex/tasks/task_b_68ade0f199d48327a5f77b153a5c5896