### PR TITLE
Handle missing drag targets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 -->
 
 # Version History
+- 0.2.165 - Guard drag target resolution failures and default to tab detachment.
 - 0.2.164 - Split widget reference reassignment into helper methods and add unit
           tests for configuration rewiring and canvas window updates.
           - Cancel widget-specific Tk ``after`` callbacks during tab detachment

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.164
+version: 0.2.165
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -380,10 +380,10 @@ class ClosableNotebook(ttk.Notebook):
         except IndexError:
             return
         target = self._target_notebook(event.x_root, event.y_root)
-        if target and target is not self:
-            self._move_tab(tab_id, target)
-        else:
+        if target is None or target is self:
             self._detach_tab(tab_id, event.x_root, event.y_root)
+            return
+        self._move_tab(tab_id, target)
 
     def _is_outside(self, event: tk.Event) -> bool:
         return (
@@ -394,9 +394,12 @@ class ClosableNotebook(ttk.Notebook):
         )
 
     def _target_notebook(self, x: int, y: int) -> t.Optional["ClosableNotebook"]:
-        widget = self.winfo_containing(x, y)
-        while widget is not None and not isinstance(widget, ClosableNotebook):
-            widget = widget.master
+        try:
+            widget = self.winfo_containing(x, y)
+            while widget is not None and not isinstance(widget, ClosableNotebook):
+                widget = widget.master
+        except (tk.TclError, KeyError):
+            return None
         return widget
 
     def _move_tab(self, tab_id: str, target: "ClosableNotebook") -> bool:

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.164"
+VERSION = "0.2.165"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/drag/test_notebook_drag.py
+++ b/tests/detachment/drag/test_notebook_drag.py
@@ -1,0 +1,110 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import pytest
+import tkinter as tk
+from tkinter import ttk
+
+from gui.utils.closable_notebook import ClosableNotebook
+
+
+class TestDragMoves:
+    def test_drag_tab_between_notebooks(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb1 = ClosableNotebook(root)
+        nb2 = ClosableNotebook(root)
+        nb1.pack(side="left")
+        nb2.pack(side="right")
+        frame = ttk.Frame(nb1)
+        nb1.add(frame, text="Tab1")
+        root.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb1._on_tab_press(press)
+        nb1._dragging = True
+        release = Event()
+        release.x_root = nb2.winfo_rootx() + 10
+        release.y_root = nb2.winfo_rooty() + 10
+        nb1._on_tab_release(release)
+
+        assert not nb1.tabs()
+        assert frame.master is nb2
+        root.destroy()
+
+
+class TestDragDetachment:
+    def test_drag_tab_outside_detaches(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        frame = ttk.Frame(nb)
+        nb.add(frame, text="Tab1")
+        nb.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert not nb.tabs()
+        assert nb._floating_windows
+        root.destroy()
+
+
+class TestDragDestroyedWidget:
+    def test_drag_onto_destroyed_widget_detaches(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb1 = ClosableNotebook(root)
+        nb2 = ClosableNotebook(root)
+        nb1.pack(side="left")
+        nb2.pack(side="right")
+        frame = ttk.Frame(nb1)
+        nb1.add(frame, text="Tab1")
+        root.update_idletasks()
+
+        x = nb2.winfo_rootx() + 10
+        y = nb2.winfo_rooty() + 10
+        nb2.destroy()
+        root.update_idletasks()
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb1._on_tab_press(press)
+        nb1._dragging = True
+        release = Event(); release.x_root = x; release.y_root = y
+        nb1._on_tab_release(release)
+
+        assert not nb1.tabs()
+        assert nb1._floating_windows
+        root.destroy()


### PR DESCRIPTION
## Summary
- guard notebook drag target resolution from Tk errors
- detach tabs when target notebooks cannot be resolved
- add regression tests for tab moves, detachment, and destroyed targets

## Testing
- `pytest tests/test_version_sync.py::test_readme_matches_version tests/detachment/drag/test_notebook_drag.py -q`
- `python tools/metrics_generator.py --path tests/detachment/drag --output metrics_tests.json`
- `python tools/metrics_generator.py --path gui/utils --output closable_metrics.json`
- `pytest` *(fails: FileNotFoundError and AttributeError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_b_68af411e8e788327ae41b4c689d51085