### PR TITLE
fix: raise clone hierarchy before pruning duplicates

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,13 @@
 -->
 
 # Version History
+- 0.2.170 - Raise cloned widgets before originals are destroyed to avoid
+          `TclError` and preserve visibility when detaching tabs.
+          - Accept original and clone roots in `_raise_widgets` and traverse a
+            cached child list while the original still exists.
+          - Invoke `_raise_widgets` ahead of duplicate pruning in `_detach_tab`.
+          - Add regression tests ensuring detachment raises no errors and all
+            widgets remain visible.
 - 0.2.169 - Prune only widgets that duplicate original parent/child relationships,
           ensure all cloned descendants register in the mapping and add layout
           tests verifying frame, label, canvas and treeview retention after

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.169
+version: 0.2.170
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -875,33 +875,39 @@ class ClosableNotebook(ttk.Notebook):
             pass
 
     def _raise_widgets(
-        self, widget: tk.Widget, mapping: t.Optional[dict[tk.Widget, tk.Widget]] = None
+        self,
+        orig: tk.Widget,
+        clone: t.Optional[tk.Widget] = None,
+        mapping: t.Optional[dict[tk.Widget, tk.Widget]] = None,
     ) -> None:
-        """Recursively lift *widget* and its cloned descendants.
+        """Recursively lift *clone* mirroring *orig*'s stacking order.
 
-        When *mapping* is provided it is expected to contain a mapping from
-        original widgets to their clones.  The traversal follows the order of
-        the original widgets' children to lift each clone relative to its
-        siblings, preserving the original stacking arrangement.
+        When *mapping* is provided the relationship between original widgets
+        and their clones is resolved through it.  The list of children from the
+        original widget is cached before any destruction so traversal remains
+        safe even if the originals vanish during detachment.
         """
 
+        target = clone or orig
         try:
-            widget.lift()
+            target.lift()
         except Exception:
             pass
 
-        if mapping:
-            reverse = {clone: orig for orig, clone in mapping.items()}
-            orig = reverse.get(widget)
-            if orig is not None:
-                for child_orig in orig.winfo_children():
-                    clone_child = mapping.get(child_orig)
-                    if clone_child is not None:
-                        self._raise_widgets(clone_child, mapping)
-                return
+        if mapping and clone is not None:
+            children: list[tk.Widget]
+            try:
+                children = list(orig.winfo_children())
+            except Exception:
+                children = []
+            for child_orig in children:
+                clone_child = mapping.get(child_orig)
+                if clone_child is not None:
+                    self._raise_widgets(child_orig, clone_child, mapping)
+            return
 
-        for child in widget.winfo_children():
-            self._raise_widgets(child, mapping)
+        for child in target.winfo_children():
+            self._raise_widgets(child, child)
 
     def _detach_tab(self, tab_id: str, x: int, y: int) -> None:
         self.update_idletasks()
@@ -929,19 +935,19 @@ class ClosableNotebook(ttk.Notebook):
                 mapping: dict[tk.Widget, tk.Widget] = {}
                 new_widget, mapping = self._clone_widget(orig, nb, mapping)
                 self._copy_widget_layout(orig, new_widget, mapping)
-                orig.destroy()
                 nb.add(new_widget, text=text)
                 nb.select(new_widget)
                 self._ensure_fills(new_widget)
                 self._reassign_widget_references(mapping)
-                self._raise_widgets(new_widget, mapping)
+                self._raise_widgets(orig, new_widget, mapping)
+                orig.destroy()
                 self._remove_duplicate_widgets(win, nb, mapping)
                 self._reassign_container_attributes(mapping)
             else:
                 tab = nb.tabs()[-1]
                 child = nb.nametowidget(tab)
                 self._ensure_fills(child)
-                self._raise_widgets(child)
+                self._raise_widgets(child, child)
                 nb.select(tab)
         except Exception:
             win.destroy()

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.169"
+VERSION = "0.2.170"
 
 __all__ = ["VERSION"]

--- a/tests/detachment/stacking/test_no_tclerror_visibility.py
+++ b/tests/detachment/stacking/test_no_tclerror_visibility.py
@@ -1,0 +1,96 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for stacked widget detachment."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tkinter as tk
+from tkinter import ttk
+
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook  # noqa: E402
+
+
+class TestStackingRegression:
+    """Grouped regression tests ensuring widgets remain visible."""
+
+    def _build_overlapping(self, nb: ClosableNotebook) -> tk.Frame:
+        container = tk.Frame(nb, width=100, height=100)
+        nb.add(container, text="Tab1")
+        bottom = tk.Frame(container, bg="red")
+        bottom.place(x=0, y=0, relwidth=1, relheight=1)
+        top = tk.Frame(container, bg="blue")
+        top.place(x=0, y=0, relwidth=1, relheight=1)
+        ttk.Label(top, text="lbl").pack()
+        ttk.Button(top, text="btn").pack()
+        top.lift()
+        nb.update_idletasks()
+        return container
+
+    def _detach(self, nb: ClosableNotebook) -> tk.Toplevel:
+        class Event:
+            ...
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+        assert nb._floating_windows, "Tab did not detach"
+        return nb._floating_windows[0]
+
+    def test_no_tclerror_on_detach(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        self._build_overlapping(nb)
+        try:
+            self._detach(nb)
+        except tk.TclError as exc:
+            root.destroy()
+            pytest.fail(f"TclError raised: {exc}")
+        root.destroy()
+
+    def test_all_widgets_visible_after_detach(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        self._build_overlapping(nb)
+        win = self._detach(nb)
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        container = new_nb.nametowidget(new_nb.tabs()[0])
+        top = next(c for c in container.winfo_children() if c.winfo_children())
+        for widget in top.winfo_children():
+            x = widget.winfo_rootx() + 1
+            y = widget.winfo_rooty() + 1
+            visible = win.winfo_containing(x, y)
+            assert visible == widget
+        root.destroy()


### PR DESCRIPTION
## Summary
- avoid TclError by raising cloned widget hierarchy before destroying originals
- reorder detachment flow to lift clones prior to pruning duplicates
- add stacking regression tests for detachment visibility

## Testing
- `pytest -q` *(fails: 219 failed, 1006 passed, 156 skipped, 2 warnings)*
- `pytest tests/detachment/stacking -q` *(skipped: 5 tests)*
- `python tools/metrics_generator.py --path gui/utils --output metrics.json`


------
https://chatgpt.com/codex/tasks/task_b_68afc033f40c832799346e711a6af9b5