### PR TITLE
Add managers facade service

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 # Version History
 
+- 0.2.115 - Group core managers into ManagersFacadeService, provide compatibility launcher module, and update core initialization.
 - 0.2.114 - Wrap versioning review helpers in service and update core initialization.
 - 0.2.113 - Wrap reporting helpers in service and delegate PDF/HTML generation.
 - 0.2.112 - Wrap validation consistency helpers in dedicated service and refactor core initialization.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.114
+version: 0.2.115
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/automl.py
+++ b/automl.py
@@ -15,9 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Compatibility wrapper exposing the AutoML package as a module."""
 
-"""Project version information."""
-
-VERSION = "0.2.115"
-
-__all__ = ["VERSION"]
+from AutoML import *  # noqa: F401,F403

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -76,10 +76,9 @@ from gui.utils.drawing_helper import FTADrawingHelper, fta_drawing_helper
 from mainappsrc.core.event_dispatcher import EventDispatcher
 from gui.controls.window_controllers import WindowControllers
 from mainappsrc.core.top_event_workflows import Top_Event_Workflows
-from mainappsrc.managers.review_manager import ReviewManager
-from mainappsrc.managers.drawing_manager import DrawingManager
 from mainappsrc.services.versioning import VersioningReviewService
 from mainappsrc.services.reporting import ReportingExportService
+from mainappsrc.services.managers import ManagersFacadeService
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from mainappsrc.services.validation import ValidationConsistencyService
@@ -163,13 +162,8 @@ from gui.styles.editing_labels_styling import Editing_Labels_Styling
 import copy
 import tkinter.font as tkFont
 import builtins
-from mainappsrc.managers.user_manager import UserManager
-from mainappsrc.managers.project_manager import ProjectManager
 from mainappsrc.managers.product_goal_manager import ProductGoalManager
 from gui.dialogs.project_properties_dialog import ProjectPropertiesDialog
-from mainappsrc.managers.sotif_manager import SOTIFManager
-from mainappsrc.managers.cyber_manager import CyberSecurityManager
-from mainappsrc.managers.cta_manager import ControlTreeManager
 if __package__ and __package__.startswith("AutoML"):
     from AutoML.config.automl_constants import (
         dynamic_recommendations,
@@ -302,6 +296,7 @@ class AutoMLApp(
 
     _instance: Optional["AutoMLApp"] = None
     validation_consistency: "ValidationConsistencyService"
+    managers: "ManagersFacadeService"
 
     #: Maximum number of characters displayed for a notebook tab title. Longer
     #: titles are truncated with an ellipsis to avoid giant tabs that overflow

--- a/mainappsrc/core/service_init_mixin.py
+++ b/mainappsrc/core/service_init_mixin.py
@@ -26,29 +26,17 @@ from mainappsrc.subapps.project_editor_subapp import ProjectEditorSubApp
 from mainappsrc.subapps.risk_assessment_subapp import RiskAssessmentSubApp
 from mainappsrc.subapps.reliability_subapp import ReliabilitySubApp
 
-from .syncing_and_ids import Syncing_And_IDs
 from mainappsrc.services.undo import UndoRedoService
 from mainappsrc.services.navigation import NavigationInputService
 from mainappsrc.services.syncing import SyncingAndIdsService
 
-from mainappsrc.managers.user_manager import UserManager
-from mainappsrc.managers.project_manager import ProjectManager
-from mainappsrc.managers.cyber_manager import CyberSecurityManager
-from mainappsrc.managers.drawing_manager import DrawingManager
 from mainappsrc.subapps.diagram_export_subapp import DiagramExportSubApp
 from mainappsrc.subapps.use_case_diagram_subapp import UseCaseDiagramSubApp
 from mainappsrc.subapps.activity_diagram_subapp import ActivityDiagramSubApp
 from mainappsrc.subapps.block_diagram_subapp import BlockDiagramSubApp
 from mainappsrc.subapps.internal_block_diagram_subapp import InternalBlockDiagramSubApp
 from mainappsrc.subapps.control_flow_diagram_subapp import ControlFlowDiagramSubApp
-from mainappsrc.managers.sotif_manager import SOTIFManager
-from mainappsrc.managers.cta_manager import ControlTreeManager
-from mainappsrc.managers.requirements_manager import RequirementsManagerSubApp
-from mainappsrc.managers.review_manager import ReviewManager
-from mainappsrc.managers.safety_case_manager import SafetyCaseManager
-from mainappsrc.managers.mission_profile_manager import MissionProfileManager
-from mainappsrc.managers.scenario_library_manager import ScenarioLibraryManager
-from mainappsrc.managers.odd_library_manager import OddLibraryManager
+from mainappsrc.services.managers import ManagersFacadeService
 from mainappsrc.services.versioning import VersioningReviewService
 from mainappsrc.services.reporting import ReportingExportService
 from mainappsrc.services.editing.editors_service import EditorsService
@@ -103,24 +91,26 @@ class ServiceInitMixin:
         ):
             setattr(self, _name, getattr(self.nav_input, _name))
         self.undo_manager = UndoRedoService(self)
-        self.user_manager = UserManager(self)
-        self.project_manager = ProjectManager(self)
-        self.cyber_manager = CyberSecurityManager(self)
+        managers = ManagersFacadeService(self)
+        self.user_manager = managers.user_manager
+        self.project_manager = managers.project_manager
+        self.cyber_manager = managers.cyber_manager
         self.diagram_export_app = DiagramExportSubApp(self)
         self.use_case_diagram_app = UseCaseDiagramSubApp(self)
         self.activity_diagram_app = ActivityDiagramSubApp(self)
         self.block_diagram_app = BlockDiagramSubApp(self)
         self.internal_block_diagram_app = InternalBlockDiagramSubApp(self)
         self.control_flow_diagram_app = ControlFlowDiagramSubApp(self)
-        self.sotif_manager = SOTIFManager(self)
-        self.cta_manager = ControlTreeManager(self)
-        self.requirements_manager = RequirementsManagerSubApp(self)
-        self.review_manager = ReviewManager(self)
-        self.safety_case_manager = SafetyCaseManager(self)
-        self.mission_profile_manager = MissionProfileManager(self)
-        self.scenario_library_manager = ScenarioLibraryManager(self)
-        self.odd_library_manager = OddLibraryManager(self)
-        self.drawing_manager = DrawingManager(self)
+        self.sotif_manager = managers.sotif_manager
+        self.cta_manager = managers.cta_manager
+        self.requirements_manager = managers.requirements_manager
+        self.review_manager = managers.review_manager
+        self.safety_case_manager = managers.safety_case_manager
+        self.mission_profile_manager = managers.mission_profile_manager
+        self.scenario_library_manager = managers.scenario_library_manager
+        self.odd_library_manager = managers.odd_library_manager
+        self.drawing_manager = managers.drawing_manager
+        self.managers = managers
         self.versioning_review = VersioningReviewService(self)
         self.data_access_queries = DataAccessQueriesService(self)
         self.validation_consistency = ValidationConsistencyService(self)

--- a/mainappsrc/services/managers/__init__.py
+++ b/mainappsrc/services/managers/__init__.py
@@ -15,9 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Manager facade service package."""
 
