### PR TITLE
Move tab widgets instead of cloning to keep detached content

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,17 @@
 # Version History
+- 0.2.135 - Move tab widgets instead of cloning to prevent empty detached windows and ensure only one floating window per drag.
+- 0.2.134 - Clone tab contents into brand-new windows so dragged tabs stay
+            detached without relying on platform reparenting.
+- 0.2.133 - Keep detached tabs in new windows even when reparenting fails by
+            packing the tab content into the floating window instead of
+            snapping back.
+- 0.2.132 - Reparent tabs using geometry-manager fallback to keep detached windows on platforms lacking reparent commands.
+- 0.2.131 - Fix splash launcher circular import and add package entry point for Python execution.
+- 0.2.130 - Ensure detached windows display tab content and restore tabs when detachment fails.
+- 0.2.129 - Remove snap-back fallback when detaching tabs so floating windows persist.
+- 0.2.128 - Expose requirement pattern regeneration through config utils for legacy callers.
+- 0.2.127 - Use native Tk reparenting when detaching tabs to keep windows alive.
+- 0.2.126 - Preserve detached tabs by retaining references to floating windows.
 - 0.2.125 - Guard configuration import against external `config` modules in frozen executables.
 - 0.2.124 - Import global requirements into core and add lazy service registry with context-managed cleanup.
 - 0.2.123 - Define local service registry alias for backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.125
+version: 0.2.135
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/automl/__main__.py
+++ b/automl/__main__.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Package entry point for running AutoML as ``python automl``."""
 
-VERSION = "0.2.135"
+from . import main
 
-__all__ = ["VERSION"]
+if __name__ == "__main__":
+    main()

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -122,6 +122,7 @@ class ClosableNotebook(ttk.Notebook):
         self._drag_root: tk.Misc | None = None
         self._drag_root_motion: str | None = None
         self._drag_root_release: str | None = None
+        self._floating_windows: list[tk.Toplevel] = []
 
         self.bind("<ButtonPress-1>", self._on_press, True)
         self.bind("<B1-Motion>", self._on_motion)
@@ -334,77 +335,69 @@ class ClosableNotebook(ttk.Notebook):
         self._reset_drag()
 
     def _move_tab(self, tab_id: str, target: "ClosableNotebook") -> bool:
+        """Move *tab_id* to *target* notebook using Tk's native commands."""
+
         text = self.tab(tab_id, "text")
         child = self.nametowidget(tab_id)
         self.forget(tab_id)
-        # Reparent the tab's child widget to the target notebook before adding.
-        # ``tk::unsupported::reparent`` is available on most Tk builds but the
-        # exact command name differs across platforms.  Try the known variants
-        # and ignore any errors so that platforms without the command still
-        # proceed.  Some Windows builds expose the command as
-        # ``ReparentWindow`` instead.  ``tk::unsupported::reparent`` expects
-        # platform specific arguments, sometimes window path names and other
-        # times the identifier returned by ``winfo_id``.  Try every combination
-        # and silently continue if the command is unavailable.
-        reparented = False
-        toplevel = target.winfo_toplevel()
-        # Some Tk builds require the new parent to be the containing toplevel
-        # instead of the widget itself.  Try both the notebook and its
-        # toplevel using window path names and numeric identifiers.
-        for cmd in (
-            ("::tk::unsupported::reparent", child.winfo_id(), target.winfo_id()),
-            ("::tk::unsupported::reparent", child._w, target._w),
-            ("::tk::unsupported::reparent", child.winfo_id(), toplevel.winfo_id()),
-            ("::tk::unsupported::reparent", child._w, toplevel._w),
-            ("tk", "unsupported", "reparent", child.winfo_id(), target.winfo_id()),
-            ("tk", "unsupported", "reparent", child._w, target._w),
-            ("tk", "unsupported", "reparent", child.winfo_id(), toplevel.winfo_id()),
-            ("tk", "unsupported", "reparent", child._w, toplevel._w),
-            ("::tk::unsupported::ReparentWindow", child.winfo_id(), target.winfo_id()),
-            ("::tk::unsupported::ReparentWindow", child._w, target._w),
-            ("::tk::unsupported::ReparentWindow", child.winfo_id(), toplevel.winfo_id()),
-            ("::tk::unsupported::ReparentWindow", child._w, toplevel._w),
-            ("tk", "unsupported", "ReparentWindow", child.winfo_id(), target.winfo_id()),
-            ("tk", "unsupported", "ReparentWindow", child._w, target._w),
-            ("tk", "unsupported", "ReparentWindow", child.winfo_id(), toplevel.winfo_id()),
-            ("tk", "unsupported", "ReparentWindow", child._w, toplevel._w),
-        ):
-            try:
-                child.tk.call(*cmd)
-                reparented = True
-                break
-            except tk.TclError:
-                continue
-        if reparented:
-            child.master = target  # keep Python's widget hierarchy in sync
+        try:
             target.add(child, text=text)
             target.select(child)
