### PR TITLE
Cancel after callbacks for destroyed widgets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,12 @@
 -->
 
 # Version History
+- 0.2.169 - Cancel Tk ``after`` callbacks referencing detached widgets and ensure
+          all widgets clear pending animations before destruction.
+          - Invoke `_cancel_after_events` for every widget slated for
+            destruction in `_detach_tab`.
+          - Add regression tests verifying animated `CapsuleButton`
+            detachment triggers no `TclError` or `AttributeError`.
 - 0.2.168 - Accumulate children from all geometry managers so every widget
           in a tab transfers to the detached window.
 - 0.2.167 - Clone children managed by grid/place so all tab contents appear in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
-version: 0.2.168
+<!--
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+version: 0.2.169
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -789,56 +789,37 @@ class ClosableNotebook(ttk.Notebook):
             cancelled = set()
 
         try:
-            tkapp = getattr(widget, "tk", None)
-            if tkapp is None or getattr(tkapp, "_tclCommands", None) is None:
-                return
-            tcl_name = str(widget)
-            ids: set[str] = set()
-            try:
-                global_ids = tkapp.call("after", "info")
-            except Exception:
-                global_ids = []
-            if isinstance(global_ids, str):
-                global_ids = [global_ids]
-            ids.update(global_ids)
-            try:
-                widget_ids = tkapp.call("after", "info", tcl_name)
-            except Exception:
-                widget_ids = []
-            if isinstance(widget_ids, str):
-                widget_ids = [widget_ids]
-            ids.update(widget_ids)
-            try:
-                commands = getattr(tkapp, "_tclCommands", None) or []
-                tcl_cmds = {cmd for cmd in commands if tcl_name in cmd}
-            except Exception:
-                tcl_cmds = set()
-            for ident in ids:
-                try:
-                    cmd = tkapp.call("after", "info", ident)
-                except Exception:
-                    cmd = ""
-                if (
-                    ident in widget_ids
-                    or tcl_name in cmd
-                    or any(c in cmd for c in tcl_cmds)
-                    or str(ident).endswith(("_animate", "_anim", "_after", "_timer"))
-                ):
-                    try:
-                        widget.after_cancel(ident)
-                    except Exception:
-                        pass
-            if getattr(tkapp, "_tclCommands", None):
-                for cmd in tcl_cmds:
-                    try:
-                        tkapp.deletecommand(cmd)
-                    except Exception:
-                        pass
+            root = widget._root()
         except Exception:
-            pass
+            return
+
+        try:
+            ids = root.tk.call("after", "info")
+        except Exception:
+            ids = []
+        if isinstance(ids, str):
+            ids = [ids]
+
+        wpath = str(widget)
+        suffixes = ("_animate", "_anim", "_after", "_timer")
+        for ident in ids:
+            if ident in cancelled:
+                continue
+            try:
+                cmd = root.tk.call("after", "info", ident)
+            except Exception:
+                cmd = ""
+            if wpath in cmd or str(ident).endswith(suffixes) or cmd.endswith(suffixes):
+                try:
+                    root.after_cancel(ident)
+                except Exception:
+                    pass
+                else:
+                    cancelled.add(ident)
+
         try:
             for name in dir(widget):
-                if name.endswith(("_anim", "_after", "_timer")):
+                if name.endswith(suffixes):
                     ident = getattr(widget, name, None)
                     if isinstance(ident, str) and ident not in cancelled:
                         try:
@@ -849,6 +830,7 @@ class ClosableNotebook(ttk.Notebook):
                             cancelled.add(ident)
         except Exception:
             pass
+
         for child in widget.winfo_children():
             self._cancel_after_events(child, cancelled)
             
@@ -919,6 +901,7 @@ class ClosableNotebook(ttk.Notebook):
                 new_widget, mapping = self._clone_widget(orig, nb, mapping)
                 self._copy_widget_layout(orig, new_widget, mapping)
                 self._raise_widgets(new_widget, mapping)
+                self._cancel_after_events(orig)
                 orig.destroy()
                 nb.add(new_widget, text=text)
                 nb.select(new_widget)
