### PR TITLE
Ensure detached tabs raise all widgets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 -->
 
 # Version History
+- 0.2.161 - Raise detached tab widgets so all elements remain visible in floating windows.
 - 0.2.160 - Map Windows system colour names via GetSysColor to avoid invalid
           command errors from temporary Tk roots when darkening capsule buttons.
 - 0.2.159 - Coerce capsule button width and height to integers so string

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.160
+version: 0.2.161
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -716,6 +716,16 @@ class ClosableNotebook(ttk.Notebook):
         except tk.TclError:
             pass
 
+    def _raise_widgets(self, widget: tk.Widget) -> None:
+        """Recursively lift *widget* and all descendants to the top of their stacks."""
+
+        try:
+            widget.lift()
+        except Exception:
+            pass
+        for child in widget.winfo_children():
+            self._raise_widgets(child)
+
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()
         width = self.winfo_width() or 200
@@ -743,6 +753,7 @@ class ClosableNotebook(ttk.Notebook):
                 nb.add(new_widget, text=text)
                 nb.select(new_widget)
                 self._ensure_fills(new_widget)
+                self._raise_widgets(new_widget)
                 self._reassign_widget_references(mapping)
                 self._remove_duplicate_widgets(win, nb, mapping)
                 self._reassign_container_attributes(mapping)
@@ -750,6 +761,7 @@ class ClosableNotebook(ttk.Notebook):
                 tab = nb.tabs()[-1]
                 child = nb.nametowidget(tab)
                 self._ensure_fills(child)
+                self._raise_widgets(child)
                 nb.select(tab)
         except Exception:
             win.destroy()

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.160"
+VERSION = "0.2.161"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/layout/test_widget_stack_order.py
+++ b/tests/detachment/layout/test_widget_stack_order.py
@@ -1,0 +1,72 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+import tkinter as tk
+from tkinter import ttk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook
+
+
+class TestWidgetStackOrder:
+    def test_overlapping_widgets_visible_after_detach(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        container = tk.Frame(nb, width=100, height=100)
+        nb.add(container, text="Tab1")
+
+        bottom = tk.Frame(container, bg="red")
+        bottom.place(x=0, y=0, relwidth=1, relheight=1)
+        top = tk.Frame(container, bg="blue")
+        top.place(x=0, y=0, relwidth=1, relheight=1)
+        lbl = ttk.Label(top, text="top")
+        lbl.pack()
+        top.lift()
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert nb._floating_windows, "Tab did not detach"
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_container = new_nb.nametowidget(new_nb.tabs()[0])
+        frames = [c for c in new_container.winfo_children() if isinstance(c, tk.Frame)]
+        new_top = next(f for f in frames if f.winfo_children())
+        new_label = new_top.winfo_children()[0]
+
+        x = new_label.winfo_rootx() + 1
+        y = new_label.winfo_rooty() + 1
+        visible = win.winfo_containing(x, y)
+        assert visible == new_label
+        root.destroy()


### PR DESCRIPTION
## Summary
- Raise widgets recursively after tab detachment so floating windows display complete content
- Verify overlapping widgets remain visible after detaching in new regression test
- Bump version to 0.2.161 and document change in history

## Testing
- `radon cc -s -j gui/utils/closable_notebook.py`
- `pytest`
- `pytest tests/detachment/layout/test_widget_stack_order.py`


------
https://chatgpt.com/codex/tasks/task_b_68af2d9aea3083278e4d0e39a20bdf8a