### PR TITLE
Handle system color names in capsule button

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,8 @@
 -->
 
 # Version History
+- 0.2.158 - Resolve system colour parsing when darkening capsule buttons to
+          prevent detachment crashes on Windows.
 - 0.2.157 - Fix explorer detachment to retain window references.
           - Reassign container attributes to cloned children after tab detachment
           - Transfer treeview item images and open flags when cloning tabs so

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.157
+version: 0.2.158
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/controls/capsule_button.py
+++ b/gui/controls/capsule_button.py
@@ -25,9 +25,36 @@ from typing import Callable, Optional
 
 
 def _hex_to_rgb(value: str) -> tuple[int, int, int]:
-    value = value.lstrip('#')
-    lv = len(value)
-    return tuple(int(value[i:i + lv // 3], 16) for i in range(0, lv, lv // 3))
+    """Return an RGB tuple for *value*.
+
+    ``value`` may be a ``#`` prefixed hex string or a Tk colour name such as
+    ``SystemButtonFace``.  When a named colour is provided we resolve it via
+    ``winfo_rgb`` using the current Tk root.  If no root exists a temporary one
+    is created and immediately destroyed to avoid stray windows.
+    """
+
+    if value.startswith("#"):
+        value = value.lstrip("#")
+        lv = len(value)
+        return tuple(int(value[i : i + lv // 3], 16) for i in range(0, lv, lv // 3))
+
+    root = tk._default_root  # type: ignore[attr-defined]
+    owns_root = False
+    if root is None:
+        try:
+            root = tk.Tk()
+            root.withdraw()
+            owns_root = True
+        except tk.TclError as exc:  # pragma: no cover - Tk unavailable
+            raise ValueError(str(exc)) from exc
+    try:
+        r, g, b = root.winfo_rgb(value)
+        return r // 256, g // 256, b // 256
+    except tk.TclError as exc:  # Invalid colour name
+        raise ValueError(str(exc)) from exc
+    finally:
+        if owns_root and root is not None:
+            root.destroy()
 
 
 def _rgb_to_hex(rgb: tuple[int, int, int]) -> str:

--- a/tests/test_capsule_button_system_color.py
+++ b/tests/test_capsule_button_system_color.py
@@ -16,8 +16,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+import sys
+from pathlib import Path
+import tkinter as tk
 
-VERSION = "0.2.158"
+import pytest
 
-__all__ = ["VERSION"]
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.controls.capsule_button import _darken
+
+
+def test_darken_accepts_system_color():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tk not available")
+    try:
+        assert _darken("SystemButtonFace").startswith("#")
+    finally:
+        root.destroy()


### PR DESCRIPTION
## Summary
- support Tk system color names when converting hex to RGB
- test CapsuleButton darkening with system colors
- bump version to 0.2.158 and document change

## Testing
- `pytest -q`
- `python tools/metrics_generator.py --path gui/controls --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68af27d85f488327af11615b79619f5a