### PR TITLE
Fix explorer callbacks after notebook tab detachment

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 # Version History
+- 0.2.157 - Reassign container attributes to cloned children after tab detachment
+          so explorer callbacks operate in detached windows.
 - 0.2.156 - Rewire canvas window widgets when cloning tabs so embedded lists,
           diagrams, comboboxes and toolboxes appear in detached windows.
 - 0.2.155 - Cancel lingering Tk ``after`` callbacks to avoid animation errors

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -738,6 +738,7 @@ class ClosableNotebook(ttk.Notebook):
                 self._ensure_fills(new_widget)
                 self._reassign_widget_references(mapping)
                 self._remove_duplicate_widgets(win, nb, mapping)
+                self._reassign_container_attributes(mapping)
             else:
                 tab = nb.tabs()[-1]
                 child = nb.nametowidget(tab)
@@ -837,6 +838,46 @@ class ClosableNotebook(ttk.Notebook):
                         pass
             except Exception:
                 continue
+
+    def _reassign_container_attributes(
+        self, mapping: dict[tk.Widget, tk.Widget]
+    ) -> None:
+        """Rebind attributes on cloned containers to point at cloned widgets."""
+
+        def _rewrite(value: t.Any) -> t.Any:
+            if isinstance(value, tk.Widget):
+                return mapping.get(value, value)
+            if isinstance(value, dict):
+                updated: dict[t.Any, t.Any] = {}
+                changed = False
+                for k, v in value.items():
+                    nk = _rewrite(k)
+                    nv = _rewrite(v)
+                    changed = changed or nk is not k or nv is not v
+                    updated[nk] = nv
+                return updated if changed else value
+            if isinstance(value, list):
+                new_list = [_rewrite(v) for v in value]
+                return new_list if any(n is not o for n, o in zip(new_list, value)) else value
+            if isinstance(value, tuple):
+                new_tuple = tuple(_rewrite(v) for v in value)
+                return new_tuple if new_tuple != value else value
+            if isinstance(value, set):
+                new_set = {_rewrite(v) for v in value}
+                return new_set if new_set != value else value
+            return value
+
+        for orig, clone in mapping.items():
+            module = getattr(orig.__class__, "__module__", "")
+            if module.startswith("tkinter"):
+                continue
+            if not hasattr(orig, "__dict__") or not hasattr(clone, "__dict__"):
+                continue
+            for name, val in vars(orig).items():
+                try:
+                    setattr(clone, name, _rewrite(val))
+                except Exception:
+                    pass
 
     def _remove_duplicate_widgets(
         self,

--- a/tests/detachment/explorer/test_explorer_detached_callbacks.py
+++ b/tests/detachment/explorer/test_explorer_detached_callbacks.py
@@ -1,0 +1,89 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Ensure explorer callbacks operate after detaching to a new window."""
+
+from __future__ import annotations
+
+import types
+import tkinter as tk
+import pytest
+
+from gui.utils.closable_notebook import ClosableNotebook
+import gui.explorers.safety_case_explorer as safety_case_explorer
+
+
+class DummyTable:
+    """Minimal stand-in for :class:`SafetyCaseTable`."""
+
+    def __init__(self, master, case, app=None):
+        self.master = master
+        self.case = case
+        self.packed = False
+
+    def pack(self, **kwargs):
+        self.packed = True
+
+
+def test_open_callback_in_detached_window(monkeypatch):
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+
+    case = types.SimpleNamespace(name="Case1", solutions=[], phase=None)
+    library = types.SimpleNamespace(list_cases=lambda: [case], cases=[case])
+
+    nb = ClosableNotebook(root)
+    explorer = safety_case_explorer.SafetyCaseExplorer(nb, library=library)
+    nb.add(explorer, text="Explorer")
+    nb.update_idletasks()
+
+    iid = explorer.tree.get_children("")[0]
+    explorer.tree.selection_set(iid)
+
+    called = {}
+
+    class DummyTab(tk.Frame):
+        def __init__(self, master):
+            super().__init__(master)
+
+        def pack(self, **kwargs):
+            called["packed_tab"] = True
+
+    def fake_new_tab(title):
+        called["title"] = title
+        return DummyTab(nb)
+
+    explorer.app = types.SimpleNamespace(_new_tab=fake_new_tab)
+    monkeypatch.setattr(safety_case_explorer, "SafetyCaseTable", DummyTable)
+
+    tab_id = nb.tabs()[0]
+    nb._detach_tab(tab_id, 50, 50)
+    win = nb._floating_windows[0]
+    nb2 = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+    clone = nb2.nametowidget(nb2.tabs()[0])
+
+    iid2 = clone.tree.get_children("")[0]
+    clone.tree.selection_set(iid2)
+    clone.open_item()
+
+    assert called["title"] == "Safety & Security Report: Case1"
+    assert called.get("packed_tab") is True
+    win.destroy()
+    root.destroy()


### PR DESCRIPTION
## Summary
- Rebind container attributes to cloned child widgets when detaching tabs
- Add regression test for explorer callback in detached window
- Document change in HISTORY

## Testing
- `python tools/metrics_generator.py --path gui/utils --output metrics.json`
- `pytest` *(fails: AttributeError, FileNotFoundError, NameError, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68af218936c08327a6abd8eae1fe9f2c