### PR TITLE
Preserve widget stacking after detachment

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,9 @@
 -->
 
 # Version History
+- 0.2.169 - Traverse clone mappings when lifting widgets and raise clones
+          before pruning duplicates to preserve visibility of overlapping
+          widgets after detachment.
 - 0.2.168 - Accumulate children from all geometry managers so every widget
           in a tab transfers to the detached window.
 - 0.2.167 - Clone children managed by grid/place so all tab contents appear in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.168
+version: 0.2.169
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -876,21 +876,33 @@ class ClosableNotebook(ttk.Notebook):
             pass
 
     def _raise_widgets(
-        self, widget: tk.Widget, _mapping: t.Optional[dict[tk.Widget, tk.Widget]] = None
+        self, widget: tk.Widget, mapping: t.Optional[dict[tk.Widget, tk.Widget]] = None
     ) -> None:
-        """Recursively lift *widget* and descendants to the top of their stacks.
+        """Recursively lift *widget* and its cloned descendants.
 
-        The optional *_mapping* parameter is accepted for backward compatibility
-        with earlier implementations that supplied the clone mapping. It is
-        ignored but kept to avoid ``TypeError`` when older call sites pass it.
+        When *mapping* is provided it is expected to contain a mapping from
+        original widgets to their clones.  The traversal follows the order of
+        the original widgets' children to lift each clone relative to its
+        siblings, preserving the original stacking arrangement.
         """
 
         try:
             widget.lift()
         except Exception:
             pass
+
+        if mapping:
+            reverse = {clone: orig for orig, clone in mapping.items()}
+            orig = reverse.get(widget)
+            if orig is not None:
+                for child_orig in orig.winfo_children():
+                    clone_child = mapping.get(child_orig)
+                    if clone_child is not None:
+                        self._raise_widgets(clone_child, mapping)
+                return
+
         for child in widget.winfo_children():
-            self._raise_widgets(child)
+            self._raise_widgets(child, mapping)
 
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()
@@ -918,13 +930,12 @@ class ClosableNotebook(ttk.Notebook):
                 mapping: dict[tk.Widget, tk.Widget] = {}
                 new_widget, mapping = self._clone_widget(orig, nb, mapping)
                 self._copy_widget_layout(orig, new_widget, mapping)
-                self._raise_widgets(new_widget, mapping)
                 orig.destroy()
                 nb.add(new_widget, text=text)
                 nb.select(new_widget)
                 self._ensure_fills(new_widget)
-                self._raise_widgets(new_widget, mapping)
                 self._reassign_widget_references(mapping)
+                self._raise_widgets(new_widget, mapping)
                 self._remove_duplicate_widgets(win, nb, mapping)
                 self._reassign_container_attributes(mapping)
             else:

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.168"
+VERSION = "0.2.169"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/stacking/test_overlapping_widgets.py
+++ b/tests/detachment/stacking/test_overlapping_widgets.py
@@ -1,0 +1,86 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Stacking behaviour tests for detached tabs."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tkinter as tk
+from tkinter import ttk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook  # noqa: E402
+
+
+WIDGET_FACTORIES = [
+    ("label", lambda p: ttk.Label(p, text="lbl")),
+    ("canvas", lambda p: tk.Canvas(p, width=20, height=20)),
+    ("button", lambda p: ttk.Button(p, text="btn")),
+]
+
+
+class TestOverlappingStacking:
+    """Grouped tests ensuring clones retain stacking order."""
+
+    @pytest.mark.parametrize("_name,factory", WIDGET_FACTORIES, ids=[n for n, _ in WIDGET_FACTORIES])
+    def test_overlapping_widget_visible_after_detach(self, _name, factory) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        container = tk.Frame(nb, width=100, height=100)
+        nb.add(container, text="Tab1")
+
+        bottom = tk.Frame(container, bg="red")
+        bottom.place(x=0, y=0, relwidth=1, relheight=1)
+        top = tk.Frame(container, bg="blue")
+        top.place(x=0, y=0, relwidth=1, relheight=1)
+        widget = factory(top)
+        widget.pack()
+        top.lift()
+        nb.update_idletasks()
+
+        class Event:
+            ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert nb._floating_windows, "Tab did not detach"
+        win = nb._floating_windows[0]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        new_container = new_nb.nametowidget(new_nb.tabs()[0])
+        new_top = next(c for c in new_container.winfo_children() if c.winfo_children())
+        new_widget = new_top.winfo_children()[0]
+
+        x = new_widget.winfo_rootx() + 1
+        y = new_widget.winfo_rooty() + 1
+        visible = win.winfo_containing(x, y)
+        assert visible == new_widget
+        root.destroy()


### PR DESCRIPTION
## Summary
- traverse clone mappings when raising widgets so clones lift in original order
- raise cloned subtrees before pruning duplicates to keep overlapping widgets visible
- add stacking regression tests and bump project version to 0.2.169

## Testing
- `python tools/metrics_generator.py --path gui/utils --output metrics.json`
- `pytest -q` *(fails: 219 failed, 1006 passed, 150 skipped)*
- `pytest tests/detachment/stacking/test_overlapping_widgets.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68afb56bf8e083278b6d053a250a84e5