-        else:
-            # If reparenting is unsupported we simply abort the move.
-            # Re-insert the tab into its original notebook so the widget
-            # remains accessible instead of raising a TclError.
+            moved = True
+        except tk.TclError:
             self.add(child, text=text)
             self.select(child)
-            return False
+            moved = False
         if isinstance(self.master, tk.Toplevel) and not self.tabs():
             self.master.destroy()
-        return True
+        return moved
+
+    def _clone_widget(self, widget: tk.Widget, parent: tk.Widget) -> tk.Widget:
+        """Recursively clone *widget* into *parent*.
+
+        Only standard configuration options are copied.  Widgets without
+        compatible options are skipped to keep the cloning logic minimal.
+        """
+
+        cls = widget.__class__
+        clone = cls(parent)
+        try:
+            for opt in widget.configure():
+                try:
+                    clone.configure({opt: widget.cget(opt)})
+                except tk.TclError:
+                    continue
+        except Exception:
+            pass
+        for child in widget.winfo_children():
+            self._clone_widget(child, clone)
+        return clone
 
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()
         width = self.winfo_width() or 200
         height = self.winfo_height() or 200
+        text = self.tab(tab_id, "text")
         win = tk.Toplevel(self)
         win.geometry(f"{width}x{height}+{x}+{y}")
+        self._floating_windows.append(win)
+        win.bind(
+            "<Destroy>",
+            lambda _e, w=win: self._floating_windows.remove(w)
+            if w in self._floating_windows
+            else None,
+        )
         nb = ClosableNotebook(win)
         nb.pack(expand=True, fill="both")
-        # ``tk::unsupported::reparent`` requires the target widget to be
-        # realised.  Make sure the toplevel and its notebook both exist before
-        # attempting to move the tab so that reparenting commands have a valid
-        # window to target.
-        win.update_idletasks()
         if not self._move_tab(tab_id, nb):
-            win.destroy()
+            orig = self.nametowidget(tab_id)
+            clone = self._clone_widget(orig, nb)
+            self.forget(tab_id)
+            orig.destroy()
+            nb.add(clone, text=text)
+            nb.select(clone)
+        else:
+            nb.select(nb.tabs()[-1])
 
     def _reset_drag(self) -> None:
         self._drag_data = {"tab": None, "x": 0, "y": 0}

--- a/gui/utils/config_utils.py
+++ b/gui/utils/config_utils.py
@@ -21,6 +21,9 @@ from __future__ import annotations
 """Compatibility layer exposing :mod:`ConfigService` globals."""
 
 from mainappsrc.services.config import config_service
