### PR TITLE
Guard CapsuleButton from late events

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,8 @@
 -->
 
 # Version History
+- 0.2.174 - Guard CapsuleButton callbacks against ``TclError`` after
+          widget destruction and add grouped detachment event tests.
 - 0.2.173 - Move FMEA and FTA helpers into ``analysis.utils`` and wrap
           ``safety_analysis_service`` methods.
           - Prevent duplicate Safety Management Explorer instances and prune

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-version: 0.2.173
+version: 0.2.174
 Author: Miguel Marina <karel.capek.robotics@gmail.com> - [LinkedIn](https://www.linkedin.com/in/progman32/)
 # AutoML
 

--- a/gui/controls/capsule_button.py
+++ b/gui/controls/capsule_button.py
@@ -523,10 +523,7 @@ class CapsuleButton(tk.Canvas):
         if not self.winfo_exists():
             return
         for item in self._shape_items:
-            try:
-                self.itemconfigure(item, fill=color)
-            except tk.TclError:
-                pass
+            self._safe_itemconfigure(item, fill=color)
         inner = _darken(color, 0.7)
         dark = _darken(color, 0.8)
         light = _lighten(color, 1.2)
@@ -551,12 +548,25 @@ class CapsuleButton(tk.Canvas):
         for item in items:
             item_type = self.type(item)
             option = "fill" if item_type == "line" else "outline"
-            try:
-                self.itemconfigure(item, **{option: color})
-            except tk.TclError:
+            if not self._safe_itemconfigure(item, **{option: color}):
                 # ``outline`` is not supported by some item types (e.g. text),
                 # so retry with ``fill`` to avoid crashes.
-                self.itemconfigure(item, fill=color)
+                self._safe_itemconfigure(item, fill=color)
+
+    def _safe_itemconfigure(self, item: int, **kwargs) -> bool:
+        """Safely configure canvas items.
+
+        Returns ``True`` if the configuration succeeded, ``False`` otherwise.
+        Any ``TclError`` raised because the widget or item no longer exists is
+        silently ignored.
+        """
+        if not self.winfo_exists():
+            return False
+        try:
+            self.itemconfigure(item, **kwargs)
+        except tk.TclError:
+            return False
+        return True
 
     def _get_glow_image(self) -> tk.PhotoImage:
         """Return a cached glowing version of the current image."""
@@ -568,7 +578,7 @@ class CapsuleButton(tk.Canvas):
 
     def _add_glow(self) -> None:
         """Lighten the button edges without covering the surface."""
-        if self._glow_items:
+        if self._glow_items or not self.winfo_exists():
             return
         w, h = int(self["width"]), int(self["height"])
         r = self._radius
@@ -602,14 +612,22 @@ class CapsuleButton(tk.Canvas):
             self.tag_raise(self._text_item)
 
     def _remove_glow(self) -> None:
+        if not self.winfo_exists():
+            self._glow_items = []
+            return
         for item in self._glow_items:
-            self.delete(item)
+            try:
+                self.delete(item)
+            except tk.TclError:
+                pass
         self._glow_items = []
 
     def _toggle_shine(self, visible: bool) -> None:
+        if not self.winfo_exists():
+            return
         state = tk.NORMAL if visible else tk.HIDDEN
         for item in self._shine_items + self._shade_items:
-            self.itemconfigure(item, state=state)
+            self._safe_itemconfigure(item, state=state)
 
     def _on_motion(self, event: tk.Event) -> None:
         if "disabled" in self._state or not self.winfo_exists():
@@ -628,24 +646,15 @@ class CapsuleButton(tk.Canvas):
                 and self._current_image is self._image
             ):
                 glow = self._get_glow_image()
-                if glow:
-                    try:
-                        self.itemconfigure(self._image_item, image=glow)
-                    except tk.TclError:
-                        pass
-                    else:
-                        self._current_image = glow
+                if glow and self._safe_itemconfigure(self._image_item, image=glow):
+                    self._current_image = glow
             self._add_glow()
             self._set_gradient(self._hover_gradient)
         else:
             if self._current_color != self._normal_color:
                 self._set_color(self._normal_color)
             if self._image_item and self._current_image is not self._image:
-                try:
-                    self.itemconfigure(self._image_item, image=self._image)
-                except tk.TclError:
-                    pass
-                else:
+                if self._safe_itemconfigure(self._image_item, image=self._image):
                     self._current_image = self._image
             self._remove_glow()
             self._set_gradient(self._normal_gradient)
