### PR TITLE
Refactor automl_core to use service classes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.119 - Replace module imports with service classes and add service orchestration tests.
 - 0.2.118 - Wrap structure tree operations in service and delegate from core.
 - 0.2.117 - Wrap safety UI helpers in service and delegate from core.
 - 0.2.116 - Centralize window helpers into WindowControllersService and refactor core initialization.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.118
+version: 0.2.119
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/mainappsrc/core/automl_core.py
+++ b/mainappsrc/core/automl_core.py
@@ -65,13 +65,6 @@ from .page_diagram import PageDiagram
 from gui.utils.node_utils import resolve_original as resolve_node_original
 from mainappsrc.services.app_init import AppInitializationService
 from mainappsrc.services.ui import UISetupService
-from analysis.mechanisms import (
-    DiagnosticMechanism,
-    MechanismLibrary,
-    ANNEX_D_MECHANISMS,
-    PAS_8800_MECHANISMS,
-)
-from pathlib import Path
 from collections.abc import Mapping
 from gui.utils.drawing_helper import FTADrawingHelper, fta_drawing_helper
 from mainappsrc.services.windows import WindowControllersService
@@ -86,58 +79,7 @@ if TYPE_CHECKING:  # pragma: no cover - type hints only
 from mainappsrc.services.node_clone import NodeCloneServiceInterface
 from mainappsrc.services.view import ViewUpdateService
 from mainappsrc.services.data_access import DataAccessQueriesService
-from analysis.user_config import (
-    load_user_config,
-    save_user_config,
-    set_current_user,
-    load_all_users,
-    set_last_user,
-    CURRENT_USER_NAME,
-    CURRENT_USER_EMAIL,
-)
-from analysis.risk_assessment import (
-    DERIVED_MATURITY_TABLE,
-    ASSURANCE_AGGREGATION_AND,
-    AND_DECOMPOSITION_TABLE,
-    OR_DECOMPOSITION_TABLE,
-    boolify,
-    AutoMLHelper,
-)
-from analysis.models import (
-    MissionProfile,
-    ReliabilityComponent,
-    ReliabilityAnalysis,
-    HazopEntry,
-    HaraEntry,
-    HazopDoc,
-    HaraDoc,
-    StpaEntry,
-    StpaDoc,
-    FI2TCDoc,
-    TC2FIDoc,
-    DamageScenario,
-    ThreatScenario,
-    AttackPath,
-    FunctionThreat,
-    ThreatEntry,
-    ThreatDoc,
-    QUALIFICATIONS,
-    COMPONENT_ATTR_TEMPLATES,
-    RELIABILITY_MODELS,
-    component_fit_map,
-    ASIL_LEVEL_OPTIONS,
-    ASIL_ORDER,
-    ASIL_TARGETS,
-    ASIL_TABLE,
-    ASIL_DECOMP_SCHEMES,
-    calc_asil,
-    global_requirements,
-    ensure_requirement_defaults,
-    REQUIREMENT_TYPE_OPTIONS,
-    REQUIREMENT_WORK_PRODUCTS,
-    CAL_LEVEL_OPTIONS,
-    CybersecurityGoal,
-)
+from mainappsrc.services.config.user_config_service import user_config_service
 from gui.utils.safety_case_table import SafetyCaseTable
 from gui.windows.architecture import (
     UseCaseDiagramWindow,
@@ -180,7 +122,6 @@ else:  # pragma: no cover - script context
         PMHF_TARGETS,
     )
 
-builtins.REQUIREMENT_WORK_PRODUCTS = REQUIREMENT_WORK_PRODUCTS
 builtins.SafetyCaseTable = SafetyCaseTable
 try:
     from PIL import Image, ImageDraw, ImageFont
@@ -256,7 +197,6 @@ from gui.toolboxes import (
 )
 
 
-from pathlib import Path
 from mainappsrc.services.config import config_service
 
 
@@ -271,6 +211,8 @@ _PATTERN_PATH = config_service.pattern_path
 _REPORT_TEMPLATE_PATH = config_service.report_template_path
 unique_node_id_counter = config_service.unique_node_id_counter
 AutoML_Helper = config_service.automl_helper
+REQUIREMENT_WORK_PRODUCTS = config_service.requirement_work_products
+builtins.REQUIREMENT_WORK_PRODUCTS = REQUIREMENT_WORK_PRODUCTS
 import uuid
 
 ##########################################
