### PR TITLE
Preserve layout managers on detached notebook tabs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.153 - Preserve mixed geometry layouts when detaching tabs.
 - 0.2.152 - Limit fill adjustments to detached tab container so child layouts remain intact.
           - Rewire cloned widgets during tab detachment and remove duplicate controls.
 - 0.2.151 - Always clone widgets when detaching tabs to avoid Tk reparent errors.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.152
+version: 0.2.153
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -656,34 +656,25 @@ class ClosableNotebook(ttk.Notebook):
     def _ensure_fills(self, widget: tk.Widget) -> None:
         """Ensure *widget* expands to fill its immediate container.
 
-        Only the geometry of ``widget`` itself is adjusted; child widgets keep
-        their original layout configuration.  ``pack`` and ``grid`` layouts are
-        supported.  Scrollbars expand only along their orientation so they
-        retain their intended shape.
+        Only the geometry of ``widget`` itself is adjusted.  Child widgets keep
+        their existing layout configuration regardless of whether they use
+        ``pack``, ``grid`` or ``place``.
         """
 
-        fill, expand, sticky, row_weight, col_weight = "both", True, "nsew", 1, 1
-        if isinstance(widget, (tk.Scrollbar, ttk.Scrollbar)):
-            orient = str(widget.cget("orient"))
-            mapping = {
-                "vertical": ("y", False, "ns", 1, 0),
-                "horizontal": ("x", False, "ew", 0, 1),
-            }
-            fill, expand, sticky, row_weight, col_weight = mapping.get(
-                orient, ("both", True, "nsew", 1, 1)
-            )
+        try:
+            manager = widget.winfo_manager()
+        except Exception:
+            return
 
         try:
-            widget.pack_configure(expand=expand, fill=fill)
+            if manager == "pack":
+                widget.pack_configure(expand=True, fill="both")
+            elif manager == "grid":
+                widget.grid_configure(sticky="nsew")
+            elif manager == "place":
+                widget.place_configure(relx=0, rely=0, relwidth=1, relheight=1)
         except tk.TclError:
-            try:
-                info = widget.grid_info()
-                widget.grid_configure(sticky=sticky)
-                parent = widget.master
-                parent.grid_rowconfigure(int(info.get("row", 0)), weight=row_weight)
-                parent.grid_columnconfigure(int(info.get("column", 0)), weight=col_weight)
-            except Exception:
-                pass
+            pass
 
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.150"
+VERSION = "0.2.153"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/test_layout_preservation.py
+++ b/tests/detachment/test_layout_preservation.py
@@ -61,3 +61,58 @@ class TestLayoutPreservation:
         assert text_before == text_after
         assert vsb_before == vsb_after
         root.destroy()
+
+    def test_mixed_geometry_unchanged_after_detach(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        container = ttk.Frame(nb)
+        nb.add(container, text="Tab1")
+
+        pack_frame = ttk.Frame(container)
+        pack_frame.pack(side="top")
+        pack_lbl = ttk.Label(pack_frame, text="p")
+        pack_lbl.pack(side="left")
+
+        grid_frame = ttk.Frame(container)
+        grid_frame.pack(side="top")
+        grid_lbl = ttk.Label(grid_frame, text="g")
+        grid_lbl.grid(row=0, column=0)
+
+        place_frame = ttk.Frame(container, width=20, height=20)
+        place_frame.pack(side="top")
+        place_lbl = ttk.Label(place_frame, text="pl")
+        place_lbl.place(x=5, y=5)
+
+        nb.update_idletasks()
+        pack_before = pack_lbl.pack_info()
+        grid_before = grid_lbl.grid_info()
+        place_before = place_lbl.place_info()
+        for info in (grid_before, place_before):
+            for key in ("in", "in_", "before", "after"):
+                info.pop(key, None)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert nb._floating_windows, "Tab did not detach"
+        pack_after = pack_lbl.pack_info()
+        grid_after = grid_lbl.grid_info()
+        place_after = place_lbl.place_info()
+        for info in (grid_after, place_after):
+            for key in ("in", "in_", "before", "after"):
+                info.pop(key, None)
+
+        assert pack_before == pack_after
+        assert grid_before == grid_after
+        assert place_before == place_after
+        root.destroy()


### PR DESCRIPTION
## Summary
- keep only top-level container filling when detaching tabs
- verify mixed geometry layouts remain unchanged after detachment
- bump version to 0.2.153

## Testing
- `radon cc gui/utils/closable_notebook.py tests/detachment/test_layout_preservation.py -j`
- `pytest` *(fails: module path issues and missing attributes in many tests)*

------
https://chatgpt.com/codex/tasks/task_b_68aefe450184832786399e335b3042ba