@@ -934,7 +917,10 @@ class ClosableNotebook(ttk.Notebook):
                 self._raise_widgets(child)
                 nb.select(tab)
         except Exception:
-            win.destroy()
+            try:
+                self._cancel_after_events(win)
+            finally:
+                win.destroy()
             raise
 
     def _rewrite_config_options(
@@ -1102,6 +1088,7 @@ class ClosableNotebook(ttk.Notebook):
                 prune(child)
                 if child not in expected and str(child) not in keep:
                     try:
+                        self._cancel_after_events(child)
                         child.destroy()
                     except Exception:
                         pass

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.168"
+VERSION = "0.2.169"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/after_callbacks/test_capsule_button_cleanup.py
+++ b/tests/detachment/after_callbacks/test_capsule_button_cleanup.py
@@ -1,0 +1,84 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for detaching animated CapsuleButtons with callbacks."""
+
+from __future__ import annotations
+
+import os
+import tkinter as tk
+
+import pytest
+
+from gui.utils.closable_notebook import ClosableNotebook
+from gui.controls.capsule_button import CapsuleButton
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+class TestAfterCallbackCleanup:
+    """Grouped tests ensuring after callbacks are cancelled on detachment."""
+
+    class AnimatedCapsule(CapsuleButton):
+        def __init__(self, master: tk.Widget) -> None:
+            super().__init__(master, text="Go")
+            self._spin_after = self.after(1, self._spin)
+
+        def _spin(self) -> None:
+            self._spin_after = self.after(1, self._spin)
+
+    def _detach(self, nb: ClosableNotebook, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+    def test_no_tcl_error(self, monkeypatch):
+        root = tk.Tk(); root.withdraw()
+        nb = ClosableNotebook(root)
+        btn = self.AnimatedCapsule(nb)
+        nb.add(btn, text="Tab")
+        nb.update_idletasks()
+        self._detach(nb, monkeypatch)
+        try:
+            root.update()
+        except tk.TclError as err:
+            pytest.fail(f"TclError: {err}")
+        nb._floating_windows[0].destroy()
+        root.destroy()
+
+    def test_no_attribute_error(self, monkeypatch):
+        root = tk.Tk(); root.withdraw()
+        nb = ClosableNotebook(root)
+        errors: list[Exception] = []
+        root.report_callback_exception = lambda exc, val, tb: errors.append(val)
+        btn = self.AnimatedCapsule(nb)
+        nb.add(btn, text="Tab")
+        nb.update_idletasks()
+        self._detach(nb, monkeypatch)
+        root.update()
+        assert not any(isinstance(e, AttributeError) for e in errors)
+        nb._floating_windows[0].destroy()
+        root.destroy()
+

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -33,10 +33,21 @@ from mainappsrc.version import VERSION
 
 def _readme_version() -> str:
     """Extract the version string from the README."""
-
-    first_line = ROOT.joinpath("README.md").read_text(encoding="utf-8").splitlines()[0]
-    prefix, version = first_line.split(":", maxsplit=1)
-    return version.strip()
+    lines = ROOT.joinpath("README.md").read_text(encoding="utf-8").splitlines()
+    in_comment = False
+    for line in lines:
+        stripped = line.strip()
+        if not in_comment and stripped.startswith("<!--"):
+            in_comment = True
+            continue
+        if in_comment:
+            if stripped.endswith("-->"):
+                in_comment = False
+            continue
+        if stripped:
+            prefix, version = stripped.split(":", maxsplit=1)
+            return version.strip()
+    raise ValueError("Version line not found")
 
 
 def test_readme_matches_version() -> None:


### PR DESCRIPTION
## Summary
- cancel Tk `after` callbacks by scanning root scheduler for widget paths or animation suffixes
- clear pending callbacks for every widget destroyed during tab detachment
- test animated CapsuleButton detachment after-callback cleanup
- document after-callback fixes and bump version to 0.2.169

## Testing
- `python tools/metrics_generator.py --path gui/utils --output metrics.json`
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory, NameError: name 'SplashLauncher' is not defined, AttributeError: 'types.SimpleNamespace' object...)*

------
https://chatgpt.com/codex/tasks/task_b_68afb56a3fe88327ae4a0bb33b05d5ca