### PR TITLE
track detached tab windows

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.150 - Track detached tab hosts and refocus floating windows on reopen.
 - 0.2.149 - Close floating project windows when loading or creating projects.
 - 0.2.148 - Reparent detached tab widgets when possible and clone with full
             geometry metadata replication to preserve layout.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.149
+version: 0.2.150
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -30,6 +30,7 @@ notebook re-attaches it to that notebook.
 import inspect
 import typing as t
 import tkinter as tk
+import weakref
 from tkinter import ttk
 
 
@@ -42,6 +43,7 @@ class ClosableNotebook(ttk.Notebook):
 
     _style_initialized = False
     _close_img: tk.PhotoImage | None = None
+    _tab_hosts: weakref.WeakKeyDictionary[tk.Widget, tk.Toplevel] = weakref.WeakKeyDictionary()
 
     def __init__(self, master: tk.Widget | None = None, **kw):
         if not ClosableNotebook._style_initialized:
@@ -136,6 +138,31 @@ class ClosableNotebook(ttk.Notebook):
         # Refresh the newly selected tab whenever focus changes
         self.bind("<<NotebookTabChanged>>", self._on_tab_changed, True)
         self.bind("<FocusIn>", self._on_focus_in, True)
+
+    # ------------------------------------------------------------------
+    # Tab management
+    # ------------------------------------------------------------------
+
+    def add(self, child: tk.Widget, **kw: t.Any) -> None:  # type: ignore[override]
+        host = ClosableNotebook._tab_hosts.get(child)
+        if host is not None and host.winfo_exists():
+            host.deiconify()
+            host.lift()
+            try:
+                host.focus_force()
+            except tk.TclError:
+                pass
+            return
+        super().add(child, **kw)
+        if isinstance(self.master, tk.Toplevel):
+            ClosableNotebook._tab_hosts[child] = self.master
+
+            def _forget(_e: tk.Event, w: tk.Widget = child) -> None:
+                ClosableNotebook._tab_hosts.pop(w, None)
+
+            self.master.bind("<Destroy>", _forget, add="+")
+        else:
+            ClosableNotebook._tab_hosts.pop(child, None)
 
     # ------------------------------------------------------------------
     # Floating window helpers
@@ -372,6 +399,7 @@ class ClosableNotebook(ttk.Notebook):
         text = self.tab(tab_id, "text")
         child = self.nametowidget(tab_id)
         self.forget(tab_id)
+        ClosableNotebook._tab_hosts.pop(child, None)
         try:
             target.add(child, text=text)
             target.select(child)

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.149"
+VERSION = "0.2.150"
 
 __all__ = ["VERSION"]

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -201,6 +201,33 @@ class TestFloatingWindowBehavior:
         assert new_frame is frame
         root.destroy()
 
+    def test_reopen_detached_tab_focuses_window(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        nb.add(frame, text="Tab1")
+        assert len(nb.tabs()) == 0
+        focused = win.focus_get()
+        assert focused is not None and focused.winfo_toplevel() is win
+        root.destroy()
+
 
 class TestFloatingWindowLayout:
     def test_detached_tab_fits_initial_window(self):


### PR DESCRIPTION
## Summary
- map tab widgets to their floating windows and focus existing windows when reopening
- remove stale mappings when tabs move between notebooks
- verify reopening a detached tab raises the original window

## Testing
- `pytest tests/test_tab_detach.py`
- `radon cc -j gui/utils/closable_notebook.py`


------
https://chatgpt.com/codex/tasks/task_b_68aef60b7e3c8327a948b752e2dba5de