### PR TITLE
Show splash-style workspace background when tabs are closed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,7 @@
 -->
 
 # Version History
+- 0.2.170 - Show splash-style background in workspace when no tabs are open.
 - 0.2.169 - Prune only widgets that duplicate original parent/child relationships,
           ensure all cloned descendants register in the mapping and add layout
           tests verifying frame, label, canvas and treeview retention after

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.169
+version: 0.2.170
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/backgrounds.py
+++ b/gui/utils/backgrounds.py
@@ -1,0 +1,97 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Background generation utilities for workspace areas."""
+
+from __future__ import annotations
+
+import random
+from PIL import Image, ImageDraw
+
+
+def generate_workspace_background(width: int, height: int) -> Image.Image:
+    """Return a PIL image with a beveled blue background.
+
+    The design mirrors the application's splash screen with slanted bands
+    and a vertical gradient.  *width* and *height* define the output size in
+    pixels.
+    """
+
+    W, H = max(1, width), max(1, height)
+    c_top = (0, 102, 153)
+    c_bottom = (0, 45, 95)
+    band_base = (0, 75, 130)
+    band_dark = (0, 40, 90)
+    n_bands_primary = 10
+    n_bands_secondary = 18
+    margin = 0.06
+    rng = random.Random(42)
+
+    img = Image.new("RGBA", (W, H))
+    for y in range(H):
+        for x in range(W):
+            t = 0.65 * x / W + 0.35 * y / H
+            r = int(c_top[0] * (1 - t) + c_bottom[0] * t)
+            g = int(c_top[1] * (1 - t) + c_bottom[1] * t)
+            b = int(c_top[2] * (1 - t) + c_bottom[2] * t)
+            img.putpixel((x, y), (r, g, b, 255))
+
+    draw = ImageDraw.Draw(img, "RGBA")
+
+    def band_poly(x0: float, width: float, skew: float, notch: float, top_off: float, bottom_off: float):
+        y_top = int(margin * H + top_off)
+        y_bot = int((1 - margin) * H - bottom_off)
+        x1 = x0 + width
+        notch_y = y_top + 0.55 * (y_bot - y_top)
+        return [
+            (x0, y_top),
+            (x0 + skew, y_bot),
+            (x1 + skew, y_bot),
+            (x1 + 0.95 * skew - notch, notch_y),
+            (x1, y_top),
+        ]
+
+    for xi in sorted(
+        rng.uniform(margin * W * 0.5, W * (0.85 - margin))
+        for _ in range(n_bands_primary)
+    ):
+        width = rng.uniform(W * 0.018, W * 0.05)
+        skew = rng.uniform(W * 0.12, W * 0.22)
+        notch = rng.uniform(W * 0.01, W * 0.03)
+        top_off = rng.uniform(0, H * 0.03)
+        bot_off = rng.uniform(0, H * 0.03)
+        poly = band_poly(xi, width, skew, notch, top_off, bot_off)
+        color = band_base if rng.random() > 0.5 else band_dark
+        draw.polygon(poly, fill=color + (int(0.35 * 255),))
+
+    for xi in sorted(
+        rng.uniform(margin * W * 0.35, W * (0.9 - margin))
+        for _ in range(n_bands_secondary)
+    ):
+        width = rng.uniform(W * 0.003, W * 0.012)
+        skew = rng.uniform(W * 0.1, W * 0.24)
+        notch = rng.uniform(W * 0.004, W * 0.009)
+        top_off = rng.uniform(0, H * 0.02)
+        bot_off = rng.uniform(0, H * 0.02)
+        poly = band_poly(xi, width, skew, notch, top_off, bot_off)
+        bright = tuple(min(int(c * 1.2), 255) for c in band_base)
+        draw.polygon(poly, fill=bright + (int(0.55 * 255),))
+
+    return img
+
+__all__ = ["generate_workspace_background"]

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -33,6 +33,8 @@ import typing as t
 import tkinter as tk
 import weakref
 from tkinter import ttk
+from PIL import ImageTk
+from gui.utils.backgrounds import generate_workspace_background
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +147,11 @@ class ClosableNotebook(ttk.Notebook):
         self.bind("<<NotebookTabChanged>>", self._on_tab_changed, True)
         self.bind("<FocusIn>", self._on_focus_in, True)
 
+        self._bg_canvas = tk.Canvas(self, highlightthickness=0, borderwidth=0)
+        self._bg_photo: ImageTk.PhotoImage | None = None
+        self.bind("<Configure>", self._resize_background, add="+")
+        self._update_background()
+
     # ------------------------------------------------------------------
     # Tab management
     # ------------------------------------------------------------------
@@ -169,6 +176,28 @@ class ClosableNotebook(ttk.Notebook):
             self.master.bind("<Destroy>", _forget, add="+")
         else:
             ClosableNotebook._tab_hosts.pop(child, None)
+        self._update_background()
+
+    def forget(self, tab_id: str) -> None:  # type: ignore[override]
+        super().forget(tab_id)
+        self._update_background()
+
+    def _resize_background(self, _event: tk.Event | None = None) -> None:
+        if self.tabs():
+            return
+        w = max(1, self.winfo_width())
+        h = max(1, self.winfo_height())
+        img = generate_workspace_background(w, h)
+        self._bg_photo = ImageTk.PhotoImage(img)
+        self._bg_canvas.delete("all")
+        self._bg_canvas.create_image(0, 0, anchor="nw", image=self._bg_photo)
+
+    def _update_background(self) -> None:
+        if self.tabs():
+            self._bg_canvas.place_forget()
+        else:
+            self._bg_canvas.place(relx=0, rely=0, relwidth=1, relheight=1)
+            self._resize_background()
 
     # ------------------------------------------------------------------
     # Floating window helpers

--- a/gui/windows/splash_screen.py
+++ b/gui/windows/splash_screen.py
@@ -18,8 +18,8 @@
 
 import tkinter as tk
 import math
-import random
 from PIL import Image, ImageDraw, ImageTk, ImageFont
+from gui.utils.backgrounds import generate_workspace_background
 
 
 class SplashScreen(tk.Toplevel):
@@ -175,68 +175,8 @@ class SplashScreen(tk.Toplevel):
 
     def _draw_background(self) -> None:
         """Draw beveled blue background with slanted bands."""
-        W = H = self.canvas_size
-        c_top = (0, 102, 153)
-        c_bottom = (0, 45, 95)
-        band_base = (0, 75, 130)
-        band_dark = (0, 40, 90)
-        n_bands_primary = 10
-        n_bands_secondary = 18
-        margin = 0.06
-        rng = random.Random(42)
-
-        img = Image.new("RGBA", (W, H))
-        for y in range(H):
-            for x in range(W):
-                t = 0.65 * x / W + 0.35 * y / H
-                r = int(c_top[0] * (1 - t) + c_bottom[0] * t)
-                g = int(c_top[1] * (1 - t) + c_bottom[1] * t)
-                b = int(c_top[2] * (1 - t) + c_bottom[2] * t)
-                img.putpixel((x, y), (r, g, b, 255))
-
-        draw = ImageDraw.Draw(img, "RGBA")
-
-        def band_poly(x0, width, skew, notch, top_off, bottom_off):
-            y_top = int(margin * H + top_off)
-            y_bot = int((1 - margin) * H - bottom_off)
-            x1 = x0 + width
-            notch_y = y_top + 0.55 * (y_bot - y_top)
-            return [
-                (x0, y_top),
-                (x0 + skew, y_bot),
-                (x1 + skew, y_bot),
-                (x1 + 0.95 * skew - notch, notch_y),
-                (x1, y_top),
-            ]
-
-        for xi in sorted(
-            rng.uniform(margin * W * 0.5, W * (0.85 - margin))
-            for _ in range(n_bands_primary)
-        ):
-            width = rng.uniform(W * 0.018, W * 0.05)
-            skew = rng.uniform(W * 0.12, W * 0.22)
-            notch = rng.uniform(W * 0.01, W * 0.03)
-            top_off = rng.uniform(0, H * 0.03)
-            bot_off = rng.uniform(0, H * 0.03)
-            poly = band_poly(xi, width, skew, notch, top_off, bot_off)
-            color = band_base if rng.random() > 0.5 else band_dark
-            draw.polygon(poly, fill=color + (int(0.35 * 255),))
-
-        for xi in sorted(
-            rng.uniform(margin * W * 0.35, W * (0.9 - margin))
-            for _ in range(n_bands_secondary)
-        ):
-            width = rng.uniform(W * 0.003, W * 0.012)
-            skew = rng.uniform(W * 0.1, W * 0.24)
-            notch = rng.uniform(W * 0.004, W * 0.009)
-            top_off = rng.uniform(0, H * 0.02)
-            bot_off = rng.uniform(0, H * 0.02)
-            poly = band_poly(xi, width, skew, notch, top_off, bot_off)
-            bright = tuple(min(int(c * 1.2), 255) for c in band_base)
-            draw.polygon(poly, fill=bright + (int(0.55 * 255),))
-
-        self._bg_pil = img
-        self._bg_photo = ImageTk.PhotoImage(img)
+        self._bg_pil = generate_workspace_background(self.canvas_size, self.canvas_size)
+        self._bg_photo = ImageTk.PhotoImage(self._bg_pil)
         self.canvas.create_image(0, 0, anchor="nw", image=self._bg_photo, tags="void_bg")
 
     def _draw_title(self) -> None:

--- a/tests/gui/test_notebook_background.py
+++ b/tests/gui/test_notebook_background.py
@@ -16,8 +16,30 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
+"""Tests for background rendering in :class:`ClosableNotebook`."""
 
-VERSION = "0.2.170"
+import os
+import tkinter as tk
 
-__all__ = ["VERSION"]
+import pytest
+
+from gui.utils.closable_notebook import ClosableNotebook
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_background_visible_without_tabs():
+    root = tk.Tk()
+    root.withdraw()
+    nb = ClosableNotebook(root)
+    root.update_idletasks()
+    assert nb._bg_canvas.winfo_ismapped()
+
+    frame = tk.Frame(nb)
+    nb.add(frame, text="T1")
+    root.update_idletasks()
+    assert not nb._bg_canvas.winfo_ismapped()
+
+    nb.forget(frame)
+    root.update_idletasks()
+    assert nb._bg_canvas.winfo_ismapped()
+    root.destroy()


### PR DESCRIPTION
## Summary
- draw reusable splash-style background image
- show background when ClosableNotebook has no open tabs
- refactor splash screen to use shared background generator
- add regression test for empty-tab background
- bump version to 0.2.170 and update history

## Testing
- `PYTHONPATH=$PWD pytest tests/gui -q`
- `PYTHONPATH=$PWD pytest tests/detachment -q`
- `PYTHONPATH=$PWD pytest tests/diagram -q`
- `PYTHONPATH=$PWD pytest tests/services -q`
- `PYTHONPATH=$PWD pytest tests/governance -q` *(fails: 'GovernanceManager' is not defined)*
- `PYTHONPATH=$PWD pytest tests/gsn -q` *(fails: 'AutoMLApp' object has no attribute 'syncing_service')*
- `python tools/metrics_generator.py --path gui/utils --output metrics.json`

------
https://chatgpt.com/codex/tasks/task_b_68afc08cf3a08327aeb20bb3b01dc67e