### PR TITLE
Retain detached tabs in separate windows

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.126 - Preserve detached tabs by retaining references to floating windows.
 - 0.2.125 - Guard configuration import against external `config` modules in frozen executables.
 - 0.2.124 - Import global requirements into core and add lazy service registry with context-managed cleanup.
 - 0.2.123 - Define local service registry alias for backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.125
+version: 0.2.126
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -122,6 +122,7 @@ class ClosableNotebook(ttk.Notebook):
         self._drag_root: tk.Misc | None = None
         self._drag_root_motion: str | None = None
         self._drag_root_release: str | None = None
+        self._floating_windows: list[tk.Toplevel] = []
 
         self.bind("<ButtonPress-1>", self._on_press, True)
         self.bind("<B1-Motion>", self._on_motion)
@@ -396,6 +397,13 @@ class ClosableNotebook(ttk.Notebook):
         height = self.winfo_height() or 200
         win = tk.Toplevel(self)
         win.geometry(f"{width}x{height}+{x}+{y}")
+        self._floating_windows.append(win)
+        win.bind(
+            "<Destroy>",
+            lambda _e, w=win: self._floating_windows.remove(w)
+            if w in self._floating_windows
+            else None,
+        )
         nb = ClosableNotebook(win)
         nb.pack(expand=True, fill="both")
         # ``tk::unsupported::reparent`` requires the target widget to be

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -26,63 +26,88 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from gui.closable_notebook import ClosableNotebook
 
 
-def test_tab_detach_and_reattach():
-    try:
-        root = tk.Tk()
-    except tk.TclError:
-        pytest.skip("Tk not available")
-    nb = ClosableNotebook(root)
-    frame = ttk.Frame(nb)
-    nb.add(frame, text="Tab1")
-    nb.update_idletasks()
+class TestTabDetach:
+    def test_tab_detach_and_reattach(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
 
-    class Event: ...
+        class Event: ...
 
-    press = Event(); press.x = 5; press.y = 5
-    nb._on_tab_press(press)
-    nb._dragging = True
-    release = Event()
-    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
-    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
-    nb._on_tab_release(release)
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
 
-    assert len(nb.tabs()) == 0
-    new_nb = frame.master
-    assert isinstance(new_nb, ClosableNotebook)
+        assert len(nb.tabs()) == 0
+        new_nb = frame.master
+        assert isinstance(new_nb, ClosableNotebook)
 
-    press2 = Event(); press2.x = 5; press2.y = 5
-    new_nb._on_tab_press(press2)
-    new_nb._dragging = True
-    release2 = Event()
-    release2.x_root = nb.winfo_rootx() + 10
-    release2.y_root = nb.winfo_rooty() + 10
-    new_nb._on_tab_release(release2)
+        press2 = Event(); press2.x = 5; press2.y = 5
+        new_nb._on_tab_press(press2)
+        new_nb._dragging = True
+        release2 = Event()
+        release2.x_root = nb.winfo_rootx() + 10
+        release2.y_root = nb.winfo_rooty() + 10
+        new_nb._on_tab_release(release2)
 
-    assert len(nb.tabs()) == 1
-    assert frame.master is nb
-    root.destroy()
+        assert len(nb.tabs()) == 1
+        assert frame.master is nb
+        root.destroy()
 
+    def test_tab_detach_without_motion(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
 
-def test_tab_detach_without_motion():
-    try:
-        root = tk.Tk()
-    except tk.TclError:
-        pytest.skip("Tk not available")
-    nb = ClosableNotebook(root)
-    frame = ttk.Frame(nb)
-    nb.add(frame, text="Tab1")
-    nb.update_idletasks()
+        class Event: ...
 
-    class Event: ...
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        release.x = nb.winfo_width() + 40
+        release.y = nb.winfo_height() + 40
+        nb._on_tab_release(release)
 
-    press = Event(); press.x = 5; press.y = 5
-    nb._on_tab_press(press)
-    release = Event()
-    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
-    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
-    release.x = nb.winfo_width() + 40
-    release.y = nb.winfo_height() + 40
-    nb._on_tab_release(release)
+        assert len(nb.tabs()) == 0
+        root.destroy()
 
-    assert len(nb.tabs()) == 0
-    root.destroy()
+    def test_detached_window_kept_alive(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert nb._floating_windows
+        win = nb._floating_windows[0]
+        assert win.winfo_exists()
+        root.destroy()


### PR DESCRIPTION
## Summary
- preserve detached tab windows by keeping references to floating toplevels
- group and extend tab detachment tests with check for floating window persistence
- bump version to 0.2.126 and document change in history

## Testing
- `radon cc -j gui/utils/closable_notebook.py` (snippet below)
- `radon cc -j tests/test_tab_detach.py` (snippet below)
- `pytest -q` *(fails: 211 failed, 1011 passed, 62 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68ae0f609b548327826834e398325d2d