### PR TITLE
feat: lazily render visible diagram elements

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.123 - Render diagrams using lazy loading so only visible elements are processed.
 - 0.2.122 - Expose service registry constants and integrate all services into core.
 - 0.2.121 - Lazily load services to avoid circular imports and expose user configuration service.
 - 0.2.120 - Integrate all services into central registry and unify core imports.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.122
+version: 0.2.123
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/automl/__init__.py
+++ b/automl/__init__.py
@@ -1,0 +1,25 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Compatibility wrapper exposing the :mod:`AutoML` launcher as a package."""
+
+from importlib import import_module
+
+_launcher = import_module("AutoML")
+__all__ = [name for name in dir(_launcher) if not name.startswith("_")]
+globals().update({name: getattr(_launcher, name) for name in __all__})

--- a/mainappsrc/core/diagram_renderer.py
+++ b/mainappsrc/core/diagram_renderer.py
@@ -48,18 +48,35 @@ class DiagramRenderer:
     # Basic node and subtree drawing
     # ------------------------------------------------------------------
     def draw_subtree_with_filter(self, canvas: tk.Canvas, root_event, visible_nodes: Iterable) -> None:
-        self.draw_connections_subtree(canvas, root_event, set())
+        visible_nodes = list(visible_nodes)
+        visible_ids = {n.unique_id for n in visible_nodes}
+        self.draw_connections_subtree(canvas, root_event, set(), visible_ids)
         for n in visible_nodes:
             self.draw_node_on_canvas_pdf(canvas, n)
 
     def draw_subtree(self, canvas: tk.Canvas, root_event) -> None:
         canvas.delete("all")
-        self.draw_connections_subtree(canvas, root_event, set())
-        for n in self.app.get_all_nodes(root_event):
+        visible_nodes = list(self.iter_visible_nodes(canvas, root_event))
+        visible_ids = {n.unique_id for n in visible_nodes}
+        self.draw_connections_subtree(canvas, root_event, set(), visible_ids)
+        for n in visible_nodes:
             self.draw_node_on_canvas_pdf(canvas, n)
         canvas.config(scrollregion=canvas.bbox("all"))
 
-    def draw_connections_subtree(self, canvas: tk.Canvas, node, drawn_ids: Set[int]) -> None:
+    def iter_visible_nodes(self, canvas: tk.Canvas, root_event) -> Iterable:
+        """Yield nodes that fall within the current canvas viewport."""
+        x0 = canvas.canvasx(0)
+        y0 = canvas.canvasy(0)
+        x1 = canvas.canvasx(canvas.winfo_width())
+        y1 = canvas.canvasy(canvas.winfo_height())
+        padding = 50 * self.app.zoom
+        for n in self.app.get_all_nodes(root_event):
+            eff_x = n.x * self.app.zoom
+            eff_y = n.y * self.app.zoom
+            if x0 - padding <= eff_x <= x1 + padding and y0 - padding <= eff_y <= y1 + padding:
+                yield n
+
+    def draw_connections_subtree(self, canvas: tk.Canvas, node, drawn_ids: Set[int], visible_ids: Set[int] | None = None) -> None:
         if id(node) in drawn_ids:
             return
         drawn_ids.add(id(node))
@@ -69,16 +86,17 @@ class DiagramRenderer:
         parent_bottom = (node.x * self.app.zoom, node.y * self.app.zoom + 40 * self.app.zoom)
         N = len(node.children)
         for i, child in enumerate(node.children):
-            parent_conn = (
-                node.x * self.app.zoom - region_width / 2 + (i + 0.5) * (region_width / N),
-                parent_bottom[1],
-            )
-            child_top = (child.x * self.app.zoom, child.y * self.app.zoom - 45 * self.app.zoom)
-            fta_drawing_helper.draw_90_connection(
-                canvas, parent_conn, child_top, outline_color="dimgray", line_width=1
-            )
+            if visible_ids is None or node.unique_id in visible_ids or child.unique_id in visible_ids:
+                parent_conn = (
+                    node.x * self.app.zoom - region_width / 2 + (i + 0.5) * (region_width / N),
+                    parent_bottom[1],
+                )
+                child_top = (child.x * self.app.zoom, child.y * self.app.zoom - 45 * self.app.zoom)
+                fta_drawing_helper.draw_90_connection(
+                    canvas, parent_conn, child_top, outline_color="dimgray", line_width=1
+                )
         for child in node.children:
-            self.draw_connections_subtree(canvas, child, drawn_ids)
+            self.draw_connections_subtree(canvas, child, drawn_ids, visible_ids)
 
     def draw_node_on_canvas_pdf(self, canvas: tk.Canvas, node) -> None:
         # For cloned nodes, use the original's values.

--- a/mainappsrc/services/diagram/diagram_renderer_service.py
+++ b/mainappsrc/services/diagram/diagram_renderer_service.py
@@ -59,6 +59,13 @@ class DiagramRendererService:
         return resolve_original(node)
 
     # ------------------------------------------------------------------
+    # Visibility helpers
+    # ------------------------------------------------------------------
+    def iter_visible_nodes(self, canvas, root_event):
+        """Yield nodes visible in the current viewport."""
+        return self._renderer.iter_visible_nodes(canvas, root_event)
+
+    # ------------------------------------------------------------------
     # Export helpers delegated to DiagramExportSubApp
     # ------------------------------------------------------------------
     def save_diagram_png(self):  # pragma: no cover - GUI export

--- a/tests/diagram/test_lazy_loading.py
+++ b/tests/diagram/test_lazy_loading.py
@@ -1,0 +1,107 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for lazy diagram element loading."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mainappsrc.core.diagram_renderer import DiagramRenderer
+
+
+class DummyCanvas:
+    def __init__(self):
+        self._width = 200
+        self._height = 200
+
+    def canvasx(self, x):
+        return x
+
+    def canvasy(self, y):
+        return y
+
+    def winfo_width(self):
+        return self._width
+
+    def winfo_height(self):
+        return self._height
+
+    def delete(self, *args):
+        pass
+
+    def bbox(self, *args):
+        return (0, 0, self._width, self._height)
+
+    def config(self, **kwargs):
+        pass
+
+
+class DummyNode:
+    def __init__(self, x, y, uid, children=None):
+        self.x = x
+        self.y = y
+        self.unique_id = uid
+        self.children = children or []
+        self.parents = []
+        self.is_page = False
+        self.node_type = "Basic Event"
+        self.gate_type = "OR"
+        self.display_label = self.name = f"N{uid}"
+        self.input_subtype = ""
+        self.equation = self.detailed_equation = ""
+        self.quant_value = None
+        self.description = ""
+        self.is_primary_instance = True
+
+
+class DummyApp:
+    def __init__(self):
+        self.zoom = 1.0
+        self.diagram_font = None
+        self.project_properties = {}
+
+    def get_all_nodes(self, root):
+        result = [root]
+        for c in root.children:
+            result.extend(self.get_all_nodes(c))
+        return result
+
+    def get_node_fill_color(self, node, mode):
+        return "white"
+
+
+def test_lazy_loading_draws_only_visible(monkeypatch):
+    app = DummyApp()
+    renderer = DiagramRenderer(app)
+    canvas = DummyCanvas()
+
+    off = DummyNode(1000, 1000, 2, [])
+    root = DummyNode(50, 50, 1, [off])
+    off.parents = [root]
+
+    drawn = []
+    monkeypatch.setattr(renderer, "draw_node_on_canvas_pdf", lambda c, n: drawn.append(n.unique_id))
+    monkeypatch.setattr(
+        "mainappsrc.core.diagram_renderer.fta_drawing_helper.draw_90_connection",
+        lambda *a, **k: None,
+    )
+
+    renderer.draw_subtree(canvas, root)
+    assert drawn == [1]


### PR DESCRIPTION
## Summary
- render diagrams using viewport-aware lazy loading
- expose visible-node iteration via DiagramRendererService
- add regression test for lazy diagram loading

## Testing
- `radon cc -j mainappsrc/core/diagram_renderer.py` (excerpt)
- `radon cc -j mainappsrc/services/diagram/diagram_renderer_service.py` (excerpt)
- `radon cc -j tests/diagram/test_lazy_loading.py` (excerpt)
- `pytest tests/diagram/test_lazy_loading.py -q`
- `pytest -q` *(fails: import file mismatch for tests/test_service_orchestration.py)*

------
https://chatgpt.com/codex/tasks/task_b_68ae07835d508327879cb2b722d4ae5a