### PR TITLE
Preserve detached widget layouts and visibility

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,8 @@
 -->
 
 # Version History
+- 0.2.165 - Preserve geometry options for all descendants when detaching tabs and raise cloned widgets before originals are destroyed to keep z-order.
+          - Verify detached labels, entries, canvases and more remain visible.
 - 0.2.164 - Split widget reference reassignment into helper methods and add unit
           tests for configuration rewiring and canvas window updates.
           - Cancel widget-specific Tk ``after`` callbacks during tab detachment

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -453,8 +453,6 @@ class ClosableNotebook(ttk.Notebook):
         mapping[widget] = clone
         self._copy_widget_config(widget, clone)
         self._copy_widget_state(widget, clone)
-        if not isinstance(widget.master, ttk.Notebook):
-            self._copy_widget_layout(widget, clone)
         for child in self._ordered_children(widget):
             try:
                 self._clone_widget(child, clone, mapping)
@@ -581,63 +579,134 @@ class ClosableNotebook(ttk.Notebook):
         except Exception:
             pass
 
-    def _copy_widget_layout(self, widget: tk.Widget, clone: tk.Widget) -> None:
-        """Apply the same geometry management as *widget* uses."""
+    def _copy_widget_layout(
+        self,
+        widget: tk.Widget,
+        clone: tk.Widget,
+        mapping: dict[tk.Widget, tk.Widget],
+    ) -> None:
+        """Apply geometry options of *widget* to *clone* and descendants."""
 
+        def recurse(src: tk.Widget, dst: tk.Widget) -> None:
+            try:
+                manager = src.winfo_manager()
+            except Exception:
+                manager = ""
+            if manager == "pack":
+                self._apply_pack_layout(src, dst, mapping)
+            elif manager == "grid":
+                self._apply_grid_layout(src, dst, mapping)
+            elif manager == "place":
+                self._apply_place_layout(src, dst, mapping)
+            for child, child_clone in zip(
+                self._ordered_children(src), self._ordered_children(dst)
+            ):
+                recurse(child, child_clone)
+
+        recurse(widget, clone)
+
+    def _apply_pack_layout(
+        self, widget: tk.Widget, clone: tk.Widget, mapping: dict[tk.Widget, tk.Widget]
+    ) -> None:
         try:
             info = widget.pack_info()
-            for key in ("in", "in_", "before", "after"):
+            for key in ("in", "in_"):
                 info.pop(key, None)
+            for key in ("before", "after"):
+                ref = info.get(key)
+                if ref:
+                    try:
+                        ref_widget = widget.nametowidget(ref)
+                    except Exception:
+                        ref_widget = None
+                    clone_ref = mapping.get(ref_widget) if ref_widget else None
+                    if clone_ref:
+                        info[key] = clone_ref
+                    else:
+                        info.pop(key, None)
             clone.pack(**info)
             try:
                 clone.pack_propagate(widget.pack_propagate())
             except Exception:
                 pass
-            return
         except tk.TclError:
             pass
+
+    def _apply_grid_layout(
+        self, widget: tk.Widget, clone: tk.Widget, mapping: dict[tk.Widget, tk.Widget]
+    ) -> None:
         try:
             info = widget.grid_info()
-            for key in ("in", "in_", "before", "after"):
+            for key in ("in", "in_"):
                 info.pop(key, None)
-            clone.grid(**info)
-            try:
-                clone.grid_propagate(widget.grid_propagate())
-                cols, rows = widget.grid_size()
-                for r in range(rows):
-                    cfg = widget.grid_rowconfigure(r)
-                    if cfg:
-                        clone.grid_rowconfigure(r, **cfg)
-                for c in range(cols):
-                    cfg = widget.grid_columnconfigure(c)
-                    if cfg:
-                        clone.grid_columnconfigure(c, **cfg)
-                if widget is not clone:
-                    orig_parent = widget.master
-                    new_parent = clone.master
+            for key in ("before", "after"):
+                ref = info.get(key)
+                if ref:
                     try:
-                        pcols, prows = orig_parent.grid_size()
-                        for r in range(prows):
-                            pcfg = orig_parent.grid_rowconfigure(r)
-                            weight = pcfg.get("weight") if pcfg else 0
-                            if weight:
-                                new_parent.grid_rowconfigure(r, weight=weight)
-                        for c in range(pcols):
-                            pcfg = orig_parent.grid_columnconfigure(c)
-                            weight = pcfg.get("weight") if pcfg else 0
-                            if weight:
-                                new_parent.grid_columnconfigure(c, weight=weight)
+                        ref_widget = widget.nametowidget(ref)
                     except Exception:
-                        pass
-            except Exception:
-                pass
-            return
+                        ref_widget = None
+                    clone_ref = mapping.get(ref_widget) if ref_widget else None
+                    if clone_ref:
+                        info[key] = clone_ref
+                    else:
+                        info.pop(key, None)
+            clone.grid(**info)
+            self._configure_grid_weights(widget, clone)
         except tk.TclError:
             pass
