### PR TITLE
Reparent canvases during tab detachment

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,11 @@
 -->
 
 # Version History
+- 0.2.173 - Reparent canvases during tab detachment or clone and discard
+          originals after copying item colors and tags. Skip reparented
+          canvases during duplicate pruning and add regression test
+          ensuring detached governance diagrams retain a single
+          interactive canvas.
 - 0.2.172 - Move ``SafetyAnalysis_FTA_FMEA`` implementation into
           ``safety_analysis_service`` and remove legacy
           ``core.safety_analysis`` module.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.172
+version: 0.2.173
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -500,6 +500,20 @@ class ClosableNotebook(ttk.Notebook):
         # this option which results in a ``TclError`` when cloning detached tabs.
         # Drop it from the keyword arguments so cloning remains robust.
         kwargs.pop("widgetName", None)
+
+        if isinstance(widget, tk.Canvas):
+            try:
+                widget.master = parent  # Reparent existing canvas when possible
+                mapping[widget] = widget
+                for child in self._ordered_children(widget):
+                    child_clone, mapping, layouts = self._clone_widget(
+                        child, widget, mapping, layouts, cancelled
+                    )
+                    mapping[child] = child_clone
+                return widget, mapping, layouts
+            except Exception:
+                pass
+
         try:
             clone = cls(parent, **kwargs)
         except Exception as exc:  # pragma: no cover - extremely rare
@@ -1201,6 +1215,11 @@ class ClosableNotebook(ttk.Notebook):
         """Remove widgets that duplicate originals based on parent/child relationships."""
 
         keep: set[tk.Widget] = {win, nb} | set(mapping.values())
+        reparented = {
+            clone
+            for orig, clone in mapping.items()
+            if orig is clone and isinstance(clone, tk.Canvas)
+        }
         expected: dict[tk.Widget, set[str]] = {}
         for orig, clone in mapping.items():
             parent_clone = mapping.get(orig.master)
@@ -1214,7 +1233,7 @@ class ClosableNotebook(ttk.Notebook):
                 if not child.winfo_exists():
                     continue
                 prune(child)
-                if child in keep:
+                if child in keep or child in reparented:
                     continue
                 names = expected.get(parent, set())
                 if child.winfo_name() in names:

--- a/tests/detachment/diagram/test_governance_diagram_canvas.py
+++ b/tests/detachment/diagram/test_governance_diagram_canvas.py
@@ -1,0 +1,73 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for detached governance diagram canvases."""
+
+import os
+import sys
+import tkinter as tk
+import pytest
+
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, "gui", "utils"))
+from closable_notebook import ClosableNotebook
+
+
+class TestGovernanceDiagramCanvas:
+    def test_detached_canvas_retains_items_and_colors(self) -> None:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        nb = ClosableNotebook(root)
+        canvas = tk.Canvas(nb, width=100, height=100)
+        rect = canvas.create_rectangle(10, 10, 40, 40, fill="green", outline="blue", tags=("node",))
+        clicked: list[tk.Event] = []
+
+        def on_click(event: tk.Event) -> None:
+            clicked.append(event)
+
+        canvas.bind("<Button-1>", on_click)
+        nb.add(canvas, text="Diag")
+        nb.update_idletasks()
+
+        class Event:
+            pass
+
+        press = Event(); press.x = 5; press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+        assert nb._floating_windows, "Tab did not detach"
+        win = nb._floating_windows[-1]
+        new_nb = next(w for w in win.winfo_children() if isinstance(w, ClosableNotebook))
+        canvases = [w for w in new_nb.winfo_children() if isinstance(w, tk.Canvas)]
+        assert len(canvases) == 1, "Expected exactly one canvas in detached window"
+        new_canvas = canvases[0]
+        item = new_canvas.find_all()[0]
+        assert new_canvas.itemcget(item, "fill") == "green"
+        assert new_canvas.itemcget(item, "outline") == "blue"
+        assert "node" in new_canvas.gettags(item)
+        new_canvas.event_generate("<Button-1>", x=15, y=15)
+        assert clicked, "Canvas binding lost after detachment"
+        root.destroy()


### PR DESCRIPTION
## Summary
- Reparent `tk.Canvas` widgets during tab cloning, falling back to cloning when needed
- Skip reparented canvases during duplicate removal to avoid duplicates
- Add regression test ensuring detached governance diagrams retain a single interactive canvas

## Testing
- `radon cc -j gui/utils/closable_notebook.py tests/detachment/diagram/test_governance_diagram_canvas.py`
- `pytest`
- `pytest tests/detachment/canvas tests/detachment/diagram/test_governance_diagram_canvas.py`


------
https://chatgpt.com/codex/tasks/task_b_68afd3c9f8008327ae8307a0938bb2a7