### PR TITLE
Retain detached tabs in separate windows

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 # Version History
+- 0.2.127 - Use native Tk reparenting when detaching tabs to keep windows alive.
+- 0.2.126 - Preserve detached tabs by retaining references to floating windows.
 - 0.2.125 - Guard configuration import against external `config` modules in frozen executables.
 - 0.2.124 - Import global requirements into core and add lazy service registry with context-managed cleanup.
 - 0.2.123 - Define local service registry alias for backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.125
+version: 0.2.127
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -122,6 +122,7 @@ class ClosableNotebook(ttk.Notebook):
         self._drag_root: tk.Misc | None = None
         self._drag_root_motion: str | None = None
         self._drag_root_release: str | None = None
+        self._floating_windows: list[tk.Toplevel] = []
 
         self.bind("<ButtonPress-1>", self._on_press, True)
         self.bind("<B1-Motion>", self._on_motion)
@@ -334,58 +335,65 @@ class ClosableNotebook(ttk.Notebook):
         self._reset_drag()
 
     def _move_tab(self, tab_id: str, target: "ClosableNotebook") -> bool:
+        """Move *tab_id* to *target* notebook.
+
+        The previous implementation relied solely on the various
+        ``tk::unsupported::reparent`` commands which are unavailable on some
+        platforms, causing the tab to snap back to its source and the floating
+        window to vanish immediately.  First try Tk's native ability to add an
+        existing child to another notebook which works on standard builds.  If
+        that fails fall back to the explicit reparent commands.  When all
+        options fail the tab is reinserted into the original notebook so the
+        widget remains accessible.
+        """
+
         text = self.tab(tab_id, "text")
         child = self.nametowidget(tab_id)
         self.forget(tab_id)
-        # Reparent the tab's child widget to the target notebook before adding.
-        # ``tk::unsupported::reparent`` is available on most Tk builds but the
-        # exact command name differs across platforms.  Try the known variants
-        # and ignore any errors so that platforms without the command still
-        # proceed.  Some Windows builds expose the command as
-        # ``ReparentWindow`` instead.  ``tk::unsupported::reparent`` expects
-        # platform specific arguments, sometimes window path names and other
-        # times the identifier returned by ``winfo_id``.  Try every combination
-        # and silently continue if the command is unavailable.
-        reparented = False
-        toplevel = target.winfo_toplevel()
-        # Some Tk builds require the new parent to be the containing toplevel
-        # instead of the widget itself.  Try both the notebook and its
-        # toplevel using window path names and numeric identifiers.
-        for cmd in (
-            ("::tk::unsupported::reparent", child.winfo_id(), target.winfo_id()),
-            ("::tk::unsupported::reparent", child._w, target._w),
-            ("::tk::unsupported::reparent", child.winfo_id(), toplevel.winfo_id()),
-            ("::tk::unsupported::reparent", child._w, toplevel._w),
-            ("tk", "unsupported", "reparent", child.winfo_id(), target.winfo_id()),
-            ("tk", "unsupported", "reparent", child._w, target._w),
-            ("tk", "unsupported", "reparent", child.winfo_id(), toplevel.winfo_id()),
-            ("tk", "unsupported", "reparent", child._w, toplevel._w),
-            ("::tk::unsupported::ReparentWindow", child.winfo_id(), target.winfo_id()),
-            ("::tk::unsupported::ReparentWindow", child._w, target._w),
-            ("::tk::unsupported::ReparentWindow", child.winfo_id(), toplevel.winfo_id()),
-            ("::tk::unsupported::ReparentWindow", child._w, toplevel._w),
-            ("tk", "unsupported", "ReparentWindow", child.winfo_id(), target.winfo_id()),
-            ("tk", "unsupported", "ReparentWindow", child._w, target._w),
-            ("tk", "unsupported", "ReparentWindow", child.winfo_id(), toplevel.winfo_id()),
-            ("tk", "unsupported", "ReparentWindow", child._w, toplevel._w),
-        ):
-            try:
-                child.tk.call(*cmd)
-                reparented = True
-                break
-            except tk.TclError:
-                continue
-        if reparented:
-            child.master = target  # keep Python's widget hierarchy in sync
+
+        try:
+            child.master = target
             target.add(child, text=text)
             target.select(child)
