### PR TITLE
Ensure detached tabs resize with floating windows

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.142 - Ensure detached tabs fill newly opened windows and resize with them.
 - 0.2.141 - Let detached tabs resize with their windows so cloned widgets expand to fit.
 - 0.2.140 - Apply original geometry when cloning tabs so detached windows retain full content layout.
 - 0.2.139 - Preserve widget state when detaching tabs so floating windows

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.141
+version: 0.2.142
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -480,6 +480,29 @@ class ClosableNotebook(ttk.Notebook):
         except Exception:
             pass
 
+    def _ensure_fills(self, widget: tk.Widget) -> None:
+        """Ensure *widget* expands to fill its container.
+
+        The detached window should display its contents using all available
+        space and react to subsequent window resizes.  ``pack`` and ``grid``
+        layouts are supported; unsupported geometry managers are ignored so
+        detachment never raises an exception.
+        """
+
+        try:
+            widget.pack_configure(expand=True, fill="both")
+            return
+        except tk.TclError:
+            pass
+        try:
+            info = widget.grid_info()
+            widget.grid_configure(sticky="nsew")
+            parent = widget.master
+            parent.grid_rowconfigure(int(info.get("row", 0)), weight=1)
+            parent.grid_columnconfigure(int(info.get("column", 0)), weight=1)
+        except Exception:
+            pass
+
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()
         width = self.winfo_width() or 200
@@ -504,8 +527,12 @@ class ClosableNotebook(ttk.Notebook):
                 orig.destroy()
                 nb.add(clone, text=text)
                 nb.select(clone)
+                self._ensure_fills(clone)
             else:
-                nb.select(nb.tabs()[-1])
+                tab = nb.tabs()[-1]
+                child = nb.nametowidget(tab)
+                self._ensure_fills(child)
+                nb.select(tab)
         except Exception:
             win.destroy()
             raise

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.139"
+VERSION = "0.2.142"
 
 __all__ = ["VERSION"]

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -197,6 +197,35 @@ class TestFloatingWindowBehavior:
 
 
 class TestFloatingWindowLayout:
+    def test_detached_tab_fits_initial_window(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        ttk.Label(frame, text="hi").pack(expand=True, fill="both")
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        new_nb.update_idletasks()
+        assert new_frame.winfo_width() == new_nb.winfo_width()
+        assert new_frame.winfo_height() == new_nb.winfo_height()
+        root.destroy()
+
     def test_detached_tab_resizes_with_window(self):
         try:
             root = tk.Tk()


### PR DESCRIPTION
## Summary
- guarantee detached notebook tabs fill their floating windows and stay responsive to resizes
- test that newly detached tabs match their window dimensions
- bump project version to 0.2.142 and document the change

## Testing
- `pytest`
- `radon cc -j gui/utils/closable_notebook.py`


------
https://chatgpt.com/codex/tasks/task_b_68ae4f7ccc508327918acd4738589faf