### PR TITLE
fix: ensure after callbacks canceled on tab detachment

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -344,6 +344,7 @@
 - 0.2.3 - Moved capsule button into dedicated controls module.
 - 0.2.2 - Moved risk assessment helpers into dedicated sub-app.
 - 0.2.1 - Extracted review diff and version functions into ReviewManager.
+- 0.1.13 - Enhanced after-callback cleanup for detachable tabs and added tests for animated button detachment.
 - 0.1.12 - Delegated reliability and risk-analysis windows to dedicated sub-app wrappers.
 - 0.1.11 - Split fault-tree and risk assessment logic into dedicated sub-app wrappers.
 - 0.1.10 - Centralised constants and moved requirement logic into a RequirementsManager sub-app.

--- a/gui/utils/closable_notebook.py
+++ b/gui/utils/closable_notebook.py
@@ -853,69 +853,61 @@ class ClosableNotebook(ttk.Notebook):
             cancelled = set()
 
         try:
-            tkapp = getattr(widget, "tk", None)
+            root = widget._root()
+            tkapp = getattr(root, "tk", None)
             if tkapp is None or getattr(tkapp, "_tclCommands", None) is None:
                 return
             tcl_name = str(widget)
-            ids: set[str] = set()
+
+            # Cancel root-level callbacks referencing the widget's Tcl name
             try:
-                global_ids = tkapp.call("after", "info")
+                root_info = tkapp.call("after", "info")
             except Exception:
-                global_ids = []
-            if isinstance(global_ids, str):
-                global_ids = [global_ids]
-            ids.update(global_ids)
+                root_info = []
+            if isinstance(root_info, str):
+                root_info = tkapp.splitlist(root_info)
+            for ident, cmd in zip(root_info[::2], root_info[1::2]):
+                if ident in cancelled:
+                    continue
+                if tcl_name in cmd:
+                    try:
+                        root.after_cancel(ident)
+                    except Exception:
+                        pass
+                    else:
+                        cancelled.add(ident)
+
+            # Cancel callbacks explicitly attached to the widget
             try:
                 widget_ids = tkapp.call("after", "info", tcl_name)
             except Exception:
                 widget_ids = []
             if isinstance(widget_ids, str):
                 widget_ids = [widget_ids]
-            ids.update(widget_ids)
-            try:
-                commands = getattr(tkapp, "_tclCommands", None) or []
-                tcl_cmds = {cmd for cmd in commands if tcl_name in cmd}
-            except Exception:
-                tcl_cmds = set()
-            for ident in ids:
-                try:
-                    cmd = tkapp.call("after", "info", ident)
-                except Exception:
-                    cmd = ""
-                if (
-                    ident in widget_ids
-                    or tcl_name in cmd
-                    or any(c in cmd for c in tcl_cmds)
-                    or str(ident).endswith(("_animate", "_anim", "_after", "_timer"))
-                ):
-                    try:
-                        widget.after_cancel(ident)
-                    except Exception:
-                        pass
-            try:
-                root_info = widget._root().tk.call("after", "info")
-            except Exception:
-                root_info = []
-            if isinstance(root_info, str):
-                root_info = [root_info]
-            for ident, cmd in zip(root_info[::2], root_info[1::2]):
+            for ident in widget_ids:
                 if ident in cancelled:
                     continue
-                if tcl_name in cmd:
-                    try:
-                        widget._root().after_cancel(ident)
-                    except Exception:
-                        pass
-                    else:
-                        cancelled.add(ident)
-            if getattr(tkapp, "_tclCommands", None):
-                for cmd in tcl_cmds:
-                    try:
-                        tkapp.deletecommand(cmd)
-                    except Exception:
-                        pass
+                try:
+                    widget.after_cancel(ident)
+                except Exception:
+                    pass
+                else:
+                    cancelled.add(ident)
+
+            # Remove command hooks referencing the widget
+            try:
+                commands = getattr(tkapp, "_tclCommands", None) or []
+                for cmd in list(commands):
+                    if tcl_name in cmd:
+                        try:
+                            tkapp.deletecommand(cmd)
+                        except Exception:
+                            pass
+            except Exception:
+                pass
         except Exception:
             pass
+
         try:
             for name in dir(widget):
                 if name.endswith(("_anim", "_after", "_timer")):
@@ -929,6 +921,7 @@ class ClosableNotebook(ttk.Notebook):
                             cancelled.add(ident)
         except Exception:
             pass
+
         for child in widget.winfo_children():
             self._cancel_after_events(child, cancelled)
             
@@ -1022,7 +1015,8 @@ class ClosableNotebook(ttk.Notebook):
             if not self._move_tab(tab_id, nb):
                 orig = self.nametowidget(tab_id)
                 cancelled: set[str] = set()
-                self._cancel_after_events(orig, cancelled)
+                for w in [orig, *orig.winfo_children()]:
+                    self._cancel_after_events(w, cancelled)
                 self.forget(tab_id)
                 mapping: dict[tk.Widget, tk.Widget] = {}
                 new_widget, mapping, layouts = self._clone_widget(

--- a/tests/detachment/after_callbacks/test_animated_widget_detach.py
+++ b/tests/detachment/after_callbacks/test_animated_widget_detach.py
@@ -1,0 +1,69 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Regression tests for detaching animated widgets."""
+
+from __future__ import annotations
+
+import os
+import tkinter as tk
+
+import pytest
+
+from gui.utils.closable_notebook import ClosableNotebook
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Tk display not available")
+class TestAnimatedWidgetDetachment:
+    """Grouped tests for detaching animated widgets."""
+
+    class AnimatedButton(tk.Button):
+        def __init__(self, master: tk.Widget) -> None:
+            super().__init__(master, text="Go")
+            self._pulse_after = self.after(1, self._pulse)
+
+        def _pulse(self) -> None:
+            self._pulse_after = self.after(1, self._pulse)
+
+    def _detach(self, nb: ClosableNotebook, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(nb, "_move_tab", lambda tab_id, target: False)
+
+        class Event: ...
+
+        press = Event()
+        press.x = 5
+        press.y = 5
+        nb._on_tab_press(press)
+        nb._dragging = True
+        release = Event()
+        release.x_root = nb.winfo_rootx() + nb.winfo_width() + 40
+        release.y_root = nb.winfo_rooty() + nb.winfo_height() + 40
+        nb._on_tab_release(release)
+
+    def test_detach_no_invalid_command_name(self, monkeypatch, capsys):
+        root = tk.Tk(); root.withdraw()
+        nb = ClosableNotebook(root)
+        btn = self.AnimatedButton(nb)
+        nb.add(btn, text="Tab")
+        nb.update_idletasks()
+        self._detach(nb, monkeypatch)
+        root.update()
+        assert "invalid command name" not in capsys.readouterr().err
+        win = nb._floating_windows[0]
+        win.destroy()
+        root.destroy()


### PR DESCRIPTION
## Summary
- robust after callback cancellation using root `after info`
- cancel callbacks for all widgets before detaching tabs
- test animated button detachment for invalid command logs

## Testing
- `radon cc -s -j gui/utils/closable_notebook.py | head -c 300`
- `pytest -q` *(fails: KeyError: 'mainappsrc')*


------
https://chatgpt.com/codex/tasks/task_b_68afd6d80d08832792c103c472bfa2b0