### PR TITLE
Handle string annotations when cloning widgets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.146 - Handle string annotations when cloning widgets so CapsuleButton tabs detach even with missing text.
 - 0.2.145 - Cancel Tk after callbacks referencing detached widgets and store
             animation identifiers for reliable tab closure.
 - 0.2.144 - Resolve _StyledButton detachment by inspecting base-class signatures and

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.145
+version: 0.2.146
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -418,7 +418,7 @@ class ClosableNotebook(ttk.Notebook):
                 if name == "master" or param.default is not inspect._empty:
                     continue
                 value = self._get_widget_value(widget, name)
-                if value is None and param.annotation is str:
+                if value is None and param.annotation in (str, "str"):
                     value = ""
                 if value is not None:
                     kwargs[name] = value

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.145"
+VERSION = "0.2.146"
 
 __all__ = ["VERSION"]

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -422,7 +422,7 @@ class TestCloning:
         root.destroy()
 
 
-class TestDetachCleanup:
+class TestCapsuleButtonDetach:
     def test_clone_capsule_with_none_text(self, monkeypatch):
         try:
             root = tk.Tk()
@@ -452,6 +452,38 @@ class TestDetachCleanup:
         assert isinstance(new_btn, CapsuleButton)
         root.destroy()
 
+    def test_detach_capsule_with_none_text(self, monkeypatch):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        btn = CapsuleButton(nb, text="ok")
+        btn._text = None
+        nb.add(btn, text="Tab1")
+        nb.update_idletasks()
+
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_btn = new_nb.nametowidget(new_nb.tabs()[0])
+        assert isinstance(new_btn, CapsuleButton)
+        assert new_btn.cget("text") == ""
+        root.destroy()
+
+
+class TestDetachCleanup:
     def test_detach_cancels_after_events(self, monkeypatch):
         try:
             root = tk.Tk()


### PR DESCRIPTION
## Summary
- accept both `str` objects and forward reference "str" annotations when collecting required kwargs for widget cloning
- add regression test ensuring CapsuleButton tabs detach even when `_text` is missing
- bump version to 0.2.146 and update history

## Testing
- `radon cc -j gui/utils/closable_notebook.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aee72eae848327a037a523f089f54e