### PR TITLE
Handle system colors and string dimensions in capsule button

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,12 @@
 -->
 
 # Version History
+- 0.2.160 - Map Windows system colour names via GetSysColor to avoid invalid
+          command errors from temporary Tk roots when darkening capsule buttons.
+- 0.2.159 - Coerce capsule button width and height to integers so string
+          dimensions clone correctly during tab detachment.
+- 0.2.158 - Resolve system colour parsing when darkening capsule buttons to
+          prevent detachment crashes on Windows.
 - 0.2.157 - Fix explorer detachment to retain window references.
           - Reassign container attributes to cloned children after tab detachment
           - Transfer treeview item images and open flags when cloning tabs so

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.157
+version: 0.2.160
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/controls/capsule_button.py
+++ b/gui/controls/capsule_button.py
@@ -19,15 +19,51 @@
 
 from __future__ import annotations
 
+import os
+import ctypes
 import tkinter as tk
 import tkinter.font as tkfont
 from typing import Callable, Optional
 
 
+_SYSTEM_COLORS = {
+    "SystemButtonFace": 15,  # COLOR_BTNFACE
+    "SystemWindow": 5,  # COLOR_WINDOW
+    "SystemWindowText": 8,  # COLOR_WINDOWTEXT
+}
+
+
 def _hex_to_rgb(value: str) -> tuple[int, int, int]:
-    value = value.lstrip('#')
-    lv = len(value)
-    return tuple(int(value[i:i + lv // 3], 16) for i in range(0, lv, lv // 3))
+    """Return an RGB tuple for *value*.
+
+    ``value`` may be a ``#`` prefixed hex string or a Tk colour name such as
+    ``SystemButtonFace``.  Hex strings are parsed directly.  For system colour
+    names on Windows we query ``GetSysColor`` to avoid creating temporary Tk
+    roots that can trigger ``after`` callbacks.  If a Tk root exists we fall
+    back to ``winfo_rgb`` for other named colours.
+    """
+
+    if value.startswith("#"):
+        value = value.lstrip("#")
+        lv = len(value)
+        return tuple(int(value[i : i + lv // 3], 16) for i in range(0, lv, lv // 3))
+
+    if os.name == "nt" and value in _SYSTEM_COLORS:
+        idx = _SYSTEM_COLORS[value]
+        colorref = ctypes.windll.user32.GetSysColor(idx)
+        r = colorref & 0xFF
+        g = (colorref >> 8) & 0xFF
+        b = (colorref >> 16) & 0xFF
+        return r, g, b
+
+    root = tk._default_root  # type: ignore[attr-defined]
+    if root is None:
+        raise ValueError(f"unknown colour name: {value}")
+    try:
+        r, g, b = root.winfo_rgb(value)
+    except tk.TclError as exc:  # Invalid colour name
+        raise ValueError(str(exc)) from exc
+    return r // 256, g // 256, b // 256
 
 
 def _rgb_to_hex(rgb: tuple[int, int, int]) -> str:
@@ -138,8 +174,8 @@ class CapsuleButton(tk.Canvas):
         master: tk.Widget,
         text: str,
         command: Optional[Callable[[], None]] = None,
-        width: int = 80,
-        height: int = 26,
+        width: int | str = 80,
+        height: int | str = 26,
         bg: str = "#c3d7ff",
         hover_bg: Optional[str] = None,
         state: str | None = None,
@@ -149,6 +185,8 @@ class CapsuleButton(tk.Canvas):
         hover_gradient: list[str] | None = None,
         **kwargs,
     ) -> None:
+        width = int(width)
+        height = int(height)
         init_kwargs = {
             "height": height,
             "highlightthickness": 0,
@@ -228,8 +266,9 @@ class CapsuleButton(tk.Canvas):
         # Apply the initial state after the button has been drawn.
         self._apply_state()
 
-    def _content_width(self, height: int) -> int:
+    def _content_width(self, height: int | str) -> int:
         """Return the minimum width to display current text and image."""
+        height = int(height)
         font = tkfont.nametofont("TkDefaultFont")
         text_w = font.measure(self._text) if self._text else 0
         img_w = self._image.width() if self._image else 0

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.157"
+VERSION = "0.2.160"
 
 __all__ = ["VERSION"]

--- a/tests/test_capsule_button.py
+++ b/tests/test_capsule_button.py
@@ -1,0 +1,66 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import sys
+import os
+import ctypes
+import types
+from pathlib import Path
+import tkinter as tk
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from gui.controls.capsule_button import CapsuleButton, _darken, _hex_to_rgb
+
+
+class TestCapsuleButtonColor:
+    def test_darken_accepts_system_color(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        try:
+            assert _darken("SystemButtonFace").startswith("#")
+        finally:
+            root.destroy()
+
+    def test_resolves_system_color_without_root(self, monkeypatch):
+        if os.name != "nt":
+            pytest.skip("Windows specific")
+        monkeypatch.setattr(tk, "_default_root", None, raising=False)
+        class DummyUser32:
+            @staticmethod
+            def GetSysColor(index):
+                return 0x00332211
+        monkeypatch.setattr(ctypes, "windll", types.SimpleNamespace(user32=DummyUser32()))
+        assert _hex_to_rgb("SystemButtonFace") == (0x11, 0x22, 0x33)
+
+
+class TestCapsuleButtonDimensions:
+    def test_accepts_string_dimensions(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        try:
+            btn = CapsuleButton(root, "Hi", width="80", height="26")
+            assert int(btn["width"]) >= 80
+            assert int(btn["height"]) == 26
+        finally:
+            root.destroy()


### PR DESCRIPTION
## Summary
- map Windows system colour names via GetSysColor so capsule buttons no longer spawn temporary Tk roots
- extend capsule button tests to cover Windows system colours
- bump version to 0.2.160 and document the change

## Testing
- `pytest tests/test_capsule_button.py -q`
- `pytest -q`
- `python tools/metrics_generator.py --path gui/controls --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68af27d85f488327af11615b79619f5a