### PR TITLE
refactor: split FMEA service to break circular import

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,9 @@
 -->
 
 # Version History
+- 0.2.172 - Factor FMEA helpers into a dedicated module and lazy-load the
+          safety analysis facade to break circular imports preventing
+          application startup.
 - 0.2.171 - Guard ``nametowidget`` lookups in Treeview hover handlers so
           detached tabs emit no ``KeyError`` or ``TclError`` when moving the
           cursor across tree items.  Add regression test covering detached

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.171
+version: 0.2.172
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/mainappsrc/core/safety_analysis.py
+++ b/mainappsrc/core/safety_analysis.py
@@ -38,7 +38,7 @@ from analysis.models import QUALIFICATIONS, COMPONENT_ATTR_TEMPLATES, component_
 from analysis.fmeda_utils import GATE_NODE_TYPES, ASIL_TARGETS
 from mainappsrc.models.fta.fault_tree_node import FaultTreeNode
 from mainappsrc.subapps.fta_subapp import FTASubApp
-from mainappsrc.services.safety_analysis.safety_analysis_service import FMEAService
+from mainappsrc.services.safety_analysis.fmea_service import FMEAService
 from mainappsrc.managers.fmeda_manager import FMEDAManager
 from gui.windows.fault_prioritization import SelectFaultDialog
 import gui.utils.config_utils as config_utils

--- a/mainappsrc/services/safety_analysis/__init__.py
+++ b/mainappsrc/services/safety_analysis/__init__.py
@@ -18,5 +18,6 @@
 """Safety analysis services."""
 
 from .safety_analysis_service import SafetyAnalysisService
+from .fmea_service import FMEAService
 
-__all__ = ["SafetyAnalysisService"]
+__all__ = ["SafetyAnalysisService", "FMEAService"]

--- a/mainappsrc/services/safety_analysis/fmea_service.py
+++ b/mainappsrc/services/safety_analysis/fmea_service.py
@@ -1,0 +1,50 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Minimal FMEA service mixin to avoid circular imports."""
+
+from __future__ import annotations
+
+
+class FMEAService:
+    """Lightweight FMEA helper used by :class:`SafetyAnalysis_FTA_FMEA`.
+
+    The original project exposed a richer FMEA service from the safety
+    analysis module.  During refactoring a circular import arose when the
+    facade and core attempted to import each other.  This stand-alone
+    mixin provides just enough structure for the core module to depend on
+    without creating those cycles.
+    """
+
+    def __init__(self, app: object) -> None:
+        self.app = app
+
+    def show_fmea_list(self):  # pragma: no cover - UI delegation
+        """Open the FMEA document manager if available.
+
+        The application may supply a dedicated implementation through an
+        ``editors_service`` attribute.  When absent the method simply
+        returns ``None`` so tests can exercise the interface without
+        requiring the full UI stack.
+        """
+        helper = getattr(self.app, "editors_service", None)
+        if helper and hasattr(helper, "show_fmea_list"):
+            return helper.show_fmea_list()
+        return None
+
+
+__all__ = ["FMEAService"]

--- a/mainappsrc/services/safety_analysis/safety_analysis_service.py
+++ b/mainappsrc/services/safety_analysis/safety_analysis_service.py
@@ -25,7 +25,7 @@ import tkinter as tk
 from tkinter import ttk
 import tkinter.font as tkFont
 
-from mainappsrc.core.safety_analysis import SafetyAnalysis_FTA_FMEA
+from .fmea_service import FMEAService
 from mainappsrc.models.fta.fault_tree_node import FaultTreeNode
 from analysis.constants import CHECK_MARK, CROSS_MARK
 from analysis.fmeda_utils import compute_fmeda_metrics as _compute_fmeda_metrics
@@ -40,6 +40,8 @@ class SafetyAnalysisService:
     """Wrap :class:`SafetyAnalysis_FTA_FMEA` and expose utility helpers."""
 
     def __init__(self, app: object) -> None:
+        from mainappsrc.core.safety_analysis import SafetyAnalysis_FTA_FMEA
+
         self.app = app
         self._impl = SafetyAnalysis_FTA_FMEA(app)
 

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.171"
+VERSION = "0.2.172"
 
 __all__ = ["VERSION"]


### PR DESCRIPTION
## Summary
- extract minimal `FMEAService` mixin to avoid safety-analysis circular imports
- lazy-load safety analysis facade inside `SafetyAnalysisService`
- bump project version to 0.2.172 and document change

## Testing
- `radon cc -s -j mainappsrc/core/safety_analysis.py mainappsrc/services/safety_analysis/safety_analysis_service.py mainappsrc/services/safety_analysis/fmea_service.py > complexity.json`
- `pytest` *(fails: AttributeError, FileNotFoundError, NameError, TypeError)*
- `pytest tests/test_safety_analysis_service.py`

------
https://chatgpt.com/codex/tasks/task_b_68afc908edd083279780f92772f0246b