### PR TITLE
Fix StyledButton tab detachment cloning

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 # Version History
+- 0.2.144 - Resolve _StyledButton detachment by inspecting base-class signatures and
+            falling back to widget text options when cloning tabs.
 - 0.2.143 - Cancel widget animations when detaching tabs and default missing text when cloning capsule buttons.
 - 0.2.142 - Ensure detached tabs fill newly opened windows and resize with them.
 - 0.2.141 - Let detached tabs resize with their windows so cloned widgets expand to fit.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.143
+version: 0.2.144
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -33,6 +33,10 @@ import tkinter as tk
 from tkinter import ttk
 
 
+# Widget types whose text is only available through ``cget`` even when the
+# constructor signature cannot be introspected (e.g. CapsuleButton subclasses)
+_KNOWN_TEXT_WIDGETS = {"CapsuleButton"}
+
 class ClosableNotebook(ttk.Notebook):
     """Notebook widget with an 'x' button on the left side of each tab."""
 
@@ -386,10 +390,31 @@ class ClosableNotebook(ttk.Notebook):
         return clone
 
     def _collect_required_kwargs(self, widget: tk.Widget, cls: type) -> dict[str, t.Any]:
+        """Return constructor kwargs required to recreate *widget* of type *cls*.
+
+        Some subclasses only expose ``*args``/``**kwargs`` in ``__init__``.  Walk
+        the method resolution order to inspect base-class signatures for required
+        parameters and fall back to widget introspection for known families like
+        ``CapsuleButton`` when no signature information is available.
+        """
+
         kwargs: dict[str, t.Any] = {}
-        try:
-            sig = inspect.signature(cls.__init__)
-            for name, param in list(sig.parameters.items())[1:]:
+        for base in inspect.getmro(cls):
+            try:
+                sig = inspect.signature(base.__init__)
+            except Exception:
+                continue
+            params = list(sig.parameters.items())[1:]
+            # Skip bases that only accept *args/**kwargs and provide no
+            # information about required parameters.
+            if all(
+                p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+                or name == "master"
+                or p.default is not inspect._empty
+                for name, p in params
+            ):
+                continue
+            for name, param in params:
                 if name == "master" or param.default is not inspect._empty:
                     continue
                 value = self._get_widget_value(widget, name)
@@ -397,8 +422,16 @@ class ClosableNotebook(ttk.Notebook):
                     value = ""
                 if value is not None:
                     kwargs[name] = value
-        except Exception:
-            pass
+            if kwargs:
+                break
+
+        if not kwargs:
+            names = {c.__name__ for c in inspect.getmro(cls)}
+            if names & _KNOWN_TEXT_WIDGETS:
+                try:
+                    kwargs["text"] = widget.cget("text")
+                except Exception:
+                    pass
         return kwargs
 
     def _get_widget_value(self, widget: tk.Widget, name: str) -> t.Any | None:

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.143"
+VERSION = "0.2.144"
 
 __all__ = ["VERSION"]

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -21,7 +21,7 @@ import sys
 import pytest
 import tkinter as tk
 from tkinter import ttk
-from gui import CapsuleButton
+from gui import CapsuleButton, _StyledButton
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from gui.closable_notebook import ClosableNotebook
@@ -389,6 +389,36 @@ class TestCloning:
         assert isinstance(new_label, ttk.Label)
         assert new_label.cget("text") == "hi"
         assert new_label.winfo_manager()
+        root.destroy()
+
+    def test_clone_styled_button(self, monkeypatch):
+        """Styled button detachment should clone required text argument."""
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        btn = _StyledButton(nb, text="ok")
+        nb.add(btn, text="Tab1")
+        nb.update_idletasks()
+
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_btn = new_nb.nametowidget(new_nb.tabs()[0])
+        assert isinstance(new_btn, _StyledButton)
+        assert new_btn.cget("text") == "ok"
         root.destroy()
 
 


### PR DESCRIPTION
## Summary
- Traverse widget MRO to collect required constructor kwargs when detaching tabs
- Fallback to `cget("text")` for CapsuleButton families during cloning
- Test StyledButton tab detachment and bump version to 0.2.144

## Testing
- `radon cc -s -j gui/utils/closable_notebook.py`
- `pytest tests/test_tab_detach.py::TestCloning::test_clone_styled_button -q` *(fails: ModuleNotFoundError: No module named 'gui')*

------
https://chatgpt.com/codex/tasks/task_b_68ae751aa18083278fe55437a8fef010