### PR TITLE
feat: reparent tabs before cloning

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.153 - Reparent tabs via Tk ``winfo`` before cloning to simplify detachment.
 - 0.2.152 - Limit fill adjustments to detached tab container so child layouts remain intact.
           - Rewire cloned widgets during tab detachment and remove duplicate controls.
 - 0.2.151 - Always clone widgets when detaching tabs to avoid Tk reparent errors.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.152
+version: 0.2.153
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -394,13 +394,22 @@ class ClosableNotebook(ttk.Notebook):
         return widget
 
     def _move_tab(self, tab_id: str, target: "ClosableNotebook") -> bool:
-        """Move *tab_id* to *target* notebook using Tk's native commands."""
+        """Move *tab_id* to *target* notebook using Tk's native commands.
+
+        The method first tries Tk's ``winfo`` reparenting to avoid cloning.  If
+        the operation fails, the widget is restored to its original notebook and
+        the caller may fall back to cloning.
+        """
 
         text = self.tab(tab_id, "text")
         child = self.nametowidget(tab_id)
         self.forget(tab_id)
         ClosableNotebook._tab_hosts.pop(child, None)
         try:
+            try:
+                child.tk.call("winfo", "reparent", child._w, target._w)
+            except tk.TclError:
+                pass
             target.add(child, text=text)
             target.select(child)
             moved = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
-
-VERSION = "0.2.153"
-
-__all__ = ["VERSION"]
+[pytest]
+markers =
+    detachment: tests covering tab detachment
+    reparenting: tests verifying widget reparenting

--- a/tests/test_detachment_reparenting.py
+++ b/tests/test_detachment_reparenting.py
@@ -1,0 +1,47 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+import pytest
+import tkinter as tk
+from tkinter import ttk
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(root_dir)
+from gui.utils.closable_notebook import ClosableNotebook
+
+
+@pytest.mark.detachment
+@pytest.mark.reparenting
+class TestDetachmentReparenting:
+    def test_standard_widget_moved_not_cloned(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb1 = ClosableNotebook(root)
+        nb1.pack()
+        label = ttk.Label(nb1, text="hello")
+        nb1.add(label, text="L1")
+        nb2 = ClosableNotebook(root)
+        nb2.pack()
+        tab_id = nb1.tabs()[0]
+        assert nb1._move_tab(tab_id, nb2)
+        assert nb2.nametowidget(nb2.tabs()[0]) is label
+        root.destroy()


### PR DESCRIPTION
## Summary
- attempt Tk `winfo` reparenting before falling back to cloning detached tabs
- cover widget reparenting in detachment tests
- document reparenting improvement and bump version to 0.2.153

## Testing
- `pytest tests/test_detachment_reparenting.py`
- `pytest`
- `python tools/metrics_generator.py --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68aefeb274f08327a6a9d90d26817769