### PR TITLE
Handle lingering callbacks during tab detachment

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 # Version History
+- 0.2.155 - Cancel lingering Tk ``after`` callbacks to avoid animation errors
+          when detaching tabs and skip toolbox fitting for destroyed widgets.
 - 0.2.154 - Ignore destroyed widgets when measuring toolbox button width.
           - Add grouped detachment regression tests for layouts, canvas cloning,
           scrollbars and GSN diagram tabs.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.154
+version: 0.2.155
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -659,8 +659,13 @@ class ClosableNotebook(ttk.Notebook):
                 try:
                     cmd = widget.tk.call("after", "info", ident)
                 except Exception:
-                    continue
-                if tcl_name in cmd:
+                    cmd = ""
+                if (
+                    tcl_name in cmd
+                    or str(ident).endswith(
+                        ("_animate", "_anim", "_after", "_timer")
+                    )
+                ):
                     try:
                         widget.after_cancel(ident)
                     except Exception:

--- a/gui/windows/architecture.py
+++ b/gui/windows/architecture.py
@@ -3893,7 +3893,20 @@ class SysMLDiagramWindow(tk.Frame):
 
     def _fit_toolbox(self) -> None:
         """Resize the toolbox to the smallest width that shows all button text."""
-        self.toolbox.update_idletasks()
+
+        widgets = (
+            getattr(self, "toolbox", None),
+            getattr(self, "toolbox_scroll", None),
+            getattr(self, "toolbox_container", None),
+            getattr(self, "toolbox_canvas", None),
+            getattr(self, "prop_view", None),
+        )
+        try:
+            if any(w is None or not w.winfo_exists() for w in widgets):
+                return
+            self.toolbox.update_idletasks()
+        except Exception:
+            return
 
         # Account for the external padding applied when packing buttons so the
         # canvas is only as wide as necessary to show them.

--- a/tests/test_cancel_after_events.py
+++ b/tests/test_cancel_after_events.py
@@ -16,8 +16,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Tests for cancelling lingering Tk ``after`` callbacks."""
 
-VERSION = "0.2.155"
+import os
+import tkinter as tk
 
-__all__ = ["VERSION"]
+import pytest
+
+from gui.utils.closable_notebook import ClosableNotebook
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_cancel_after_events_cancels_animate(monkeypatch):
+    root = tk.Tk()
+    root.withdraw()
+    btn = tk.Button(root)
+    # Schedule a bogus Tcl command ending with ``_animate`` to mirror real-world animations
+    ident = btn.tk.call("after", "1000000", "12345_animate")
+    nb = ClosableNotebook(root)
+    nb._cancel_after_events(btn)
+    assert ident not in btn.tk.call("after", "info")
+    root.destroy()


### PR DESCRIPTION
## Summary
- Avoid fitting detached toolboxes after their widgets are destroyed
- Cancel lingering Tk `after` callbacks to prevent invalid command errors
- Add regression test for cancelling `after` animations

## Testing
- `pytest tests/test_button_utils_max_width.py tests/test_cancel_after_events.py -q`
- `radon cc gui/windows/architecture.py gui/utils/closable_notebook.py -j | jq '. | to_entries | .[0:1]'`


------
https://chatgpt.com/codex/tasks/task_b_68af0bcab1448327ba49f777826df864