-        else:
-            # If reparenting is unsupported we simply abort the move.
-            # Re-insert the tab into its original notebook so the widget
-            # remains accessible instead of raising a TclError.
+            moved = True
+        except tk.TclError:
+            moved = False
+
+        if not moved:
+            toplevel = target.winfo_toplevel()
+            for cmd in (
+                ("::tk::unsupported::reparent", child.winfo_id(), target.winfo_id()),
+                ("::tk::unsupported::reparent", child._w, target._w),
+                ("::tk::unsupported::reparent", child.winfo_id(), toplevel.winfo_id()),
+                ("::tk::unsupported::reparent", child._w, toplevel._w),
+                ("tk", "unsupported", "reparent", child.winfo_id(), target.winfo_id()),
+                ("tk", "unsupported", "reparent", child._w, target._w),
+                ("tk", "unsupported", "reparent", child.winfo_id(), toplevel.winfo_id()),
+                ("tk", "unsupported", "reparent", child._w, toplevel._w),
+                ("::tk::unsupported::ReparentWindow", child.winfo_id(), target.winfo_id()),
+                ("::tk::unsupported::ReparentWindow", child._w, target._w),
+                ("::tk::unsupported::ReparentWindow", child.winfo_id(), toplevel.winfo_id()),
+                ("::tk::unsupported::ReparentWindow", child._w, toplevel._w),
+                ("tk", "unsupported", "ReparentWindow", child.winfo_id(), target.winfo_id()),
+                ("tk", "unsupported", "ReparentWindow", child._w, target._w),
+                ("tk", "unsupported", "ReparentWindow", child.winfo_id(), toplevel.winfo_id()),
+                ("tk", "unsupported", "ReparentWindow", child._w, toplevel._w),
+            ):
+                try:
+                    child.tk.call(*cmd)
+                    child.master = target
+                    target.add(child, text=text)
+                    target.select(child)
+                    moved = True
+                    break
+                except tk.TclError:
+                    continue
+
+        if not moved:
             self.add(child, text=text)
             self.select(child)
             return False
+
         if isinstance(self.master, tk.Toplevel) and not self.tabs():
             self.master.destroy()
         return True
@@ -396,6 +404,13 @@ class ClosableNotebook(ttk.Notebook):
         height = self.winfo_height() or 200
         win = tk.Toplevel(self)
         win.geometry(f"{width}x{height}+{x}+{y}")
+        self._floating_windows.append(win)
+        win.bind(
+            "<Destroy>",
+            lambda _e, w=win: self._floating_windows.remove(w)
+            if w in self._floating_windows
+            else None,
+        )
         nb = ClosableNotebook(win)
         nb.pack(expand=True, fill="both")
         # ``tk::unsupported::reparent`` requires the target widget to be

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -26,63 +26,88 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from gui.closable_notebook import ClosableNotebook
 
 
-def test_tab_detach_and_reattach():
-    try:
-        root = tk.Tk()
-    except tk.TclError:
-        pytest.skip("Tk not available")
-    nb = ClosableNotebook(root)
-    frame = ttk.Frame(nb)
-    nb.add(frame, text="Tab1")
-    nb.update_idletasks()
+class TestTabDetach:
+    def test_tab_detach_and_reattach(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
 
-    class Event: ...
+        class Event: ...
 
-    press = Event(); press.x = 5; press.y = 5
-    nb._on_tab_press(press)
-    nb._dragging = True
-    release = Event()
-    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
-    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
-    nb._on_tab_release(release)
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
 
-    assert len(nb.tabs()) == 0
-    new_nb = frame.master
-    assert isinstance(new_nb, ClosableNotebook)
+        assert len(nb.tabs()) == 0
+        new_nb = frame.master
+        assert isinstance(new_nb, ClosableNotebook)
 
-    press2 = Event(); press2.x = 5; press2.y = 5
-    new_nb._on_tab_press(press2)
-    new_nb._dragging = True
-    release2 = Event()
-    release2.x_root = nb.winfo_rootx() + 10
-    release2.y_root = nb.winfo_rooty() + 10
-    new_nb._on_tab_release(release2)
+        press2 = Event(); press2.x = 5; press2.y = 5
+        new_nb._on_tab_press(press2)
+        new_nb._dragging = True
+        release2 = Event()
+        release2.x_root = nb.winfo_rootx() + 10
+        release2.y_root = nb.winfo_rooty() + 10
+        new_nb._on_tab_release(release2)
 
-    assert len(nb.tabs()) == 1
-    assert frame.master is nb
-    root.destroy()
+        assert len(nb.tabs()) == 1
+        assert frame.master is nb
+        root.destroy()
 
+    def test_tab_detach_without_motion(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
 
-def test_tab_detach_without_motion():
-    try:
-        root = tk.Tk()
-    except tk.TclError:
-        pytest.skip("Tk not available")
-    nb = ClosableNotebook(root)
-    frame = ttk.Frame(nb)
-    nb.add(frame, text="Tab1")
-    nb.update_idletasks()
+        class Event: ...
 
-    class Event: ...
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        release.x = nb.winfo_width() + 40
+        release.y = nb.winfo_height() + 40
+        nb._on_tab_release(release)
 
-    press = Event(); press.x = 5; press.y = 5
-    nb._on_tab_press(press)
-    release = Event()
-    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
-    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
-    release.x = nb.winfo_width() + 40
-    release.y = nb.winfo_height() + 40
-    nb._on_tab_release(release)
+        assert len(nb.tabs()) == 0
+        root.destroy()
 
-    assert len(nb.tabs()) == 0
-    root.destroy()
+    def test_detached_window_kept_alive(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert nb._floating_windows
+        win = nb._floating_windows[0]
+        assert win.winfo_exists()
+        root.destroy()


### PR DESCRIPTION
## Summary
- use Tk's native reparenting before falling back to unsupported commands so detached tabs stay open
- bump version to 0.2.127 and document the fix

## Testing
- `radon cc -j gui/utils/closable_notebook.py`
- `radon cc -j tests/test_tab_detach.py`
- `pytest -q` *(fails: 211 failed, 1011 passed, 62 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68ae0f609b548327826834e398325d2d