@@ -655,13 +664,8 @@ class CapsuleButton(tk.Canvas):
             self._set_color(self._hover_color)
             if self._image_item and self._image:
                 glow = self._get_glow_image()
-                if glow:
-                    try:
-                        self.itemconfigure(self._image_item, image=glow)
-                    except tk.TclError:
-                        pass
-                    else:
-                        self._current_image = glow
+                if glow and self._safe_itemconfigure(self._image_item, image=glow):
+                    self._current_image = glow
             self._add_glow()
             self._set_gradient(self._hover_gradient)
 
@@ -669,26 +673,25 @@ class CapsuleButton(tk.Canvas):
         if "disabled" not in self._state and self.winfo_exists():
             self._set_color(self._normal_color)
             if self._image_item and self._current_image is not self._image:
-                try:
-                    self.itemconfigure(self._image_item, image=self._image)
-                except tk.TclError:
-                    pass
-                else:
+                if self._safe_itemconfigure(self._image_item, image=self._image):
                     self._current_image = self._image
             self._remove_glow()
             self._set_gradient(self._normal_gradient)
 
     def _on_press(self, _event: tk.Event) -> None:
-        if "disabled" not in self._state:
+        if "disabled" not in self._state and self.winfo_exists():
             self._remove_glow()
             self._toggle_shine(False)
             self._set_color(self._pressed_color)
             self._set_gradient(self._normal_gradient)
 
     def _on_release(self, event: tk.Event) -> None:
-        if "disabled" in self._state:
+        if "disabled" in self._state or not self.winfo_exists():
             return
-        w, h = int(self["width"]), int(self["height"])
+        try:
+            w, h = int(self["width"]), int(self["height"])
+        except tk.TclError:
+            return
         inside = 0 <= event.x < w and 0 <= event.y < h
         if inside:
             self._set_color(self._hover_color)

--- a/tests/controls/capsule_button/__init__.py
+++ b/tests/controls/capsule_button/__init__.py
@@ -16,8 +16,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Project version information."""
-
-VERSION = "0.2.174"
-
-__all__ = ["VERSION"]
+"""Tests for the CapsuleButton control."""

--- a/tests/controls/capsule_button/test_detach_events.py
+++ b/tests/controls/capsule_button/test_detach_events.py
@@ -1,0 +1,66 @@
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Copyright (C) 2025 Capek System Safety & Robotic Solutions
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Event handling tests for :class:`CapsuleButton` after detachment."""
+
+import pathlib
+import sys
+import tkinter as tk
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[3]))
+
+from gui.controls.capsule_button import CapsuleButton
+
+
+class TestCapsuleButtonDetachedEvents:
+    """Grouped tests exercising events on a destroyed button."""
+
+    def _create_button(self) -> tuple[tk.Tk, CapsuleButton]:
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            pytest.skip("Tk not available")
+        btn = CapsuleButton(root, text="Demo")
+        btn.pack()
+        root.update_idletasks()
+        return root, btn
+
+    def test_hover_after_detach(self) -> None:
+        root, btn = self._create_button()
+        btn.destroy()
+        event = tk.Event()  # type: ignore[call-arg]
+        btn._on_enter(event)
+        root.destroy()
+
+    def test_motion_after_detach(self) -> None:
+        root, btn = self._create_button()
+        btn.destroy()
+        event = tk.Event()  # type: ignore[call-arg]
+        event.x = 0
+        event.y = 0
+        btn._on_motion(event)
+        root.destroy()
+
+    def test_leave_after_detach(self) -> None:
+        root, btn = self._create_button()
+        btn.destroy()
+        event = tk.Event()  # type: ignore[call-arg]
+        btn._on_leave(event)
+        root.destroy()


### PR DESCRIPTION
## Summary
- add safe item configuration helper and guard CapsuleButton callbacks against Tcl errors when widgets are destroyed
- add grouped tests for CapsuleButton hover, motion and leave events after detachment
- bump version to 0.2.174 and record changes in history

## Testing
- `radon cc -s -j gui/controls/capsule_button.py`
- `pytest` *(fails: 300 errors during collection)*
- `pytest tests/controls/capsule_button/test_detach_events.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68afd6d6e6548327a57e982ca907608c