### PR TITLE
Close floating project windows during project lifecycle

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.149 - Close floating project windows when loading or creating projects.
 - 0.2.148 - Reparent detached tab widgets when possible and clone with full
             geometry metadata replication to preserve layout.
 - 0.2.147 - Drop parent references when cloning packed widgets so detached tabs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.146
+version: 0.2.149
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -138,6 +138,19 @@ class ClosableNotebook(ttk.Notebook):
         self.bind("<FocusIn>", self._on_focus_in, True)
 
     # ------------------------------------------------------------------
+    # Floating window helpers
+    # ------------------------------------------------------------------
+
+    def close_all_floating(self) -> None:
+        """Destroy every floating window detached from this notebook."""
+        for win in list(self._floating_windows):
+            try:
+                win.destroy()
+            except Exception:
+                pass
+        self._floating_windows.clear()
+
+    # ------------------------------------------------------------------
     # Backwards compatible helpers
     # ------------------------------------------------------------------
     #

--- a/mainappsrc/managers/project_manager.py
+++ b/mainappsrc/managers/project_manager.py
@@ -106,6 +106,8 @@ class ProjectManager:
                 return
             if result:
                 self.save_model()
+        if hasattr(app, "doc_nb"):
+            app.doc_nb.close_all_floating()
         if hasattr(app, "page_diagram") and app.page_diagram is not None:
             app.close_page_diagram()
         for tab_id in list(app.doc_nb.tabs()):
@@ -162,6 +164,8 @@ class ProjectManager:
     def _reset_on_load(self) -> None:
         model_loader.cleanup()
         app = self.app
+        if hasattr(app, "doc_nb"):
+            app.doc_nb.close_all_floating()
         if getattr(app, "page_diagram", None) is not None:
             app.close_page_diagram()
         for tab_id in list(getattr(app.doc_nb, "tabs", lambda: [])()):

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.146"
+VERSION = "0.2.149"
 
 __all__ = ["VERSION"]

--- a/tests/test_project_windows.py
+++ b/tests/test_project_windows.py
@@ -1,0 +1,114 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Project window lifecycle tests."""
+
+import os
+import sys
+import tkinter as tk
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from gui.utils.closable_notebook import ClosableNotebook
+from mainappsrc.managers.project_manager import ProjectManager
+
+
+pytestmark = [
+    pytest.mark.ProjectLifecycle,
+    pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available"),
+]
+
+
+def test_new_model_closes_floating_windows():
+    root = tk.Tk()
+    root.withdraw()
+    nb = ClosableNotebook(root)
+    win = tk.Toplevel(root)
+    nb._floating_windows.append(win)
+
+    class MB:
+        def askyesnocancel(self, *args, **kwargs):
+            return False
+
+    class DummyApp:
+        def __init__(self, notebook: ClosableNotebook):
+            self.messagebox = MB()
+            self.doc_nb = notebook
+
+        def has_unsaved_changes(self) -> bool:
+            return False
+
+    app = DummyApp(nb)
+    pm = ProjectManager(app)
+
+    called = {"flag": False}
+    orig_close = nb.close_all_floating
+
+    def fake_close() -> None:
+        called["flag"] = True
+        orig_close()
+        raise SystemExit
+
+    nb.close_all_floating = fake_close  # type: ignore[assignment]
+
+    with pytest.raises(SystemExit):
+        pm.new_model()
+
+    assert called["flag"]
+    assert nb._floating_windows == []
+    assert not win.winfo_exists()
+    root.destroy()
+
+
+def test_reset_on_load_closes_floating_windows(monkeypatch):
+    root = tk.Tk()
+    root.withdraw()
+    nb = ClosableNotebook(root)
+    win = tk.Toplevel(root)
+    nb._floating_windows.append(win)
+
+    class DummyApp:
+        def __init__(self, notebook: ClosableNotebook):
+            self.doc_nb = notebook
+
+    app = DummyApp(nb)
+    pm = ProjectManager(app)
+
+    called = {"flag": False}
+    orig_close = nb.close_all_floating
+
+    def fake_close() -> None:
+        called["flag"] = True
+        orig_close()
+        raise SystemExit
+
+    nb.close_all_floating = fake_close  # type: ignore[assignment]
+
+    monkeypatch.setattr(
+        "mainappsrc.managers.project_manager.model_loader.cleanup", lambda: None
+    )
+
+    with pytest.raises(SystemExit):
+        pm._reset_on_load()
+
+    assert called["flag"]
+    assert nb._floating_windows == []
+    assert not win.winfo_exists()
+    root.destroy()
+


### PR DESCRIPTION
## Summary
- add `ClosableNotebook.close_all_floating` to destroy tracked floating windows
- ensure new and loaded projects close floating windows before populating tabs
- document version 0.2.149 and add tests for project window lifecycle

## Testing
- `pytest tests/test_project_windows.py`
- `pytest tests/test_version_sync.py`
- `pytest` *(fails: FileNotFoundError, AttributeError, etc.)*
- `radon cc -j gui/utils/closable_notebook.py`


------
https://chatgpt.com/codex/tasks/task_b_68aef42aa3548327a782ce0d3cdd6be4