-"""Project version information."""
+from .managers_facade_service import ManagersFacadeService
 
-VERSION = "0.2.115"
-
-__all__ = ["VERSION"]
+__all__ = ["ManagersFacadeService"]

--- a/mainappsrc/services/managers/managers_facade_service.py
+++ b/mainappsrc/services/managers/managers_facade_service.py
@@ -1,0 +1,76 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Facade service bundling core application managers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mainappsrc.managers.user_manager import UserManager
+from mainappsrc.managers.project_manager import ProjectManager
+from mainappsrc.managers.drawing_manager import DrawingManager
+from mainappsrc.managers.sotif_manager import SOTIFManager
+from mainappsrc.managers.cyber_manager import CyberSecurityManager
+from mainappsrc.managers.cta_manager import ControlTreeManager
+from mainappsrc.managers.requirements_manager import RequirementsManagerSubApp
+from mainappsrc.managers.review_manager import ReviewManager
+from mainappsrc.managers.safety_case_manager import SafetyCaseManager
+from mainappsrc.managers.mission_profile_manager import MissionProfileManager
+from mainappsrc.managers.scenario_library_manager import ScenarioLibraryManager
+from mainappsrc.managers.odd_library_manager import OddLibraryManager
+
+
+class ManagersFacadeService:
+    """Aggregate manager classes for simplified access."""
+
+    def __init__(self, app: Any) -> None:  # pragma: no cover - simple container
+        self.user_manager = UserManager(app)
+        self.project_manager = ProjectManager(app)
+        self.drawing_manager = DrawingManager(app)
+        self.sotif_manager = SOTIFManager(app)
+        self.cyber_manager = CyberSecurityManager(app)
+        self.cta_manager = ControlTreeManager(app)
+        self.requirements_manager = RequirementsManagerSubApp(app)
+        self.review_manager = ReviewManager(app)
+        self.safety_case_manager = SafetyCaseManager(app)
+        self.mission_profile_manager = MissionProfileManager(app)
+        self.scenario_library_manager = ScenarioLibraryManager(app)
+        self.odd_library_manager = OddLibraryManager(app)
+
+    def __getattr__(self, name: str):
+        """Delegate attribute lookups to wrapped managers."""
+        for manager in (
+            self.user_manager,
+            self.project_manager,
+            self.drawing_manager,
+            self.sotif_manager,
+            self.cyber_manager,
+            self.cta_manager,
+            self.requirements_manager,
+            self.review_manager,
+            self.safety_case_manager,
+            self.mission_profile_manager,
+            self.scenario_library_manager,
+            self.odd_library_manager,
+        ):
+            if hasattr(manager, name):
+                return getattr(manager, name)
+        raise AttributeError(name)
+
+
+__all__ = ["ManagersFacadeService"]

