### PR TITLE
Cancel lingering callbacks on tab close

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,10 @@
 -->
 
 # Version History
+- 0.2.165 - Cancel pending callbacks for all descendant widgets when detaching or
+          closing tabs and guard Tcl command deletions.
+          - Add regression tests for animated CapsuleButton detachment to
+          prevent invalid command name and ``AttributeError`` exceptions.
 - 0.2.164 - Split widget reference reassignment into helper methods and add unit
           tests for configuration rewiring and canvas window updates.
           - Cancel widget-specific Tk ``after`` callbacks during tab detachment

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.164
+version: 0.2.165
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -360,6 +360,7 @@ class ClosableNotebook(ttk.Notebook):
                 self._active = None
                 self._reset_drag()
                 return True
+            child = self.nametowidget(tab_id)
             self._closing_tab = tab_id
             self.event_generate("<<NotebookTabClosed>>")
             if tab_id in self.tabs():
@@ -367,6 +368,14 @@ class ClosableNotebook(ttk.Notebook):
                     self.forget(tab_id)
                 except tk.TclError:
                     pass
+            try:
+                self._cancel_after_events(child)
+            except Exception:
+                pass
+            try:
+                child.destroy()
+            except Exception:
+                pass
         self.state(["!pressed"])
         self._active = None
         self._reset_drag()
@@ -712,12 +721,19 @@ class ClosableNotebook(ttk.Notebook):
                 except Exception:
                     cmd = ""
                 if (
-                    tcl_name in cmd
+                    ident in widget_ids
+                    or tcl_name in cmd
                     or any(c in cmd for c in tcl_cmds)
                     or str(ident).endswith(("_animate", "_anim", "_after", "_timer"))
                 ):
                     try:
                         widget.after_cancel(ident)
+                    except Exception:
+                        pass
+            if getattr(tkapp, "_tclCommands", None):
+                for cmd in tcl_cmds:
+                    try:
+                        tkapp.deletecommand(cmd)
                     except Exception:
                         pass
         except Exception:

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.164"
+VERSION = "0.2.165"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/callbacks/test_capsule_button_animation.py
+++ b/tests/detachment/callbacks/test_capsule_button_animation.py
@@ -1,0 +1,81 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for detaching animated CapsuleButtons."""
+
+from __future__ import annotations
+
+import os
+import tkinter as tk
+
+import pytest
+
+from gui.utils.closable_notebook import ClosableNotebook
+from gui.controls.capsule_button import CapsuleButton
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+class TestAnimatedCapsuleDetach:
+    """Grouped tests for detaching animated CapsuleButtons."""
+
+    class AnimatedCapsule(CapsuleButton):
+        def __init__(self, master: tk.Widget) -> None:
+            super().__init__(master, text="Go")
+            self._spin_after = self.after(1, self._spin)
+
+        def _spin(self) -> None:
+            self._spin_after = self.after(1, self._spin)
+
+    def _detach(self, nb: ClosableNotebook, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+    def test_no_invalid_command_name(self, monkeypatch, capsys):
+        root = tk.Tk(); root.withdraw()
+        nb = ClosableNotebook(root)
+        btn = self.AnimatedCapsule(nb)
+        nb.add(btn, text="Tab")
+        nb.update_idletasks()
+        self._detach(nb, monkeypatch)
+        root.update()
+        assert "invalid command name" not in capsys.readouterr().err
+        nb._floating_windows[0].destroy()
+        root.destroy()
+
+    def test_no_attribute_error(self, monkeypatch):
+        root = tk.Tk(); root.withdraw()
+        nb = ClosableNotebook(root)
+        errors: list[Exception] = []
+        root.report_callback_exception = lambda exc, val, tb: errors.append(val)
+        btn = self.AnimatedCapsule(nb)
+        nb.add(btn, text="Tab")
+        nb.update_idletasks()
+        self._detach(nb, monkeypatch)
+        root.update()
+        assert not any(isinstance(e, AttributeError) for e in errors)
+        nb._floating_windows[0].destroy()
+        root.destroy()


### PR DESCRIPTION
## Summary
- cancel all descendant `after` callbacks when closing or detaching tabs
- guard Tcl `deletecommand` calls during shutdown
- add regression tests for animated CapsuleButton detachment
- bump version to 0.2.165

## Testing
- `radon cc -j gui/utils/closable_notebook.py`
- `pytest tests/detachment/callbacks/test_capsule_button_animation.py tests/detachment/callbacks/test_invalid_command_names.py -q` (skipped: Tk display not available)
- `pytest -q` (failed: process terminated due to duration)


------
https://chatgpt.com/codex/tasks/task_b_68af41470ca88327ab580e5d980e18f5