### PR TITLE
Guard detached capsule buttons from Tcl errors

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,9 @@
 -->
 
 # Version History
+- 0.2.164 - Guard capsule button events after detachment.
+          - Cancel after callbacks on duplicate widgets prior to destruction.
+          - Verify detached capsule buttons handle hover and motion safely.
 - 0.2.163 - Always parent detached windows to the main root so repeated
           detachment yields windows owned by the primary application.
 - 0.2.162 - Parent detached windows to the main root so tab content remains

--- a/gui/controls/capsule_button.py
+++ b/gui/controls/capsule_button.py
@@ -520,8 +520,13 @@ class CapsuleButton(tk.Canvas):
         ]
 
     def _set_color(self, color: str) -> None:
+        if not self.winfo_exists():
+            return
         for item in self._shape_items:
-            self.itemconfigure(item, fill=color)
+            try:
+                self.itemconfigure(item, fill=color)
+            except tk.TclError:
+                pass
         inner = _darken(color, 0.7)
         dark = _darken(color, 0.8)
         light = _lighten(color, 1.2)
@@ -607,46 +612,69 @@ class CapsuleButton(tk.Canvas):
             self.itemconfigure(item, state=state)
 
     def _on_motion(self, event: tk.Event) -> None:
-        if "disabled" in self._state:
+        if "disabled" in self._state or not self.winfo_exists():
             return
-        w, h = int(self["width"]), int(self["height"])
+        try:
+            w, h = int(self["width"]), int(self["height"])
+        except tk.TclError:
+            return
         inside = 0 <= event.x < w and 0 <= event.y < h
         if inside:
             if self._current_color == self._normal_color:
                 self._set_color(self._hover_color)
-            if self._image_item and self._image and self._current_image is self._image:
+            if (
+                self._image_item
+                and self._image
+                and self._current_image is self._image
+            ):
                 glow = self._get_glow_image()
                 if glow:
-                    self.itemconfigure(self._image_item, image=glow)
-                    self._current_image = glow
+                    try:
+                        self.itemconfigure(self._image_item, image=glow)
+                    except tk.TclError:
+                        pass
+                    else:
+                        self._current_image = glow
             self._add_glow()
             self._set_gradient(self._hover_gradient)
         else:
             if self._current_color != self._normal_color:
                 self._set_color(self._normal_color)
             if self._image_item and self._current_image is not self._image:
-                self.itemconfigure(self._image_item, image=self._image)
-                self._current_image = self._image
+                try:
+                    self.itemconfigure(self._image_item, image=self._image)
+                except tk.TclError:
+                    pass
+                else:
+                    self._current_image = self._image
             self._remove_glow()
             self._set_gradient(self._normal_gradient)
 
     def _on_enter(self, _event: tk.Event) -> None:
-        if "disabled" not in self._state:
+        if "disabled" not in self._state and self.winfo_exists():
             self._set_color(self._hover_color)
             if self._image_item and self._image:
                 glow = self._get_glow_image()
                 if glow:
-                    self.itemconfigure(self._image_item, image=glow)
-                    self._current_image = glow
+                    try:
+                        self.itemconfigure(self._image_item, image=glow)
+                    except tk.TclError:
+                        pass
+                    else:
+                        self._current_image = glow
             self._add_glow()
             self._set_gradient(self._hover_gradient)
 
     def _on_leave(self, _event: tk.Event) -> None:
-        if "disabled" not in self._state:
+        if "disabled" not in self._state and self.winfo_exists():
             self._set_color(self._normal_color)
             if self._image_item and self._current_image is not self._image:
-                self.itemconfigure(self._image_item, image=self._image)
-                self._current_image = self._image
+                try:
+                    self.itemconfigure(self._image_item, image=self._image)
+                except tk.TclError:
+                    pass
+                else:
+                    self._current_image = self._image
             self._remove_glow()
             self._set_gradient(self._normal_gradient)
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -918,6 +918,10 @@ class ClosableNotebook(ttk.Notebook):
                 prune(child)
             if str(widget) not in keep:
                 try:
+                    self._cancel_after_events(widget)
+                except Exception:
+                    pass
+                try:
                     widget.destroy()
                 except Exception:
                     pass

--- a/tests/detachment/widget/test_capsule_button_detach.py
+++ b/tests/detachment/widget/test_capsule_button_detach.py
@@ -1,0 +1,87 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for capsule button behaviour after tab detachment."""
+
+from __future__ import annotations
+
+import tkinter as tk
+import pytest
+from gui.utils.closable_notebook import ClosableNotebook
+from gui.controls.capsule_button import CapsuleButton
+
+
+@pytest.mark.skipif(CapsuleButton is None, reason="CapsuleButton unavailable")
+class TestDetachedCapsuleButton:
+    def _detach(self, nb: ClosableNotebook) -> CapsuleButton:
+        """Detach the first tab in *nb* and return the cloned button."""
+        monkey_move = lambda tab_id, target: False
+        nb._move_tab = monkey_move  # type: ignore[assignment]
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        win = nb._floating_windows[0]
+        new_nb = next(
+            w for w in win.winfo_children() if isinstance(w, ClosableNotebook)
+        )
+        tab = new_nb.tabs()[0]
+        return new_nb.nametowidget(tab)
+
+    def test_hover_after_detach(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        root.report_callback_exception = lambda exc, val, tb: (_ for _ in ()).throw(val)
+
+        nb = ClosableNotebook(root)
+        btn = CapsuleButton(nb, text="ok")
+        nb.add(btn, text="Tab1")
+        nb.update_idletasks()
+
+        new_btn = self._detach(nb)
+        new_btn.event_generate("<Enter>", x=1, y=1)
+        root.update()
+        root.destroy()
+
+    def test_motion_after_detach(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        errors: list[Exception] = []
+        root.report_callback_exception = lambda exc, val, tb: errors.append(val)
+
+        nb = ClosableNotebook(root)
+        btn = CapsuleButton(nb, text="ok")
+        nb.add(btn, text="Tab1")
+        nb.update_idletasks()
+
+        new_btn = self._detach(nb)
+        new_btn.event_generate("<Motion>", x=1, y=1)
+        root.update()
+        assert not errors
+        root.destroy()


### PR DESCRIPTION
## Summary
- Prevent capsule button callbacks from manipulating destroyed widgets
- Cancel after callbacks on duplicate widgets during tab detachment
- Add regression tests covering hover and motion on detached capsule buttons

## Testing
- `pytest tests/detachment/widget tests/test_capsule_button.py tests/test_cancel_after_events.py -q`
- `pytest -q` *(fails: AttributeError, FileNotFoundError, NameError, etc.)*
- `radon cc -j gui/controls/capsule_button.py gui/utils/closable_notebook.py`

------
https://chatgpt.com/codex/tasks/task_b_68af3bd29308832799a7378174c756f8