### PR TITLE
Add detachment regression tests and fixtures

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 # Version History
+- 0.2.154 - Add grouped detachment regression tests for layouts, canvas cloning,
+          scrollbars and GSN diagram tabs.
 - 0.2.153 - Reparent tabs via Tk ``winfo`` before cloning to simplify detachment.
           - Clone canvas items, scroll regions and bindings when detaching tabs.
           - Guard tab widget reference rewrites when cloned widgets report no configuration.

--- a/tests/detachment/README.md
+++ b/tests/detachment/README.md
@@ -1,0 +1,8 @@
+# Detachment Regression Tests
+
+These suites verify that notebook tab detachment preserves widget state.
+
+* `canvas/` – Canvas state and cloning behaviour.
+* `layout/` – Geometry managers retain configurations.
+* `scrollbars/` – Scrollbar positions persist across detachment.
+* `gsn/` – GSN diagram windows remain interactive when detached.

--- a/tests/detachment/canvas/test_canvas_clone.py
+++ b/tests/detachment/canvas/test_canvas_clone.py
@@ -1,0 +1,43 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Canvas cloning tests ensuring widgets replicate state when detached."""
+
+import os
+import sys
+import tkinter as tk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook
+
+
+def test_canvas_clone_retains_items() -> None:
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    nb = ClosableNotebook(root)
+    canvas = tk.Canvas(nb, width=50, height=50)
+    canvas.create_line(0, 0, 10, 10)
+    clone, _ = nb._clone_widget(canvas, nb)
+    assert isinstance(clone, tk.Canvas)
+    assert clone.find_all(), "Cloned canvas lost its items"
+    root.destroy()

--- a/tests/detachment/canvas/test_canvas_state.py
+++ b/tests/detachment/canvas/test_canvas_state.py
@@ -19,31 +19,26 @@
 import os
 import sys
 import tkinter as tk
-from tkinter import ttk
 import pytest
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 sys.path.append(root_dir)
 sys.path.append(os.path.join(root_dir, "gui", "utils"))
 from closable_notebook import ClosableNotebook
 
 
-class TestLayoutPreservation:
-    def test_control_geometry_unchanged_after_detach(self) -> None:
+class TestCanvasState:
+    def test_canvas_items_preserved_after_detach(self) -> None:
         try:
             root = tk.Tk()
         except tk.TclError:
             pytest.skip("Tk not available")
         nb = ClosableNotebook(root)
-        container = ttk.Frame(nb)
-        text = tk.Text(container)
-        text.pack(side="left")
-        vsb = ttk.Scrollbar(container, orient="vertical")
-        vsb.pack(side="right", fill="y")
-        nb.add(container, text="Tab1")
+        canvas = tk.Canvas(nb, width=200, height=200)
+        canvas.create_rectangle(10, 10, 50, 50, fill="red")
+        canvas.create_oval(60, 60, 100, 100, fill="blue")
+        nb.add(canvas, text="Canvas")
         nb.update_idletasks()
-        text_before = text.pack_info()
-        vsb_before = vsb.pack_info()
 
         class Event: ...
 
@@ -56,43 +51,28 @@ class TestLayoutPreservation:
         nb._on_tab_release(release)
 
         assert nb._floating_windows, "Tab did not detach"
-        text_after = text.pack_info()
-        vsb_after = vsb.pack_info()
-        assert text_before == text_after
-        assert vsb_before == vsb_after
+        win = nb._floating_windows[-1]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_canvas = next(w for w in new_nb.winfo_children() if isinstance(w, tk.Canvas))
+        assert len(new_canvas.find_all()) == 2
         root.destroy()
 
-    def test_mixed_geometry_unchanged_after_detach(self) -> None:
+    def test_canvas_binding_and_scrollregion_preserved_after_detach(self) -> None:
         try:
             root = tk.Tk()
         except tk.TclError:
             pytest.skip("Tk not available")
         nb = ClosableNotebook(root)
-        container = ttk.Frame(nb)
-        nb.add(container, text="Tab1")
+        canvas = tk.Canvas(nb, width=100, height=100)
+        canvas.configure(scrollregion=(0, 0, 300, 300))
+        clicked: list[tk.Event] = []
 
-        pack_frame = ttk.Frame(container)
-        pack_frame.pack(side="top")
-        pack_lbl = ttk.Label(pack_frame, text="p")
-        pack_lbl.pack(side="left")
+        def on_click(event: tk.Event) -> None:
+            clicked.append(event)
 
-        grid_frame = ttk.Frame(container)
-        grid_frame.pack(side="top")
-        grid_lbl = ttk.Label(grid_frame, text="g")
-        grid_lbl.grid(row=0, column=0)
-
-        place_frame = ttk.Frame(container, width=20, height=20)
-        place_frame.pack(side="top")
-        place_lbl = ttk.Label(place_frame, text="pl")
-        place_lbl.place(x=5, y=5)
-
+        canvas.bind("<Button-1>", on_click)
+        nb.add(canvas, text="Canvas")
         nb.update_idletasks()
-        pack_before = pack_lbl.pack_info()
-        grid_before = grid_lbl.grid_info()
-        place_before = place_lbl.place_info()
-        for info in (grid_before, place_before):
-            for key in ("in", "in_", "before", "after"):
-                info.pop(key, None)
 
         class Event: ...
 
@@ -105,14 +85,10 @@ class TestLayoutPreservation:
         nb._on_tab_release(release)
 
         assert nb._floating_windows, "Tab did not detach"
-        pack_after = pack_lbl.pack_info()
-        grid_after = grid_lbl.grid_info()
-        place_after = place_lbl.place_info()
-        for info in (grid_after, place_after):
-            for key in ("in", "in_", "before", "after"):
-                info.pop(key, None)
-
-        assert pack_before == pack_after
-        assert grid_before == grid_after
-        assert place_before == place_after
+        win = nb._floating_windows[-1]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_canvas = next(w for w in new_nb.winfo_children() if isinstance(w, tk.Canvas))
+        assert new_canvas.cget("scrollregion") == canvas.cget("scrollregion")
+        new_canvas.event_generate("<Button-1>", x=1, y=1)
+        assert clicked
         root.destroy()

--- a/tests/detachment/conftest.py
+++ b/tests/detachment/conftest.py
@@ -1,0 +1,79 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Common fixtures for detachment regression tests."""
+
+import os
+import sys
+import types
+import tkinter as tk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+
+from closable_notebook import ClosableNotebook
+from mainappsrc.models.gsn import GSNNode, GSNDiagram
+
+
+class DummyToolbox:
+    """Minimal stand-in for :class:`SafetyManagementToolbox`."""
+
+    def __init__(self) -> None:
+        self.diagrams: dict[str, str] = {}
+
+
+class DummyGSNDiagramWindow(tk.Frame):
+    """Simplified GSN diagram tab used for detachment tests."""
+
+    def __init__(self, master, app, diagram):
+        super().__init__(master)
+        self.app = app
+        self.diagram = diagram
+        self.zoom = 1.0
+
+    def zoom_in(self) -> None:
+        self.zoom *= 1.1
+
+
+@pytest.fixture
+def tk_root():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    yield root
+    root.destroy()
+
+
+@pytest.fixture
+def toolbox() -> DummyToolbox:
+    return DummyToolbox()
+
+
+@pytest.fixture
+def gsn_diagram_window(tk_root, toolbox):
+    node = GSNNode("Goal", "Goal")
+    diagram = GSNDiagram(node)
+    app = types.SimpleNamespace(safety_mgmt_toolbox=toolbox)
+    win = DummyGSNDiagramWindow(tk_root, app, diagram)
+    nb = ClosableNotebook(tk_root)
+    nb.add(win, text="GSN")
+    nb.update_idletasks()
+    return nb, win

