### PR TITLE
Limit detachment fill adjustments

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.152 - Limit fill adjustments to detached tab container so child layouts remain intact.
 - 0.2.151 - Always clone widgets when detaching tabs to avoid Tk reparent errors.
 - 0.2.150 - Strip geometry manager before/after references when cloning widgets
             and mirror grid parent weights so detached tabs retain layout.

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -641,28 +641,36 @@ class ClosableNotebook(ttk.Notebook):
             self._cancel_after_events(child)
             
     def _ensure_fills(self, widget: tk.Widget) -> None:
-        """Ensure *widget* expands to fill its container.
+        """Ensure *widget* expands to fill its immediate container.
 
-        The detached window should display its contents using all available
-        space and react to subsequent window resizes.  ``pack`` and ``grid``
-        layouts are supported; unsupported geometry managers are ignored so
-        detachment never raises an exception.
+        Only the geometry of ``widget`` itself is adjusted; child widgets keep
+        their original layout configuration.  ``pack`` and ``grid`` layouts are
+        supported.  Scrollbars expand only along their orientation so they
+        retain their intended shape.
         """
 
+        fill, expand, sticky, row_weight, col_weight = "both", True, "nsew", 1, 1
+        if isinstance(widget, (tk.Scrollbar, ttk.Scrollbar)):
+            orient = str(widget.cget("orient"))
+            mapping = {
+                "vertical": ("y", False, "ns", 1, 0),
+                "horizontal": ("x", False, "ew", 0, 1),
+            }
+            fill, expand, sticky, row_weight, col_weight = mapping.get(
+                orient, ("both", True, "nsew", 1, 1)
+            )
+
         try:
-            widget.pack_configure(expand=True, fill="both")
+            widget.pack_configure(expand=expand, fill=fill)
         except tk.TclError:
             try:
                 info = widget.grid_info()
-                widget.grid_configure(sticky="nsew")
+                widget.grid_configure(sticky=sticky)
                 parent = widget.master
-                parent.grid_rowconfigure(int(info.get("row", 0)), weight=1)
-                parent.grid_columnconfigure(int(info.get("column", 0)), weight=1)
+                parent.grid_rowconfigure(int(info.get("row", 0)), weight=row_weight)
+                parent.grid_columnconfigure(int(info.get("column", 0)), weight=col_weight)
             except Exception:
                 pass
-
-        for child in widget.winfo_children():
-            self._ensure_fills(child)
 
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()

--- a/tests/detachment/test_layout_preservation.py
+++ b/tests/detachment/test_layout_preservation.py
@@ -1,0 +1,63 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+import tkinter as tk
+from tkinter import ttk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook
+
+
+class TestLayoutPreservation:
+    def test_control_geometry_unchanged_after_detach(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        container = ttk.Frame(nb)
+        text = tk.Text(container)
+        text.pack(side="left")
+        vsb = ttk.Scrollbar(container, orient="vertical")
+        vsb.pack(side="right", fill="y")
+        nb.add(container, text="Tab1")
+        nb.update_idletasks()
+        text_before = text.pack_info()
+        vsb_before = vsb.pack_info()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert nb._floating_windows, "Tab did not detach"
+        text_after = text.pack_info()
+        vsb_after = vsb.pack_info()
+        assert text_before == text_after
+        assert vsb_before == vsb_after
+        root.destroy()


### PR DESCRIPTION
## Summary
- Prevent `_ensure_fills` from rewriting child widget geometry and respect scrollbar orientation
- Test detachment layout to ensure widget pack options remain stable
- Document layout preservation in HISTORY

## Testing
- `python tools/metrics_generator.py --path gui/utils --output metrics.json`
- `pytest tests/detachment/test_layout_preservation.py::TestLayoutPreservation::test_control_geometry_unchanged_after_detach -q` *(skipped: Tk not available)*
- `pytest -q` *(fails: 220 failed, 1004 passed, 89 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68aefc60023c8327a5e9175a8e4c2cc5