### PR TITLE
Handle missing widgets during duplicate pruning

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,12 @@
 -->
 
 # Version History
+- 0.2.174 - Guard duplicate pruning against missing originals and orphaned
+          clones.
+          - Skip ``winfo_children`` lookups when originals vanish and ignore
+            clones whose parents are absent from the mapping.
+          - Add grouped detachment tests confirming frames, treeviews,
+            canvases and buttons appear only once after detachment.
 - 0.2.173 - Move FMEA and FTA helpers into ``analysis.utils`` and wrap
           ``safety_analysis_service`` methods.
           - Prevent duplicate Safety Management Explorer instances and prune

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -1234,10 +1234,15 @@ class ClosableNotebook(ttk.Notebook):
         # widgets are destroyed so pruning has a complete view of the original
         # hierarchy. This prevents lookups on partially destroyed widget trees.
         expected: dict[tk.Widget, set[str]] = {}
+        reparented: set[tk.Widget] = set()
         for orig, clone in mapping.items():
+            if not orig.winfo_exists():
+                continue
             parent_clone = mapping.get(orig.master)
             if parent_clone is not None:
                 expected.setdefault(parent_clone, set()).add(clone.winfo_name())
+            else:
+                reparented.add(clone)
 
         def prune(parent: tk.Widget) -> None:
             if not parent.winfo_exists():

--- a/tests/detachment/layout/test_widget_type_uniqueness.py
+++ b/tests/detachment/layout/test_widget_type_uniqueness.py
@@ -66,6 +66,18 @@ class TestWidgetTypeUniqueness:
         self.nb.update_idletasks()
         return _detach_notebook(self.nb)
 
+    def test_frames_unique(self) -> None:
+        ttk.Frame(self.container).pack()
+        detached = self._detach()
+        clones = [w for w in detached.winfo_children() if isinstance(w, ttk.Frame)]
+        assert len(clones) == 1
+
+    def test_treeviews_unique(self) -> None:
+        ttk.Treeview(self.container).pack()
+        detached = self._detach()
+        clones = [w for w in detached.winfo_children() if isinstance(w, ttk.Treeview)]
+        assert len(clones) == 1
+
     def test_buttons_unique(self) -> None:
         ttk.Button(self.container, text="b").pack()
         detached = self._detach()


### PR DESCRIPTION
## Summary
- Guard `_remove_duplicate_widgets` against vanished originals and orphaned clones
- Test that frames, treeviews, canvases and buttons remain single after detachment
- Document duplicate-pruning guard in HISTORY

## Testing
- `radon cc gui/utils/closable_notebook.py -s`
- `radon cc tests/detachment/layout/test_widget_type_uniqueness.py -s`
- `pytest -q` *(fails: ImportError: cannot import name 'ACTIVE_TOOLBOX')*

------
https://chatgpt.com/codex/tasks/task_b_68afd6d8d79083279f4ec76ba8742fb8