--- a/tests/detachment/gsn/test_gsn_tab_detach.py
+++ b/tests/detachment/gsn/test_gsn_tab_detach.py
@@ -1,0 +1,47 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Validate GSN diagram tabs remain functional after detachment."""
+
+import pytest
+
+from closable_notebook import ClosableNotebook
+
+
+def test_gsn_window_zoom_after_detach(gsn_diagram_window, toolbox):
+    nb, win = gsn_diagram_window
+    win_cls = type(win)
+
+    class Event: ...
+
+    press = Event(); press.x = 5; press.y = 5
+    nb._on_tab_press(press)
+    nb._dragging = True
+    release = Event()
+    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+    nb._on_tab_release(release)
+
+    assert nb._floating_windows, "Tab did not detach"
+    win = nb._floating_windows[-1]
+    new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+    new_win = next(w for w in new_nb.winfo_children() if isinstance(w, win_cls))
+    zoom_before = new_win.zoom
+    new_win.zoom_in()
+    assert new_win.zoom > zoom_before
+    assert toolbox is not None  # ensure fixture exercised

--- a/tests/detachment/layout/test_layout_preservation.py
+++ b/tests/detachment/layout/test_layout_preservation.py
@@ -19,26 +19,31 @@
 import os
 import sys
 import tkinter as tk
+from tkinter import ttk
 import pytest
 
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 sys.path.append(root_dir)
 sys.path.append(os.path.join(root_dir, "gui", "utils"))
 from closable_notebook import ClosableNotebook
 
 
-class TestCanvasState:
-    def test_canvas_items_preserved_after_detach(self) -> None:
+class TestLayoutPreservation:
+    def test_control_geometry_unchanged_after_detach(self) -> None:
         try:
             root = tk.Tk()
         except tk.TclError:
             pytest.skip("Tk not available")
         nb = ClosableNotebook(root)
-        canvas = tk.Canvas(nb, width=200, height=200)
-        canvas.create_rectangle(10, 10, 50, 50, fill="red")
-        canvas.create_oval(60, 60, 100, 100, fill="blue")
-        nb.add(canvas, text="Canvas")
+        container = ttk.Frame(nb)
+        text = tk.Text(container)
+        text.pack(side="left")
+        vsb = ttk.Scrollbar(container, orient="vertical")
+        vsb.pack(side="right", fill="y")
+        nb.add(container, text="Tab1")
         nb.update_idletasks()
+        text_before = text.pack_info()
+        vsb_before = vsb.pack_info()
 
         class Event: ...
 
@@ -51,28 +56,43 @@ class TestCanvasState:
         nb._on_tab_release(release)
 
         assert nb._floating_windows, "Tab did not detach"
-        win = nb._floating_windows[-1]
-        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
-        new_canvas = next(w for w in new_nb.winfo_children() if isinstance(w, tk.Canvas))
-        assert len(new_canvas.find_all()) == 2
+        text_after = text.pack_info()
+        vsb_after = vsb.pack_info()
+        assert text_before == text_after
+        assert vsb_before == vsb_after
         root.destroy()
 
-    def test_canvas_binding_and_scrollregion_preserved_after_detach(self) -> None:
+    def test_mixed_geometry_unchanged_after_detach(self) -> None:
         try:
             root = tk.Tk()
         except tk.TclError:
             pytest.skip("Tk not available")
         nb = ClosableNotebook(root)
-        canvas = tk.Canvas(nb, width=100, height=100)
-        canvas.configure(scrollregion=(0, 0, 300, 300))
-        clicked: list[tk.Event] = []
+        container = ttk.Frame(nb)
+        nb.add(container, text="Tab1")
 
-        def on_click(event: tk.Event) -> None:
-            clicked.append(event)
+        pack_frame = ttk.Frame(container)
+        pack_frame.pack(side="top")
+        pack_lbl = ttk.Label(pack_frame, text="p")
+        pack_lbl.pack(side="left")
 
-        canvas.bind("<Button-1>", on_click)
-        nb.add(canvas, text="Canvas")
+        grid_frame = ttk.Frame(container)
+        grid_frame.pack(side="top")
+        grid_lbl = ttk.Label(grid_frame, text="g")
+        grid_lbl.grid(row=0, column=0)
+
+        place_frame = ttk.Frame(container, width=20, height=20)
+        place_frame.pack(side="top")
+        place_lbl = ttk.Label(place_frame, text="pl")
+        place_lbl.place(x=5, y=5)
+
         nb.update_idletasks()
+        pack_before = pack_lbl.pack_info()
+        grid_before = grid_lbl.grid_info()
+        place_before = place_lbl.place_info()
+        for info in (grid_before, place_before):
+            for key in ("in", "in_", "before", "after"):
+                info.pop(key, None)
 
         class Event: ...
 
@@ -85,10 +105,14 @@ class TestCanvasState:
         nb._on_tab_release(release)
 
         assert nb._floating_windows, "Tab did not detach"
-        win = nb._floating_windows[-1]
-        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
-        new_canvas = next(w for w in new_nb.winfo_children() if isinstance(w, tk.Canvas))
-        assert new_canvas.cget("scrollregion") == canvas.cget("scrollregion")
-        new_canvas.event_generate("<Button-1>", x=1, y=1)
-        assert clicked
+        pack_after = pack_lbl.pack_info()
+        grid_after = grid_lbl.grid_info()
+        place_after = place_lbl.place_info()
+        for info in (grid_after, place_after):
+            for key in ("in", "in_", "before", "after"):
+                info.pop(key, None)
+
+        assert pack_before == pack_after
+        assert grid_before == grid_after
+        assert place_before == place_after
         root.destroy()

--- a/tests/detachment/scrollbars/test_scrollbar_preservation.py
+++ b/tests/detachment/scrollbars/test_scrollbar_preservation.py
@@ -1,0 +1,65 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Scrollbar tests verifying view offsets persist after detachment."""
+
+import os
+import sys
+import tkinter as tk
+from tkinter import ttk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook
+
+
+def test_scrollbar_offset_preserved() -> None:
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    nb = ClosableNotebook(root)
+    container = ttk.Frame(nb)
+    canvas = tk.Canvas(container, width=100, height=100)
+    vsb = ttk.Scrollbar(container, orient="vertical", command=canvas.yview)
+    canvas.configure(yscrollcommand=vsb.set)
+    canvas.pack(side="left", fill="both", expand=True)
+    vsb.pack(side="right", fill="y")
+    nb.add(container, text="Canvas")
+    canvas.create_rectangle(0, 0, 200, 400)
+    canvas.yview_moveto(1.0)
+
+    class Event: ...
+
+    press = Event(); press.x = 5; press.y = 5
+    nb._on_tab_press(press)
+    nb._dragging = True
+    release = Event()
+    release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+    release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+    nb._on_tab_release(release)
+
+    assert nb._floating_windows, "Tab did not detach"
+    win = nb._floating_windows[-1]
+    new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+    new_container = next(w for w in new_nb.winfo_children() if isinstance(w, ttk.Frame))
+    new_canvas = next(w for w in new_container.winfo_children() if isinstance(w, tk.Canvas))
+    assert new_canvas.yview()[0] > 0
+    root.destroy()


### PR DESCRIPTION
## Summary
- group detachment regression tests under dedicated subdirectories
- add fixtures for dummy GSN diagram tabs and toolbox
- verify canvas cloning, scrollbar offsets, and GSN tab functionality after detachment
- document new tests and update history

## Testing
- `radon cc -s -j tests/detachment`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af06ec4cd48327945c59c35dcfde80