### PR TITLE
Preserve tab layout on detach

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 # Version History
+- 0.2.141 - Let detached tabs resize with their windows so cloned widgets expand to fit.
+- 0.2.140 - Apply original geometry when cloning tabs so detached windows retain full content layout.
 - 0.2.139 - Preserve widget state when detaching tabs so floating windows
             contain full content.
 - 0.2.138 - Reduce tab-detachment cyclomatic complexity and ignore master when cloning widgets.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.139
+version: 0.2.141
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -379,6 +379,8 @@ class ClosableNotebook(ttk.Notebook):
         clone = cls(parent, **kwargs)
         self._copy_widget_config(widget, clone)
         self._copy_widget_state(widget, clone)
+        if not isinstance(widget.master, ttk.Notebook):
+            self._copy_widget_layout(widget, clone)
         for child in widget.winfo_children():
             self._clone_widget(child, clone)
         return clone
@@ -435,6 +437,27 @@ class ClosableNotebook(ttk.Notebook):
                 for iid in widget.get_children(""):
                     self._copy_tree_item(widget, clone, iid, "")
         except Exception:
+            pass
+
+    def _copy_widget_layout(self, widget: tk.Widget, clone: tk.Widget) -> None:
+        """Apply the same geometry management as *widget* uses."""
+        try:
+            info = widget.pack_info()
+            clone.pack(**info)
+            return
+        except tk.TclError:
+            pass
+        try:
+            info = widget.grid_info()
+            info.pop("in", None)
+            clone.grid(**info)
+            return
+        except tk.TclError:
+            pass
+        try:
+            info = widget.place_info()
+            clone.place(**info)
+        except tk.TclError:
             pass
 
     def _copy_tree_item(

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -195,6 +195,40 @@ class TestFloatingWindowBehavior:
         assert new_frame is frame
         root.destroy()
 
+
+class TestFloatingWindowLayout:
+    def test_detached_tab_resizes_with_window(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        ttk.Label(frame, text="hi").pack(expand=True, fill="both")
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        old_w, old_h = new_frame.winfo_width(), new_frame.winfo_height()
+        win.geometry("400x400")
+        win.update_idletasks()
+        new_nb.update_idletasks()
+        assert new_frame.winfo_width() == new_nb.winfo_width() >= old_w
+        assert new_frame.winfo_height() == new_nb.winfo_height() >= old_h
+        root.destroy()
+
 class TestCloning:
     def test_clone_handles_required_args(self, monkeypatch):
         try:
@@ -290,4 +324,39 @@ class TestCloning:
         new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
         new_entry = new_nb.nametowidget(new_nb.tabs()[0])
         assert new_entry.get() == "data"
+        root.destroy()
+
+    def test_clone_preserves_layout(self, monkeypatch):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        label = ttk.Label(frame, text="hi")
+        label.pack()
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        children = new_frame.winfo_children()
+        assert len(children) == 1
+        new_label = children[0]
+        assert isinstance(new_label, ttk.Label)
+        assert new_label.cget("text") == "hi"
+        assert new_label.winfo_manager()
         root.destroy()


### PR DESCRIPTION
## Summary
- Skip geometry cloning for notebook pages so detached tabs resize with their windows
- Test detached tabs expand when floating window size changes
- Bump version to 0.2.141

## Testing
- `radon cc -s -j gui/utils/closable_notebook.py | python -m json.tool`
- `radon cc -s -j tests/test_tab_detach.py | python -m json.tool`
- `pytest -q` *(fails: 222 failed, 1002 passed, 70 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68ae3e9d20248327b39c357c257c9270