### PR TITLE
Guard config import for frozen builds

### DIFF
--- a/AutoML.py
+++ b/AutoML.py
@@ -42,10 +42,11 @@ else:
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-# Provide default configuration when the external package is absent
+# Provide default configuration when the external package is absent or incompatible
 try:  # pragma: no cover - executed in frozen builds
-    from config import automl_constants as _automl_constants
-except ModuleNotFoundError:
+    _prefix = "AutoML." if __package__ and __package__.startswith("AutoML") else ""
+    _automl_constants = importlib.import_module(f"{_prefix}config.automl_constants")
+except ImportError:
     _automl_constants = types.SimpleNamespace(
         AUTHOR="Miguel Marina",
         AUTHOR_EMAIL="karel.capek.robotics@gmail.com",
@@ -56,7 +57,7 @@ except ModuleNotFoundError:
     )
     _config_module = types.ModuleType("config")
     _config_module.automl_constants = _automl_constants
-    sys.modules["config"] = _config_module
+    sys.modules.setdefault("config", _config_module)
     sys.modules["config.automl_constants"] = _automl_constants
 else:
     sys.modules.setdefault("config", types.ModuleType("config"))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.125 - Guard configuration import against external `config` modules in frozen executables.
 - 0.2.124 - Import global requirements into core and add lazy service registry with context-managed cleanup.
 - 0.2.123 - Define local service registry alias for backwards compatibility.
 - 0.2.122 - Expose service registry constants and integrate all services into core.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.123
+version: 0.2.125
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.123"
+VERSION = "0.2.125"
 
 __all__ = ["VERSION"]

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -19,7 +19,9 @@
 import json
 from pathlib import Path
 
-import mainappsrc.services.config.config_service as cs_module
+import importlib
+
+cs_module = importlib.import_module("mainappsrc.services.config.config_service")
 
 
 def test_reload_local_config_updates_gate_types(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- prevent external `config` modules from breaking frozen builds by importing project constants with a package prefix
- bump version to 0.2.125 and document change in HISTORY
- adjust configuration service test to import module explicitly

## Testing
- `radon cc -s -j AutoML.py`
- `PYTHONPATH=. pytest tests/test_config_loader_resource_fallback.py tests/test_config_service.py tests/test_crash_report_logger.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae0c2565ac8327b1be39ab32c2d68f