### PR TITLE
feat: expand nested widgets in detached tabs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 # Version History
+- 0.2.146 - Recursively expand nested widgets in detached tabs and verify
+            window resizing keeps them visible.
 - 0.2.145 - Cancel Tk after callbacks referencing detached widgets and store
             animation identifiers for reliable tab closure.
 - 0.2.144 - Resolve _StyledButton detachment by inspecting base-class signatures and

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.145
+version: 0.2.146
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -559,17 +559,18 @@ class ClosableNotebook(ttk.Notebook):
 
         try:
             widget.pack_configure(expand=True, fill="both")
-            return
         except tk.TclError:
-            pass
-        try:
-            info = widget.grid_info()
-            widget.grid_configure(sticky="nsew")
-            parent = widget.master
-            parent.grid_rowconfigure(int(info.get("row", 0)), weight=1)
-            parent.grid_columnconfigure(int(info.get("column", 0)), weight=1)
-        except Exception:
-            pass
+            try:
+                info = widget.grid_info()
+                widget.grid_configure(sticky="nsew")
+                parent = widget.master
+                parent.grid_rowconfigure(int(info.get("row", 0)), weight=1)
+                parent.grid_columnconfigure(int(info.get("column", 0)), weight=1)
+            except Exception:
+                pass
+
+        for child in widget.winfo_children():
+            self._ensure_fills(child)
 
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.145"
+VERSION = "0.2.146"
 
 __all__ = ["VERSION"]

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -259,6 +259,42 @@ class TestFloatingWindowLayout:
         assert new_frame.winfo_height() == new_nb.winfo_height() >= old_h
         root.destroy()
 
+    def test_nested_widgets_expand_with_window(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        outer = ttk.Frame(nb)
+        inner = ttk.Frame(outer)
+        ttk.Label(inner, text="hi").pack()
+        inner.pack()
+        nb.add(outer, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_outer = new_nb.nametowidget(new_nb.tabs()[0])
+        new_inner = new_outer.winfo_children()[0]
+        win.geometry("400x400")
+        win.update_idletasks()
+        new_nb.update_idletasks()
+        assert new_outer.winfo_width() == new_nb.winfo_width()
+        assert new_outer.winfo_height() == new_nb.winfo_height()
+        assert new_inner.winfo_width() == new_nb.winfo_width()
+        assert new_inner.winfo_height() == new_nb.winfo_height()
+        root.destroy()
+
 class TestCloning:
     def test_clone_handles_required_args(self, monkeypatch):
         try:


### PR DESCRIPTION
## Summary
- ensure `_ensure_fills` recursively configures all child widgets
- test that nested widgets fill floating window after resize
- bump project version to 0.2.146

## Testing
- `python tools/metrics_generator.py --path gui/utils --output /tmp/metrics.json`
- `pytest -q` *(fails: AttributeError: 'AutoMLApp' object has no attribute 'governance_manager')*


------
https://chatgpt.com/codex/tasks/task_b_68aee73cce70832792816129d78a9441