### PR TITLE
Mirror grid weights when cloning tabs and ignore geometry references

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
 # Version History
+- 0.2.151 - Always clone widgets when detaching tabs to avoid Tk reparent errors.
+- 0.2.150 - Strip geometry manager before/after references when cloning widgets
+            and mirror grid parent weights so detached tabs retain layout.
 - 0.2.149 - Close floating project windows when loading or creating projects.
 - 0.2.148 - Reparent detached tab widgets when possible and clone with full
             geometry metadata replication to preserve layout.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.149
+version: 0.2.151
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -385,15 +385,7 @@ class ClosableNotebook(ttk.Notebook):
         return moved
 
     def _clone_widget(self, widget: tk.Widget, parent: tk.Widget) -> tk.Widget:
-        """Re-parent *widget* into *parent* or clone it if necessary."""
-
-        try:
-            widget.master = parent  # Try re-parenting first
-            if not isinstance(parent, ttk.Notebook):
-                self._copy_widget_layout(widget, widget)
-            return widget
-        except Exception:
-            pass
+        """Return a clone of *widget* re-parented into *parent*."""
 
         cls = widget.__class__
         kwargs = self._collect_required_kwargs(widget, cls)
@@ -511,7 +503,8 @@ class ClosableNotebook(ttk.Notebook):
 
         try:
             info = widget.pack_info()
-            info.pop("in", None)
+            for key in ("in", "in_", "before", "after"):
+                info.pop(key, None)
             clone.pack(**info)
             try:
                 clone.pack_propagate(widget.pack_propagate())
@@ -522,7 +515,8 @@ class ClosableNotebook(ttk.Notebook):
             pass
         try:
             info = widget.grid_info()
-            info.pop("in", None)
+            for key in ("in", "in_", "before", "after"):
+                info.pop(key, None)
             clone.grid(**info)
             try:
                 clone.grid_propagate(widget.grid_propagate())
@@ -535,6 +529,23 @@ class ClosableNotebook(ttk.Notebook):
                     cfg = widget.grid_columnconfigure(c)
                     if cfg:
                         clone.grid_columnconfigure(c, **cfg)
+                if widget is not clone:
+                    orig_parent = widget.master
+                    new_parent = clone.master
+                    try:
+                        pcols, prows = orig_parent.grid_size()
+                        for r in range(prows):
+                            pcfg = orig_parent.grid_rowconfigure(r)
+                            weight = pcfg.get("weight") if pcfg else 0
+                            if weight:
+                                new_parent.grid_rowconfigure(r, weight=weight)
+                        for c in range(pcols):
+                            pcfg = orig_parent.grid_columnconfigure(c)
+                            weight = pcfg.get("weight") if pcfg else 0
+                            if weight:
+                                new_parent.grid_columnconfigure(c, weight=weight)
+                    except Exception:
+                        pass
             except Exception:
                 pass
             return
@@ -542,7 +553,8 @@ class ClosableNotebook(ttk.Notebook):
             pass
         try:
             info = widget.place_info()
-            info.pop("in", None)
+            for key in ("in", "in_", "before", "after"):
+                info.pop(key, None)
             clone.place(**info)
         except tk.TclError:
             pass
@@ -646,11 +658,8 @@ class ClosableNotebook(ttk.Notebook):
                 self._cancel_after_events(orig)
                 self.forget(tab_id)
                 new_widget = self._clone_widget(orig, nb)
-                if new_widget is orig:
-                    nb.add(orig, text=text)
-                else:
-                    orig.destroy()
-                    nb.add(new_widget, text=text)
+                orig.destroy()
+                nb.add(new_widget, text=text)
                 nb.select(new_widget)
                 self._ensure_fills(new_widget)
             else:

--- a/tests/test_tab_detach.py
+++ b/tests/test_tab_detach.py
@@ -394,6 +394,97 @@ class TestDetachedWindowLayout:
         assert infos == new_infos
         root.destroy()
 
+    def test_pack_before_after_ignored(self, monkeypatch):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        l1 = ttk.Label(frame, text="1")
+        l2 = ttk.Label(frame, text="2")
+        l3 = ttk.Label(frame, text="3")
+        l3.pack()
+        l1.pack(after=l3)
+        l2.pack(before=l1)
+        order = [w.cget("text") for w in frame.pack_slaves()]
+        infos = [
+            {k: v for k, v in w.pack_info().items() if k not in {"in", "before", "after"}}
+            for w in frame.pack_slaves()
+        ]
+        nb.add(frame, text="T")
+        nb.update_idletasks()
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        new_order = [w.cget("text") for w in new_frame.pack_slaves()]
+        new_infos = [
+            {k: v for k, v in w.pack_info().items() if k not in {"in", "before", "after"}}
+            for w in new_frame.pack_slaves()
+        ]
+        assert order == new_order
+        assert infos == new_infos
+        root.destroy()
+
+    def test_grid_parent_weights_preserved(self, monkeypatch):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        nb.grid_rowconfigure(0, weight=1)
+        nb.grid_columnconfigure(0, weight=1)
+        nb.grid_columnconfigure(1, weight=2)
+        frame = ttk.Frame(nb)
+        g1 = ttk.Label(frame, text="1")
+        g2 = ttk.Label(frame, text="2")
+        g1.grid(row=0, column=0, sticky="nsew")
+        g2.grid(row=0, column=1, sticky="nsew")
+        frame.grid(row=0, column=0, sticky="nsew")
+        infos = [
+            {k: v for k, v in w.grid_info().items() if k != "in"}
+            for w in frame.winfo_children()
+        ]
+        nb.add(frame, text="T")
+        nb.update_idletasks()
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_frame = new_nb.nametowidget(new_nb.tabs()[0])
+        new_infos = [
+            {k: v for k, v in w.grid_info().items() if k != "in"}
+            for w in new_frame.winfo_children()
+        ]
+        assert len(frame.winfo_children()) == len(new_frame.winfo_children())
+        assert infos == new_infos
+        assert nb.grid_rowconfigure(0) == new_nb.grid_rowconfigure(0)
+        assert nb.grid_columnconfigure(0) == new_nb.grid_columnconfigure(0)
+        assert nb.grid_columnconfigure(1) == new_nb.grid_columnconfigure(1)
+        root.destroy()
+
 class TestCloning:
     def test_clone_handles_required_args(self, monkeypatch):
         try:


### PR DESCRIPTION
## Summary
- drop before/after and parent `in` references when applying pack/grid/place to detached tabs
- mirror grid parent row/column weights so cloned widgets keep their layout
- always clone widgets when detaching tabs to avoid Tk reparent errors

## Testing
- `pytest tests/test_tab_detach.py`
- `pytest`
- `radon cc -j gui/utils/closable_notebook.py | jq '.' | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68aef65b24008327a7c0f3142d9ec41f