### PR TITLE
Guard toolbox width calculation against destroyed widgets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 # Version History
+- 0.2.154 - Ignore destroyed widgets when measuring toolbox button width.
 - 0.2.153 - Reparent tabs via Tk ``winfo`` before cloning to simplify detachment.
           - Clone canvas items, scroll regions and bindings when detaching tabs.
           - Guard tab widget reference rewrites when cloned widgets report no configuration.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.153
+version: 0.2.154
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/controls/button_utils.py
+++ b/gui/controls/button_utils.py
@@ -57,6 +57,33 @@ def set_uniform_button_width(widget: tk.Misc) -> None:
         except Exception:  # pragma: no cover - defensive
             pass
 
+
+def max_button_reqwidth(widget: tk.Misc) -> int:
+    """Return the widest requested width of ``ttk.Button`` descendants.
+
+    Traverses *widget*'s children recursively while gracefully handling widgets
+    that have already been destroyed.  If a child no longer exists, it is
+    ignored so callers can safely compute widths during dynamic UI updates
+    without triggering :class:`tk.TclError` exceptions.
+    """
+
+    max_width = 0
+    try:
+        children = widget.winfo_children()
+    except tk.TclError:
+        return 0
+    for child in children:
+        try:
+            if not child.winfo_exists():
+                continue
+            if isinstance(child, ttk.Button):
+                max_width = max(max_width, child.winfo_reqwidth())
+            else:
+                max_width = max(max_width, max_button_reqwidth(child))
+        except tk.TclError:  # pragma: no cover - defensive
+            continue
+    return max_width
+
 def _lighten_color(color: str, factor: float = 1.2) -> str:
     """Return a subtly glowing version of *color*.
 

--- a/gui/windows/architecture.py
+++ b/gui/windows/architecture.py
@@ -41,7 +41,7 @@ from gui.utils.drawing_helper import fta_drawing_helper
 from config import load_diagram_rules, load_json_with_comments
 import json
 from gui.utils.icon_factory import create_icon
-from gui.controls.button_utils import set_uniform_button_width
+from gui.controls.button_utils import set_uniform_button_width, max_button_reqwidth
 from tools.memory_manager import manager as memory_manager
 
 from mainappsrc.models.sysml.sysml_spec import SYSML_PROPERTIES
@@ -3895,18 +3895,9 @@ class SysMLDiagramWindow(tk.Frame):
         """Resize the toolbox to the smallest width that shows all button text."""
         self.toolbox.update_idletasks()
 
-        def max_button_width(widget: tk.Misc) -> int:
-            width = 0
-            for child in widget.winfo_children():
-                if isinstance(child, ttk.Button):
-                    width = max(width, child.winfo_reqwidth())
-                else:
-                    width = max(width, max_button_width(child))
-            return width
-
         # Account for the external padding applied when packing buttons so the
         # canvas is only as wide as necessary to show them.
-        button_width = max_button_width(self.toolbox) + 4
+        button_width = max_button_reqwidth(self.toolbox) + 4
         scroll_width = self.toolbox_scroll.winfo_reqwidth()
 
         self.toolbox_container.configure(width=button_width + scroll_width)

--- a/gui/windows/causal_bayesian_network_window.py
+++ b/gui/windows/causal_bayesian_network_window.py
@@ -33,7 +33,7 @@ from gui.utils.tooltip import ToolTip
 from gui.utils.drawing_helper import FTADrawingHelper
 from gui.styles.style_manager import StyleManager
 from gui.utils.icon_factory import create_icon as draw_icon
-from gui.controls.button_utils import set_uniform_button_width
+from gui.controls.button_utils import set_uniform_button_width, max_button_reqwidth
 
 
 CBN_WINDOWS: set[weakref.ReferenceType] = set()
@@ -202,16 +202,7 @@ class CausalBayesianNetworkWindow(tk.Frame):
         self.toolbox.update_idletasks()
         set_uniform_button_width(self.toolbox)
 
-        def max_button_width(widget: tk.Misc) -> int:
-            width = 0
-            for child in widget.winfo_children():
-                if isinstance(child, ttk.Button):
-                    width = max(width, child.winfo_reqwidth())
-                else:
-                    width = max(width, max_button_width(child))
-            return width
-
-        button_width = max_button_width(self.toolbox)
+        button_width = max_button_reqwidth(self.toolbox)
 
         def _set_uniform(widget: tk.Misc) -> None:
             for child in getattr(widget, "winfo_children", lambda: [])():

--- a/gui/windows/gsn_diagram_window.py
+++ b/gui/windows/gsn_diagram_window.py
@@ -39,7 +39,7 @@ from gui.dialogs.gsn_connection_config import GSNConnectionConfig
 from gui.controls import messagebox
 from gui.styles.style_manager import StyleManager
 from gui.utils.icon_factory import create_icon
-from gui.controls.button_utils import set_uniform_button_width
+from gui.controls.button_utils import set_uniform_button_width, max_button_reqwidth
 from gui import TranslucidButton
 
 GSN_WINDOWS: set[weakref.ReferenceType] = set()
@@ -272,16 +272,7 @@ class GSNDiagramWindow(tk.Frame):
         """Resize toolbox to the smallest width that shows all button text."""
         self.toolbox.update_idletasks()
 
-        def max_button_width(widget: tk.Misc) -> int:
-            width = 0
-            for child in widget.winfo_children():
-                if isinstance(child, ttk.Button):
-                    width = max(width, child.winfo_reqwidth())
-                else:
-                    width = max(width, max_button_width(child))
-            return width
-
-        button_width = max_button_width(self.toolbox) + 4
+        button_width = max_button_reqwidth(self.toolbox) + 4
         scroll_width = self.toolbox_scroll.winfo_reqwidth()
         self.toolbox_container.configure(width=button_width + scroll_width)
         self.toolbox_canvas.configure(width=button_width)

--- a/tests/test_button_utils_max_width.py
+++ b/tests/test_button_utils_max_width.py
@@ -16,8 +16,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Tests for toolbox button width utilities."""
 
-VERSION = "0.2.154"
+import os
+import tkinter as tk
+from tkinter import ttk
 
-__all__ = ["VERSION"]
+import pytest
+
+from gui.controls.button_utils import max_button_reqwidth
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_max_button_reqwidth_ignores_destroyed_widgets():
+    root = tk.Tk()
+    root.withdraw()
+    frame = ttk.Frame(root)
+    frame.pack()
+    btn = ttk.Button(frame, text="Sample")
+    btn.pack()
+    root.update_idletasks()
+
+    # Ensure width measured while button exists
+    assert max_button_reqwidth(frame) == btn.winfo_reqwidth()
+
+    # Destroy button and ensure function handles it gracefully
+    btn.destroy()
+    root.update_idletasks()
+    assert max_button_reqwidth(frame) == 0
+    root.destroy()


### PR DESCRIPTION
## Summary
- ignore destroyed widgets when computing toolbox button widths
- reuse safe width helper across architecture, GSN, and CBN windows
- bump version to 0.2.154 and document change

## Testing
- `radon cc -j gui/controls/button_utils.py gui/windows/architecture.py gui/windows/gsn_diagram_window.py gui/windows/causal_bayesian_network_window.py`
- `pytest -q` *(fails: 219 failed, 1005 passed, 97 skipped)*
- `PYTHONPATH=. pytest tests/test_button_utils_max_width.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68af074da8508327b66f1be6f1e57555