@@ -2846,8 +2788,8 @@ class AutoMLApp(
 
         global AutoML_Helper, unique_node_id_counter
         SysMLRepository.reset_instance()
-        AutoML_Helper = config_service.automl_helper = AutoMLHelper()
-        unique_node_id_counter = config_service.unique_node_id_counter = 1
+        AutoML_Helper = config_service.reset_automl_helper()
+        unique_node_id_counter = config_service.unique_node_id_counter
 
         self.top_events = []
         self.cta_events = []
@@ -3049,8 +2991,8 @@ class AutoMLApp(
 def load_user_data() -> tuple[dict, tuple[str, str]]:
     """Load cached users and last user config concurrently."""
     with ThreadPoolExecutor() as executor:
-        users_future = executor.submit(load_all_users)
-        config_future = executor.submit(load_user_config)
+        users_future = executor.submit(user_config_service.load_all_users)
+        config_future = executor.submit(user_config_service.load_user_config)
         return users_future.result(), config_future.result()
 
 
@@ -3068,18 +3010,18 @@ def _launch_app() -> None:
                 info = WindowControllersService.prompt_user_info(root, "", "")
                 if info:
                     name, email = info
-                    save_user_config(name, email)
+                    user_config_service.save_user_config(name, email)
             else:
                 email = users.get(name, email)
-                set_last_user(name)
+                user_config_service.set_last_user(name)
     else:
         info = WindowControllersService.prompt_user_info(root, last_name, last_email)
         if info:
             name, email = info
-            save_user_config(name, email)
-    set_current_user(name, email)
+            user_config_service.save_user_config(name, email)
+    user_config_service.set_current_user(name, email)
     global AutoML_Helper
-    AutoML_Helper = config_service.automl_helper = AutoMLHelper()
+    AutoML_Helper = config_service.reset_automl_helper()
     root.deiconify()
     try:
         root.state("zoomed")

--- a/mainappsrc/services/config/config_service.py
+++ b/mainappsrc/services/config/config_service.py
@@ -27,6 +27,24 @@ from config import load_diagram_rules
 from analysis.requirement_rule_generator import regenerate_requirement_patterns
 from analysis.risk_assessment import AutoMLHelper
 
+REQUIREMENT_WORK_PRODUCTS = [
+    "Requirement Specification",
+    "Vehicle Requirement Specification",
+    "Operational Requirement Specification",
+    "Operational Safety Requirement Specification",
+    "Functional Safety Requirement Specification",
+    "Technical Safety Requirement Specification",
+    "AI Safety Requirement Specification",
+    "Functional Modification Requirement Specification",
+    "Cybersecurity Requirement Specification",
+    "Production Requirement Specification",
+    "Service Requirement Specification",
+    "Decommissioning Requirement Specification",
+    "Product Requirement Specification",
+    "Legal Requirement Specification",
+    "Organizational Requirement Specification",
+]
+
 
 class ConfigService:
     """Provide access to global configuration paths and helpers."""
@@ -42,6 +60,7 @@ class ConfigService:
         self.gate_node_types: set[str] = set(self._config.get("gate_node_types", []))
         self.automl_helper = AutoMLHelper()
         self.unique_node_id_counter = 1
+        self.requirement_work_products = REQUIREMENT_WORK_PRODUCTS
         regenerate_requirement_patterns()
 
     def reload_local_config(self) -> None:
@@ -50,6 +69,12 @@ class ConfigService:
         self.gate_node_types.clear()
         self.gate_node_types.update(self._config.get("gate_node_types", []))
         regenerate_requirement_patterns()
+
+    def reset_automl_helper(self) -> AutoMLHelper:
+        """Recreate and return a fresh :class:`AutoMLHelper`."""
+        self.automl_helper = AutoMLHelper()
+        self.unique_node_id_counter = 1
+        return self.automl_helper
 
 
 config_service = ConfigService()

--- a/mainappsrc/services/config/user_config_service.py
+++ b/mainappsrc/services/config/user_config_service.py
@@ -1,0 +1,57 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Service wrapper around user configuration helpers."""
+
+from __future__ import annotations
+
+from analysis import user_config as _uc
+
+
+class UserConfigService:
+    """Provide a service interface over ``analysis.user_config``."""
+
+    def load_all_users(self) -> dict:
+        return _uc.load_all_users()
+
+    def get_last_user(self) -> str:
+        return _uc.get_last_user()
+
+    def load_user_config(self):
+        return _uc.load_user_config()
+
+    def save_user_config(self, name: str, email: str) -> None:
+        _uc.save_user_config(name, email)
+
+    def set_last_user(self, name: str) -> None:
+        _uc.set_last_user(name)
+
+    def set_current_user(self, name: str, email: str) -> None:
+        _uc.set_current_user(name, email)
+
+    @property
+    def current_user_name(self) -> str:
+        return _uc.CURRENT_USER_NAME
+
+    @property
+    def current_user_email(self) -> str:
+        return _uc.CURRENT_USER_EMAIL
+
+
+user_config_service = UserConfigService()
+
+__all__ = ["UserConfigService", "user_config_service"]

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.118"
+VERSION = "0.2.119"
 
 __all__ = ["VERSION"]

--- a/tests/test_service_orchestration.py
+++ b/tests/test_service_orchestration.py
@@ -1,0 +1,57 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Integration tests verifying service orchestration."""
+
+from __future__ import annotations
+
+from mainappsrc.automl_core import AutoMLApp, user_config_service
+
+
+class TestAnalysisServices:
+    def test_analysis_utils_delegation(self):
+        """AutoMLApp delegates analysis tasks to its service."""
+
+        class DummyService:
+            def __init__(self) -> None:
+                self.classified = False
+                self.loaded = False
+
+            def classify_scenarios(self):
+                self.classified = True
+
+            def load_default_mechanisms(self):
+                self.loaded = True
+
+        app = AutoMLApp.__new__(AutoMLApp)
+        service = DummyService()
+        app.analysis_utils_service = service
+
+        app.classify_scenarios()
+        app.load_default_mechanisms()
+
+        assert service.classified and service.loaded
+
+
+class TestUserConfigService:
+    def test_set_current_user(self):
+        """User configuration updates propagate through the service."""
+        name = "Tester"
+        email = "tester@example.com"
+        user_config_service.set_current_user(name, email)
+        assert user_config_service.current_user_name == name
+        assert user_config_service.current_user_email == email


### PR DESCRIPTION
## Summary
- delegate user config handling to a new `UserConfigService`
- reset AutoML helpers via `ConfigService` and drop analysis module imports
- add integration tests for analysis and user config service orchestration
- bump version to 0.2.119 and update docs

## Testing
- `pytest` *(fails: FileNotFoundError, AttributeError, TypeError)*
- `radon cc -j mainappsrc/core/automl_core.py mainappsrc/services/config/config_service.py mainappsrc/services/config/user_config_service.py tests/test_service_orchestration.py`

------
https://chatgpt.com/codex/tasks/task_b_68adfcb53ca8832796aea80673097522