### PR TITLE
Fix notebook resize binding and add regression test

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,10 @@
 -->
 
 # Version History
+- 0.2.174 - Remove stale `<Configure>` binding referencing missing background resize
+          handler in `ClosableNotebook` to prevent `AttributeError` during
+          initialization and resizing. Add regression test ensuring notebooks
+          create and resize without errors.
 - 0.2.173 - Display splash-style background in document area when no tabs are open.
 - 0.2.172 - Move ``SafetyAnalysis_FTA_FMEA`` implementation into
           ``safety_analysis_service`` and remove legacy

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.173
+version: 0.2.174
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -34,7 +34,6 @@ import tkinter as tk
 import weakref
 from tkinter import ttk
 from PIL import ImageTk
-from gui.utils.backgrounds import generate_workspace_background
 
 try:
     from .background_factory import generate_splash_background
@@ -111,7 +110,7 @@ class ClosableNotebook(ttk.Notebook):
         self._dragging = False
 
         self._bg_canvas = tk.Canvas(self, highlightthickness=0, borderwidth=0)
-        self._bg_photo: tk.PhotoImage | None = None
+        self._bg_photo: ImageTk.PhotoImage | None = None
         self.bind("<<NotebookTabChanged>>", lambda _e: self._update_background(), add="+")
         self.bind("<<NotebookTabClosed>>", lambda _e: self._update_background(), add="+")
         self.bind("<Configure>", lambda _e: self._update_background(), add="+")
@@ -158,11 +157,6 @@ class ClosableNotebook(ttk.Notebook):
         # Refresh the newly selected tab whenever focus changes
         self.bind("<<NotebookTabChanged>>", self._on_tab_changed, True)
         self.bind("<FocusIn>", self._on_focus_in, True)
-
-        self._bg_canvas = tk.Canvas(self, highlightthickness=0, borderwidth=0)
-        self._bg_photo: ImageTk.PhotoImage | None = None
-        self.bind("<Configure>", self._resize_background, add="+")
-        self._update_background()
 
     # ------------------------------------------------------------------
     # Tab management

--- a/mainappsrc/version.py
+++ b/mainappsrc/version.py
@@ -18,6 +18,6 @@
 
 """Project version information."""
 
-VERSION = "0.2.173"
+VERSION = "0.2.174"
 
 __all__ = ["VERSION"]

--- a/tests/gui/test_notebook_background.py
+++ b/tests/gui/test_notebook_background.py
@@ -43,3 +43,18 @@ def test_background_visible_without_tabs():
     root.update_idletasks()
     assert nb._bg_canvas.winfo_ismapped()
     root.destroy()
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+def test_notebook_initializes_and_resizes_without_attribute_error():
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        nb = ClosableNotebook(root)
+        nb.configure(width=200, height=200)
+        root.update_idletasks()
+        nb.event_generate("<Configure>")
+    except AttributeError as exc:  # pragma: no cover - explicit assertion
+        pytest.fail(f"Unexpected AttributeError: {exc}")
+    finally:
+        root.destroy()


### PR DESCRIPTION
## Summary
- remove stale `<Configure>` binding to missing background resize handler in `ClosableNotebook`
- add regression test ensuring notebook initialization and resize succeed
- bump version to 0.2.174 and document fix

## Testing
- `radon cc -s -j gui/utils/closable_notebook.py`
- `PYTHONPATH=$PWD pytest tests/gui tests/detachment tests/diagram tests/services -q`


------
https://chatgpt.com/codex/tasks/task_b_68afcebdbf388327b76df7d74a27beda