--- a/tests/services/test_managers_facade_service.py
+++ b/tests/services/test_managers_facade_service.py
@@ -1,0 +1,73 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for :mod:`ManagersFacadeService`."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from contextlib import contextmanager, ExitStack
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mainappsrc.services.managers import ManagersFacadeService
+
+MANAGER_PATH = "mainappsrc.services.managers.managers_facade_service"
+
+
+@contextmanager
+def _patch_managers():
+    names = [
+        "UserManager",
+        "ProjectManager",
+        "DrawingManager",
+        "SOTIFManager",
+        "CyberSecurityManager",
+        "ControlTreeManager",
+        "RequirementsManagerSubApp",
+        "ReviewManager",
+        "SafetyCaseManager",
+        "MissionProfileManager",
+        "ScenarioLibraryManager",
+        "OddLibraryManager",
+    ]
+    with ExitStack() as stack:
+        mocks = {
+            name: stack.enter_context(patch(f"{MANAGER_PATH}.{name}", MagicMock()))
+            for name in names
+        }
+        yield mocks
+
+
+class TestManagersFacadeService:
+    def test_initializes_all_managers(self):
+        app = object()
+        with _patch_managers() as mocks:
+            ManagersFacadeService(app)
+            for mock in mocks.values():
+                mock.assert_called_once_with(app)
+
+    def test_delegates_attribute_lookup(self):
+        app = object()
+        with _patch_managers() as mocks:
+            user = mocks["UserManager"].return_value
+            user.greet.return_value = 42
+            service = ManagersFacadeService(app)
+            assert service.greet() == 42
+            user.greet.assert_called_once_with()


### PR DESCRIPTION
## Summary
- bundle manager classes under new ManagersFacadeService for simplified core setup
- wire ManagersFacadeService into application initialization
- expose AutoML package as `automl` module for compatibility

## Testing
- `radon cc -j mainappsrc/services/managers/managers_facade_service.py mainappsrc/core/service_init_mixin.py mainappsrc/core/automl_core.py`
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: ... and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_68adebe9aed88327a3c6e3ac371d995e