### PR TITLE
Cancel lingering Tk callbacks for detached widgets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,8 @@
 -->
 
 # Version History
+- 0.2.164 - Cancel after callbacks referencing destroyed widgets during tab
+          detachment and verify no invalid command messages remain.
 - 0.2.163 - Always parent detached windows to the main root so repeated
           detachment yields windows owned by the primary application.
 - 0.2.162 - Parent detached windows to the main root so tab content remains

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.163
+version: 0.2.164
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -658,43 +658,75 @@ class ClosableNotebook(ttk.Notebook):
         except Exception:
             pass
 
-    def _cancel_after_events(self, widget: tk.Widget) -> None:
-        """Cancel common Tk ``after`` callbacks for *widget* and children."""
+    def _cancel_after_events(
+        self, widget: tk.Widget, cancelled: set[str] | None = None
+    ) -> None:
+        """Cancel Tk ``after`` callbacks tied to *widget* or dead commands.
+
+        Parameters
+        ----------
+        widget:
+            Widget whose callbacks should be cancelled.
+        cancelled:
+            Set of identifiers that have already been cancelled.  This avoids
+            issuing multiple ``after_cancel`` calls for the same callback when
+            widgets share identifiers.
+        """
+
+        if cancelled is None:
+            cancelled = set()
+
         try:
             tcl_name = str(widget)
             ids = widget.tk.call("after", "info")
             if isinstance(ids, str):
                 ids = [ids]
-            for ident in ids:
-                try:
-                    cmd = widget.tk.call("after", "info", ident)
-                except Exception:
-                    cmd = ""
-                if (
-                    tcl_name in cmd
-                    or str(ident).endswith(
-                        ("_animate", "_anim", "_after", "_timer")
-                    )
-                ):
-                    try:
-                        widget.after_cancel(ident)
-                    except Exception:
-                        pass
         except Exception:
-            pass
+            ids = []
+
+        for ident in ids:
+            if ident in cancelled:
+                continue
+            try:
+                cmd = widget.tk.call("after", "info", ident)
+            except Exception:
+                cmd = ""
+            parts = cmd.split()
+            target = parts[0] if parts else ""
+            cancel = False
+            if tcl_name and tcl_name in cmd:
+                cancel = True
+            elif target:
+                try:
+                    exists = bool(int(widget.tk.call("winfo", "exists", target)))
+                except Exception:
+                    exists = False
+                cancel = not exists
+            elif str(ident).endswith(("_animate", "_anim", "_after", "_timer")):
+                cancel = True
+            if cancel:
+                try:
+                    widget.after_cancel(ident)
+                except Exception:
+                    pass
+                else:
+                    cancelled.add(ident)
+
         try:
             for name in dir(widget):
                 if name.endswith(("_anim", "_after", "_timer")):
                     ident = getattr(widget, name, None)
-                    if isinstance(ident, str):
+                    if isinstance(ident, str) and ident not in cancelled:
                         try:
                             widget.after_cancel(ident)
                         except Exception:
                             pass
+                        else:
+                            cancelled.add(ident)
         except Exception:
             pass
         for child in widget.winfo_children():
-            self._cancel_after_events(child)
+            self._cancel_after_events(child, cancelled)
             
     def _ensure_fills(self, widget: tk.Widget) -> None:
         """Ensure *widget* expands to fill its immediate container.

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.163"
+VERSION = "0.2.164"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/callbacks/test_invalid_command_names.py
+++ b/tests/detachment/callbacks/test_invalid_command_names.py
@@ -1,0 +1,64 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for cancelling stale ``after`` callbacks on detachment."""
+
+from __future__ import annotations
+
+import os
+import tkinter as tk
+
+import pytest
+
+from gui.utils.closable_notebook import ClosableNotebook
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_detached_tab_cancels_widget_after(capsys):
+    """Cancel callbacks referencing the top-level widget."""
+    root = tk.Tk()
+    root.withdraw()
+    nb = ClosableNotebook(root)
+    frame = tk.Frame(nb)
+    btn = tk.Button(frame)
+    btn.pack()
+    nb.add(frame, text="Tab")
+    btn.tk.call("after", "1", f"{btn} config -text hi")
+    nb._detach_tab(nb.tabs()[0], 10, 10)
+    root.update()
+    assert "invalid command name" not in capsys.readouterr().err
+    nb._floating_windows[0].destroy()
+    root.destroy()
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_detached_tab_cancels_child_after(capsys):
+    """Cancel callbacks referencing child widgets recursively."""
+    root = tk.Tk()
+    root.withdraw()
+    nb = ClosableNotebook(root)
+    frame = tk.Frame(nb)
+    inner = tk.Label(frame, text="x")
+    inner.pack()
+    nb.add(frame, text="Tab")
+    inner.tk.call("after", "1", f"{inner} config -text hi")
+    nb._detach_tab(nb.tabs()[0], 10, 10)
+    root.update()
+    assert "invalid command name" not in capsys.readouterr().err
+    nb._floating_windows[0].destroy()
+    root.destroy()


### PR DESCRIPTION
## Summary
- cancel Tk `after` callbacks that reference destroyed widgets or missing targets
- add regression tests ensuring no `invalid command name` messages after detachment
- bump version to 0.2.164 and document changes

## Testing
- `python tools/metrics_generator.py --path gui/utils --output metrics.json`
- `pytest` *(fails: AttributeError: 'AutoMLApp' object ...)*
- `pytest tests/detachment/callbacks/test_invalid_command_names.py -vv` *(skipped: Tk display not available)*

------
https://chatgpt.com/codex/tasks/task_b_68af3bd78e788327ba482e43e2b6234c