### PR TITLE
Handle orphaned after callbacks

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,10 @@
 -->
 
 # Version History
+- 0.2.165 - Skip Tk ``after`` cancellation when widgets lack roots and
+          search identifiers referencing widget names to remove pending
+          callbacks.  Add detachment event tests to ensure closing and
+          destroying tabs leaves no residual callbacks or ``TclError``.
 - 0.2.164 - Split widget reference reassignment into helper methods and add unit
           tests for configuration rewiring and canvas window updates.
           - Cancel widget-specific Tk ``after`` callbacks during tab detachment

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.164
+version: 0.2.165
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -683,8 +683,10 @@ class ClosableNotebook(ttk.Notebook):
             cancelled = set()
 
         try:
+            tkapp = getattr(widget, "tk", None)
+            if tkapp is None or getattr(tkapp, "_tclCommands", None) is None:
+                return
             tcl_name = str(widget)
-            tkapp = widget.tk
             ids: set[str] = set()
             try:
                 global_ids = tkapp.call("after", "info")
@@ -701,9 +703,8 @@ class ClosableNotebook(ttk.Notebook):
                 widget_ids = [widget_ids]
             ids.update(widget_ids)
             try:
-                tcl_cmds = {
-                    cmd for cmd in getattr(tkapp, "_tclCommands", []) if tcl_name in cmd
-                }
+                commands = getattr(tkapp, "_tclCommands", None) or []
+                tcl_cmds = {cmd for cmd in commands if tcl_name in cmd}
             except Exception:
                 tcl_cmds = set()
             for ident in ids:
@@ -713,6 +714,7 @@ class ClosableNotebook(ttk.Notebook):
                     cmd = ""
                 if (
                     tcl_name in cmd
+                    or tcl_name in str(ident)
                     or any(c in cmd for c in tcl_cmds)
                     or str(ident).endswith(("_animate", "_anim", "_after", "_timer"))
                 ):

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.164"
+VERSION = "0.2.165"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/events/test_after_callbacks.py
+++ b/tests/detachment/events/test_after_callbacks.py
@@ -1,0 +1,78 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for ``after`` callback cleanup on detachment."""
+
+from __future__ import annotations
+
+import os
+import tkinter as tk
+
+import pytest
+
+from gui.utils.closable_notebook import ClosableNotebook
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_detach_tab_leaves_no_after_callbacks(tk_root, capsys):
+    """Detaching a tab cancels callbacks referencing the original widget."""
+    nb = ClosableNotebook(tk_root)
+    frame = tk.Frame(nb)
+    btn = tk.Button(frame)
+    btn.pack()
+    nb.add(frame, text="Tab")
+    btn.tk.call("after", "1", f"{btn} config -text hi")
+    nb._detach_tab(nb.tabs()[0], 10, 10)
+    tk_root.update()
+    err = capsys.readouterr().err
+    assert "TclError" not in err and "invalid command name" not in err
+    tcl_name = str(btn)
+    ids = tk_root.tk.call("after", "info")
+    if isinstance(ids, str):
+        ids = [ids]
+    assert not any(
+        tcl_name in tk_root.tk.call("after", "info", i) or tcl_name in str(i)
+        for i in ids
+    )
+    nb.close_all_floating()
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_close_detached_tab_cancels_after_callbacks(tk_root, capsys):
+    """Destroying a detached window leaves no pending callbacks."""
+    nb = ClosableNotebook(tk_root)
+    frame = tk.Frame(nb)
+    lbl = tk.Label(frame, text="x")
+    lbl.pack()
+    nb.add(frame, text="Tab")
+    lbl.tk.call("after", "1", f"{lbl} config -text hi")
+    nb._detach_tab(nb.tabs()[0], 10, 10)
+    tk_root.update()
+    win = nb._floating_windows[0]
+    win.destroy()
+    tk_root.update()
+    err = capsys.readouterr().err
+    assert "TclError" not in err and "invalid command name" not in err
+    tcl_name = str(lbl)
+    ids = tk_root.tk.call("after", "info")
+    if isinstance(ids, str):
+        ids = [ids]
+    assert not any(
+        tcl_name in tk_root.tk.call("after", "info", i) or tcl_name in str(i)
+        for i in ids
+    )


### PR DESCRIPTION
## Summary
- Skip cancelling Tk after events when widgets lack tk roots or _tclCommands
- Cancel callbacks whose identifiers reference widget names and add detachment tests
- Bump version to 0.2.165 and document changes

## Testing
- `python tools/metrics_generator.py --path gui/utils --output metrics.json`
- `pytest` *(fails: AttributeError, FileNotFoundError, NameError, etc.)*
- `pytest tests/detachment/events -q`


------
https://chatgpt.com/codex/tasks/task_b_68af411a90dc83279bc9944f4009ee9f