+
+    def _configure_grid_weights(self, widget: tk.Widget, clone: tk.Widget) -> None:
+        try:
+            clone.grid_propagate(widget.grid_propagate())
+            cols, rows = widget.grid_size()
+            for r in range(rows):
+                cfg = widget.grid_rowconfigure(r)
+                if cfg:
+                    clone.grid_rowconfigure(r, **cfg)
+            for c in range(cols):
+                cfg = widget.grid_columnconfigure(c)
+                if cfg:
+                    clone.grid_columnconfigure(c, **cfg)
+            if widget is not clone:
+                orig_parent = widget.master
+                new_parent = clone.master
+                try:
+                    pcols, prows = orig_parent.grid_size()
+                    for r in range(prows):
+                        pcfg = orig_parent.grid_rowconfigure(r)
+                        weight = pcfg.get("weight") if pcfg else 0
+                        if weight:
+                            new_parent.grid_rowconfigure(r, weight=weight)
+                    for c in range(pcols):
+                        pcfg = orig_parent.grid_columnconfigure(c)
+                        weight = pcfg.get("weight") if pcfg else 0
+                        if weight:
+                            new_parent.grid_columnconfigure(c, weight=weight)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+    def _apply_place_layout(
+        self, widget: tk.Widget, clone: tk.Widget, mapping: dict[tk.Widget, tk.Widget]
+    ) -> None:
         try:
             info = widget.place_info()
-            for key in ("in", "in_", "before", "after"):
+            for key in ("in", "in_"):
                 info.pop(key, None)
+            for key in ("before", "after"):
+                ref = info.get(key)
+                if ref:
+                    try:
+                        ref_widget = widget.nametowidget(ref)
+                    except Exception:
+                        ref_widget = None
+                    clone_ref = mapping.get(ref_widget) if ref_widget else None
+                    if clone_ref:
+                        info[key] = clone_ref
+                    else:
+                        info.pop(key, None)
             clone.place(**info)
         except tk.TclError:
             pass
@@ -796,12 +865,13 @@ class ClosableNotebook(ttk.Notebook):
                 self.forget(tab_id)
                 mapping: dict[tk.Widget, tk.Widget] = {}
                 new_widget, mapping = self._clone_widget(orig, nb, mapping)
+                self._copy_widget_layout(orig, new_widget, mapping)
+                self._raise_widgets(new_widget)
                 orig.destroy()
                 nb.add(new_widget, text=text)
                 nb.select(new_widget)
                 for cloned in mapping.values():
                     self._ensure_fills(cloned)
-                    self._raise_widgets(cloned)
                 self._reassign_widget_references(mapping)
                 self._remove_duplicate_widgets(win, nb, mapping)
                 self._reassign_container_attributes(mapping)

--- a/tests/detachment/layout/test_widget_visibility.py
+++ b/tests/detachment/layout/test_widget_visibility.py
@@ -1,0 +1,88 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+import tkinter as tk
+from tkinter import ttk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook
+
+
+WIDGET_FACTORIES = [
+    ("label", lambda p: ttk.Label(p, text="lbl")),
+    ("entry", lambda p: ttk.Entry(p)),
+    ("text", lambda p: tk.Text(p, width=10, height=2)),
+    ("canvas", lambda p: tk.Canvas(p, width=20, height=20)),
+    ("listbox", lambda p: tk.Listbox(p)),
+    ("treeview", lambda p: ttk.Treeview(p)),
+]
+
+
+class TestWidgetVisibility:
+    @pytest.mark.parametrize("_name,factory", WIDGET_FACTORIES, ids=[n for n, _ in WIDGET_FACTORIES])
+    def test_widget_visible_after_detach(self, _name, factory) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        container = ttk.Frame(nb)
+        nb.add(container, text="Tab1")
+        widget = factory(container)
+        widget.pack(expand=True)
+        nb.update_idletasks()
+
+        class Event:
+            ...
+
+        press = Event()
+        press.x = 5
+        press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert nb._floating_windows, "Tab did not detach"
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_container = new_nb.nametowidget(new_nb.tabs()[0])
+
+        def find_widget(parent: tk.Widget, cls: type[tk.Widget]) -> tk.Widget | None:
+            for child in parent.winfo_children():
+                if isinstance(child, cls):
+                    return child
+                found = find_widget(child, cls)
+                if found is not None:
+                    return found
+            return None
+
+        new_widget = find_widget(new_container, type(widget))
+        assert new_widget is not None
+        x = new_widget.winfo_rootx() + 1
+        y = new_widget.winfo_rooty() + 1
+        visible = win.winfo_containing(x, y)
+        assert visible == new_widget
+        root.destroy()


### PR DESCRIPTION
## Summary
- Record and reapply geometry options for entire widget trees during tab detachment
- Raise cloned widget hierarchy before destroying originals to keep z-order
- Test that labels, entries, canvases, listboxes, text areas, and treeviews remain visible after detachment

## Testing
- `radon cc -j gui/utils/closable_notebook.py`
- `pytest` *(fails: 219 failed, 1006 passed, 127 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68af4121e7088327a0f828a649fd7db6