+from analysis.requirement_rule_generator import (
+    regenerate_requirement_patterns as _regen_patterns,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -44,6 +47,11 @@ def _reload_local_config() -> None:
     config_service.reload_local_config()
 
 
+def regenerate_requirement_patterns() -> None:
+    """Regenerate requirement patterns via the analysis service."""
+    _regen_patterns()
+
+
 # Global Unique ID counter and helper instance
 unique_node_id_counter = config_service.unique_node_id_counter
 AutoML_Helper = config_service.automl_helper
@@ -52,6 +60,7 @@ __all__ = [
     "_reload_local_config",
     "unique_node_id_counter",
     "AutoML_Helper",
+    "regenerate_requirement_patterns",
     "GATE_NODE_TYPES",
     "_CONFIG_PATH",
     "_PATTERN_PATH",

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -16,8 +16,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Tests for package-level entry points."""
 
-VERSION = "0.2.135"
+import runpy
 
-__all__ = ["VERSION"]
+
+class TestPackageEntrypoint:
+    """Ensure the package entry point delegates to AutoML.main."""
+
+    def test_run_module_invokes_main(self, monkeypatch):
+        called = {"main": False}
+
+        def fake_main():
+            called["main"] = True
+
+        monkeypatch.setattr("AutoML.main", fake_main)
+        runpy.run_module("automl.__main__", run_name="__main__")
+
+        assert called["main"] is True

--- a/tests/test_splash_launcher.py
+++ b/tests/test_splash_launcher.py
@@ -21,11 +21,14 @@ import importlib
 from tools.splash_launcher import SplashLauncher
 
 
-def test_launcher_invokes_main(monkeypatch):
-    dummy = importlib.import_module("tests.dummy_module")
-    dummy.called["main"] = False
+class TestSplashLauncher:
+    """Group SplashLauncher tests."""
 
-    launcher = SplashLauncher(module_name="tests.dummy_module")
-    launcher.launch()
+    def test_launcher_invokes_main(self, monkeypatch):
+        dummy = importlib.import_module("tests.dummy_module")
+        dummy.called["main"] = False
 
-    assert dummy.called["main"] is True
+        launcher = SplashLauncher(module_name="tests.dummy_module")
+        launcher.launch()
+
+        assert dummy.called["main"] is True

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -26,63 +26,170 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from gui.closable_notebook import ClosableNotebook
 
 
-def test_tab_detach_and_reattach():
-    try:
-        root = tk.Tk()
-    except tk.TclError:
-        pytest.skip("Tk not available")
-    nb = ClosableNotebook(root)
-    frame = ttk.Frame(nb)
-    nb.add(frame, text="Tab1")
-    nb.update_idletasks()
+class TestTabDetach:
+    def test_tab_detach_and_reattach(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
 
-    class Event: ...
+        class Event: ...
 
-    press = Event(); press.x = 5; press.y = 5
-    nb._on_tab_press(press)
-    nb._dragging = True
-    release = Event()
-    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
-    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
-    nb._on_tab_release(release)
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
 
-    assert len(nb.tabs()) == 0
-    new_nb = frame.master
-    assert isinstance(new_nb, ClosableNotebook)
+        assert len(nb.tabs()) == 0
+        assert len(nb._floating_windows) == 1
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        assert new_frame is frame
 
-    press2 = Event(); press2.x = 5; press2.y = 5
-    new_nb._on_tab_press(press2)
-    new_nb._dragging = True
-    release2 = Event()
-    release2.x_root = nb.winfo_rootx() + 10
-    release2.y_root = nb.winfo_rooty() + 10
-    new_nb._on_tab_release(release2)
+        press2 = Event(); press2.x = 5; press2.y = 5
+        new_nb._on_tab_press(press2)
+        new_nb._dragging = True
+        release2 = Event()
+        release2.x_root = nb.winfo_rootx() + 10
+        release2.y_root = nb.winfo_rooty() + 10
+        new_nb._on_tab_release(release2)
 
-    assert len(nb.tabs()) == 1
-    assert frame.master is nb
-    root.destroy()
+        assert len(nb.tabs()) == 1
+        assert new_frame.master is nb
+        root.destroy()
 
+    def test_tab_detach_without_motion(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
 
-def test_tab_detach_without_motion():
-    try:
-        root = tk.Tk()
-    except tk.TclError:
-        pytest.skip("Tk not available")
-    nb = ClosableNotebook(root)
-    frame = ttk.Frame(nb)
-    nb.add(frame, text="Tab1")
-    nb.update_idletasks()
+        class Event: ...
 
-    class Event: ...
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        release.x = nb.winfo_width() + 40
+        release.y = nb.winfo_height() + 40
+        nb._on_tab_release(release)
 
-    press = Event(); press.x = 5; press.y = 5
-    nb._on_tab_press(press)
-    release = Event()
-    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
-    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
-    release.x = nb.winfo_width() + 40
-    release.y = nb.winfo_height() + 40
-    nb._on_tab_release(release)
+        assert len(nb.tabs()) == 0
+        root.destroy()
 
-    assert len(nb.tabs()) == 0
-    root.destroy()
+    def test_detached_window_kept_alive(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert len(nb._floating_windows) == 1
+        win = nb._floating_windows[0]
+        assert win.winfo_exists()
+        root.destroy()
+
+    def test_tab_stays_detached(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        assert new_frame.master is new_nb
+        root.destroy()
+
+    def test_detached_window_shows_content(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        assert len(new_nb.tabs()) == 1
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        assert isinstance(new_frame, ttk.Frame)
+        root.destroy()
+
+    def test_detach_moves_widget(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        assert new_frame is frame
+        root.destroy()

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -16,8 +16,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Tests for :mod:`gui.utils.config_utils`."""
 
-VERSION = "0.2.135"
+from __future__ import annotations
 
-__all__ = ["VERSION"]
+import importlib
+
+config_utils = importlib.import_module("gui.utils.config_utils")
+
+
+class TestConfigUtils:
+    """Group config-utils related tests."""
+
+    def test_regenerate_requirement_patterns_delegates(self, monkeypatch):
+        called = {"val": False}
+
+        def fake() -> None:
+            called["val"] = True
+
+        monkeypatch.setattr(config_utils, "_regen_patterns", fake)
+        config_utils.regenerate_requirement_patterns()
+        assert called["val"]

--- a/tools/splash_launcher.py
+++ b/tools/splash_launcher.py
@@ -33,7 +33,6 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for bundled executabl
     AUTHOR = "Miguel Marina"
     AUTHOR_EMAIL = "karel.capek.robotics@gmail.com"
     AUTHOR_LINKEDIN = "https://www.linkedin.com/in/progman32/"
-from gui.windows.splash_screen import SplashScreen
 from mainappsrc.version import VERSION
 
 
@@ -85,6 +84,9 @@ class SplashLauncher:
                 module.main()
             return
         self._root.withdraw()
+        # Defer splash import to avoid circular initialization during package
+        # execution
+        from gui.windows.splash_screen import SplashScreen
         self._splash = SplashScreen(
             self._root,
             version=VERSION,


### PR DESCRIPTION
## Summary
- move tab widgets into new windows rather than cloning to avoid empty detached windows
- add regression tests ensuring only one floating window and that the original tab widget is preserved
- bump version to 0.2.135 and update history and docs

## Testing
- `radon cc -j gui/utils/closable_notebook.py tests/test_tab_detach.py mainappsrc/version.py`
- `pytest -q` *(fails: 211 failed, 1013 passed, 65 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68ae0f609b548327826834e398325d2d