### PR TITLE
Ensure detached tabs cancel animations and clone safely

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 # Version History
+- 0.2.143 - Cancel widget animations when detaching tabs and default missing text when cloning capsule buttons.
+- 0.2.142 - Ensure detached tabs fill newly opened windows and resize with them.
 - 0.2.141 - Let detached tabs resize with their windows so cloned widgets expand to fit.
 - 0.2.140 - Apply original geometry when cloning tabs so detached windows retain full content layout.
 - 0.2.139 - Preserve widget state when detaching tabs so floating windows

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.141
+version: 0.2.143
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -393,6 +393,8 @@ class ClosableNotebook(ttk.Notebook):
                 if name == "master" or param.default is not inspect._empty:
                     continue
                 value = self._get_widget_value(widget, name)
+                if value is None and param.annotation is str:
+                    value = ""
                 if value is not None:
                     kwargs[name] = value
         except Exception:
@@ -480,6 +482,45 @@ class ClosableNotebook(ttk.Notebook):
         except Exception:
             pass
 
+    def _cancel_after_events(self, widget: tk.Widget) -> None:
+        """Cancel common Tk ``after`` callbacks for *widget* and children."""
+        try:
+            for name in dir(widget):
+                if name.endswith(("_anim", "_after", "_timer")):
+                    ident = getattr(widget, name, None)
+                    if isinstance(ident, str):
+                        try:
+                            widget.after_cancel(ident)
+                        except Exception:
+                            pass
+        except Exception:
+            pass
+        for child in widget.winfo_children():
+            self._cancel_after_events(child)
+
+    def _ensure_fills(self, widget: tk.Widget) -> None:
+        """Ensure *widget* expands to fill its container.
+
+        The detached window should display its contents using all available
+        space and react to subsequent window resizes.  ``pack`` and ``grid``
+        layouts are supported; unsupported geometry managers are ignored so
+        detachment never raises an exception.
+        """
+
+        try:
+            widget.pack_configure(expand=True, fill="both")
+            return
+        except tk.TclError:
+            pass
+        try:
+            info = widget.grid_info()
+            widget.grid_configure(sticky="nsew")
+            parent = widget.master
+            parent.grid_rowconfigure(int(info.get("row", 0)), weight=1)
+            parent.grid_columnconfigure(int(info.get("column", 0)), weight=1)
+        except Exception:
+            pass
+
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()
         width = self.winfo_width() or 200
@@ -501,11 +542,16 @@ class ClosableNotebook(ttk.Notebook):
                 orig = self.nametowidget(tab_id)
                 clone = self._clone_widget(orig, nb)
                 self.forget(tab_id)
+                self._cancel_after_events(orig)
                 orig.destroy()
                 nb.add(clone, text=text)
                 nb.select(clone)
+                self._ensure_fills(clone)
             else:
-                nb.select(nb.tabs()[-1])
+                tab = nb.tabs()[-1]
+                child = nb.nametowidget(tab)
+                self._ensure_fills(child)
+                nb.select(tab)
         except Exception:
             win.destroy()
             raise

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.139"
+VERSION = "0.2.143"
 
 __all__ = ["VERSION"]

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -21,6 +21,7 @@ import sys
 import pytest
 import tkinter as tk
 from tkinter import ttk
+from gui import CapsuleButton
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from gui.closable_notebook import ClosableNotebook
@@ -197,6 +198,35 @@ class TestFloatingWindowBehavior:
 
 
 class TestFloatingWindowLayout:
+    def test_detached_tab_fits_initial_window(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        ttk.Label(frame, text="hi").pack(expand=True, fill="both")
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        new_nb.update_idletasks()
+        assert new_frame.winfo_width() == new_nb.winfo_width()
+        assert new_frame.winfo_height() == new_nb.winfo_height()
+        root.destroy()
+
     def test_detached_tab_resizes_with_window(self):
         try:
             root = tk.Tk()
@@ -359,4 +389,76 @@ class TestCloning:
         assert isinstance(new_label, ttk.Label)
         assert new_label.cget("text") == "hi"
         assert new_label.winfo_manager()
+        root.destroy()
+
+
+class TestDetachCleanup:
+    def test_clone_capsule_with_none_text(self, monkeypatch):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        btn = CapsuleButton(nb, text="ok")
+        btn._text = None
+        nb.add(btn, text="Tab1")
+        nb.update_idletasks()
+
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_btn = new_nb.nametowidget(new_nb.tabs()[0])
+        assert isinstance(new_btn, CapsuleButton)
+        root.destroy()
+
+    def test_detach_cancels_after_events(self, monkeypatch):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+
+        class Blinker(ttk.Label):
+            def __init__(self, master):
+                super().__init__(master, text="hi")
+                self._anim = self.after(10, self._blink)
+
+            def _blink(self):
+                self._anim = self.after(10, self._blink)
+
+        lbl = Blinker(nb)
+        nb.add(lbl, text="Tab1")
+        nb.update_idletasks()
+
+        errors = []
+
+        def handler(exc, val, tb):
+            errors.append(val)
+
+        root.report_callback_exception = handler
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        root.update()
+        assert not errors
         root.destroy()


### PR DESCRIPTION
## Summary
- cancel widget `after` callbacks before destroying tabs and supply empty text for required widget args
- test detaching tabs with running animations and capsule buttons missing text
- bump project version to 0.2.143 and document timer cleanup

## Testing
- `pytest`
- `radon cc -j gui/utils/closable_notebook.py`

------
https://chatgpt.com/codex/tasks/task_b_68ae4f7ccc508327918acd4738589faf