### PR TITLE
Handle destroyed widget in target lookup

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,9 @@
 -->
 
 # Version History
+- 0.2.165 - Guard target notebook lookup when widgets are destroyed during drag.
+          - Wrap ``winfo_containing`` in ``try/except`` and return ``None`` on failure.
+          - Add regression test verifying drag over destroyed widget raises no errors.
 - 0.2.164 - Split widget reference reassignment into helper methods and add unit
           tests for configuration rewiring and canvas window updates.
           - Cancel widget-specific Tk ``after`` callbacks during tab detachment

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.164
+version: 0.2.165
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -394,7 +394,10 @@ class ClosableNotebook(ttk.Notebook):
         )
 
     def _target_notebook(self, x: int, y: int) -> t.Optional["ClosableNotebook"]:
-        widget = self.winfo_containing(x, y)
+        try:
+            widget = self.winfo_containing(x, y)
+        except (tk.TclError, KeyError):
+            return None
         while widget is not None and not isinstance(widget, ClosableNotebook):
             widget = widget.master
         return widget

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.164"
+VERSION = "0.2.165"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/dragging/test_target_notebook.py
+++ b/tests/detachment/dragging/test_target_notebook.py
@@ -1,0 +1,47 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+import tkinter as tk
+
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook
+
+
+class TestTargetNotebook:
+    def test_drag_over_destroyed_widget(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        nb.pack()
+        top = tk.Toplevel(root)
+        frame = tk.Frame(top, width=20, height=20)
+        frame.pack()
+        root.update_idletasks()
+        x = frame.winfo_rootx() + 1
+        y = frame.winfo_rooty() + 1
+        top.destroy()
+        assert nb._target_notebook(x, y) is None
+        root.destroy()


### PR DESCRIPTION
## Summary
- guard target notebook detection against `tk.TclError`/`KeyError`
- add regression test for dragging over destroyed widgets
- document fix and bump version to 0.2.165

## Testing
- `radon cc -s -j gui/utils/closable_notebook.py | jq '."gui/utils/closable_notebook.py"[] | select(.name=="_target_notebook")' /tmp/cc.json`
- `pytest`
- `pytest tests/detachment/dragging/test_target_notebook.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68af4147a4508327a1eacf35958f0e81