### PR TITLE
feat: add reporting export service

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 # Version History
 
+- 0.2.113 - Wrap reporting helpers in service and delegate PDF/HTML generation.
 - 0.2.112 - Wrap validation consistency helpers in dedicated service and refactor core initialization.
 - 0.2.111 - Wrap data access queries in service and update core.
 - 0.2.110 - Add radial green highlight to gear on splash screen.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.112
+version: 0.2.113
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/automl.py
+++ b/automl.py
@@ -15,9 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Lowercase import wrapper for :mod:`AutoML`."""
 
-"""Project version information."""
-
-VERSION = "0.2.113"
-
-__all__ = ["VERSION"]
+from AutoML import *  # noqa: F401,F403

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -79,7 +79,7 @@ from mainappsrc.core.top_event_workflows import Top_Event_Workflows
 from mainappsrc.managers.review_manager import ReviewManager
 from mainappsrc.managers.drawing_manager import DrawingManager
 from .versioning_review import Versioning_Review
-from .reporting_export import Reporting_Export
+from mainappsrc.services.reporting import ReportingExportService
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from mainappsrc.services.validation import ValidationConsistencyService

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -50,7 +50,7 @@ from mainappsrc.managers.mission_profile_manager import MissionProfileManager
 from mainappsrc.managers.scenario_library_manager import ScenarioLibraryManager
 from mainappsrc.managers.odd_library_manager import OddLibraryManager
 from .versioning_review import Versioning_Review
-from .reporting_export import Reporting_Export
+from mainappsrc.services.reporting import ReportingExportService
 from mainappsrc.services.editing.editors_service import EditorsService
 from mainappsrc.services.analysis.analysis_utils_service import AnalysisUtilsService
 from mainappsrc.services.safety_analysis import SafetyAnalysisService
@@ -124,7 +124,7 @@ class ServiceInitMixin:
         self.versioning_review = Versioning_Review(self)
         self.data_access_queries = DataAccessQueriesService(self)
         self.validation_consistency = ValidationConsistencyService(self)
-        self.reporting_export = Reporting_Export(self)
+        self.reporting_export = ReportingExportService(self)
         self.editors_service = EditorsService(self)
         self.analysis_utils_service = AnalysisUtilsService(self)
         self.probability_reliability = self.analysis_utils_service.probability_reliability

--- a/mainappsrc/services/reporting/__init__.py
+++ b/mainappsrc/services/reporting/__init__.py
@@ -15,9 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Services for report generation and export."""
 
-"""Project version information."""
+from .reporting_export_service import ReportingExportService
 
-VERSION = "0.2.113"
-
-__all__ = ["VERSION"]
+__all__ = ["ReportingExportService"]

--- a/mainappsrc/services/reporting/reporting_export_service.py
+++ b/mainappsrc/services/reporting/reporting_export_service.py
@@ -1,0 +1,61 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Wrapper service providing PDF and HTML report generation."""
+
+from __future__ import annotations
+
+from mainappsrc.core.reporting_export import Reporting_Export
+
+
+class ReportingExportService:
+    """Facade around :class:`~mainappsrc.core.reporting_export.Reporting_Export`.
+
+    The service delegates to the underlying exporter while exposing a
+    concise surface for generating PDF and HTML reports.  Other helper
+    methods are transparently forwarded via ``__getattr__`` so existing
+    callers continue to function.
+    """
+
+    def __init__(self, app: object) -> None:
+        self._exporter = Reporting_Export(app)
+
+    # ------------------------------------------------------------------
+    # Focused report generation helpers
+    def _generate_pdf_report(self):
+        """Generate raw PDF data using the underlying exporter."""
+        return self._exporter._generate_pdf_report()
+
+    def generate_pdf_report(self):
+        """Create a PDF report and return the output path."""
+        return self._exporter.generate_pdf_report()
+
+    def generate_report(self):
+        """Create an HTML report and return its path."""
+        return self._exporter.generate_report()
+
+    def build_html_report(self):
+        """Build HTML report content without writing to disk."""
+        return self._exporter.build_html_report()
+
+    # ------------------------------------------------------------------
+    # Delegate any other attribute access to the wrapped exporter
+    def __getattr__(self, item):  # pragma: no cover - simple delegation
+        return getattr(self._exporter, item)
+
+
+__all__ = ["ReportingExportService"]

--- a/tests/test_reporting_export_import.py
+++ b/tests/test_reporting_export_import.py
@@ -20,12 +20,12 @@ import ast
 from pathlib import Path
 
 
-def test_automl_core_imports_reporting_export():
+def test_automl_core_imports_reporting_service():
     code = Path("mainappsrc/core/automl_core.py").read_text()
     tree = ast.parse(code)
     assert any(
         isinstance(node, ast.ImportFrom)
-        and node.module == "reporting_export"
-        and any(alias.name == "Reporting_Export" for alias in node.names)
+        and node.module == "mainappsrc.services.reporting"
+        and any(alias.name == "ReportingExportService" for alias in node.names)
         for node in ast.walk(tree)
-    ), "Reporting_Export import missing in automl_core"
+    ), "ReportingExportService import missing in automl_core"

--- a/tests/test_reporting_export_init.py
+++ b/tests/test_reporting_export_init.py
@@ -20,8 +20,8 @@ import ast
 from pathlib import Path
 
 
-def test_automl_core_initialises_reporting_export():
-    code = Path("mainappsrc/core/automl_core.py").read_text()
+def test_service_init_mixin_initialises_reporting_service():
+    code = Path("mainappsrc/core/service_init_mixin.py").read_text()
     tree = ast.parse(code)
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
@@ -34,10 +34,10 @@ def test_automl_core_initialises_reporting_export():
             ):
                 if (
                     isinstance(node.value, ast.Call)
-                    and getattr(node.value.func, "id", None) == "Reporting_Export"
+                    and getattr(node.value.func, "id", None) == "ReportingExportService"
                 ):
                     break
     else:
         raise AssertionError(
-            "AutoMLApp.__init__ does not assign Reporting_Export to self.reporting_export"
+            "ServiceInitMixin.setup_services does not assign ReportingExportService to self.reporting_export"
         )

--- a/tests/test_reporting_export_service.py
+++ b/tests/test_reporting_export_service.py
@@ -1,0 +1,52 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for :mod:`mainappsrc.services.reporting`."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from mainappsrc.services.reporting import ReportingExportService
+
+
+class DummyExporter:
+    def __init__(self, app):
+        self.app = app
+
+    def generate_pdf_report(self):
+        return "pdf"
+
+    def generate_report(self):
+        return "report"
+
+    def extra(self):
+        return "extra"
+
+
+@pytest.fixture
+def patch_exporter(monkeypatch):
+    monkeypatch.setattr(
+        "mainappsrc.core.reporting_export.Reporting_Export", DummyExporter
+    )
+
+
+def test_service_delegates_pdf_generation(patch_exporter):
+    service = ReportingExportService(SimpleNamespace())
+    assert service.generate_pdf_report() == "pdf"
+    assert service.generate_report() == "report"
+    assert service.extra() == "extra"


### PR DESCRIPTION
## Summary
- wrap core reporting export helper in service
- delegate reporting operations through new ReportingExportService
- add tests and version history

## Testing
- `pytest` *(fails: AttributeError: 'AutoMLApp' object ...)*
- `radon cc -j mainappsrc/services/reporting/reporting_export_service.py`


------
https://chatgpt.com/codex/tasks/task_b_68ade66346088327b32e0cfd35c05bf0