### PR TITLE
Ensure detached tabs raise all widgets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,11 @@
 -->
 
 # Version History
+- 0.2.163 - Always parent detached windows to the main root so repeated
+          detachment yields windows owned by the primary application.
+- 0.2.162 - Parent detached windows to the main root so tab content remains
+          visible and callbacks operate on valid widgets.
+- 0.2.161 - Raise detached tab widgets so all elements remain visible in floating windows.
 - 0.2.160 - Map Windows system colour names via GetSysColor to avoid invalid
           command errors from temporary Tk roots when darkening capsule buttons.
 - 0.2.159 - Coerce capsule button width and height to integers so string

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.160
+version: 0.2.163
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -115,6 +115,9 @@ class ClosableNotebook(ttk.Notebook):
         except ValueError:
             self._data_strategy = 4
         self._focused_tab: str | None = None
+        # Cache application root so floating windows always attach to the main
+        # window even when this notebook resides in a detached toplevel.
+        self._app_root = self._root()
         # ``_root_bindings`` store identifiers for bindings that temporarily
         # attach to the containing toplevel while a drag operation is active.
         # This ensures that we still receive ``<B1-Motion>`` and
@@ -716,12 +719,24 @@ class ClosableNotebook(ttk.Notebook):
         except tk.TclError:
             pass
 
+    def _raise_widgets(self, widget: tk.Widget) -> None:
+        """Recursively lift *widget* and all descendants to the top of their stacks."""
+
+        try:
+            widget.lift()
+        except Exception:
+            pass
+        for child in widget.winfo_children():
+            self._raise_widgets(child)
+
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()
         width = self.winfo_width() or 200
         height = self.winfo_height() or 200
         text = self.tab(tab_id, "text")
-        win = tk.Toplevel(self)
+        root_win = self._app_root
+        win = tk.Toplevel(root_win)
+        win.transient(root_win)
         win.geometry(f"{width}x{height}+{x}+{y}")
         self._floating_windows.append(win)
         win.bind(
@@ -743,6 +758,7 @@ class ClosableNotebook(ttk.Notebook):
                 nb.add(new_widget, text=text)
                 nb.select(new_widget)
                 self._ensure_fills(new_widget)
+                self._raise_widgets(new_widget)
                 self._reassign_widget_references(mapping)
                 self._remove_duplicate_widgets(win, nb, mapping)
                 self._reassign_container_attributes(mapping)
@@ -750,6 +766,7 @@ class ClosableNotebook(ttk.Notebook):
                 tab = nb.tabs()[-1]
                 child = nb.nametowidget(tab)
                 self._ensure_fills(child)
+                self._raise_widgets(child)
                 nb.select(tab)
         except Exception:
             win.destroy()

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.160"
+VERSION = "0.2.163"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/layout/test_detached_window_parent.py
+++ b/tests/detachment/layout/test_detached_window_parent.py
@@ -1,0 +1,62 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for detached window parentage."""
+
+import os
+import sys
+import tkinter as tk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook
+
+
+class TestDetachedWindowParent:
+    def test_detached_window_parent_is_root(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = tk.Frame(nb)
+        nb.add(frame, text="tab")
+        nb._detach_tab(nb.tabs()[0], 50, 50)
+        assert nb._floating_windows, "Tab did not detach"
+        win = nb._floating_windows[0]
+        assert win.master is root
+        root.destroy()
+
+    def test_nested_detached_window_parent_is_root(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = tk.Frame(nb)
+        nb.add(frame, text="tab")
+        nb._detach_tab(nb.tabs()[0], 50, 50)
+        win = nb._floating_windows[0]
+        inner_nb = win.winfo_children()[0]
+        inner_nb._detach_tab(inner_nb.tabs()[0], 100, 100)
+        assert inner_nb._floating_windows, "Nested tab did not detach"
+        win2 = inner_nb._floating_windows[0]
+        assert win2.master is root
+        root.destroy()

--- a/tests/detachment/layout/test_widget_stack_order.py
+++ b/tests/detachment/layout/test_widget_stack_order.py
@@ -1,0 +1,72 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+import tkinter as tk
+from tkinter import ttk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook
+
+
+class TestWidgetStackOrder:
+    def test_overlapping_widgets_visible_after_detach(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        container = tk.Frame(nb, width=100, height=100)
+        nb.add(container, text="Tab1")
+
+        bottom = tk.Frame(container, bg="red")
+        bottom.place(x=0, y=0, relwidth=1, relheight=1)
+        top = tk.Frame(container, bg="blue")
+        top.place(x=0, y=0, relwidth=1, relheight=1)
+        lbl = ttk.Label(top, text="top")
+        lbl.pack()
+        top.lift()
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert nb._floating_windows, "Tab did not detach"
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_container = new_nb.nametowidget(new_nb.tabs()[0])
+        frames = [c for c in new_container.winfo_children() if isinstance(c, tk.Frame)]
+        new_top = next(f for f in frames if f.winfo_children())
+        new_label = new_top.winfo_children()[0]
+
+        x = new_label.winfo_rootx() + 1
+        y = new_label.winfo_rooty() + 1
+        visible = win.winfo_containing(x, y)
+        assert visible == new_label
+        root.destroy()


### PR DESCRIPTION
## Summary
- Cache application root and parent all detached windows to the main root even when detaching from floating notebooks
- Verify nested detachment still produces windows owned by the primary application
- Bump version to 0.2.163 and update documentation

## Testing
- `radon cc -s -j gui/utils/closable_notebook.py`
- `pytest`
- `pytest tests/detachment/layout/`

------
https://chatgpt.com/codex/tasks/task_b_68af2d9aea3083278e4d0e39a20bdf8a